### PR TITLE
feat: add OpenTelemetry tracing support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ make deploy IMG=<registry>/mercan:tag
 - **Session Manager**: Manages conversation continuity via SQLite store with serial execution enforcement
 - **Store** (`internal/store/`): Storage interfaces (`ResultStore`, `SessionStore`) with SQLite implementation (`internal/store/sqlite/`)
 - **Workers** (`workers/`): AI worker (LLM agent with tools), general worker (container commands), and agent workers (`workers/agent/copilot/`, `workers/agent/claude/`) for external CLI runtimes; workers POST results to controller via HTTP
+- **Tracing** (`internal/tracing/`): Optional OpenTelemetry tracing with OTLP gRPC export, enabled via `--enable-tracing`
 - **Web UI** (`ui/`): React SPA embedded into controller binary via `//go:embed`
 
 ### Custom Resources
@@ -212,6 +213,10 @@ Prefer running single tests over the whole suite for faster feedback:
 ```bash
 go test ./internal/api/ -run TestHandlerName -v
 cd ui && bun run test -- src/components/tasks/task-list.test.tsx
+
+# After editing tracing code
+go test ./internal/tracing/ -v
+go test ./internal/llm/ -run TestTracing -v
 ```
 
 ## Worker Security Context

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ MIT License - see LICENSE file for details.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"fmt"
@@ -36,6 +37,7 @@ import (
 	_ "github.com/sozercan/mercan/internal/llm/openai"
 	_ "github.com/sozercan/mercan/internal/metrics"
 	"github.com/sozercan/mercan/internal/store/sqlite"
+	"github.com/sozercan/mercan/internal/tracing"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -78,6 +80,7 @@ func main() {
 	var storePath string
 	var controllerURL string
 	var enforceNamespaceIsolation bool
+	var enableTracing bool
 	var tlsOpts []func(*tls.Config)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
@@ -121,6 +124,8 @@ func main() {
 		"Base URL for the controller API, used by workers. E.g. http://mercan-controller.mercan-system.svc:8080")
 	flag.BoolVar(&enforceNamespaceIsolation, "enforce-namespace-isolation", false,
 		"When true, restrict users to their ServiceAccount's namespace for all operations.")
+	flag.BoolVar(&enableTracing, "enable-tracing", false,
+		"Enable OpenTelemetry tracing. Configure endpoint via OTEL_EXPORTER_OTLP_ENDPOINT env var.")
 
 	opts := zap.Options{
 		Development: true,
@@ -129,6 +134,20 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// Initialize OpenTelemetry tracing (noop when disabled)
+	tracingShutdown, err := tracing.Init("mercan-controller", enableTracing)
+	if err != nil {
+		setupLog.Error(err, "failed to initialize tracing")
+		os.Exit(1)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := tracingShutdown(shutdownCtx); err != nil {
+			setupLog.Error(err, "failed to shutdown tracing")
+		}
+	}()
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -263,3 +263,47 @@ monitoring:
 | `mercan_agent_tasks_active` | Gauge | Active tasks per agent |
 | `mercan_agent_tasks_total` | Counter | Total tasks per agent |
 | `mercan_skills_loaded_total` | Counter | Skills loaded |
+
+## OpenTelemetry Tracing
+
+Mercan supports opt-in OpenTelemetry distributed tracing for debugging and performance analysis. Tracing is disabled by default (zero overhead).
+
+### Enabling Tracing
+
+Add the `--enable-tracing` flag to the controller:
+
+```yaml
+args:
+  - --enable-tracing
+env:
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: "jaeger-collector.observability.svc:4317"
+```
+
+| Flag / Environment Variable | Default | Description |
+|------------------------------|---------|-------------|
+| `--enable-tracing` | `false` | Enable OpenTelemetry tracing |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `localhost:4317` | OTLP gRPC collector endpoint |
+
+### Instrumented Components
+
+| Tracer | Span | Attributes |
+|--------|------|------------|
+| `mercan.api` | `GET /api/v1/tasks` | `http.method`, `http.route`, `http.status_code`, `http.request_id` |
+| `mercan.chat` | `chat.request` | `session.id`, `chat.provider`, `chat.model` |
+| `mercan.chat` | `chat.tool_loop.iteration` | `chat.iteration` |
+| `mercan.llm` | `llm.complete` | `llm.provider`, `llm.model`, `llm.input_tokens`, `llm.output_tokens` |
+| `mercan.tools` | `tool.execute` | `tool.name`, `tool.success` |
+| `mercan.controller` | `task.reconcile` | `task.name`, `task.namespace`, `task.type` |
+
+### Example: Jaeger Setup
+
+```bash
+# Deploy Jaeger all-in-one (development only)
+kubectl create namespace observability
+kubectl apply -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/main/examples/simplest.yaml
+
+# Configure the controller
+kubectl set env deployment/mercan-controller \
+  OTEL_EXPORTER_OTLP_ENDPOINT=jaeger-collector.observability.svc:4317
+```

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.3
 require (
 	github.com/anthropics/anthropic-sdk-go v1.20.0
 	github.com/github/copilot-sdk/go v0.1.22
+	github.com/go-logr/logr v1.4.3
 	github.com/gofiber/fiber/v3 v3.0.0
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
@@ -13,6 +14,10 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.11.1
+	go.opentelemetry.io/otel v1.36.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0
+	go.opentelemetry.io/otel/sdk v1.36.0
+	go.opentelemetry.io/otel/trace v1.36.0
 	k8s.io/api v0.35.0
 	k8s.io/apiextensions-apiserver v0.35.0
 	k8s.io/apimachinery v0.35.0
@@ -40,7 +45,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -86,12 +90,8 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
-	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0 // indirect
 	go.opentelemetry.io/otel/metric v1.36.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.36.0 // indirect
-	go.opentelemetry.io/otel/trace v1.36.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect

--- a/internal/api/chat.go
+++ b/internal/api/chat.go
@@ -23,10 +23,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
 	corev1alpha1 "github.com/sozercan/mercan/api/v1alpha1"
 	"github.com/sozercan/mercan/internal/controller"
 	"github.com/sozercan/mercan/internal/llm"
 	"github.com/sozercan/mercan/internal/store"
+	"github.com/sozercan/mercan/internal/tracing"
 )
 
 var chatLog = logf.Log.WithName("chat-handler")
@@ -190,6 +195,20 @@ func (ch *ChatHandler) HandleChat(c fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("failed to resolve provider: %v", err))
 	}
 
+	// Wrap provider with tracing
+	provider = llm.NewTracingProvider(provider)
+
+	// Start chat.request span
+	tracer := tracing.Tracer("mercan.chat")
+	ctx, span := tracer.Start(ctx, "chat.request",
+		trace.WithAttributes(
+			attribute.String("session.id", sessionID),
+			attribute.String("chat.provider", provider.Name()),
+			attribute.String("chat.model", model),
+		),
+	)
+	defer span.End()
+
 	// Build system prompt
 	promptBuilder := NewSystemPromptBuilder(ch.client, namespace)
 	systemPrompt, err := promptBuilder.BuildSystemPrompt(ctx, req.SystemPrompt)
@@ -237,6 +256,8 @@ func (ch *ChatHandler) HandleChat(c fiber.Ctx) error {
 		content, usage, toolCalls, err := ch.runToolLoop(ctx, provider, messages, systemPrompt, tools, executor, sessionID, namespace, model, temperature, maxTokens, persistedCount, nil)
 		if err != nil {
 			chatLog.Error(err, "tool loop error")
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("chat error: %v", err))
 		}
 
@@ -312,10 +333,19 @@ func (ch *ChatHandler) runToolLoop(
 	start := time.Now()
 
 	for iteration := 0; ; iteration++ {
+		// Start a span for this iteration
+		iterTracer := tracing.Tracer("mercan.chat")
+		iterCtx, iterSpan := iterTracer.Start(ctx, "chat.tool_loop.iteration",
+			trace.WithAttributes(
+				attribute.Int("chat.iteration", iteration),
+			),
+		)
+
 		// Check context cancellation
 		select {
-		case <-ctx.Done():
+		case <-iterCtx.Done():
 			usage.Duration = time.Since(start).Round(time.Millisecond).String()
+			iterSpan.End()
 			return "I ran out of time. Here's what I accomplished so far.", usage, allToolCalls, nil
 		default:
 		}
@@ -328,7 +358,7 @@ func (ch *ChatHandler) runToolLoop(
 				Content: "[System: You have reached the maximum number of iterations. Please provide a final summary of what you accomplished.]",
 			})
 
-			resp, err := provider.Complete(ctx, &llm.CompletionRequest{
+			resp, err := provider.Complete(iterCtx, &llm.CompletionRequest{
 				Model:        model,
 				SystemPrompt: systemPrompt,
 				Messages:     messages,
@@ -337,6 +367,7 @@ func (ch *ChatHandler) runToolLoop(
 			})
 			if err != nil {
 				usage.Duration = time.Since(start).Round(time.Millisecond).String()
+				iterSpan.End()
 				return "Reached iteration limit.", usage, allToolCalls, nil
 			}
 			usage.LLMCalls++
@@ -352,10 +383,16 @@ func (ch *ChatHandler) runToolLoop(
 			finalMessages := append(messages, llm.Message{Role: "assistant", Content: resp.Content})
 			usage.Duration = time.Since(start).Round(time.Millisecond).String()
 			usage.TasksCreated = executor.tasksCreated
-			_ = ch.saveChatSession(ctx, namespace, sessionID, finalMessages, persistedCount, usage)
-			if err := ch.sessionStore.UpdateTokenCounts(ctx, namespace, sessionID, usage.InputTokens, usage.OutputTokens); err != nil {
+			_ = ch.saveChatSession(iterCtx, namespace, sessionID, finalMessages, persistedCount, usage)
+			if err := ch.sessionStore.UpdateTokenCounts(iterCtx, namespace, sessionID, usage.InputTokens, usage.OutputTokens); err != nil {
 				chatLog.Error(err, "failed to update token counts")
 			}
+			iterSpan.SetAttributes(
+				attribute.Int("chat.llm_calls", usage.LLMCalls),
+				attribute.Int("chat.input_tokens", usage.InputTokens),
+				attribute.Int("chat.output_tokens", usage.OutputTokens),
+			)
+			iterSpan.End()
 			return resp.Content, usage, allToolCalls, nil
 		}
 
@@ -374,7 +411,7 @@ func (ch *ChatHandler) runToolLoop(
 		}
 
 		// Call LLM
-		resp, err := provider.Complete(ctx, &llm.CompletionRequest{
+		resp, err := provider.Complete(iterCtx, &llm.CompletionRequest{
 			Model:        model,
 			SystemPrompt: systemPrompt,
 			Messages:     messages,
@@ -384,6 +421,9 @@ func (ch *ChatHandler) runToolLoop(
 		})
 		if err != nil {
 			usage.Duration = time.Since(start).Round(time.Millisecond).String()
+			iterSpan.RecordError(err)
+			iterSpan.SetStatus(codes.Error, err.Error())
+			iterSpan.End()
 			return "", usage, allToolCalls, fmt.Errorf("LLM completion failed: %w", err)
 		}
 		usage.LLMCalls++
@@ -420,7 +460,7 @@ func (ch *ChatHandler) runToolLoop(
 				}
 
 				// Execute tool
-				result, execErr := executor.Execute(ctx, tc)
+				result, execErr := executor.Execute(iterCtx, tc)
 				if execErr != nil {
 					result = fmt.Sprintf(`{"success":false,"error":"%s"}`, execErr.Error())
 				}
@@ -466,6 +506,7 @@ func (ch *ChatHandler) runToolLoop(
 			}
 
 			// Continue loop for next LLM call
+			iterSpan.End()
 			continue
 		}
 
@@ -479,11 +520,17 @@ func (ch *ChatHandler) runToolLoop(
 		finalMessages := append(messages, llm.Message{Role: "assistant", Content: resp.Content})
 		usage.Duration = time.Since(start).Round(time.Millisecond).String()
 		usage.TasksCreated = executor.tasksCreated
-		_ = ch.saveChatSession(ctx, namespace, sessionID, finalMessages, persistedCount, usage)
-		if err := ch.sessionStore.UpdateTokenCounts(ctx, namespace, sessionID, usage.InputTokens, usage.OutputTokens); err != nil {
+		_ = ch.saveChatSession(iterCtx, namespace, sessionID, finalMessages, persistedCount, usage)
+		if err := ch.sessionStore.UpdateTokenCounts(iterCtx, namespace, sessionID, usage.InputTokens, usage.OutputTokens); err != nil {
 			chatLog.Error(err, "failed to update token counts")
 		}
 
+		iterSpan.SetAttributes(
+			attribute.Int("chat.llm_calls", usage.LLMCalls),
+			attribute.Int("chat.input_tokens", usage.InputTokens),
+			attribute.Int("chat.output_tokens", usage.OutputTokens),
+		)
+		iterSpan.End()
 		return resp.Content, usage, allToolCalls, nil
 	}
 }

--- a/internal/api/chat_tool_executor.go
+++ b/internal/api/chat_tool_executor.go
@@ -20,10 +20,15 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
 	corev1alpha1 "github.com/sozercan/mercan/api/v1alpha1"
 	"github.com/sozercan/mercan/internal/controller"
 	"github.com/sozercan/mercan/internal/llm"
 	"github.com/sozercan/mercan/internal/store"
+	"github.com/sozercan/mercan/internal/tracing"
 )
 
 const taskCreatedMsg = "Task created"
@@ -71,8 +76,18 @@ type ToolResult struct {
 // Execute dispatches a tool call to the appropriate handler and returns
 // the JSON-serialized result.
 func (e *ToolExecutor) Execute(ctx context.Context, toolCall llm.ToolCall) (string, error) {
+	tracer := tracing.Tracer("mercan.tools")
+	ctx, span := tracer.Start(ctx, "tool.execute",
+		trace.WithAttributes(
+			attribute.String("tool.name", toolCall.Name),
+		),
+	)
+	defer span.End()
+
 	var args map[string]any
 	if err := json.Unmarshal(toolCall.Arguments, &args); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		result := toolError("invalid_arguments", fmt.Sprintf("failed to parse arguments: %v", err), "Ensure arguments are valid JSON")
 		return marshalResult(result)
 	}
@@ -116,6 +131,12 @@ func (e *ToolExecutor) Execute(ctx context.Context, toolCall llm.ToolCall) (stri
 		result = e.executeDeleteSession(toolCtx, args)
 	default:
 		result = toolError("unknown_tool", fmt.Sprintf("unknown tool: %s", toolCall.Name), "Use one of the available tools")
+	}
+
+	if result.Success {
+		span.SetAttributes(attribute.Bool("tool.success", true))
+	} else {
+		span.SetStatus(codes.Error, result.Error)
 	}
 
 	return marshalResult(result)

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -7,11 +7,17 @@ MIT License - see LICENSE file for details.
 package api
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/middleware/requestid"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/sozercan/mercan/internal/metrics"
+	"github.com/sozercan/mercan/internal/tracing"
 )
 
 // NewLoggingMiddleware creates a logging middleware
@@ -58,6 +64,38 @@ func NewMetricsMiddleware() fiber.Handler {
 
 		// Record in Prometheus metrics
 		metrics.RecordAPIRequest(path, method, status, duration.Seconds())
+
+		return err
+	}
+}
+
+// NewTracingMiddleware creates an OpenTelemetry tracing middleware.
+func NewTracingMiddleware() fiber.Handler {
+	return func(c fiber.Ctx) error {
+		tracer := tracing.Tracer("mercan.api")
+		ctx, span := tracer.Start(c.Context(), fmt.Sprintf("%s %s", c.Method(), c.Route().Path),
+			trace.WithSpanKind(trace.SpanKindServer),
+			trace.WithAttributes(
+				attribute.String("http.method", c.Method()),
+				attribute.String("http.route", c.Route().Path),
+				attribute.String("http.url", c.OriginalURL()),
+			),
+		)
+		defer span.End()
+
+		c.SetContext(ctx)
+
+		if reqID := requestid.FromContext(c); reqID != "" {
+			span.SetAttributes(attribute.String("http.request_id", reqID))
+		}
+
+		err := c.Next()
+
+		status := c.Response().StatusCode()
+		span.SetAttributes(attribute.Int("http.status_code", status))
+		if status >= 400 {
+			span.SetStatus(codes.Error, fmt.Sprintf("HTTP %d", status))
+		}
 
 		return err
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -87,6 +87,9 @@ func (s *Server) setupMiddleware() {
 	// Request ID middleware
 	s.app.Use(requestid.New())
 
+	// Tracing middleware (after request ID so spans include it)
+	s.app.Use(NewTracingMiddleware())
+
 	// CORS middleware
 	s.app.Use(cors.New(cors.Config{
 		AllowOrigins: []string{"*"},

--- a/internal/api/truncate_test.go
+++ b/internal/api/truncate_test.go
@@ -33,9 +33,9 @@ func TestTruncateMessages_EmptyInput(t *testing.T) {
 
 func TestTruncateMessages_DropsMiddleKeepsFirstAndRecent(t *testing.T) {
 	msgs := []llm.Message{
-		{Role: "user", Content: "original request"},   // ~4 tokens
-		{Role: "assistant", Content: "first response"}, // ~4 tokens — will be dropped
-		{Role: "user", Content: "second question"},     // ~4 tokens — will be dropped
+		{Role: "user", Content: "original request"},     // ~4 tokens
+		{Role: "assistant", Content: "first response"},  // ~4 tokens — will be dropped
+		{Role: "user", Content: "second question"},      // ~4 tokens — will be dropped
 		{Role: "assistant", Content: "second response"}, // ~4 tokens
 		{Role: "user", Content: "latest question"},      // ~4 tokens
 	}

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -34,6 +34,10 @@ import (
 
 	corev1alpha1 "github.com/sozercan/mercan/api/v1alpha1"
 	"github.com/sozercan/mercan/internal/store"
+	"github.com/sozercan/mercan/internal/tracing"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -105,6 +109,16 @@ func (r *TaskReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, err
 	}
 
+	tracer := tracing.Tracer("mercan.controller")
+	ctx, span := tracer.Start(ctx, "task.reconcile",
+		trace.WithAttributes(
+			attribute.String("task.name", task.Name),
+			attribute.String("task.namespace", task.Namespace),
+			attribute.String("task.type", string(task.Spec.Type)),
+		),
+	)
+	defer span.End()
+
 	// Handle deletion with finalizer
 	if !task.DeletionTimestamp.IsZero() {
 		return r.handleDeletion(ctx, task)
@@ -115,6 +129,8 @@ func (r *TaskReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		controllerutil.AddFinalizer(task, TaskFinalizer)
 		if err := r.Update(ctx, task); err != nil {
 			log.Error(err, "failed to add finalizer")
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: time.Second}, nil
@@ -125,6 +141,8 @@ func (r *TaskReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		task.Status.Phase = corev1alpha1.TaskPhasePending
 		if err := r.Status().Update(ctx, task); err != nil {
 			log.Error(err, "failed to update initial status")
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: time.Second}, nil
@@ -462,6 +480,12 @@ func (r *TaskReconciler) createTaskJob(ctx context.Context, task *corev1alpha1.T
 	task.Status.StartTime = &now
 	task.Status.Attempts++
 
+	if s := trace.SpanFromContext(ctx); s.IsRecording() {
+		s.AddEvent("phase.transition", trace.WithAttributes(
+			attribute.String("task.phase", string(corev1alpha1.TaskPhaseRunning)),
+		))
+	}
+
 	meta.SetStatusCondition(&task.Status.Conditions, metav1.Condition{
 		Type:               ConditionTypeJobCreated,
 		Status:             metav1.ConditionTrue,
@@ -590,6 +614,12 @@ func (r *TaskReconciler) completeTask(ctx context.Context, task *corev1alpha1.Ta
 	task.Status.Phase = phase
 	task.Status.CompletionTime = &now
 	task.Status.Message = message
+
+	if s := trace.SpanFromContext(ctx); s.IsRecording() {
+		s.AddEvent("phase.transition", trace.WithAttributes(
+			attribute.String("task.phase", string(phase)),
+		))
+	}
 
 	// Collect result from Job output
 	if err := r.collectResult(ctx, task); err != nil {

--- a/internal/llm/tracing.go
+++ b/internal/llm/tracing.go
@@ -1,0 +1,58 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package llm
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/sozercan/mercan/internal/tracing"
+)
+
+// TracingProvider wraps an LLM Provider with OpenTelemetry tracing.
+type TracingProvider struct {
+	inner Provider
+}
+
+// NewTracingProvider returns a Provider that records a span for every LLM call.
+func NewTracingProvider(p Provider) Provider {
+	return &TracingProvider{inner: p}
+}
+
+func (tp *TracingProvider) Name() string { return tp.inner.Name() }
+
+func (tp *TracingProvider) Complete(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error) {
+	tracer := tracing.Tracer("mercan.llm")
+	ctx, span := tracer.Start(ctx, "llm.complete",
+		trace.WithAttributes(
+			attribute.String("llm.provider", tp.inner.Name()),
+			attribute.String("llm.model", req.Model),
+		),
+	)
+	defer span.End()
+
+	resp, err := tp.inner.Complete(ctx, req)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	span.SetAttributes(
+		attribute.Int("llm.input_tokens", resp.InputTokens),
+		attribute.Int("llm.output_tokens", resp.OutputTokens),
+		attribute.Int("llm.tool_calls", len(resp.ToolCalls)),
+	)
+	return resp, nil
+}
+
+func (tp *TracingProvider) Stream(ctx context.Context, req *CompletionRequest) (<-chan StreamChunk, error) {
+	return tp.inner.Stream(ctx, req)
+}

--- a/internal/llm/tracing_test.go
+++ b/internal/llm/tracing_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package llm
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestTracingProviderName(t *testing.T) {
+	tp := NewTracingProvider(&mockProvider{name: "test-provider"})
+	if got := tp.Name(); got != "test-provider" {
+		t.Errorf("Name() = %q, want %q", got, "test-provider")
+	}
+}
+
+func TestTracingProviderComplete(t *testing.T) {
+	tests := []struct {
+		name    string
+		inner   Provider
+		wantErr bool
+	}{
+		{
+			name:    "success delegates to inner",
+			inner:   &mockProvider{name: "test"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tp := NewTracingProvider(tt.inner)
+			resp, err := tp.Complete(context.Background(), &CompletionRequest{Model: "gpt-4"})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Complete() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && resp == nil {
+				t.Fatal("Complete() returned nil response")
+			}
+			if !tt.wantErr && resp.Content != "mock response" {
+				t.Errorf("Content = %q, want %q", resp.Content, "mock response")
+			}
+		})
+	}
+}
+
+// errorProvider always returns an error from Complete.
+type errorProvider struct{ mockProvider }
+
+func (e *errorProvider) Complete(_ context.Context, _ *CompletionRequest) (*CompletionResponse, error) {
+	return nil, errors.New("api error")
+}
+
+func TestTracingProviderCompleteError(t *testing.T) {
+	tp := NewTracingProvider(&errorProvider{mockProvider: mockProvider{name: "err"}})
+	_, err := tp.Complete(context.Background(), &CompletionRequest{Model: "gpt-4"})
+	if err == nil {
+		t.Fatal("Complete() expected error")
+	}
+	if err.Error() != "api error" {
+		t.Errorf("error = %q, want %q", err.Error(), "api error")
+	}
+}
+
+func TestTracingProviderStream(t *testing.T) {
+	tp := NewTracingProvider(&mockProvider{name: "test"})
+	ch, err := tp.Stream(context.Background(), &CompletionRequest{Model: "gpt-4"})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	chunk := <-ch
+	if chunk.Content != "mock" {
+		t.Errorf("chunk.Content = %q, want %q", chunk.Content, "mock")
+	}
+}
+

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -1,0 +1,70 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package tracing
+
+import (
+	"context"
+	"runtime/debug"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Init initializes OpenTelemetry tracing. When enabled is false, the global
+// tracer provider remains the default noop implementation and the returned
+// shutdown function is a no-op.
+//
+// The OTLP gRPC endpoint is read from the standard OTEL_EXPORTER_OTLP_ENDPOINT
+// environment variable (default: localhost:4317).
+func Init(serviceName string, enabled bool) (shutdown func(ctx context.Context) error, err error) {
+	noop := func(context.Context) error { return nil }
+	if !enabled {
+		return noop, nil
+	}
+
+	ctx := context.Background()
+
+	// Build resource with service name and version
+	version := "unknown"
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" {
+		version = info.Main.Version
+	}
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceNameKey.String(serviceName),
+			semconv.ServiceVersionKey.String(version),
+		),
+	)
+	if err != nil {
+		return noop, err
+	}
+
+	// Create OTLP gRPC exporter (reads OTEL_EXPORTER_OTLP_ENDPOINT env var)
+	exporter, err := otlptracegrpc.New(ctx)
+	if err != nil {
+		return noop, err
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tp)
+
+	return func(ctx context.Context) error {
+		return tp.Shutdown(ctx)
+	}, nil
+}
+
+// Tracer returns a named tracer instance.
+func Tracer(name string) trace.Tracer {
+	return otel.Tracer(name)
+}

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package tracing
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInit(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{
+			name:    "disabled returns noop shutdown",
+			enabled: false,
+		},
+		{
+			name:    "enabled creates provider",
+			enabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shutdown, err := Init("test-service", tt.enabled)
+			if err != nil {
+				t.Fatalf("Init() error = %v", err)
+			}
+			if shutdown == nil {
+				t.Fatal("Init() returned nil shutdown")
+			}
+			// Shutdown should not error
+			if err := shutdown(context.Background()); err != nil {
+				t.Fatalf("shutdown() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestTracer(t *testing.T) {
+	tracer := Tracer("test")
+	if tracer == nil {
+		t.Fatal("Tracer() returned nil")
+	}
+}


### PR DESCRIPTION
## Summary

Add opt-in OpenTelemetry distributed tracing to the controller, inspired by [kagent's tracing approach](https://github.com/kagent-dev/kagent).

## Changes

### New files
- `internal/tracing/tracing.go` — `Init()` / `Tracer()` with OTLP gRPC exporter, `BatchSpanProcessor`, noop when disabled
- `internal/tracing/tracing_test.go` — Unit tests
- `internal/llm/tracing.go` — `TracingProvider` wrapper for LLM providers
- `internal/llm/tracing_test.go` — Unit tests

### Modified files
- `cmd/main.go` — `--enable-tracing` flag + tracing init/shutdown lifecycle
- `internal/api/middleware.go` — `NewTracingMiddleware()` with HTTP request spans
- `internal/api/server.go` — Register tracing middleware
- `internal/api/chat.go` — `chat.request` and `chat.tool_loop.iteration` spans, `TracingProvider` wrapping
- `internal/api/chat_tool_executor.go` — `tool.execute` spans
- `internal/controller/task_controller.go` — `task.reconcile` spans with phase transition events
- `docs/configuration.md` — Tracing configuration reference
- `CLAUDE.md` — Updated architecture docs

## Instrumented Components

| Tracer | Span | Key Attributes |
|--------|------|----------------|
| `mercan.api` | `{METHOD} {route}` | `http.method`, `http.route`, `http.status_code`, `http.request_id` |
| `mercan.chat` | `chat.request` | `session.id`, `chat.provider`, `chat.model` |
| `mercan.chat` | `chat.tool_loop.iteration` | `chat.iteration` |
| `mercan.llm` | `llm.complete` | `llm.provider`, `llm.model`, `llm.input_tokens`, `llm.output_tokens` |
| `mercan.tools` | `tool.execute` | `tool.name`, `tool.success` |
| `mercan.controller` | `task.reconcile` | `task.name`, `task.namespace`, `task.type` |

## Usage

```bash
# Enable tracing with Jaeger
mercan-controller --enable-tracing
export OTEL_EXPORTER_OTLP_ENDPOINT=jaeger-collector.observability.svc:4317
```

Disabled by default — zero overhead when not enabled (noop tracer).

## Design Decisions

- **Opt-in via flag** — matches kagent's `OTEL_TRACING_ENABLED=false` default pattern
- **TracingProvider wrapper** — keeps LLM provider implementations clean; tracing is a cross-cutting concern
- **Controller-only scope** — worker-side tracing (cross-process propagation) deferred to follow-up
- **OTel deps promoted from indirect to direct** — they were already in go.mod via k8s.io/apiserver

## Testing

- `go build ./...` ✅
- `go test ./internal/tracing/` ✅
- `go test ./internal/llm/` ✅  
- `go test ./internal/controller/` ✅ (73/73)
- `go test ./internal/api/` ⚠️ 1 pre-existing failure (`TestServer_HealthEndpoints/readyz` — unrelated)