### PR TITLE
fix: Anthropic base URL doubling, CLI health check parsing, and Helm RBAC

### DIFF
--- a/charts/orka/templates/rbac.yaml
+++ b/charts/orka/templates/rbac.yaml
@@ -7,65 +7,94 @@ metadata:
   labels:
     {{- include "orka.labels" . | nindent 4 }}
 rules:
-  # Task CRD permissions
+  # Custom Resource permissions
   - apiGroups: ["core.orka.ai"]
-    resources: ["tasks"]
+    resources: ["tasks", "tools", "agents", "providers"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["core.orka.ai"]
-    resources: ["tasks/status"]
+    resources: ["tasks/status", "tools/status", "agents/status", "providers/status"]
     verbs: ["get", "update", "patch"]
   - apiGroups: ["core.orka.ai"]
-    resources: ["tasks/finalizers"]
+    resources: ["tasks/finalizers", "tools/finalizers", "agents/finalizers", "providers/finalizers"]
     verbs: ["update"]
-
-  # Tool CRD permissions
-  - apiGroups: ["core.orka.ai"]
-    resources: ["tools"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["core.orka.ai"]
-    resources: ["tools/status"]
-    verbs: ["get", "update", "patch"]
-
-  # Agent CRD permissions
-  - apiGroups: ["core.orka.ai"]
-    resources: ["agents"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["core.orka.ai"]
-    resources: ["agents/status"]
-    verbs: ["get", "update", "patch"]
 
   # Job permissions
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    verbs: ["get", "list", "watch"]
 
-  # ConfigMap permissions (results, sessions)
+  # Core resource permissions
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-
-  # Secret permissions (read-only for API keys)
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
-
-  # Pod permissions (for logs)
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["pods/log"]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "list", "watch", "create"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes", "services", "endpoints"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "persistentvolumeclaims", "replicationcontrollers"]
+    verbs: ["get", "list", "watch"]
+
+  # Workload resource permissions (read-only, for chat K8s tools)
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["get", "list"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+
+  # RBAC permissions (for chat K8s tools)
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+    verbs: ["get", "list", "watch"]
 
   # TokenReview for authentication
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]
 
-  # Events
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
+  # Leader election
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 # Controller ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/internal/cli/client/client.go
+++ b/internal/cli/client/client.go
@@ -215,11 +215,12 @@ func (c *Client) HealthCheck(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	var resp map[string]string
+	var resp map[string]any
 	if err := json.Unmarshal(body, &resp); err != nil {
 		return false, nil
 	}
-	return resp["status"] == "ok", nil
+	status, _ := resp["status"].(string)
+	return status == "ok", nil
 }
 
 // ReadyCheck calls GET /readyz and returns true if ready.
@@ -228,11 +229,12 @@ func (c *Client) ReadyCheck(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	var resp map[string]string
+	var resp map[string]any
 	if err := json.Unmarshal(body, &resp); err != nil {
 		return false, nil
 	}
-	return resp["status"] == "ok", nil
+	status, _ := resp["status"].(string)
+	return status == "ok", nil
 }
 
 // extractAgentSummary pulls summary fields from the raw agent JSON.

--- a/internal/llm/anthropic/provider.go
+++ b/internal/llm/anthropic/provider.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
@@ -40,7 +41,11 @@ func NewProvider(config llm.ProviderConfig) (*Provider, error) {
 	}
 
 	if config.BaseURL != "" {
-		opts = append(opts, option.WithBaseURL(config.BaseURL))
+		// The Anthropic SDK appends "v1/messages" to the base URL, so strip
+		// a trailing "/v1" or "/v1/" to avoid a doubled path segment.
+		base := strings.TrimRight(config.BaseURL, "/")
+		base = strings.TrimSuffix(base, "/v1")
+		opts = append(opts, option.WithBaseURL(base))
 	}
 
 	client := anthropic.NewClient(opts...)

--- a/internal/llm/anthropic/provider_test.go
+++ b/internal/llm/anthropic/provider_test.go
@@ -40,6 +40,14 @@ func TestNewProvider(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "with base URL ending in /v1",
+			config: llm.ProviderConfig{
+				APIKey:  "test-api-key",
+				BaseURL: "https://proxy.example.com/v1",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Three bugs found during extensive CLI `run` command testing against a live cluster.

### 1. Anthropic provider: doubled base URL path
The Anthropic SDK appends `v1/messages` to the base URL. When the Provider CRD has a `/v1`-suffixed base URL (common when reusing OpenAI-style configs), the resulting URL becomes `/v1/v1/messages` → 404.

**Fix**: Strip trailing `/v1` from the base URL before passing to the SDK.

### 2. CLI HealthCheck/ReadyCheck always returns false
The `/readyz` endpoint returns nested JSON (`{"checks":{...},"status":"ok"}`). The CLI parsed this with `map[string]string`, causing `json.Unmarshal` to fail silently. Result: `orka status` always showed "Not Ready" even when the server was healthy.

**Fix**: Use `map[string]any` with type assertion.

### 3. Helm chart RBAC missing 15+ resource permissions
The controller's cache requires informers for many Kubernetes resources (used by chat K8s inspection tools). The Helm chart was missing permissions for `serviceaccounts`, `namespaces`, `providers/status`, `clusterrolebindings`, `deployments`, `nodes`, `services`, and more. Without these, the cache never synced and **all task reconciliation was blocked** — tasks stayed in Pending forever.

**Fix**: Comprehensive RBAC update matching the kubebuilder-generated `config/rbac/role.yaml`.

## Testing
- Built CLI and ran 20+ test scenarios against a live AKS cluster
- Verified container task creation, execution, and result fetching end-to-end
- All existing tests pass (`go test ./internal/llm/...`)
- Added test case for base URL with `/v1` suffix