### PR TITLE
feat: add inter-agent messaging, cancel_task, and Cancelled phase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,18 @@ cd ui && bun run lint && bun run test  # After editing UI code
 
 Single tests: `go test ./internal/api/ -run TestHandlerName -v`
 
+## Key Gotchas
+
+- Provider secret key defaults to `api-key` — if your K8s Secret uses a different key, set `secretRef.key`
+- Worker filesystem is read-only except `/tmp`, `/home/worker`, and `/workspace` — writes elsewhere will fail
+- `make build` requires UI assets — run `make ui-build` first, or the `ensure-ui-embed` target creates a stub
+- Fallback providers are resolved at Job build time, not worker runtime — provider changes after Job creation don't take effect
+- On context length errors, the AI worker naively truncates messages to ~50% — oldest context is lost first
+- Copilot agent worker auto-approves all permission requests — no tool filtering in autonomous mode
+- OpenAI provider auto-detects API mode: tries Responses API first, falls back to Chat Completions on 404/405
+- Auth tokens are cached for 60s (SHA256 hash) — token revocation has up to 60s propagation delay
+- `code_exec` tool silently caps timeout at 60s — values above 60 fall back to the 30s default
+
 ## Documentation
 
 See @docs/ for detailed documentation:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,11 @@ This file provides guidance to Claude Code when working with code in this reposi
 - Never commit secrets to version control
 - Never log or print API keys, tokens, or passwords
 - Never include secrets in error messages or responses
+- Always use Kubernetes Secrets or environment variables for sensitive data
 
 ## CRITICAL: No Binaries in Repo
 
 **NEVER commit compiled binaries to the repository.** Build artifacts belong in `bin/` (which is gitignored) or CI release pipelines — not in version control.
-- Always use Kubernetes Secrets or environment variables for sensitive data
-- Never hardcode credentials in code or configuration files
 
 ## CRITICAL: Fix Pre-existing Issues
 
@@ -21,108 +20,21 @@ When you encounter pre-existing bugs, failing tests, or broken CI — **fix them
 
 ## Project Overview
 
-Orka is a Kubernetes-native task execution platform. A controller manages Jobs and Pods for incoming task requests, supporting container tasks, AI agent tasks with LLM integration, and external agent CLI runtimes (Copilot, Claude Code). See @docs/architecture.md for full architecture details.
+Orka is a Kubernetes-native task execution platform. A controller manages Jobs and Pods for incoming task requests, supporting container tasks, AI agent tasks with LLM integration, and external agent CLI runtimes (Copilot, Claude Code). CRDs: Task, Agent, Tool, Provider. See @docs/architecture.md for full details.
 
 ## Build & Development Commands
 
 ```bash
-# Generate CRD manifests and Go types (run after editing *_types.go or markers)
-make manifests
-make generate
-
-# Build (includes UI)
-make build
-
-# Run tests
-make test
-
-# Lint
-make lint-fix
-
-# UI development
-cd ui && bun install && bun run dev   # Dev server on :5173
-cd ui && bun run test                 # UI tests
-cd ui && bun run test:coverage        # UI tests with coverage
-
-# Docker images
-make docker-build-all                 # Controller + all agent workers
-make docker-push-all
-
-# Deploy
+make manifests          # Generate CRD manifests (run after editing *_types.go or markers)
+make generate           # Generate Go types
+make build              # Build (includes UI)
+make test               # Run tests
+make lint-fix           # Lint and fix
+make docker-build-all   # Docker images (controller + workers)
 make deploy IMG=<registry>/orka:tag
 ```
 
-## Architecture
-
-### Core Components
-
-- **Controller** (`cmd/main.go`): Main entrypoint with `--watch-namespace`, `--copilot-worker-image`, `--claude-worker-image`, `--ai-worker-image`, `--store-backend`, `--store-path`, `--controller-url`, `--enforce-namespace-isolation`, and `--max-tasks-per-namespace` flags
-- **CLI** (`cmd/cli/`): Command-line tool with `login`, `chat`, `agent`, `task`, and `status` commands
-- **Migrate** (`cmd/migrate/`): Database migration tool for moving data from ConfigMaps to SQLite
-- **API Server** (`internal/api/`): REST API using Fiber framework with ServiceAccount token auth
-- **Chat Endpoint** (`internal/api/chat.go`): Agentic chat with SSE streaming, tool execution loop, session persistence
-- **Task Reconciler** (`internal/controller/`): Watches Task CRDs, creates Jobs, manages lifecycle
-- **Session Manager**: Manages conversation continuity via SQLite store with serial execution enforcement
-- **Store** (`internal/store/`): Storage interfaces (`ResultStore`, `SessionStore`, `PlanStore`, `MessageStore`) with SQLite implementation (`internal/store/sqlite/`)
-- **Workers** (`workers/`): AI worker (LLM agent with tools), general worker (container commands), and agent workers (`workers/agent/copilot/`, `workers/agent/claude/`) for external CLI runtimes; workers POST results to controller via HTTP
-- **Tracing** (`internal/tracing/`): Optional OpenTelemetry tracing with OTLP gRPC export, enabled via `--enable-tracing`
-- **Web UI** (`ui/`): React SPA embedded into controller binary via `//go:embed`
-
-### Custom Resources
-
-- **Task** (`api/v1alpha1/task_types.go`): Core work unit — `container`, `ai`, or `agent` type with optional scheduling
-- **Tool** (`api/v1alpha1/tool_types.go`): Custom HTTP-based tool definitions
-- **Agent** (`api/v1alpha1/agent_types.go`): Reusable agent configurations with model, tools, skills, and optional `runtime` field for CLI runtimes
-- **Provider** (`api/v1alpha1/provider_types.go`): LLM provider configuration (anthropic, openai, azure-openai)
-
-### Task Types
-
-- **`container`**: Runs arbitrary container commands
-- **`ai`**: Runs AI agent tasks with built-in LLM integration (Anthropic, OpenAI)
-- **`agent`**: Runs external agent CLI runtimes (Copilot CLI, Claude Code CLI) via dedicated worker images
-
-### Key Patterns
-
-- Results stored in SQLite via the `ResultStore` interface (no size limit)
-- Sessions stored in SQLite with normalized schema (session metadata + messages) via the `SessionStore` interface
-- Workers POST results to the controller's internal HTTP endpoint (`/internal/v1/results/:namespace/:taskName`)
-- Session transcripts delivered to worker pods via an init container that fetches from the controller
-- Skills are ConfigMaps with `skill.md` content injected into system prompts
-- Tools execute via HTTP calls to internal services
-- Priority queue (0-1000) for task scheduling
-- Finalizers ensure cleanup of session locks
-- LLM tool args for nested objects arrive as `map[string]any`, not strings — always type-switch
-- Multi-agent coordination: coordinator agents delegate to specialists via `delegate_task`/`wait_for_tasks`/`cancel_task` tools; controller enforces depth, allowedAgents, concurrency limits
-- Inter-agent messaging: sibling tasks (same parent) exchange messages via `send_message`/`check_messages` tools; messages flow through controller's internal API; scoped to siblings only; broadcast via `to_task="*"`
-- Iterative coordination: `delegate_task` supports `prior_task`, `feedback`, and `pushBranch` params; workers apply prior diffs via `PrepareWorkspace()` and produce structured results via `FinalizeResult()`
-- Auto-push: When `pushBranch` is set on workspace config, `FinalizeResult` commits and pushes changes to that branch automatically
-- PR creation: `create_pull_request` coordination tool creates GitHub PRs from pushed branches using git credentials from task workspace config
-- PR management: `merge_pull_request` merges PRs after CI checks pass (instant); `auto_merge_pull_request` polls CI and auto-merges when green (blocking with timeout); `review_pull_request` fetches PR diffs for analysis; `post_review_comment` posts reviews with verdicts and line-level comments
-- Self-healing coordination: `delegate_task` supports `auto_retry` and `max_retries` params; `wait_for_tasks` automatically re-creates failed child tasks with error context prepended to original prompt; retry config stored as annotations (`orka.ai/auto-retry`, `orka.ai/max-retries`, `orka.ai/retry-count`)
-- Autonomous mode: When `coordination.autonomous: true`, controller loops Jobs instead of completing; plan state persisted in SQLite via `PlanStore`; worker fetches plan via HTTP GET; `update_plan` tool saves progress; termination via goal_complete flag, maxIterations, or Suspend
-
-### Multi-Agent Coordination
-
-- **Coordination tools** (`internal/tools/delegate_task.go`, `internal/tools/wait_for_tasks.go`, `internal/tools/cancel_task.go`, `internal/tools/update_plan.go`): LLM tools that create child Tasks, poll for results, cancel tasks, and update autonomous plan state
-- **Messaging tools** (`internal/tools/send_message.go`, `internal/tools/check_messages.go`): Inter-agent messaging between sibling tasks (same parent coordinator); messages stored in SQLite via `MessageStore`
-- **PR workflow tools** (`internal/tools/create_pull_request.go`, `internal/tools/merge_pull_request.go`, `internal/tools/auto_merge_pull_request.go`, `internal/tools/review_pull_request.go`, `internal/tools/post_review_comment.go`): GitHub PR creation, merging (instant and polling), review fetching, and review posting
-- **Agent management tools** (`internal/tools/create_agent.go`, `internal/tools/delete_agent.go`): Dynamic Agent CRD creation and deletion at runtime
-- **Controller enforcement** (`internal/controller/task_controller.go`): Validates `maxDepth`, `allowedAgents`, `maxConcurrentChildren` in `handlePending`; populates `status.childTasks` in `handleRunning`
-- **Job builder** (`internal/controller/job_builder.go`): Injects `ORKA_COORDINATION_*` env vars and auto-adds coordination tools when `agent.Spec.Coordination.Enabled`
-- **AI worker** (`workers/ai/main.go`): Registers coordination tools via `tools.RegisterCoordinationTools()` when `ORKA_COORDINATION_ENABLED=true`; increases `maxIterations` to 50
-- **RBAC** (`config/rbac/worker_role.yaml`): Workers have Task `create/get/list/watch` and Agent `get/create/update/delete` for coordination
-- Child tasks use labels (`orka.ai/parent-task`, `orka.ai/delegated-agent`) and annotations (`orka.ai/coordination-depth`) for tracking
-- Owner references enable cascade deletion of child tasks
-- **Iterative workflows**: `prior_task` param in `delegate_task` sets `PriorTaskRef` on child tasks; job builder injects `ORKA_PRIOR_TASK`/`ORKA_PRIOR_TASK_NAMESPACE` env vars; workers apply prior diffs before starting
-- **Auto-push**: `PushBranch` field on `WorkspaceConfig` → `ORKA_PUSH_BRANCH` env var → `FinalizeResult` commits and pushes to that branch
-- **PR creation tool** (`internal/tools/create_pull_request.go`): Reads git secret from child task's workspace config, creates PR via GitHub REST API
-- **PR merge tool** (`internal/tools/merge_pull_request.go`): Verifies CI checks pass, then merges PR via GitHub REST API
-- **PR auto-merge tool** (`internal/tools/auto_merge_pull_request.go`): Polls CI checks every 30s and auto-merges when green; handles force-pushes, external closures, and transient API errors
-- **PR review tool** (`internal/tools/review_pull_request.go`): Fetches PR diff, file changes, and metadata for code review
-- **PR comment tool** (`internal/tools/post_review_comment.go`): Posts review with verdict (APPROVE/REQUEST_CHANGES/COMMENT) and line-level comments
-- **Autonomous mode** (`api/v1alpha1/agent_types.go`): `CoordinationConfig.Autonomous` enables controller-level Job loop; `MaxIterations` caps iterations; `TaskStatus.Iteration` tracks current iteration; `PlanStore` persists plan state in SQLite
-- **Structured results** (`workers/common/result.go`): `StructuredResult` envelope with summary, diff, verdict, feedback, files, pushBranch; `wait_for_tasks` strips diffs from coordinator context
-- See @docs/multi-agent-coordination.md for full details
+UI: `cd ui && bun install && bun run dev` (dev server on :5173). See @docs/development.md for full commands.
 
 ## Auto-Generated Files — Do NOT Edit
 
@@ -137,119 +49,42 @@ Do NOT delete `// +kubebuilder:scaffold:*` comments — the CLI injects code at 
 ## Code Style & Conventions
 
 ### Go
-
-- Use table-driven tests with descriptive subtests
-- Use `sigs.k8s.io/controller-runtime/pkg/client/fake` for K8s client mocking in tests
-- Use `httptest.NewServer` for HTTP mocking
 - Structured logging: `log := log.FromContext(ctx); log.Info("msg", "key", val)`
-- Idempotent reconciliation — safe to run multiple times
-- Re-fetch before updates: `r.Get(ctx, req.NamespacedName, obj)` before `r.Update`
-- Owner references for automatic garbage collection (`SetControllerReference`)
-- RBAC markers above reconciler methods, then run `make manifests`
+- Idempotent reconciliation — re-fetch before updates (`r.Get` before `r.Update`)
+- Owner references for garbage collection (`SetControllerReference`)
+- RBAC markers above reconciler methods, then `make manifests`
+- Table-driven tests; `fake.NewClientBuilder()` for K8s; `httptest.NewServer` for HTTP
+- LLM tool args for nested objects arrive as `map[string]any`, not strings — always type-switch
 
 ### TypeScript (UI)
-
-- React 19 + TanStack Router (file-based routes in `ui/src/routes/`)
-- Zustand stores for auth and UI state (`ui/src/stores/`)
-- TanStack Query hooks per resource (`ui/src/hooks/use-*.ts`)
+- React 19 + TanStack Router + TanStack Query + Zustand + shadcn/ui + Tailwind CSS 4
 - Zod schemas matching Go API types (`ui/src/schemas/`)
-- shadcn/ui components (new-york style) with Tailwind CSS 4
-- Mock `zustand/middleware` with `vi.mock('zustand/middleware', () => ({ persist: (fn: unknown) => fn }))` in tests
-
-## Dependencies
-
-- `sigs.k8s.io/controller-runtime` — Controller framework
-- `k8s.io/client-go` — Kubernetes client
-- `github.com/gofiber/fiber/v3` — HTTP router
-- `github.com/anthropics/anthropic-sdk-go` — Anthropic Claude API
-- `github.com/openai/openai-go/v3` — OpenAI API (official SDK)
-- `github.com/github/copilot-sdk/go` — GitHub Copilot SDK
-- `modernc.org/sqlite` — Embedded SQLite (pure Go, no CGO)
-
-## API Endpoints
-
-```
-POST   /api/v1/tasks              Create task
-GET    /api/v1/tasks              List tasks (?namespace=, ?limit=, ?continue=)
-GET    /api/v1/tasks/{id}         Get task details
-DELETE /api/v1/tasks/{id}         Cancel/delete task
-GET    /api/v1/tasks/{id}/logs    Stream logs
-GET    /api/v1/tasks/{id}/result  Get result from SQLite store
-GET    /api/v1/tasks/{id}/plan    Get autonomous plan state
-GET    /api/v1/tasks/{id}/children Get child tasks
-GET    /api/v1/sessions           List sessions
-GET    /api/v1/sessions/{id}      Get session transcript
-DELETE /api/v1/sessions/{id}      Delete session
-GET    /api/v1/tools              List tools
-GET    /api/v1/tools/{name}       Get tool details
-POST   /api/v1/agents             Create agent
-GET    /api/v1/agents             List agents
-GET    /api/v1/agents/{name}      Get agent details
-PUT    /api/v1/agents/{name}      Update agent
-DELETE /api/v1/agents/{name}      Delete agent
-GET    /api/v1/auth/validate      Validate auth token
-GET    /api/v1/secrets            List secret names (metadata only)
-POST   /api/v1/chat               Chat with SSE streaming (if enabled)
-GET    /api/v1/chat/config        Get chat configuration
-DELETE /api/v1/chat/{sessionId}   Cancel chat session
-GET    /healthz                   Health check
-GET    /readyz                    Readiness check
-POST   /v1/chat/completions      OpenAI-compatible chat completions (streaming & non-streaming)
-GET    /v1/models                OpenAI-compatible model listing
-
-Internal endpoints (worker communication):
-POST   /internal/v1/results/{namespace}/{taskName}              Submit task result
-GET    /internal/v1/sessions/{namespace}/{name}/transcript      Get session transcript
-POST   /internal/v1/plans/{namespace}/{taskName}                Save autonomous plan state
-GET    /internal/v1/plans/{namespace}/{taskName}                Get autonomous plan state
-POST   /internal/v1/messages/{namespace}                        Send inter-agent message
-GET    /internal/v1/messages/{namespace}/{taskName}             Get messages for a task
-```
+- See @docs/ui.md for details
 
 ## Verification
 
-After making changes, always verify:
-
 ```bash
-# After editing *_types.go or markers
-make manifests generate
-
-# After editing any *.go files
-make lint-fix
-make test
-
-# After editing UI code
-cd ui && bun run lint && bun run test
+make manifests generate  # After editing *_types.go or markers
+make lint-fix && make test  # After editing any *.go files
+cd ui && bun run lint && bun run test  # After editing UI code
 ```
 
-Prefer running single tests over the whole suite for faster feedback:
-```bash
-go test ./internal/api/ -run TestHandlerName -v
-cd ui && bun run test -- src/components/tasks/task-list.test.tsx
-
-# After editing tracing code
-go test ./internal/tracing/ -v
-go test ./internal/llm/ -run TestTracing -v
-```
-
-## Worker Security Context
-
-All worker pods run with: non-root (uid 1000), read-only rootfs, all capabilities dropped, seccomp RuntimeDefault.
+Single tests: `go test ./internal/api/ -run TestHandlerName -v`
 
 ## Documentation
 
 See @docs/ for detailed documentation:
-- @docs/architecture.md — System design and components
-- @docs/agent-runtimes.md — Claude Code CLI and Copilot CLI runtime configuration
-- @docs/api-reference.md — REST API endpoint reference
+- @docs/architecture.md — System design, components, key patterns, project structure
+- @docs/multi-agent-coordination.md — Coordination tools, delegation, controller enforcement, PR workflows
+- @docs/autonomous-tasks.md — Autonomous task execution and planning loops
+- @docs/api-reference.md — REST API endpoints (public and internal)
 - @docs/chat.md — Chat endpoint, tools, SSE streaming
-- @docs/cicd-integration.md — CI/CD integration patterns
 - @docs/configuration.md — CRD configuration reference
 - @docs/development.md — Build, test, and development setup
-- @docs/getting-started.md — Installation and quick start
-- @docs/multi-agent-coordination.md — Coordinator agents, delegation tools, controller enforcement
-- @docs/autonomous-tasks.md — Autonomous task execution and planning loops
+- @docs/testing.md — Test structure, patterns, and chat testing guidelines
+- @docs/security.md — Security model, worker hardening, multi-tenancy
+- @docs/agent-runtimes.md — Claude Code CLI and Copilot CLI runtime configuration
 - @docs/openai-compat.md — OpenAI-compatible API proxy
-- @docs/security.md — Security model and hardening
-- @docs/testing.md — Test structure and patterns
+- @docs/cicd-integration.md — CI/CD integration patterns
+- @docs/getting-started.md — Installation and quick start
 - @docs/ui.md — Web dashboard architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ make deploy IMG=<registry>/orka:tag
 - **Chat Endpoint** (`internal/api/chat.go`): Agentic chat with SSE streaming, tool execution loop, session persistence
 - **Task Reconciler** (`internal/controller/`): Watches Task CRDs, creates Jobs, manages lifecycle
 - **Session Manager**: Manages conversation continuity via SQLite store with serial execution enforcement
-- **Store** (`internal/store/`): Storage interfaces (`ResultStore`, `SessionStore`, `PlanStore`) with SQLite implementation (`internal/store/sqlite/`)
+- **Store** (`internal/store/`): Storage interfaces (`ResultStore`, `SessionStore`, `PlanStore`, `MessageStore`) with SQLite implementation (`internal/store/sqlite/`)
 - **Workers** (`workers/`): AI worker (LLM agent with tools), general worker (container commands), and agent workers (`workers/agent/copilot/`, `workers/agent/claude/`) for external CLI runtimes; workers POST results to controller via HTTP
 - **Tracing** (`internal/tracing/`): Optional OpenTelemetry tracing with OTLP gRPC export, enabled via `--enable-tracing`
 - **Web UI** (`ui/`): React SPA embedded into controller binary via `//go:embed`
@@ -92,7 +92,8 @@ make deploy IMG=<registry>/orka:tag
 - Priority queue (0-1000) for task scheduling
 - Finalizers ensure cleanup of session locks
 - LLM tool args for nested objects arrive as `map[string]any`, not strings — always type-switch
-- Multi-agent coordination: coordinator agents delegate to specialists via `delegate_task`/`wait_for_tasks` tools; controller enforces depth, allowedAgents, concurrency limits
+- Multi-agent coordination: coordinator agents delegate to specialists via `delegate_task`/`wait_for_tasks`/`cancel_task` tools; controller enforces depth, allowedAgents, concurrency limits
+- Inter-agent messaging: sibling tasks (same parent) exchange messages via `send_message`/`check_messages` tools; messages flow through controller's internal API; scoped to siblings only; broadcast via `to_task="*"`
 - Iterative coordination: `delegate_task` supports `prior_task`, `feedback`, and `pushBranch` params; workers apply prior diffs via `PrepareWorkspace()` and produce structured results via `FinalizeResult()`
 - Auto-push: When `pushBranch` is set on workspace config, `FinalizeResult` commits and pushes changes to that branch automatically
 - PR creation: `create_pull_request` coordination tool creates GitHub PRs from pushed branches using git credentials from task workspace config
@@ -102,7 +103,8 @@ make deploy IMG=<registry>/orka:tag
 
 ### Multi-Agent Coordination
 
-- **Coordination tools** (`internal/tools/delegate_task.go`, `internal/tools/wait_for_tasks.go`, `internal/tools/update_plan.go`): LLM tools that create child Tasks, poll for results, and update autonomous plan state
+- **Coordination tools** (`internal/tools/delegate_task.go`, `internal/tools/wait_for_tasks.go`, `internal/tools/cancel_task.go`, `internal/tools/update_plan.go`): LLM tools that create child Tasks, poll for results, cancel tasks, and update autonomous plan state
+- **Messaging tools** (`internal/tools/send_message.go`, `internal/tools/check_messages.go`): Inter-agent messaging between sibling tasks (same parent coordinator); messages stored in SQLite via `MessageStore`
 - **PR workflow tools** (`internal/tools/create_pull_request.go`, `internal/tools/merge_pull_request.go`, `internal/tools/auto_merge_pull_request.go`, `internal/tools/review_pull_request.go`, `internal/tools/post_review_comment.go`): GitHub PR creation, merging (instant and polling), review fetching, and review posting
 - **Agent management tools** (`internal/tools/create_agent.go`, `internal/tools/delete_agent.go`): Dynamic Agent CRD creation and deletion at runtime
 - **Controller enforcement** (`internal/controller/task_controller.go`): Validates `maxDepth`, `allowedAgents`, `maxConcurrentChildren` in `handlePending`; populates `status.childTasks` in `handleRunning`
@@ -200,6 +202,8 @@ POST   /internal/v1/results/{namespace}/{taskName}              Submit task resu
 GET    /internal/v1/sessions/{namespace}/{name}/transcript      Get session transcript
 POST   /internal/v1/plans/{namespace}/{taskName}                Save autonomous plan state
 GET    /internal/v1/plans/{namespace}/{taskName}                Get autonomous plan state
+POST   /internal/v1/messages/{namespace}                        Send inter-agent message
+GET    /internal/v1/messages/{namespace}/{taskName}             Get messages for a task
 ```
 
 ## Verification

--- a/api/v1alpha1/task_types.go
+++ b/api/v1alpha1/task_types.go
@@ -25,7 +25,7 @@ const (
 )
 
 // TaskPhase defines the phase of task execution
-// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;Scheduled
+// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;Scheduled;Cancelled
 type TaskPhase string
 
 const (
@@ -34,6 +34,7 @@ const (
 	TaskPhaseSucceeded TaskPhase = "Succeeded"
 	TaskPhaseFailed    TaskPhase = "Failed"
 	TaskPhaseScheduled TaskPhase = "Scheduled"
+	TaskPhaseCancelled TaskPhase = "Cancelled"
 )
 
 // ConcurrencyPolicy describes how the controller will handle concurrent scheduled runs.

--- a/charts/orka/templates/deployment.yaml
+++ b/charts/orka/templates/deployment.yaml
@@ -36,15 +36,19 @@ spec:
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           args:
             - --api-port={{ .Values.controller.apiPort }}
-            - --metrics-port={{ .Values.controller.metricsPort }}
-            - --health-port={{ .Values.controller.healthPort }}
+            - --metrics-bind-address=:{{ .Values.controller.metricsPort }}
+            - --health-probe-bind-address=:{{ .Values.controller.healthPort }}
+            - --metrics-secure=false
             {{- if .Values.controller.watchNamespace }}
             - --watch-namespace={{ .Values.controller.watchNamespace }}
             {{- end }}
             - --leader-elect={{ .Values.controller.leaderElect }}
-            - --log-level={{ .Values.controller.logLevel }}
+            - --zap-log-level={{ .Values.controller.logLevel }}
             - --store-backend=sqlite
             - --store-path={{ .Values.store.path }}
+            - --ai-worker-image={{ .Values.workers.ai.image.repository }}:{{ .Values.workers.ai.image.tag }}
+            - --copilot-worker-image={{ .Values.workers.copilot.image.repository | default "ghcr.io/sozercan/orka-agent-worker-copilot" }}:{{ .Values.workers.copilot.image.tag | default "latest" }}
+            - --claude-worker-image={{ .Values.workers.claude.image.repository | default "ghcr.io/sozercan/orka-agent-worker-claude" }}:{{ .Values.workers.claude.image.tag | default "latest" }}
             {{- if .Values.controller.enforceNamespaceIsolation }}
             - --enforce-namespace-isolation=true
             {{- end }}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -261,15 +261,16 @@ func main() {
 	jobBuilder.ControllerURL = controllerURL
 	// Setup Task controller with helper components
 	if err := (&controller.TaskReconciler{
-		Client:          mgr.GetClient(),
-		Scheme:          mgr.GetScheme(),
-		JobBuilder:      jobBuilder,
-		SessionManager:  sessionManager,
-		WebhookNotifier: webhookNotifier,
-		KubeClient:      kubeClient,
-		ResultStore:     sqliteStore,
-		SessionStore:    sqliteStore,
+		Client:                    mgr.GetClient(),
+		Scheme:                    mgr.GetScheme(),
+		JobBuilder:                jobBuilder,
+		SessionManager:            sessionManager,
+		WebhookNotifier:           webhookNotifier,
+		KubeClient:                kubeClient,
+		ResultStore:               sqliteStore,
+		SessionStore:              sqliteStore,
 		PlanStore:                 sqliteStore,
+		MessageStore:              sqliteStore,
 		EnforceNamespaceIsolation: enforceNamespaceIsolation,
 		MaxTasksPerNamespace:      int32(maxTasksPerNamespace), //nolint:gosec // validated non-negative by flag default
 	}).SetupWithManager(mgr); err != nil {
@@ -319,6 +320,7 @@ func main() {
 		ResultStore:               sqliteStore,
 		SessionStore:              sqliteStore,
 		PlanStore:                 sqliteStore,
+		MessageStore:              sqliteStore,
 		HealthChecker:             sqliteStore,
 		Clientset:                 kubeClient,
 		Chat: api.ChatConfig{

--- a/config/crd/bases/core.orka.ai_tasks.yaml
+++ b/config/crd/bases/core.orka.ai_tasks.yaml
@@ -614,6 +614,7 @@ spec:
                       - Succeeded
                       - Failed
                       - Scheduled
+                      - Cancelled
                       type: string
                     result:
                       description: Result is the result from the child task (if completed)
@@ -719,6 +720,7 @@ spec:
                 - Succeeded
                 - Failed
                 - Scheduled
+                - Cancelled
                 type: string
               resultRef:
                 description: ResultRef indicates whether a result is available

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -104,6 +104,8 @@ See [OpenAI Compatibility](openai-compat.md) for details.
 | `/internal/v1/sessions/:namespace/:name/transcript` | GET | Get session transcript |
 | `/internal/v1/plans/:namespace/:taskName` | POST | Save plan state |
 | `/internal/v1/plans/:namespace/:taskName` | GET | Get plan state |
+| `/internal/v1/messages/:namespace` | POST | Send inter-agent message |
+| `/internal/v1/messages/:namespace/:taskName` | GET | Get messages for a task |
 
 ### Save Plan State
 
@@ -133,6 +135,52 @@ Workers call this to load the current plan state at startup.
 
 **Errors:**
 - `404` — No plan found
+
+### Send Message
+
+Workers call this to send messages to sibling tasks (same parent coordinator).
+
+**Endpoint:** `POST /internal/v1/messages/{namespace}`
+
+**Request Body:**
+```json
+{
+  "fromTask": "worker-a",
+  "toTask": "worker-b",
+  "parentTask": "coordinator",
+  "content": "Found a bug in the auth module"
+}
+```
+
+Use `"toTask": "*"` to broadcast to all siblings.
+
+**Response:** `204 No Content`
+
+### Get Messages
+
+Workers call this to check for unread messages.
+
+**Endpoint:** `GET /internal/v1/messages/{namespace}/{taskName}?parentTask={parentTask}&markRead={true|false}`
+
+**Query Parameters:**
+- `parentTask` (required) — Parent coordinator task name (scopes messages to siblings)
+- `markRead` (optional, default: `true`) — Whether to mark returned messages as read
+
+**Response (200):**
+```json
+[
+  {
+    "id": 1,
+    "namespace": "default",
+    "fromTask": "worker-b",
+    "toTask": "worker-a",
+    "parentTask": "coordinator",
+    "content": "Found a bug in the auth module",
+    "read": false,
+    "createdAt": "2026-01-15T10:30:00Z"
+  }
+]
+```
 
 ## Health
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -248,3 +248,72 @@ Key behaviors:
 | `github.com/openai/openai-go/v3` | OpenAI API (official SDK) |
 | `github.com/github/copilot-sdk/go` | GitHub Copilot SDK |
 | `modernc.org/sqlite` | Embedded SQLite (pure Go, no CGO) |
+
+## SQLite Store Internals
+
+All persistent data uses SQLite via `modernc.org/sqlite` (pure Go, no CGO dependency).
+
+### Schema
+
+| Table | Primary Key | Purpose |
+|-------|-------------|---------|
+| `results` | `(namespace, task_name)` | Task output data (BLOB) |
+| `sessions` | `(namespace, name)` | Session metadata, `active_task` field for locking, token counters |
+| `session_messages` | `id` (FK → sessions) | Individual messages with role, content, tool_calls (JSON) |
+| `messages` | `id` + `namespace` + `parent_task` | Inter-agent messages, broadcast via `to_task='*'` |
+| `plan_states` | `(namespace, task_name)` | Autonomous loop state: iteration, progress %, goal_complete flag |
+
+### Configuration
+
+- **WAL mode** with single-writer enforcement: `SetMaxOpenConns(1)`, `SetMaxIdleConns(1)`
+- **Per-connection pragmas** (set on every new connection, not persistent):
+  - `busy_timeout=5000` — wait up to 5s for locks
+  - `synchronous=NORMAL` — balance between safety and performance
+  - `foreign_keys=ON` — enforce referential integrity
+- **Namespace scoping**: All queries filter by `namespace` — data isolation is enforced at the SQL level
+
+### Session Locking
+
+Sessions use optimistic locking via an `active_task` column. `AcquireLock` atomically UPDATEs `active_task` only if it's currently empty. Tasks that fail to acquire the lock requeue every 5 seconds. The lock is released on task completion or deletion (via finalizer cleanup). There is no timeout — if the lock holder crashes, the lock persists until the task is deleted.
+
+### Message Broadcast Scoping
+
+Inter-agent broadcast messages (`to_task='*'`) are scoped by `parent_task`:
+
+```sql
+WHERE (to_task = ? OR (to_task = '*' AND parent_task = ?))
+```
+
+This ensures only sibling tasks (same parent coordinator) receive broadcasts. Senders don't receive their own broadcasts.
+
+## LLM Provider Internals
+
+### Retry Strategy
+
+LLM calls use exponential backoff with jitter:
+- **Default**: 3 retries
+- **Backoff**: `baseDelay × 2^attempt`, capped at 30s, with ±10% random jitter
+- **Retryable status codes**: 429, 500, 502, 503, 529
+- **Non-retryable**: 401, 403 (trigger fallback instead), context canceled/deadline exceeded (never retried)
+- **Stream retry**: Peeks at the first chunk to detect errors before consuming the stream
+
+### Provider Cooldown
+
+Failed providers are temporarily cooled down to prevent repeated failures:
+- **Cooldown formula**: `1min × 5^(errorCount-1)`, capped at 1 hour
+- Rate-limited providers (429) are tracked and skipped in subsequent requests
+- Cooldown is per-provider and resets on successful requests
+
+### OpenAI API Auto-Detection
+
+The OpenAI provider automatically detects which API to use:
+1. Tries the **Responses API** first
+2. If the endpoint returns 404/405, switches to **Chat Completions API**
+3. The API mode is stored as an `atomic.Int32` for thread-safe switching
+4. Once detected, the mode persists for the provider's lifetime
+
+### Anthropic Quirks
+
+- The Anthropic SDK appends `v1/messages` to the base URL — strip trailing `/v1` from custom `baseURL` to avoid doubled paths
+- System messages are converted to `tool_result` blocks, not user messages
+- Tool input JSON parsing errors are silently ignored (`_ = json.Unmarshal`)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,10 @@ spec:
 | `maxConcurrentChildren` | int32 | `0` | Maximum number of concurrent child tasks. `0` means unlimited |
 | `maxDepth` | int32 | `0` | Maximum delegation depth. `0` means unlimited |
 
+**Auto-injected coordination tools** (when `enabled: true`):
+
+`delegate_task`, `wait_for_tasks`, `cancel_task`, `send_message`, `check_messages`, `create_pull_request`, `merge_pull_request`, `auto_merge_pull_request`, `review_pull_request`, `post_review_comment`, `create_agent`, `delete_agent`, `update_plan`
+
 ### Provider Fallback Chain
 
 You can configure fallback providers that are automatically tried when the primary provider fails (e.g., due to auth errors, provider outages, or rate limiting). Fallbacks are configured on the Agent CRD's `spec.model.fallbacks` field.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -274,6 +274,8 @@ See [charts/orka/values.yaml](../charts/orka/values.yaml) for the full list.
 | `--watch-namespace` | `""` | Namespace to watch (empty = all) |
 | `--enforce-namespace-isolation` | `false` | Restrict users to their ServiceAccount's namespace |
 | `--max-tasks-per-namespace` | `0` | Max active tasks per namespace (0 = unlimited) |
+| `--controller-url` | `""` | Base URL workers use to reach the controller API (e.g., `http://orka-api.orka-system.svc:8080`). Required for worker result callbacks and session transcript fetching |
+| `--ai-worker-image` | `orka-ai-worker:latest` | AI worker container image |
 | `--copilot-worker-image` | `orka-agent-worker-copilot:latest` | Copilot agent worker image |
 | `--claude-worker-image` | `orka-agent-worker-claude:latest` | Claude agent worker image |
 | `--store-backend` | `sqlite` | Storage backend (sqlite) |
@@ -292,6 +294,7 @@ See [charts/orka/values.yaml](../charts/orka/values.yaml) for the full list.
 | `--health-probe-bind-address` | `:8081` | Health probe address |
 | `--metrics-secure` | `true` | Serve metrics via HTTPS |
 | `--enable-http2` | `false` | Enable HTTP/2 for metrics and webhook servers |
+| `--enable-tracing` | `false` | Enable OpenTelemetry distributed tracing (requires `OTEL_EXPORTER_OTLP_ENDPOINT`) |
 
 ## Prometheus Metrics
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -81,3 +81,40 @@ make deploy IMG=<registry>/orka:tag
 ```bash
 make build-installer IMG=ghcr.io/sozercan/orka:latest
 ```
+
+## Build Gotchas
+
+### UI Embedding
+
+`make build` embeds the React UI into the controller binary via `//go:embed`. The UI must be built first:
+
+```bash
+make ui-build    # Build UI and copy to internal/uiembed/dist/
+make build       # Now the Go build will succeed
+```
+
+If the UI isn't built, the `ensure-ui-embed` Makefile target creates a stub `internal/uiembed/dist/index.html` so the Go build doesn't fail — but the embedded UI won't work.
+
+### CLI Version Injection
+
+`make build-cli` injects Git version info via `-ldflags`:
+
+```bash
+make build-cli   # Produces bin/orka with embedded version
+```
+
+### Metrics Disabled by Default
+
+The controller's `--metrics-bind-address` defaults to `0` (disabled). Set it explicitly to enable Prometheus metrics:
+
+```
+--metrics-bind-address=:8443
+```
+
+### HTTP/2 Disabled by Default
+
+HTTP/2 is disabled for metrics and webhook servers due to CVEs ([GHSA-qppj-fm5r-hxr3](https://github.com/advisories/GHSA-qppj-fm5r-hxr3), [GHSA-4374-p667-p6c8](https://github.com/advisories/GHSA-4374-p667-p6c8)). Use `--enable-http2=true` only if needed.
+
+### Leader Election
+
+Leader election ID is hardcoded as `03b49a10.orka.ai`. Multiple controller deployments in the same cluster will coordinate via this ID.

--- a/docs/multi-agent-coordination.md
+++ b/docs/multi-agent-coordination.md
@@ -51,7 +51,7 @@ Controller: parent Job succeeded → parent Task → Succeeded
 
 ### Coordination Tools
 
-Located in `internal/tools/`. Coordination tools include `delegate_task`, `wait_for_tasks`, PR tools (`create_pull_request`, `merge_pull_request`, `auto_merge_pull_request`, `review_pull_request`, `post_review_comment`), and agent management tools (`create_agent`, `delete_agent`). All are registered via `RegisterCoordinationTools(k8sClient)` in `internal/tools/registry.go` when `ORKA_COORDINATION_ENABLED=true`.
+Located in `internal/tools/`. Coordination tools include `delegate_task`, `wait_for_tasks`, `cancel_task`, `send_message`, `check_messages`, PR tools (`create_pull_request`, `merge_pull_request`, `auto_merge_pull_request`, `review_pull_request`, `post_review_comment`), and agent management tools (`create_agent`, `delete_agent`). All are registered via `RegisterCoordinationTools(k8sClient)` in `internal/tools/registry.go` when `ORKA_COORDINATION_ENABLED=true`.
 
 #### `delegate_task` Tool
 
@@ -117,6 +117,81 @@ Implementation (`internal/tools/wait_for_tasks.go`):
      ]
    }
    ```
+
+#### `cancel_task` Tool
+
+LLM-visible parameter schema:
+```json
+{
+  "type": "object",
+  "properties": {
+    "task_name":  {"type": "string", "description": "Name of the child task to cancel"},
+    "namespace":  {"type": "string", "description": "Namespace (defaults to current)"},
+    "reason":     {"type": "string", "description": "Reason for cancellation"}
+  },
+  "required": ["task_name"]
+}
+```
+
+Implementation (`internal/tools/cancel_task.go`):
+1. Reads `ORKA_TASK_NAME`, `ORKA_TASK_NAMESPACE` from env
+2. Validates the target task is a child of the calling task via `orka.ai/parent-task` label
+3. Only cancels tasks in `Pending` or `Running` phase
+4. Sets the task phase to `Cancelled` via status subresource update
+5. Returns confirmation with task name and cancellation reason
+
+#### `send_message` Tool
+
+LLM-visible parameter schema:
+```json
+{
+  "type": "object",
+  "properties": {
+    "to_task": {"type": "string", "description": "Name of the sibling task to message, or \"*\" to broadcast"},
+    "content": {"type": "string", "description": "Message content to send"}
+  },
+  "required": ["to_task", "content"]
+}
+```
+
+Implementation (`internal/tools/send_message.go`):
+1. Reads `ORKA_TASK_NAME`, `ORKA_TASK_NAMESPACE`, `ORKA_PARENT_TASK`, `ORKA_CONTROLLER_URL` from env
+2. Posts message to controller's internal messaging API
+3. Messages are scoped to siblings (same parent task) — agents can only message tasks that share the same coordinator
+4. Use `to_task="*"` to broadcast to all siblings
+
+#### `check_messages` Tool
+
+LLM-visible parameter schema:
+```json
+{
+  "type": "object",
+  "properties": {
+    "mark_read": {"type": "boolean", "description": "Whether to mark messages as read (default: true)"}
+  }
+}
+```
+
+Implementation (`internal/tools/check_messages.go`):
+1. Reads `ORKA_TASK_NAME`, `ORKA_TASK_NAMESPACE`, `ORKA_PARENT_TASK`, `ORKA_CONTROLLER_URL` from env
+2. Fetches unread messages from controller's internal messaging API
+3. Returns all unread messages addressed to this task or broadcast to all siblings (same parent)
+4. Messages are marked as read by default to avoid re-delivery
+
+### Inter-Agent Messaging
+
+Sibling tasks (children of the same coordinator) can exchange messages to coordinate work, share findings, and avoid duplicated effort. Messages flow through the controller's internal API — no direct pod-to-pod communication.
+
+**Architecture:**
+- Messages stored in SQLite via `MessageStore` interface (`internal/store/store.go`)
+- Internal endpoints: `POST /internal/v1/messages/{namespace}` and `GET /internal/v1/messages/{namespace}/{taskName}`
+- Scoped to siblings only: messages filtered by `parent_task` column
+- Broadcast: `to_task="*"` sends to all siblings (sender excluded from own broadcasts)
+- Cleanup: messages are automatically deleted when tasks or parent coordinators are deleted
+
+**Environment Variables:**
+- `ORKA_PARENT_TASK`: Set automatically by the job builder for child tasks (from `orka.ai/parent-task` label)
+- `ORKA_CONTROLLER_URL`, `ORKA_TASK_NAME`, `ORKA_TASK_NAMESPACE`: Already available for all workers
 
 ### Controller Enforcement
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,6 +9,25 @@ All worker pods run with a hardened security context:
 - All Linux capabilities dropped
 - Seccomp profile: RuntimeDefault
 
+### Writable Paths
+
+Only three paths are writable (mounted as EmptyDir volumes):
+
+| Path | Purpose |
+|------|---------|
+| `/tmp` | Container runtime temporary files |
+| `/home/worker` | CLI config/cache (Claude, Copilot) |
+| `/workspace` | Git clone and working directory |
+
+All other filesystem paths are read-only. Workers that write outside these paths will fail.
+
+### Agent Runtime Security Notes
+
+- **Copilot agent worker**: Auto-approves **all** permission requests from the Copilot SDK without filtering. The agent can execute shell commands, file operations, and network requests in autonomous mode with no safeguards beyond the read-only rootfs
+- **Claude agent worker**: Sets `HOME=/home/worker` unconditionally, bypassing default HOME permissions
+- **Git credentials**: `GIT_TOKEN` and `GITHUB_TOKEN` are set as environment variables, visible to all child processes. If the prompt is user-controlled, the LLM agent could potentially access these via `os.Environ()`
+- **Prior task diffs**: Applied via `git apply --check` (dry-run) then `git apply`, but without verifying patch author or integrity. A compromised prior task could inject arbitrary changes
+
 ## Controller
 
 The controller runs with:
@@ -22,6 +41,7 @@ The controller runs with:
 - All API endpoints require a Kubernetes ServiceAccount bearer token
 - Token validation uses the Kubernetes TokenReview API
 - The `orka` CLI extracts tokens from kubeconfig for browser-based login
+- **Token caching**: Validated tokens are cached for 60 seconds using SHA256 hashes to avoid repeated TokenReview API calls. Token revocation has up to 60s propagation delay. The cache is in-memory only — not persistent across pod restarts
 
 ## Secret Management
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -125,3 +125,19 @@ vi.mock('zustand/middleware', () => ({ persist: (fn: unknown) => fn }))
 // Use test utils with QueryClient wrapper
 import { render } from '@/test/test-utils'
 ```
+
+## Testing with Chat
+
+When testing features via the chat endpoint, use **natural prompts** — the kind a human would actually type. Never reference internal concepts like agent names, tool names, or implementation details. Describe what you want done, not how the system should do it. The chat should infer the right agents, tools, delegation patterns, and cancellation logic on its own.
+
+Good examples:
+- "Research the benefits of Kubernetes and write a technical guide based on the findings."
+- "What's the best container orchestration tool? Get me an answer as fast as possible."
+- "Draft an outline for a blog post about containers and turn it into a full post."
+- "Compare microservices vs monoliths from three angles, then synthesize into a recommendation."
+
+Bad examples:
+- "Create a coordinator agent and a researcher agent, then delegate two tasks..."
+- "Use the send_message tool to send a message to task msg-receiver..."
+- "Have three researchers race to answer..." (users don't think in terms of "researchers")
+- "Use the first answer and cancel the others." (the system should infer this automatically)

--- a/internal/api/chat_system_prompt.go
+++ b/internal/api/chat_system_prompt.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+
 	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -177,6 +179,13 @@ func buildTaskTypesSection(mode PromptMode) string {
   Use for: code changes in a git repo, multi-file refactoring.
   IMPORTANT: When the user specifies an agent (via --agent or agentRef) that has a
   runtime configured, ALWAYS use create_agent_task with that agent name.
+  When the task involves a git repository, ALWAYS include the gitRepo URL in the
+  workspace config so credentials are automatically mounted:
+    create_agent_task(agent: "coder", prompt: "...", gitRepo: "https://github.com/org/repo", timeout: "15m")
+  When creating new agents for coding tasks, check the agent_runtimes in the Runtime line above.
+  Use whichever runtime is available. If both are available, prefer copilot.
+  If no agent runtimes are available, use create_ai_task with workspace config instead.
+  Agent tasks need more time than AI tasks. Set timeout to at least 15m.
   Do NOT use create_container_task or create_ai_task for runtime agents.
 </task_types>
 
@@ -204,6 +213,20 @@ The coordinator agent will then:
 3. Use wait_for_tasks to collect results
 4. Synthesize results and iterate if needed
 5. Specialist agents are auto-cleaned up when the coordinator task is deleted
+
+INTER-AGENT MESSAGING: Child tasks delegated by a coordinator can communicate with
+each other using send_message and check_messages. This is useful when:
+- One task produces results that a sibling task needs before it can start
+- Tasks need to coordinate or exchange intermediate findings
+- A pipeline of tasks where each step builds on the previous
+
+The coordinator should instruct child tasks to use send_message (with to_task="*" to
+broadcast to all siblings) and check_messages in their prompts. For reliable delivery,
+delegate the sender first, wait for it to complete, then delegate the receiver.
+
+CANCEL: The coordinator can use cancel_task to cancel running child tasks. This is
+useful for race patterns (start multiple tasks, keep the first result, cancel the rest)
+or when a child task's result makes other tasks unnecessary.
 
 MANUAL (multi-step): For more control, create agents separately:
 1. Create specialist agents with create_agent
@@ -284,13 +307,26 @@ Example 4: "review this code for security issues"
 → wait_for_task → fetch_task_output → summarize findings
 
 Example 5: "refactor the auth module" (with agent available)
-→ create_agent_task (agent: "coder", prompt: "Refactor the auth module...")
+→ create_agent_task (agent: "coder", prompt: "Refactor the auth module...", gitRepo: "https://github.com/org/repo")
 → wait_for_task → fetch_task_output
 
 Example 6: User specifies --agent my-agent (which has runtime: copilot)
-→ create_agent_task (agent: "my-agent", prompt: "...")
-  (Use create_agent_task because the agent has a runtime)
+→ create_agent_task (agent: "my-agent", prompt: "...", gitRepo: "https://github.com/org/repo")
+  (Use create_agent_task because the agent has a runtime; include gitRepo for credentials)
 → wait_for_task → fetch_task_output
+
+Example 7: "Research X and then write a guide based on findings" (multi-step pipeline)
+→ Use the coordinator pattern. The coordinator should:
+  1. delegate_task to a researcher agent with prompt to research X and use send_message to broadcast findings
+  2. wait_for_tasks for the researcher to complete
+  3. delegate_task to a writer agent with prompt to check_messages for research findings and write the guide
+  4. wait_for_tasks and synthesize the final result
+
+Example 8: "Get me an answer as fast as possible" (race pattern)
+→ Use the coordinator pattern. The coordinator should:
+  1. delegate_task multiple agents with the same prompt in parallel
+  2. wait_for_tasks — as soon as one completes, use cancel_task on the others
+  3. Return the winning result
 </examples>
 `
 }
@@ -348,8 +384,32 @@ func (b *SystemPromptBuilder) buildDynamicContext(ctx context.Context) (agentsSe
 		providerNames = append(providerNames, providerList.Items[i].Name)
 	}
 
-	providersSection = fmt.Sprintf("Runtime: providers=[%s] | agents=%d | tools=%d | container=yes\n",
-		strings.Join(providerNames, ", "), len(agentList.Items), len(toolList.Items)+3)
+	// Detect available agent runtimes by checking for well-known secrets
+	var availableRuntimes []string
+	var secretList corev1.SecretList
+	if err := b.client.List(ctx, &secretList, client.InNamespace(b.namespace)); err == nil {
+		secretNames := make(map[string]bool, len(secretList.Items))
+		for i := range secretList.Items {
+			secretNames[secretList.Items[i].Name] = true
+		}
+		for _, name := range []string{"github-credentials", "git-credentials", "github-token", "git-token"} {
+			if secretNames[name] {
+				availableRuntimes = append(availableRuntimes, "copilot")
+				break
+			}
+		}
+		if secretNames["anthropic-api-key"] {
+			availableRuntimes = append(availableRuntimes, "claude")
+		}
+	}
+
+	runtimeInfo := "none"
+	if len(availableRuntimes) > 0 {
+		runtimeInfo = strings.Join(availableRuntimes, ", ")
+	}
+
+	providersSection = fmt.Sprintf("Runtime: providers=[%s] | agents=%d | tools=%d | container=yes | agent_runtimes=[%s]\n",
+		strings.Join(providerNames, ", "), len(agentList.Items), len(toolList.Items)+3, runtimeInfo)
 
 	return agentsSection, toolsSection, providersSection, nil
 }

--- a/internal/api/internal_handlers.go
+++ b/internal/api/internal_handlers.go
@@ -25,14 +25,16 @@ type InternalHandlers struct {
 	resultStore  store.ResultStore
 	sessionStore store.SessionStore
 	planStore    store.PlanStore
+	messageStore store.MessageStore
 }
 
 // NewInternalHandlers creates a new InternalHandlers instance.
-func NewInternalHandlers(rs store.ResultStore, ss store.SessionStore, ps store.PlanStore) *InternalHandlers {
+func NewInternalHandlers(rs store.ResultStore, ss store.SessionStore, ps store.PlanStore, ms store.MessageStore) *InternalHandlers {
 	return &InternalHandlers{
 		resultStore:  rs,
 		sessionStore: ss,
 		planStore:    ps,
+		messageStore: ms,
 	}
 }
 
@@ -208,4 +210,84 @@ func verifyCallerNamespace(c fiber.Ctx, namespace string) error {
 	}
 
 	return nil
+}
+
+// SendMessage handles POST /internal/v1/messages/{namespace}.
+// Workers call this to send messages to sibling tasks.
+func (h *InternalHandlers) SendMessage(c fiber.Ctx) error {
+	if h.messageStore == nil {
+		return fiber.NewError(fiber.StatusNotImplemented, "messaging not enabled")
+	}
+
+	namespace := c.Params("namespace")
+	if namespace == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "namespace is required")
+	}
+
+	if err := verifyCallerNamespace(c, namespace); err != nil {
+		return err
+	}
+
+	var req struct {
+		FromTask   string `json:"fromTask"`
+		ToTask     string `json:"toTask"`
+		ParentTask string `json:"parentTask"`
+		Content    string `json:"content"`
+	}
+	if err := c.Bind().JSON(&req); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("invalid request body: %v", err))
+	}
+
+	if req.FromTask == "" || req.ToTask == "" || req.Content == "" || req.ParentTask == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "fromTask, toTask, parentTask, and content are required")
+	}
+
+	msg := &store.Message{
+		Namespace:  namespace,
+		FromTask:   req.FromTask,
+		ToTask:     req.ToTask,
+		ParentTask: req.ParentTask,
+		Content:    req.Content,
+	}
+
+	ctx := c.Context()
+	if err := h.messageStore.SendMessage(ctx, msg); err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to send message: %v", err))
+	}
+
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// GetMessages handles GET /internal/v1/messages/{namespace}/{taskName}.
+// Workers call this to check for messages from sibling tasks.
+func (h *InternalHandlers) GetMessages(c fiber.Ctx) error {
+	if h.messageStore == nil {
+		return fiber.NewError(fiber.StatusNotImplemented, "messaging not enabled")
+	}
+
+	namespace := c.Params("namespace")
+	taskName := c.Params("taskName")
+
+	if namespace == "" || taskName == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "namespace and taskName are required")
+	}
+
+	parentTask := c.Query("parentTask")
+	if parentTask == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "parentTask query parameter is required")
+	}
+
+	markRead := c.Query("markRead", "true") == "true"
+
+	ctx := c.Context()
+	messages, err := h.messageStore.GetMessages(ctx, namespace, taskName, parentTask, markRead)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to get messages: %v", err))
+	}
+
+	if messages == nil {
+		messages = []store.Message{}
+	}
+
+	return c.JSON(messages)
 }

--- a/internal/api/internal_handlers_test.go
+++ b/internal/api/internal_handlers_test.go
@@ -24,7 +24,7 @@ import (
 func setupTestInternalHandlers() (*InternalHandlers, *fiber.App, *sqlite.Store) {
 	db, _ := sqlite.NewDB(":memory:")
 	ss := sqlite.NewStore(db, ":memory:")
-	h := NewInternalHandlers(ss, ss, ss)
+	h := NewInternalHandlers(ss, ss, ss, ss)
 	app := fiber.New()
 
 	// Inject a default UserInfo so verifyCallerNamespace passes
@@ -115,5 +115,95 @@ func TestGetPlan(t *testing.T) {
 		resp, err := app.Test(req)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+}
+
+func TestSendMessage(t *testing.T) {
+	h, app, _ := setupTestInternalHandlers()
+	app.Post("/internal/v1/messages/:namespace", h.SendMessage)
+
+	t.Run("success", func(t *testing.T) {
+		body := map[string]string{
+			"fromTask":   "worker-a",
+			"toTask":     "worker-b",
+			"parentTask": "coordinator",
+			"content":    "found a bug",
+		}
+		bodyBytes, _ := json.Marshal(body)
+
+		req := httptest.NewRequest(http.MethodPost, "/internal/v1/messages/default", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	})
+
+	t.Run("missing required fields", func(t *testing.T) {
+		body := map[string]string{
+			"fromTask": "worker-a",
+		}
+		bodyBytes, _ := json.Marshal(body)
+
+		req := httptest.NewRequest(http.MethodPost, "/internal/v1/messages/default", bytes.NewReader(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("invalid body", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/internal/v1/messages/default", bytes.NewReader([]byte("not json")))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+}
+
+func TestGetMessages(t *testing.T) {
+	h, app, ss := setupTestInternalHandlers()
+	app.Get("/internal/v1/messages/:namespace/:taskName", h.GetMessages)
+
+	// Pre-send a message
+	err := ss.SendMessage(context.Background(), &store.Message{
+		Namespace:  "default",
+		FromTask:   "worker-a",
+		ToTask:     "worker-b",
+		ParentTask: "coordinator",
+		Content:    "hello from a",
+	})
+	require.NoError(t, err)
+
+	t.Run("has messages", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/internal/v1/messages/default/worker-b?parentTask=coordinator&markRead=false", nil)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var messages []store.Message
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&messages))
+		require.Len(t, messages, 1)
+		require.Equal(t, "hello from a", messages[0].Content)
+	})
+
+	t.Run("no messages", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/internal/v1/messages/default/worker-c?parentTask=coordinator", nil)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var messages []store.Message
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&messages))
+		require.Empty(t, messages)
+	})
+
+	t.Run("missing parentTask", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/internal/v1/messages/default/worker-b", nil)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -36,6 +36,7 @@ type ServerConfig struct {
 	ResultStore               store.ResultStore
 	SessionStore              store.SessionStore
 	PlanStore                 store.PlanStore
+	MessageStore              store.MessageStore
 	HealthChecker             store.HealthChecker
 	Clientset                 kubernetes.Interface
 }
@@ -53,6 +54,7 @@ type Server struct {
 	ResultStore      store.ResultStore
 	SessionStore     store.SessionStore
 	PlanStore        store.PlanStore
+	MessageStore     store.MessageStore
 }
 
 // NewServer creates a new API server
@@ -70,6 +72,7 @@ func NewServer(c client.Client, sessionManager *controller.SessionManager, confi
 		ResultStore:    config.ResultStore,
 		SessionStore:   config.SessionStore,
 		PlanStore:      config.PlanStore,
+		MessageStore:   config.MessageStore,
 	}
 
 	server.handlers = NewHandlers(c, sessionManager, config.WatchNamespace, config.EnforceNamespaceIsolation, config.ResultStore, config.SessionStore, config.PlanStore, config.Clientset, config.HealthChecker)
@@ -167,7 +170,7 @@ func (s *Server) setupRoutes() {
 
 	// Internal API for worker communication
 	if s.ResultStore != nil && s.SessionStore != nil {
-		s.internalHandlers = NewInternalHandlers(s.ResultStore, s.SessionStore, s.PlanStore)
+		s.internalHandlers = NewInternalHandlers(s.ResultStore, s.SessionStore, s.PlanStore, s.MessageStore)
 		internal := s.app.Group("/internal/v1")
 		internal.Use(NewAuthMiddleware(s.client))
 		internal.Post("/results/:namespace/:taskName", s.internalHandlers.SubmitResult)
@@ -175,6 +178,10 @@ func (s *Server) setupRoutes() {
 		if s.PlanStore != nil {
 			internal.Post("/plans/:namespace/:taskName", s.internalHandlers.SubmitPlan)
 			internal.Get("/plans/:namespace/:taskName", s.internalHandlers.GetPlan)
+		}
+		if s.MessageStore != nil {
+			internal.Post("/messages/:namespace", s.internalHandlers.SendMessage)
+			internal.Get("/messages/:namespace/:taskName", s.internalHandlers.GetMessages)
 		}
 	}
 }

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -446,12 +446,28 @@ func (b *JobBuilder) addAIEnvVars(envVars []corev1.EnvVar, task *corev1alpha1.Ta
 		}
 	}
 
+	// Auto-inject messaging tools for child tasks (tasks delegated by a coordinator)
+	// so they can communicate with sibling tasks via send_message/check_messages
+	_, isChildTask := task.Labels["orka.ai/parent-task"]
+	if isChildTask {
+		for _, ct := range []string{"send_message", "check_messages"} {
+			if !slices.Contains(cfg.tools, ct) {
+				cfg.tools = append(cfg.tools, ct)
+			}
+		}
+	}
+
 	if len(cfg.tools) > 0 {
 		envVars = append(envVars, corev1.EnvVar{Name: "ORKA_AI_TOOLS", Value: strings.Join(cfg.tools, ",")})
 	}
 
 	if agent != nil && agent.Spec.Coordination != nil && agent.Spec.Coordination.Enabled {
 		envVars = b.addCoordinationEnvVars(envVars, task, agent)
+	}
+
+	// Enable coordination in worker for child tasks so messaging tools are registered
+	if isChildTask && (agent == nil || agent.Spec.Coordination == nil || !agent.Spec.Coordination.Enabled) {
+		envVars = append(envVars, corev1.EnvVar{Name: "ORKA_COORDINATION_ENABLED", Value: "true"})
 	}
 
 	// Add fallback provider environment variables

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -282,6 +282,13 @@ func (b *JobBuilder) buildEnvVars(task *corev1alpha1.Task, agent *corev1alpha1.A
 		)
 	}
 
+	// Add parent task env var for inter-agent messaging
+	if parentTask, ok := task.Labels["orka.ai/parent-task"]; ok {
+		envVars = append(envVars,
+			corev1.EnvVar{Name: "ORKA_PARENT_TASK", Value: parentTask},
+		)
+	}
+
 	// Add AI-specific env vars
 	if task.Spec.Type == corev1alpha1.TaskTypeAI {
 		envVars = b.addAIEnvVars(envVars, task, agent, provider)
@@ -432,7 +439,7 @@ func (b *JobBuilder) addAIEnvVars(envVars []corev1.EnvVar, task *corev1alpha1.Ta
 
 	// Auto-inject coordination tools when coordination is enabled
 	if agent != nil && agent.Spec.Coordination != nil && agent.Spec.Coordination.Enabled {
-		for _, ct := range []string{"delegate_task", "wait_for_tasks", "create_pull_request", "merge_pull_request", "auto_merge_pull_request", "review_pull_request", "post_review_comment", "create_agent", "delete_agent", "update_plan"} {
+		for _, ct := range []string{"delegate_task", "wait_for_tasks", "cancel_task", "send_message", "check_messages", "create_pull_request", "merge_pull_request", "auto_merge_pull_request", "review_pull_request", "post_review_comment", "create_agent", "delete_agent", "update_plan"} {
 			if !slices.Contains(cfg.tools, ct) {
 				cfg.tools = append(cfg.tools, ct)
 			}

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -439,6 +439,19 @@ func (r *TaskReconciler) validateCoordinationConstraints(ctx context.Context, ta
 				break
 			}
 		}
+		// Allow agents dynamically created by the parent task via create_agent tool
+		if !allowed {
+			childAgent := &corev1alpha1.Agent{}
+			agentNS := task.Spec.AgentRef.Namespace
+			if agentNS == "" {
+				agentNS = task.Namespace
+			}
+			if err := r.Get(ctx, types.NamespacedName{Name: task.Spec.AgentRef.Name, Namespace: agentNS}, childAgent); err == nil {
+				if childAgent.Labels["orka.ai/created-by"] == "create_agent" && childAgent.Labels["orka.ai/parent-task"] == parentName {
+					allowed = true
+				}
+			}
+		}
 		if !allowed {
 			result, err := r.failTask(ctx, task, fmt.Sprintf("agent %q not in parent's allowedAgents", task.Spec.AgentRef.Name))
 			return result, err, true
@@ -580,9 +593,13 @@ func (r *TaskReconciler) handleRunning(ctx context.Context, task *corev1alpha1.T
 			client.MatchingLabels{"orka.ai/parent-task": task.Name}); err == nil && len(children.Items) > 0 {
 			childStatuses := make([]corev1alpha1.ChildTaskStatus, 0, len(children.Items))
 			for _, child := range children.Items {
+				phase := child.Status.Phase
+				if phase == "" {
+					phase = corev1alpha1.TaskPhasePending
+				}
 				cs := corev1alpha1.ChildTaskStatus{
 					Name:  child.Name,
-					Phase: child.Status.Phase,
+					Phase: phase,
 				}
 				if child.Spec.AgentRef != nil {
 					cs.Agent = child.Spec.AgentRef.Name

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -63,6 +63,7 @@ type TaskReconciler struct {
 	ResultStore               store.ResultStore
 	SessionStore              store.SessionStore
 	PlanStore                 store.PlanStore
+	MessageStore              store.MessageStore
 	EnforceNamespaceIsolation bool
 	MaxTasksPerNamespace      int32
 }
@@ -159,7 +160,7 @@ func (r *TaskReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return r.handleScheduled(ctx, task)
 	case corev1alpha1.TaskPhaseRunning:
 		return r.handleRunning(ctx, task)
-	case corev1alpha1.TaskPhaseSucceeded, corev1alpha1.TaskPhaseFailed:
+	case corev1alpha1.TaskPhaseSucceeded, corev1alpha1.TaskPhaseFailed, corev1alpha1.TaskPhaseCancelled:
 		return r.handleCompleted(ctx, task)
 	}
 
@@ -184,6 +185,17 @@ func (r *TaskReconciler) handleDeletion(ctx context.Context, task *corev1alpha1.
 			if err := r.PlanStore.DeletePlan(ctx, task.Namespace, task.Name); err != nil {
 				log.Error(err, "failed to delete plan state", "task", task.Name)
 				// Continue with finalizer removal anyway
+			}
+		}
+
+		// Clean up inter-agent messages
+		if r.MessageStore != nil {
+			if err := r.MessageStore.DeleteTaskMessages(ctx, task.Namespace, task.Name); err != nil {
+				log.Error(err, "failed to delete task messages", "task", task.Name)
+			}
+			// If this is a coordinator, clean up all children's messages
+			if err := r.MessageStore.DeleteParentMessages(ctx, task.Namespace, task.Name); err != nil {
+				log.Error(err, "failed to delete parent messages", "task", task.Name)
 			}
 		}
 
@@ -698,9 +710,13 @@ func (r *TaskReconciler) completeTask(ctx context.Context, task *corev1alpha1.Ta
 
 	conditionStatus := metav1.ConditionTrue
 	reason := "TaskSucceeded"
-	if phase == corev1alpha1.TaskPhaseFailed {
+	switch phase {
+	case corev1alpha1.TaskPhaseFailed:
 		conditionStatus = metav1.ConditionFalse
 		reason = "TaskFailed"
+	case corev1alpha1.TaskPhaseCancelled:
+		conditionStatus = metav1.ConditionFalse
+		reason = "TaskCancelled"
 	}
 
 	meta.SetStatusCondition(&task.Status.Conditions, metav1.Condition{

--- a/internal/llm/openai/provider.go
+++ b/internal/llm/openai/provider.go
@@ -94,14 +94,16 @@ func isUnsupportedAPIError(err error) bool {
 		case 404, 405:
 			return true
 		}
-		if apiErr.Code == "unsupported_api" || apiErr.Code == "invalid_url" {
+		if apiErr.Code == "unsupported_api" || apiErr.Code == "invalid_url" ||
+			apiErr.Code == "unsupported_api_for_model" {
 			return true
 		}
 	}
 	msg := err.Error()
 	return strings.Contains(msg, "404") ||
 		strings.Contains(msg, "Not Found") ||
-		strings.Contains(msg, "invalid_url")
+		strings.Contains(msg, "invalid_url") ||
+		strings.Contains(msg, "unsupported_api_for_model")
 }
 
 // -------------------------------------------------------------------------

--- a/internal/store/sqlite/message_store.go
+++ b/internal/store/sqlite/message_store.go
@@ -1,0 +1,87 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package sqlite
+
+import (
+	"context"
+	"time"
+
+	"github.com/sozercan/orka/internal/store"
+)
+
+// SendMessage stores a new inter-agent message.
+func (s *Store) SendMessage(ctx context.Context, msg *store.Message) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO messages (namespace, from_task, to_task, parent_task, content, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		msg.Namespace, msg.FromTask, msg.ToTask, msg.ParentTask, msg.Content, time.Now().UTC(),
+	)
+	return err
+}
+
+// GetMessages returns unread messages for a task, including broadcasts to siblings.
+// parentTask scopes broadcasts: only messages with matching parent_task where to_task="*" are included.
+// If markRead is true, messages are marked as read atomically.
+func (s *Store) GetMessages(ctx context.Context, namespace, taskName, parentTask string, markRead bool) ([]store.Message, error) {
+	// Fetch messages addressed directly to this task OR broadcast to siblings (same parent)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, namespace, from_task, to_task, parent_task, content, read, created_at
+		 FROM messages
+		 WHERE namespace = ? AND read = FALSE
+		   AND from_task != ?
+		   AND (to_task = ? OR (to_task = '*' AND parent_task = ?))
+		 ORDER BY id ASC`,
+		namespace, taskName, taskName, parentTask,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var messages []store.Message
+	var ids []int64
+	for rows.Next() {
+		var m store.Message
+		if err := rows.Scan(&m.ID, &m.Namespace, &m.FromTask, &m.ToTask, &m.ParentTask, &m.Content, &m.Read, &m.CreatedAt); err != nil {
+			return nil, err
+		}
+		messages = append(messages, m)
+		ids = append(ids, m.ID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Mark as read if requested
+	if markRead && len(ids) > 0 {
+		for _, id := range ids {
+			if _, err := s.db.ExecContext(ctx, `UPDATE messages SET read = TRUE WHERE id = ?`, id); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return messages, nil
+}
+
+// DeleteTaskMessages deletes all messages involving a task (sent or received).
+func (s *Store) DeleteTaskMessages(ctx context.Context, namespace, taskName string) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM messages WHERE namespace = ? AND (from_task = ? OR to_task = ?)`,
+		namespace, taskName, taskName,
+	)
+	return err
+}
+
+// DeleteParentMessages deletes all messages for children of a parent task.
+func (s *Store) DeleteParentMessages(ctx context.Context, namespace, parentTask string) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM messages WHERE namespace = ? AND parent_task = ?`,
+		namespace, parentTask,
+	)
+	return err
+}

--- a/internal/store/sqlite/message_store_test.go
+++ b/internal/store/sqlite/message_store_test.go
@@ -1,0 +1,180 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sozercan/orka/internal/store"
+)
+
+func TestMessageStore(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	t.Run("send and get direct message", func(t *testing.T) {
+		msg := &store.Message{
+			Namespace:  "ns1",
+			FromTask:   "task-a",
+			ToTask:     "task-b",
+			ParentTask: "coordinator",
+			Content:    "hello from A",
+		}
+		if err := s.SendMessage(ctx, msg); err != nil {
+			t.Fatalf("SendMessage: %v", err)
+		}
+
+		msgs, err := s.GetMessages(ctx, "ns1", "task-b", "coordinator", false)
+		if err != nil {
+			t.Fatalf("GetMessages: %v", err)
+		}
+		if len(msgs) != 1 {
+			t.Fatalf("got %d messages, want 1", len(msgs))
+		}
+		if msgs[0].Content != "hello from A" {
+			t.Errorf("content = %q, want %q", msgs[0].Content, "hello from A")
+		}
+		if msgs[0].FromTask != "task-a" {
+			t.Errorf("fromTask = %q, want %q", msgs[0].FromTask, "task-a")
+		}
+	})
+
+	t.Run("broadcast message to all siblings", func(t *testing.T) {
+		msg := &store.Message{
+			Namespace:  "ns1",
+			FromTask:   "task-c",
+			ToTask:     "*",
+			ParentTask: "coordinator",
+			Content:    "broadcast msg",
+		}
+		if err := s.SendMessage(ctx, msg); err != nil {
+			t.Fatalf("SendMessage: %v", err)
+		}
+
+		// task-b should see the broadcast (same parent, different sender)
+		msgs, err := s.GetMessages(ctx, "ns1", "task-b", "coordinator", false)
+		if err != nil {
+			t.Fatalf("GetMessages: %v", err)
+		}
+		found := false
+		for _, m := range msgs {
+			if m.Content == "broadcast msg" && m.FromTask == "task-c" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("task-b did not receive broadcast from task-c")
+		}
+
+		// task-c should NOT see its own broadcast
+		msgs, err = s.GetMessages(ctx, "ns1", "task-c", "coordinator", false)
+		if err != nil {
+			t.Fatalf("GetMessages: %v", err)
+		}
+		for _, m := range msgs {
+			if m.Content == "broadcast msg" && m.FromTask == "task-c" {
+				t.Error("sender received its own broadcast message")
+			}
+		}
+	})
+
+	t.Run("mark read prevents re-reading", func(t *testing.T) {
+		msg := &store.Message{
+			Namespace:  "ns2",
+			FromTask:   "sender",
+			ToTask:     "reader",
+			ParentTask: "parent",
+			Content:    "read me once",
+		}
+		if err := s.SendMessage(ctx, msg); err != nil {
+			t.Fatalf("SendMessage: %v", err)
+		}
+
+		// First read with markRead=true
+		msgs, err := s.GetMessages(ctx, "ns2", "reader", "parent", true)
+		if err != nil {
+			t.Fatalf("GetMessages: %v", err)
+		}
+		if len(msgs) != 1 {
+			t.Fatalf("got %d messages, want 1", len(msgs))
+		}
+
+		// Second read should return nothing
+		msgs, err = s.GetMessages(ctx, "ns2", "reader", "parent", false)
+		if err != nil {
+			t.Fatalf("GetMessages: %v", err)
+		}
+		if len(msgs) != 0 {
+			t.Errorf("got %d messages after markRead, want 0", len(msgs))
+		}
+	})
+
+	t.Run("different parent scopes messages", func(t *testing.T) {
+		msg := &store.Message{
+			Namespace:  "ns3",
+			FromTask:   "worker-x",
+			ToTask:     "*",
+			ParentTask: "parent-1",
+			Content:    "scoped msg",
+		}
+		if err := s.SendMessage(ctx, msg); err != nil {
+			t.Fatalf("SendMessage: %v", err)
+		}
+
+		// Worker in parent-2 should NOT see messages from parent-1
+		msgs, err := s.GetMessages(ctx, "ns3", "worker-y", "parent-2", false)
+		if err != nil {
+			t.Fatalf("GetMessages: %v", err)
+		}
+		if len(msgs) != 0 {
+			t.Errorf("got %d messages from different parent, want 0", len(msgs))
+		}
+	})
+
+	t.Run("delete task messages", func(t *testing.T) {
+		msg := &store.Message{
+			Namespace:  "ns4",
+			FromTask:   "del-sender",
+			ToTask:     "del-receiver",
+			ParentTask: "del-parent",
+			Content:    "will be deleted",
+		}
+		if err := s.SendMessage(ctx, msg); err != nil {
+			t.Fatalf("SendMessage: %v", err)
+		}
+
+		if err := s.DeleteTaskMessages(ctx, "ns4", "del-sender"); err != nil {
+			t.Fatalf("DeleteTaskMessages: %v", err)
+		}
+
+		msgs, err := s.GetMessages(ctx, "ns4", "del-receiver", "del-parent", false)
+		if err != nil {
+			t.Fatalf("GetMessages: %v", err)
+		}
+		if len(msgs) != 0 {
+			t.Errorf("got %d messages after delete, want 0", len(msgs))
+		}
+	})
+
+	t.Run("delete parent messages", func(t *testing.T) {
+		for _, m := range []*store.Message{
+			{Namespace: "ns5", FromTask: "child-1", ToTask: "child-2", ParentTask: "parent-del", Content: "msg1"},
+			{Namespace: "ns5", FromTask: "child-2", ToTask: "*", ParentTask: "parent-del", Content: "msg2"},
+		} {
+			if err := s.SendMessage(ctx, m); err != nil {
+				t.Fatalf("SendMessage: %v", err)
+			}
+		}
+
+		if err := s.DeleteParentMessages(ctx, "ns5", "parent-del"); err != nil {
+			t.Fatalf("DeleteParentMessages: %v", err)
+		}
+
+		msgs, err := s.GetMessages(ctx, "ns5", "child-1", "parent-del", false)
+		if err != nil {
+			t.Fatalf("GetMessages: %v", err)
+		}
+		if len(msgs) != 0 {
+			t.Errorf("got %d messages after parent delete, want 0", len(msgs))
+		}
+	})
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -116,6 +116,18 @@ func migrate(db *sql.DB) error {
 		`CREATE INDEX IF NOT EXISTS idx_sessions_namespace ON sessions(namespace)`,
 		`CREATE INDEX IF NOT EXISTS idx_results_namespace ON results(namespace)`,
 		`CREATE INDEX IF NOT EXISTS idx_plan_states_namespace ON plan_states(namespace)`,
+		`CREATE TABLE IF NOT EXISTS messages (
+			id          INTEGER PRIMARY KEY AUTOINCREMENT,
+			namespace   TEXT NOT NULL,
+			from_task   TEXT NOT NULL,
+			to_task     TEXT NOT NULL,
+			parent_task TEXT NOT NULL,
+			content     TEXT NOT NULL,
+			read        BOOLEAN NOT NULL DEFAULT FALSE,
+			created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_messages_recipient ON messages(namespace, to_task, read)`,
+		`CREATE INDEX IF NOT EXISTS idx_messages_parent ON messages(namespace, parent_task)`,
 	}
 
 	for _, stmt := range statements {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -46,3 +46,30 @@ type PlanStore interface {
 	GetPlan(ctx context.Context, namespace, taskName string) (*PlanState, error)
 	DeletePlan(ctx context.Context, namespace, taskName string) error
 }
+
+// Message represents an inter-agent message.
+type Message struct {
+	ID         int64  `json:"id"`
+	Namespace  string `json:"namespace"`
+	FromTask   string `json:"fromTask"`
+	ToTask     string `json:"toTask"` // "*" for broadcast to all siblings
+	ParentTask string `json:"parentTask"`
+	Content    string `json:"content"`
+	Read       bool   `json:"read"`
+	CreatedAt  string `json:"createdAt"`
+}
+
+// MessageStore handles inter-agent message persistence.
+type MessageStore interface {
+	// SendMessage stores a new message. Use toTask="*" for broadcast.
+	SendMessage(ctx context.Context, msg *Message) error
+
+	// GetMessages returns unread messages for a task, optionally marking them as read.
+	GetMessages(ctx context.Context, namespace, taskName, parentTask string, markRead bool) ([]Message, error)
+
+	// DeleteTaskMessages deletes all messages involving a task (sent or received).
+	DeleteTaskMessages(ctx context.Context, namespace, taskName string) error
+
+	// DeleteParentMessages deletes all messages for children of a parent task.
+	DeleteParentMessages(ctx context.Context, namespace, parentTask string) error
+}

--- a/internal/tools/cancel_task.go
+++ b/internal/tools/cancel_task.go
@@ -1,0 +1,149 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
+)
+
+// CancelTaskTool implements task cancellation for coordination workflows
+type CancelTaskTool struct {
+	k8sClient client.Client
+}
+
+// CancelTaskArgs are the arguments for the cancel_task tool
+type CancelTaskArgs struct {
+	TaskName  string `json:"task_name"`
+	Namespace string `json:"namespace,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// CancelTaskResult represents the cancellation result
+type CancelTaskResult struct {
+	TaskName string `json:"taskName"`
+	Status   string `json:"status"`
+}
+
+// NewCancelTaskTool creates a new cancel task tool
+func NewCancelTaskTool(k8sClient client.Client) *CancelTaskTool {
+	return &CancelTaskTool{
+		k8sClient: k8sClient,
+	}
+}
+
+// Name returns the tool name
+func (t *CancelTaskTool) Name() string {
+	return "cancel_task"
+}
+
+// Description returns the tool description
+func (t *CancelTaskTool) Description() string {
+	return "Cancel a running child task. The task's Job will be terminated and the task will be marked as Cancelled. " +
+		"Use this to stop a task that is going down the wrong path, taking too long, or is no longer needed. " +
+		"You can only cancel tasks that are children of the current task."
+}
+
+// Parameters returns the JSON Schema for the tool parameters
+func (t *CancelTaskTool) Parameters() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"task_name": {
+				"type": "string",
+				"description": "Name of the child task to cancel"
+			},
+			"namespace": {
+				"type": "string",
+				"description": "Namespace of the task (defaults to current namespace)"
+			},
+			"reason": {
+				"type": "string",
+				"description": "Reason for cancellation (optional, included in task status message)"
+			}
+		},
+		"required": ["task_name"]
+	}`)
+}
+
+// Execute cancels a running child task
+func (t *CancelTaskTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var a CancelTaskArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return "", fmt.Errorf("failed to parse arguments: %w", err)
+	}
+
+	if a.TaskName == "" {
+		return "", fmt.Errorf("task_name is required")
+	}
+
+	namespace := a.Namespace
+	if namespace == "" {
+		namespace = os.Getenv("ORKA_TASK_NAMESPACE")
+	}
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+
+	parentTaskName := os.Getenv("ORKA_TASK_NAME")
+
+	// Get the target task
+	task := &corev1alpha1.Task{}
+	if err := t.k8sClient.Get(ctx, types.NamespacedName{
+		Name:      a.TaskName,
+		Namespace: namespace,
+	}, task); err != nil {
+		return "", fmt.Errorf("failed to get task %q: %w", a.TaskName, err)
+	}
+
+	// Verify this is a child of the current task
+	if parentTaskName != "" {
+		parentLabel := task.Labels["orka.ai/parent-task"]
+		if parentLabel != parentTaskName {
+			return "", fmt.Errorf("task %q is not a child of the current task %q", a.TaskName, parentTaskName)
+		}
+	}
+
+	// Can only cancel Pending or Running tasks
+	if task.Status.Phase != corev1alpha1.TaskPhasePending && task.Status.Phase != corev1alpha1.TaskPhaseRunning {
+		result := CancelTaskResult{
+			TaskName: a.TaskName,
+			Status:   fmt.Sprintf("task is already in %s phase, cannot cancel", task.Status.Phase),
+		}
+		data, _ := json.Marshal(result)
+		return string(data), nil
+	}
+
+	// Set the task phase to Cancelled
+	now := metav1.Now()
+	task.Status.Phase = corev1alpha1.TaskPhaseCancelled
+	task.Status.CompletionTime = &now
+	message := "cancelled by parent task"
+	if a.Reason != "" {
+		message = fmt.Sprintf("cancelled by parent task: %s", a.Reason)
+	}
+	task.Status.Message = message
+
+	if err := t.k8sClient.Status().Update(ctx, task); err != nil {
+		return "", fmt.Errorf("failed to cancel task %q: %w", a.TaskName, err)
+	}
+
+	result := CancelTaskResult{
+		TaskName: a.TaskName,
+		Status:   "cancelled",
+	}
+	data, _ := json.Marshal(result)
+	return string(data), nil
+}

--- a/internal/tools/cancel_task_test.go
+++ b/internal/tools/cancel_task_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
+)
+
+func TestCancelTaskTool_Name(t *testing.T) {
+	tool := NewCancelTaskTool(newFakeClient())
+	if got := tool.Name(); got != "cancel_task" {
+		t.Errorf("Name() = %v, want %v", got, "cancel_task")
+	}
+}
+
+func TestCancelTaskTool_Description(t *testing.T) {
+	tool := NewCancelTaskTool(newFakeClient())
+	if got := tool.Description(); got == "" {
+		t.Error("Description() returned empty string")
+	}
+}
+
+func TestCancelTaskTool_Execute(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       CancelTaskArgs
+		childTask  *corev1alpha1.Task
+		envVars    map[string]string
+		wantErr    bool
+		wantStatus string
+	}{
+		{
+			name: "cancel running child task",
+			args: CancelTaskArgs{
+				TaskName:  "child-task-1",
+				Namespace: "default",
+				Reason:    "wrong approach",
+			},
+			childTask: &corev1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "child-task-1",
+					Namespace: "default",
+					Labels: map[string]string{
+						"orka.ai/parent-task": parentTaskName,
+					},
+				},
+				Spec: corev1alpha1.TaskSpec{
+					Type: corev1alpha1.TaskTypeAI,
+				},
+				Status: corev1alpha1.TaskStatus{
+					Phase: corev1alpha1.TaskPhaseRunning,
+				},
+			},
+			envVars:    map[string]string{"ORKA_TASK_NAME": parentTaskName, "ORKA_TASK_NAMESPACE": "default"},
+			wantStatus: "cancelled",
+		},
+		{
+			name: "cancel pending child task",
+			args: CancelTaskArgs{
+				TaskName:  "child-task-2",
+				Namespace: "default",
+			},
+			childTask: &corev1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "child-task-2",
+					Namespace: "default",
+					Labels: map[string]string{
+						"orka.ai/parent-task": parentTaskName,
+					},
+				},
+				Spec: corev1alpha1.TaskSpec{
+					Type: corev1alpha1.TaskTypeAI,
+				},
+				Status: corev1alpha1.TaskStatus{
+					Phase: corev1alpha1.TaskPhasePending,
+				},
+			},
+			envVars:    map[string]string{"ORKA_TASK_NAME": parentTaskName, "ORKA_TASK_NAMESPACE": "default"},
+			wantStatus: "cancelled",
+		},
+		{
+			name: "cannot cancel already succeeded task",
+			args: CancelTaskArgs{
+				TaskName:  "child-task-3",
+				Namespace: "default",
+			},
+			childTask: &corev1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "child-task-3",
+					Namespace: "default",
+					Labels: map[string]string{
+						"orka.ai/parent-task": parentTaskName,
+					},
+				},
+				Spec: corev1alpha1.TaskSpec{
+					Type: corev1alpha1.TaskTypeAI,
+				},
+				Status: corev1alpha1.TaskStatus{
+					Phase: corev1alpha1.TaskPhaseSucceeded,
+				},
+			},
+			envVars:    map[string]string{"ORKA_TASK_NAME": parentTaskName, "ORKA_TASK_NAMESPACE": "default"},
+			wantStatus: "task is already in Succeeded phase, cannot cancel",
+		},
+		{
+			name: "cannot cancel task from different parent",
+			args: CancelTaskArgs{
+				TaskName:  "other-child",
+				Namespace: "default",
+			},
+			childTask: &corev1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-child",
+					Namespace: "default",
+					Labels: map[string]string{
+						"orka.ai/parent-task": "other-parent",
+					},
+				},
+				Spec: corev1alpha1.TaskSpec{
+					Type: corev1alpha1.TaskTypeAI,
+				},
+				Status: corev1alpha1.TaskStatus{
+					Phase: corev1alpha1.TaskPhaseRunning,
+				},
+			},
+			envVars: map[string]string{"ORKA_TASK_NAME": parentTaskName, "ORKA_TASK_NAMESPACE": "default"},
+			wantErr: true,
+		},
+		{
+			name: "missing task name",
+			args: CancelTaskArgs{
+				Namespace: "default",
+			},
+			envVars: map[string]string{"ORKA_TASK_NAME": parentTaskName},
+			wantErr: true,
+		},
+		{
+			name: "task not found",
+			args: CancelTaskArgs{
+				TaskName:  "nonexistent",
+				Namespace: "default",
+			},
+			envVars: map[string]string{"ORKA_TASK_NAME": parentTaskName},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+
+			var objs []client.Object
+			if tt.childTask != nil {
+				objs = append(objs, tt.childTask)
+			}
+
+			fc := newFakeClient(objs...)
+			tool := NewCancelTaskTool(fc)
+
+			argsJSON, _ := json.Marshal(tt.args)
+			result, err := tool.Execute(context.Background(), argsJSON)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var res CancelTaskResult
+			if err := json.Unmarshal([]byte(result), &res); err != nil {
+				t.Fatalf("failed to parse result: %v", err)
+			}
+
+			if res.Status != tt.wantStatus {
+				t.Errorf("status = %q, want %q", res.Status, tt.wantStatus)
+			}
+
+			// Verify task was updated if cancelled
+			if tt.wantStatus == "cancelled" && tt.childTask != nil {
+				updated := &corev1alpha1.Task{}
+				err := fc.Get(context.Background(), apitypes.NamespacedName{
+					Name:      tt.childTask.Name,
+					Namespace: tt.childTask.Namespace,
+				}, updated)
+				if err != nil {
+					t.Fatalf("failed to get updated task: %v", err)
+				}
+				if updated.Status.Phase != corev1alpha1.TaskPhaseCancelled {
+					t.Errorf("task phase = %v, want Cancelled", updated.Status.Phase)
+				}
+			}
+		})
+	}
+}

--- a/internal/tools/check_messages.go
+++ b/internal/tools/check_messages.go
@@ -1,0 +1,121 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// CheckMessagesTool implements checking for inter-agent messages
+type CheckMessagesTool struct{}
+
+// CheckMessagesArgs are the arguments for the check_messages tool
+type CheckMessagesArgs struct {
+	MarkRead *bool `json:"mark_read,omitempty"`
+}
+
+// NewCheckMessagesTool creates a new check messages tool
+func NewCheckMessagesTool() *CheckMessagesTool {
+	return &CheckMessagesTool{}
+}
+
+// Name returns the tool name
+func (t *CheckMessagesTool) Name() string {
+	return "check_messages"
+}
+
+// Description returns the tool description
+func (t *CheckMessagesTool) Description() string {
+	return "Check for messages from sibling tasks. Returns all unread messages sent to you or broadcast to all siblings. " +
+		"Call this periodically during long-running tasks to stay coordinated with your siblings. " +
+		"Messages are marked as read by default so you won't see them again."
+}
+
+// Parameters returns the JSON Schema for the tool parameters
+func (t *CheckMessagesTool) Parameters() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"mark_read": {
+				"type": "boolean",
+				"description": "Whether to mark returned messages as read (default: true)"
+			}
+		}
+	}`)
+}
+
+// Execute checks for messages from sibling tasks via the controller's internal API
+func (t *CheckMessagesTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var a CheckMessagesArgs
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &a); err != nil {
+			return "", fmt.Errorf("failed to parse arguments: %w", err)
+		}
+	}
+
+	markRead := "true"
+	if a.MarkRead != nil && !*a.MarkRead {
+		markRead = "false"
+	}
+
+	taskName := os.Getenv("ORKA_TASK_NAME")
+	namespace := os.Getenv("ORKA_TASK_NAMESPACE")
+	parentTask := os.Getenv("ORKA_PARENT_TASK")
+	controllerURL := strings.TrimRight(os.Getenv("ORKA_CONTROLLER_URL"), "/")
+
+	if controllerURL == "" || taskName == "" || namespace == "" || parentTask == "" {
+		return "", fmt.Errorf("messaging requires ORKA_CONTROLLER_URL, ORKA_TASK_NAME, ORKA_TASK_NAMESPACE, and ORKA_PARENT_TASK")
+	}
+
+	endpoint := fmt.Sprintf("%s/internal/v1/messages/%s/%s?parentTask=%s&markRead=%s",
+		controllerURL, namespace, taskName, parentTask, markRead)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	token, _ := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	if len(token) > 0 {
+		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(string(token)))
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to check messages: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB limit
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("failed to check messages: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Parse to count messages
+	var messages []json.RawMessage
+	if err := json.Unmarshal(body, &messages); err != nil {
+		return string(body), nil
+	}
+
+	if len(messages) == 0 {
+		return "No new messages", nil
+	}
+
+	return string(body), nil
+}

--- a/internal/tools/check_messages_test.go
+++ b/internal/tools/check_messages_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckMessagesTool_Name(t *testing.T) {
+	tool := NewCheckMessagesTool()
+	if got := tool.Name(); got != "check_messages" {
+		t.Errorf("Name() = %v, want %v", got, "check_messages")
+	}
+}
+
+func TestCheckMessagesTool_Description(t *testing.T) {
+	tool := NewCheckMessagesTool()
+	if got := tool.Description(); got == "" {
+		t.Error("Description() returned empty string")
+	}
+}
+
+func TestCheckMessagesTool_Execute(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       *CheckMessagesArgs
+		envVars    map[string]string
+		serverCode int
+		serverBody string
+		wantErr    bool
+		wantMsg    string
+	}{
+		{
+			name: "no new messages",
+			envVars: map[string]string{
+				"ORKA_TASK_NAME":      "worker-a",
+				"ORKA_TASK_NAMESPACE": "default",
+				"ORKA_PARENT_TASK":    "coordinator",
+			},
+			serverCode: http.StatusOK,
+			serverBody: `[]`,
+			wantMsg:    "No new messages",
+		},
+		{
+			name: "has messages",
+			envVars: map[string]string{
+				"ORKA_TASK_NAME":      "worker-a",
+				"ORKA_TASK_NAMESPACE": "default",
+				"ORKA_PARENT_TASK":    "coordinator",
+			},
+			serverCode: http.StatusOK,
+			serverBody: `[{"id":1,"fromTask":"worker-b","toTask":"worker-a","content":"found issue"}]`,
+			wantMsg:    `[{"id":1,"fromTask":"worker-b","toTask":"worker-a","content":"found issue"}]`,
+		},
+		{
+			name: "mark_read false",
+			args: func() *CheckMessagesArgs {
+				f := false
+				return &CheckMessagesArgs{MarkRead: &f}
+			}(),
+			envVars: map[string]string{
+				"ORKA_TASK_NAME":      "worker-a",
+				"ORKA_TASK_NAMESPACE": "default",
+				"ORKA_PARENT_TASK":    "coordinator",
+			},
+			serverCode: http.StatusOK,
+			serverBody: `[]`,
+			wantMsg:    "No new messages",
+		},
+		{
+			name: "missing env vars",
+			envVars: map[string]string{},
+			wantErr: true,
+		},
+		{
+			name: "server error",
+			envVars: map[string]string{
+				"ORKA_TASK_NAME":      "worker-a",
+				"ORKA_TASK_NAMESPACE": "default",
+				"ORKA_PARENT_TASK":    "coordinator",
+			},
+			serverCode: http.StatusInternalServerError,
+			serverBody: "internal error",
+			wantErr:    true,
+		},
+		{
+			name: "nil args (defaults)",
+			envVars: map[string]string{
+				"ORKA_TASK_NAME":      "worker-a",
+				"ORKA_TASK_NAMESPACE": "default",
+				"ORKA_PARENT_TASK":    "coordinator",
+			},
+			serverCode: http.StatusOK,
+			serverBody: `[]`,
+			wantMsg:    "No new messages",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear env vars first
+			for _, k := range []string{"ORKA_TASK_NAME", "ORKA_TASK_NAMESPACE", "ORKA_PARENT_TASK", "ORKA_CONTROLLER_URL"} {
+				t.Setenv(k, "")
+			}
+
+			if tt.serverCode != 0 {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method != http.MethodGet {
+						t.Errorf("expected GET, got %s", r.Method)
+					}
+					// Verify markRead query param
+					if tt.args != nil && tt.args.MarkRead != nil && !*tt.args.MarkRead {
+						if r.URL.Query().Get("markRead") != "false" {
+							t.Errorf("expected markRead=false, got %s", r.URL.Query().Get("markRead"))
+						}
+					}
+					w.WriteHeader(tt.serverCode)
+					w.Write([]byte(tt.serverBody)) //nolint:errcheck
+				}))
+				defer server.Close()
+				tt.envVars["ORKA_CONTROLLER_URL"] = server.URL
+			}
+
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+
+			tool := NewCheckMessagesTool()
+			var argsJSON json.RawMessage
+			if tt.args != nil {
+				argsJSON, _ = json.Marshal(tt.args)
+			}
+			result, err := tool.Execute(context.Background(), argsJSON)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result != tt.wantMsg {
+				t.Errorf("result = %q, want %q", result, tt.wantMsg)
+			}
+		})
+	}
+}

--- a/internal/tools/create_agent.go
+++ b/internal/tools/create_agent.go
@@ -190,21 +190,33 @@ func (t *CreateAgentTool) Execute(ctx context.Context, args json.RawMessage) (st
 		return "", fmt.Errorf("failed to get parent task: %w", err)
 	}
 
-	// Build model config
+	// Build model config — clear provider to avoid mismatch with providerRef
 	model := &corev1alpha1.ModelConfig{}
 	if a.Model != nil {
-		model.Provider = a.Model.Provider
 		model.Name = a.Model.Name
-	}
-	if model.Provider == "" {
-		model.Provider = os.Getenv("ORKA_AI_PROVIDER")
 	}
 	if model.Name == "" {
 		model.Name = os.Getenv("ORKA_AI_MODEL")
 	}
 
-	// Build provider ref
-	providerRefName := a.ProviderRef
+	// Build provider ref — inherit from parent agent's providerRef for reliability,
+	// since the LLM often guesses wrong provider names (e.g., "anthropic" instead of "default")
+	providerRefName := ""
+	if parentTask.Spec.AgentRef != nil {
+		parentAgent := &corev1alpha1.Agent{}
+		agentNS := parentTask.Spec.AgentRef.Namespace
+		if agentNS == "" {
+			agentNS = ns
+		}
+		if err := t.k8sClient.Get(ctx, types.NamespacedName{Name: parentTask.Spec.AgentRef.Name, Namespace: agentNS}, parentAgent); err == nil {
+			if parentAgent.Spec.ProviderRef != nil {
+				providerRefName = parentAgent.Spec.ProviderRef.Name
+			}
+		}
+	}
+	if providerRefName == "" {
+		providerRefName = a.ProviderRef
+	}
 	if providerRefName == "" {
 		providerRefName = os.Getenv("ORKA_AI_PROVIDER")
 	}

--- a/internal/tools/create_agent_test.go
+++ b/internal/tools/create_agent_test.go
@@ -297,8 +297,8 @@ func TestCreateAgentTool_Execute_AllFields(t *testing.T) {
 	if agent.Spec.Model == nil {
 		t.Fatal("agent.Spec.Model is nil")
 	}
-	if agent.Spec.Model.Provider != "anthropic" {
-		t.Errorf("model.provider = %q, want %q", agent.Spec.Model.Provider, "anthropic")
+	if agent.Spec.Model.Provider != "" {
+		t.Errorf("model.provider = %q, want empty (cleared to avoid mismatch with providerRef)", agent.Spec.Model.Provider)
 	}
 	if agent.Spec.Model.Name != "claude-sonnet-4-20250514" {
 		t.Errorf("model.name = %q, want %q", agent.Spec.Model.Name, "claude-sonnet-4-20250514")
@@ -399,8 +399,8 @@ func TestCreateAgentTool_Execute_InheritedModelProvider(t *testing.T) {
 	if agent.Spec.Model == nil {
 		t.Fatal("agent.Spec.Model is nil")
 	}
-	if agent.Spec.Model.Provider != "openai" {
-		t.Errorf("model.provider = %q, want %q (inherited)", agent.Spec.Model.Provider, "openai")
+	if agent.Spec.Model.Provider != "" {
+		t.Errorf("model.provider = %q, want empty (cleared to avoid mismatch with providerRef)", agent.Spec.Model.Provider)
 	}
 	if agent.Spec.Model.Name != "gpt-4o" {
 		t.Errorf("model.name = %q, want %q (inherited)", agent.Spec.Model.Name, "gpt-4o")

--- a/internal/tools/messaging_test.go
+++ b/internal/tools/messaging_test.go
@@ -1,0 +1,217 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+func TestSendMessageTool(t *testing.T) {
+	tool := NewSendMessageTool()
+
+	if tool.Name() != "send_message" {
+		t.Errorf("Name() = %q, want %q", tool.Name(), "send_message")
+	}
+
+	t.Run("missing env vars returns error", func(t *testing.T) {
+		t.Setenv("ORKA_CONTROLLER_URL", "")
+		t.Setenv("ORKA_TASK_NAME", "")
+		t.Setenv("ORKA_TASK_NAMESPACE", "")
+		t.Setenv("ORKA_PARENT_TASK", "")
+
+		args, _ := json.Marshal(SendMessageArgs{ToTask: "peer", Content: "hi"})
+		_, err := tool.Execute(context.Background(), args)
+		if err == nil {
+			t.Fatal("expected error for missing env vars")
+		}
+	})
+
+	t.Run("missing required args returns error", func(t *testing.T) {
+		t.Setenv("ORKA_CONTROLLER_URL", "http://localhost")
+		t.Setenv("ORKA_TASK_NAME", "task-a")
+		t.Setenv("ORKA_TASK_NAMESPACE", "ns")
+		t.Setenv("ORKA_PARENT_TASK", "parent")
+
+		args, _ := json.Marshal(SendMessageArgs{ToTask: "", Content: "hi"})
+		_, err := tool.Execute(context.Background(), args)
+		if err == nil {
+			t.Fatal("expected error for empty to_task")
+		}
+	})
+
+	t.Run("sends message successfully", func(t *testing.T) {
+		var mu sync.Mutex
+		var receivedBody map[string]string
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+			if r.Method != http.MethodPost {
+				t.Errorf("method = %s, want POST", r.Method)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
+				t.Errorf("decode body: %v", err)
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		t.Setenv("ORKA_CONTROLLER_URL", server.URL)
+		t.Setenv("ORKA_TASK_NAME", "task-a")
+		t.Setenv("ORKA_TASK_NAMESPACE", "default")
+		t.Setenv("ORKA_PARENT_TASK", "coordinator")
+
+		args, _ := json.Marshal(SendMessageArgs{ToTask: "task-b", Content: "found a bug"})
+		result, err := tool.Execute(context.Background(), args)
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if result != "Message sent to task-b" {
+			t.Errorf("result = %q, want %q", result, "Message sent to task-b")
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if receivedBody["fromTask"] != "task-a" {
+			t.Errorf("fromTask = %q, want %q", receivedBody["fromTask"], "task-a")
+		}
+		if receivedBody["toTask"] != "task-b" {
+			t.Errorf("toTask = %q, want %q", receivedBody["toTask"], "task-b")
+		}
+		if receivedBody["parentTask"] != "coordinator" {
+			t.Errorf("parentTask = %q, want %q", receivedBody["parentTask"], "coordinator")
+		}
+	})
+
+	t.Run("broadcast to all siblings", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		t.Setenv("ORKA_CONTROLLER_URL", server.URL)
+		t.Setenv("ORKA_TASK_NAME", "task-a")
+		t.Setenv("ORKA_TASK_NAMESPACE", "default")
+		t.Setenv("ORKA_PARENT_TASK", "coordinator")
+
+		args, _ := json.Marshal(SendMessageArgs{ToTask: "*", Content: "heads up everyone"})
+		result, err := tool.Execute(context.Background(), args)
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if result != "Message sent to all siblings" {
+			t.Errorf("result = %q, want %q", result, "Message sent to all siblings")
+		}
+	})
+
+	t.Run("server error returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("db error")) //nolint:errcheck
+		}))
+		defer server.Close()
+
+		t.Setenv("ORKA_CONTROLLER_URL", server.URL)
+		t.Setenv("ORKA_TASK_NAME", "task-a")
+		t.Setenv("ORKA_TASK_NAMESPACE", "default")
+		t.Setenv("ORKA_PARENT_TASK", "coordinator")
+
+		args, _ := json.Marshal(SendMessageArgs{ToTask: "task-b", Content: "hi"})
+		_, err := tool.Execute(context.Background(), args)
+		if err == nil {
+			t.Fatal("expected error for 500 response")
+		}
+	})
+}
+
+func TestCheckMessagesTool(t *testing.T) {
+	tool := NewCheckMessagesTool()
+
+	if tool.Name() != "check_messages" {
+		t.Errorf("Name() = %q, want %q", tool.Name(), "check_messages")
+	}
+
+	t.Run("missing env vars returns error", func(t *testing.T) {
+		t.Setenv("ORKA_CONTROLLER_URL", "")
+		t.Setenv("ORKA_TASK_NAME", "")
+		t.Setenv("ORKA_TASK_NAMESPACE", "")
+		t.Setenv("ORKA_PARENT_TASK", "")
+
+		_, err := tool.Execute(context.Background(), nil)
+		if err == nil {
+			t.Fatal("expected error for missing env vars")
+		}
+	})
+
+	t.Run("returns no messages", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte("[]")) //nolint:errcheck
+		}))
+		defer server.Close()
+
+		t.Setenv("ORKA_CONTROLLER_URL", server.URL)
+		t.Setenv("ORKA_TASK_NAME", "task-b")
+		t.Setenv("ORKA_TASK_NAMESPACE", "default")
+		t.Setenv("ORKA_PARENT_TASK", "coordinator")
+
+		result, err := tool.Execute(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if result != "No new messages" {
+			t.Errorf("result = %q, want %q", result, "No new messages")
+		}
+	})
+
+	t.Run("returns messages", func(t *testing.T) {
+		msgs := `[{"id":1,"fromTask":"task-a","content":"hello"}]`
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("markRead") != "true" {
+				t.Errorf("markRead = %q, want %q", r.URL.Query().Get("markRead"), "true")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(msgs)) //nolint:errcheck
+		}))
+		defer server.Close()
+
+		t.Setenv("ORKA_CONTROLLER_URL", server.URL)
+		t.Setenv("ORKA_TASK_NAME", "task-b")
+		t.Setenv("ORKA_TASK_NAMESPACE", "default")
+		t.Setenv("ORKA_PARENT_TASK", "coordinator")
+
+		result, err := tool.Execute(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if result != msgs {
+			t.Errorf("result = %q, want %q", result, msgs)
+		}
+	})
+
+	t.Run("mark_read false passes through", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("markRead") != "false" {
+				t.Errorf("markRead = %q, want %q", r.URL.Query().Get("markRead"), "false")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte("[]")) //nolint:errcheck
+		}))
+		defer server.Close()
+
+		t.Setenv("ORKA_CONTROLLER_URL", server.URL)
+		t.Setenv("ORKA_TASK_NAME", "task-b")
+		t.Setenv("ORKA_TASK_NAMESPACE", "default")
+		t.Setenv("ORKA_PARENT_TASK", "coordinator")
+
+		markRead := false
+		args, _ := json.Marshal(CheckMessagesArgs{MarkRead: &markRead})
+		_, err := tool.Execute(context.Background(), args)
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+	})
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -119,6 +119,9 @@ func RegisterBuiltinTools() {
 func RegisterCoordinationTools(k8sClient client.Client) {
 	DefaultRegistry.Register(NewDelegateTaskTool(k8sClient))
 	DefaultRegistry.Register(NewWaitForTasksTool(k8sClient))
+	DefaultRegistry.Register(NewCancelTaskTool(k8sClient))
+	DefaultRegistry.Register(NewSendMessageTool())
+	DefaultRegistry.Register(NewCheckMessagesTool())
 	DefaultRegistry.Register(NewCreatePullRequestTool(k8sClient))
 	DefaultRegistry.Register(NewMergePullRequestTool(k8sClient))
 	DefaultRegistry.Register(NewAutoMergePullRequestTool(k8sClient))

--- a/internal/tools/send_message.go
+++ b/internal/tools/send_message.go
@@ -1,0 +1,122 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// SendMessageTool implements inter-agent messaging
+type SendMessageTool struct{}
+
+// SendMessageArgs are the arguments for the send_message tool
+type SendMessageArgs struct {
+	ToTask  string `json:"to_task"`
+	Content string `json:"content"`
+}
+
+// NewSendMessageTool creates a new send message tool
+func NewSendMessageTool() *SendMessageTool {
+	return &SendMessageTool{}
+}
+
+// Name returns the tool name
+func (t *SendMessageTool) Name() string {
+	return "send_message"
+}
+
+// Description returns the tool description
+func (t *SendMessageTool) Description() string {
+	return "Send a message to a sibling task (another child of the same parent coordinator). " +
+		"Use this to share findings, coordinate work, challenge hypotheses, or avoid duplicated effort. " +
+		"Use to_task=\"*\" to broadcast to all siblings. Messages are delivered asynchronously — " +
+		"the recipient will see them next time they call check_messages."
+}
+
+// Parameters returns the JSON Schema for the tool parameters
+func (t *SendMessageTool) Parameters() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"to_task": {
+				"type": "string",
+				"description": "Name of the sibling task to message, or \"*\" to broadcast to all siblings"
+			},
+			"content": {
+				"type": "string",
+				"description": "Message content to send"
+			}
+		},
+		"required": ["to_task", "content"]
+	}`)
+}
+
+// Execute sends a message to a sibling task via the controller's internal API
+func (t *SendMessageTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var a SendMessageArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return "", fmt.Errorf("failed to parse arguments: %w", err)
+	}
+
+	if a.ToTask == "" || a.Content == "" {
+		return "", fmt.Errorf("to_task and content are required")
+	}
+
+	taskName := os.Getenv("ORKA_TASK_NAME")
+	namespace := os.Getenv("ORKA_TASK_NAMESPACE")
+	parentTask := os.Getenv("ORKA_PARENT_TASK")
+	controllerURL := strings.TrimRight(os.Getenv("ORKA_CONTROLLER_URL"), "/")
+
+	if controllerURL == "" || taskName == "" || namespace == "" || parentTask == "" {
+		return "", fmt.Errorf("messaging requires ORKA_CONTROLLER_URL, ORKA_TASK_NAME, ORKA_TASK_NAMESPACE, and ORKA_PARENT_TASK")
+	}
+
+	body, _ := json.Marshal(map[string]string{
+		"fromTask":   taskName,
+		"toTask":     a.ToTask,
+		"parentTask": parentTask,
+		"content":    a.Content,
+	})
+
+	endpoint := fmt.Sprintf("%s/internal/v1/messages/%s", controllerURL, namespace)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	token, _ := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	if len(token) > 0 {
+		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(string(token)))
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send message: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		target := a.ToTask
+		if target == "*" {
+			target = "all siblings"
+		}
+		return fmt.Sprintf("Message sent to %s", target), nil
+	}
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	return "", fmt.Errorf("failed to send message: HTTP %d: %s", resp.StatusCode, string(respBody))
+}

--- a/internal/tools/send_message_test.go
+++ b/internal/tools/send_message_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSendMessageTool_Name(t *testing.T) {
+	tool := NewSendMessageTool()
+	if got := tool.Name(); got != "send_message" {
+		t.Errorf("Name() = %v, want %v", got, "send_message")
+	}
+}
+
+func TestSendMessageTool_Description(t *testing.T) {
+	tool := NewSendMessageTool()
+	if got := tool.Description(); got == "" {
+		t.Error("Description() returned empty string")
+	}
+}
+
+func TestSendMessageTool_Execute(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       SendMessageArgs
+		envVars    map[string]string
+		serverCode int
+		wantErr    bool
+		wantMsg    string
+	}{
+		{
+			name: "send to specific sibling",
+			args: SendMessageArgs{
+				ToTask:  "sibling-1",
+				Content: "found a bug in auth module",
+			},
+			envVars: map[string]string{
+				"ORKA_TASK_NAME":      "worker-a",
+				"ORKA_TASK_NAMESPACE": "default",
+				"ORKA_PARENT_TASK":    "coordinator",
+			},
+			serverCode: http.StatusNoContent,
+			wantMsg:    "Message sent to sibling-1",
+		},
+		{
+			name: "broadcast to all siblings",
+			args: SendMessageArgs{
+				ToTask:  "*",
+				Content: "phase 1 complete",
+			},
+			envVars: map[string]string{
+				"ORKA_TASK_NAME":      "worker-a",
+				"ORKA_TASK_NAMESPACE": "default",
+				"ORKA_PARENT_TASK":    "coordinator",
+			},
+			serverCode: http.StatusNoContent,
+			wantMsg:    "Message sent to all siblings",
+		},
+		{
+			name: "missing to_task",
+			args: SendMessageArgs{
+				Content: "hello",
+			},
+			envVars: map[string]string{
+				"ORKA_TASK_NAME":      "worker-a",
+				"ORKA_TASK_NAMESPACE": "default",
+				"ORKA_PARENT_TASK":    "coordinator",
+				"ORKA_CONTROLLER_URL": "http://localhost",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing content",
+			args: SendMessageArgs{
+				ToTask: "sibling-1",
+			},
+			envVars: map[string]string{
+				"ORKA_TASK_NAME":      "worker-a",
+				"ORKA_TASK_NAMESPACE": "default",
+				"ORKA_PARENT_TASK":    "coordinator",
+				"ORKA_CONTROLLER_URL": "http://localhost",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing env vars",
+			args: SendMessageArgs{
+				ToTask:  "sibling-1",
+				Content: "hello",
+			},
+			envVars: map[string]string{},
+			wantErr: true,
+		},
+		{
+			name: "server error",
+			args: SendMessageArgs{
+				ToTask:  "sibling-1",
+				Content: "hello",
+			},
+			envVars: map[string]string{
+				"ORKA_TASK_NAME":      "worker-a",
+				"ORKA_TASK_NAMESPACE": "default",
+				"ORKA_PARENT_TASK":    "coordinator",
+			},
+			serverCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear env vars first
+			for _, k := range []string{"ORKA_TASK_NAME", "ORKA_TASK_NAMESPACE", "ORKA_PARENT_TASK", "ORKA_CONTROLLER_URL"} {
+				t.Setenv(k, "")
+			}
+
+			var server *httptest.Server
+			if tt.serverCode != 0 {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method != http.MethodPost {
+						t.Errorf("expected POST, got %s", r.Method)
+					}
+					w.WriteHeader(tt.serverCode)
+				}))
+				defer server.Close()
+				tt.envVars["ORKA_CONTROLLER_URL"] = server.URL
+			}
+
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+
+			tool := NewSendMessageTool()
+			argsJSON, _ := json.Marshal(tt.args)
+			result, err := tool.Execute(context.Background(), argsJSON)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result != tt.wantMsg {
+				t.Errorf("result = %q, want %q", result, tt.wantMsg)
+			}
+		})
+	}
+}

--- a/internal/tools/test_helpers_test.go
+++ b/internal/tools/test_helpers_test.go
@@ -26,5 +26,6 @@ func newFakeClient(objs ...client.Object) client.Client {
 	return fake.NewClientBuilder().
 		WithScheme(newTestScheme()).
 		WithObjects(objs...).
+		WithStatusSubresource(&corev1alpha1.Task{}).
 		Build()
 }

--- a/workers/common/agent_runtime.go
+++ b/workers/common/agent_runtime.go
@@ -91,6 +91,7 @@ func SetupGitCredentials() {
 			token := strings.TrimSpace(string(data))
 			if token != "" {
 				os.Setenv("GIT_TOKEN", token)               //nolint:errcheck
+			os.Setenv("GITHUB_TOKEN", token)             //nolint:errcheck
 				os.Setenv("GIT_ASKPASS", "/bin/echo-token") //nolint:errcheck
 				break
 			}


### PR DESCRIPTION
## Summary

Add inter-agent messaging system and task cancellation for multi-agent coordination.

### New Features

- **`send_message` tool** — Send messages to specific sibling tasks or broadcast to all (`to_task="*"`)
- **`check_messages` tool** — Poll for unread messages with optional mark-as-read
- **`cancel_task` tool** — Cancel running/pending child tasks with parent validation
- **`Cancelled` task phase** — New terminal phase with controller lifecycle support
- **Message cleanup** — Automatic deletion on task/coordinator removal
- **`ORKA_PARENT_TASK` env var** — Auto-injected by job builder for child tasks

### Additional Fixes

- **Helm chart**: Correct controller flag names (`metrics-bind-address`, `health-probe-bind-address`, `zap-log-level`) and add worker image flags
- **OpenAI provider**: Handle `unsupported_api_for_model` error code

### Docs & Tests

- Unit tests for `send_message`, `check_messages`, `cancel_task` tools
- Unit tests for `SendMessage`/`GetMessages` internal API handlers
- Updated `api-reference.md`, `configuration.md`, `multi-agent-coordination.md`, `CLAUDE.md`