### PR TITLE
docs: refresh outdated documentation

### DIFF
--- a/docs/agent-runtimes.md
+++ b/docs/agent-runtimes.md
@@ -194,6 +194,12 @@ spec:
       #   name: git-credentials
       # subPath: subdirectory within repo to use as workspace root
       # subPath: "services/api"
+      # forkRepo: writable fork URL used as git remote for pushes
+      # forkRepo: "https://github.com/my-org/my-project.git"
+      # prBaseBranch: upstream branch to target when creating PRs
+      # prBaseBranch: "main"
+      # pushBranch: branch name to push changes to after task completion
+      # pushBranch: "feature/my-change"
 
     # maxTurns: override Agent's defaultMaxTurns (range: 1-1000)
     maxTurns: 100
@@ -294,6 +300,20 @@ agentRuntime:
   workspace:
     gitRepo: "https://github.com/example/repo.git"
     ref: "v1.2.3"
+```
+
+### Push Changes to a Branch
+
+Use `pushBranch` to have the worker commit and push changes automatically at the end of the task.
+For fork-based workflows, also set `forkRepo` and `prBaseBranch`.
+
+```yaml
+agentRuntime:
+  workspace:
+    gitRepo: "https://github.com/upstream/repo.git"
+    forkRepo: "https://github.com/my-user/repo.git"
+    prBaseBranch: "main"
+    pushBranch: "feature/my-change"
 ```
 
 ## Session Continuity

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -226,6 +226,8 @@ These tools are available to AI worker agents:
 | `web_search` | Search the web via configurable API (Tavily, etc.) | `query` (required), `limit` (default 5) |
 | `code_exec` | Execute code in a sandboxed environment | `language` (python/javascript/bash), `code`, `timeout` (max 60s) |
 | `file_read` | Read files from the workspace | `path`, `offset`, `limit` (max 1MB) |
+| `web_fetch` | Fetch and extract URL content | `url` (required), `max_chars` (default 50000), `raw` |
+| `file_write` | Write or append files in workspace paths | `path` (required), `content` (required), `mode` (`write`/`append`), `create_dirs` |
 
 ### Coordination Tools
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ spec:
     - configMapRef:
         name: skill-researcher
   session:
-    persistence: sqlite    # sqlite or none
+    persistence: configmap # configmap, pvc, or none
     ttl: 24h
     maxMessages: 50
   coordination:
@@ -82,8 +82,8 @@ spec:
 | `autonomous` | bool | `false` | Enables autonomous loop mode. When true, the controller re-creates Jobs in a loop instead of marking the task as Succeeded |
 | `maxIterations` | int32 | `0` | Limits the number of autonomous loop iterations. Only used when `autonomous` is true. `0` means unlimited |
 | `allowedAgents` | list | `[]` | List of agent names this agent is allowed to delegate to |
-| `maxConcurrentChildren` | int32 | `0` | Maximum number of concurrent child tasks. `0` means unlimited |
-| `maxDepth` | int32 | `0` | Maximum delegation depth. `0` means unlimited |
+| `maxConcurrentChildren` | int32 | `5` | Maximum number of concurrent child tasks |
+| `maxDepth` | int32 | `3` | Maximum delegation depth |
 
 **Auto-injected coordination tools** (when `enabled: true`):
 
@@ -94,7 +94,7 @@ spec:
 You can configure fallback providers that are automatically tried when the primary provider fails (e.g., due to auth errors, provider outages, or rate limiting). Fallbacks are configured on the Agent CRD's `spec.model.fallbacks` field.
 
 ```yaml
-apiVersion: orka.ai/v1alpha1
+apiVersion: core.orka.ai/v1alpha1
 kind: Agent
 metadata:
   name: resilient-agent

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,11 +2,11 @@
 
 ## Prerequisites
 
-- Go 1.25+
+- Go 1.25.3+
 - Bun (for UI build)
 - Docker 17.03+
-- kubectl v1.11.3+
-- Access to a Kubernetes v1.11.3+ cluster
+- kubectl (version compatible with your cluster)
+- Access to a Kubernetes cluster
 
 ## Build Commands
 
@@ -28,7 +28,7 @@ make run
 ## Testing
 
 ```bash
-# Run all Go unit tests (uses envtest for K8s API + etcd)
+# Run test pipeline (manifests, generate, fmt, vet, then Go tests)
 make test
 
 # Lint
@@ -59,6 +59,8 @@ make ui-test-coverage   # Run UI tests with coverage
 make docker-build                  # Controller image
 make docker-build-claude-worker    # Claude agent worker
 make docker-build-copilot-worker   # Copilot agent worker
+make docker-build-ai-worker        # AI worker
+make docker-build-general-worker   # General worker
 make docker-build-all              # All images
 
 # Push images

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,12 +3,12 @@
 ## Prerequisites
 
 - Docker 17.03+
-- kubectl v1.11.3+
-- Access to a Kubernetes v1.11.3+ cluster
+- kubectl (version compatible with your cluster)
+- Access to a Kubernetes cluster
 - An LLM API key (Anthropic, OpenAI, or Azure OpenAI)
 
 For development, you also need:
-- Go 1.25+
+- Go 1.25.3+
 - Bun (for UI build)
 
 ## Installation

--- a/docs/openai-compat.md
+++ b/docs/openai-compat.md
@@ -51,6 +51,28 @@ stringData:
   api-key: sk-ant-...
 ```
 
+### Azure OpenAI provider example
+
+If you use Azure OpenAI, configure a Provider with `type: azure-openai`:
+
+```yaml
+apiVersion: core.orka.ai/v1alpha1
+kind: Provider
+metadata:
+  name: azure-openai
+  namespace: default
+spec:
+  type: azure-openai
+  secretRef:
+    name: azure-openai-secret
+    key: api-key
+  baseURL: https://<resource>.openai.azure.com
+  defaultModel: gpt-4o-deployment
+  azure:
+    deploymentName: gpt-4o-deployment
+    apiVersion: "2024-02-15-preview"
+```
+
 3. **ServiceAccount token** for authentication:
 
 ```bash

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,7 +5,7 @@ Orka has comprehensive test coverage across all packages, including unit tests, 
 ## Running Tests
 
 ```bash
-# Run all Go unit tests (uses envtest for K8s API + etcd)
+# Run test pipeline (manifests, generate, fmt, vet, then Go tests)
 make test
 
 # Run Go tests with coverage report


### PR DESCRIPTION
## Summary
- refresh stale docs after deep repo/code audit
- update setup/dev/testing guidance to match current project state
- document runtime/workspace fields and built-in AI tool coverage
- add Azure OpenAI provider example for OpenAI-compatible API docs

## Validation
- documentation-only changes (no runtime code changes)