### PR TITLE
feat: Anthropic-compatible proxy with server-side tool execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ See @docs/ for detailed documentation:
 - @docs/security.md — Security model, worker hardening, multi-tenancy
 - @docs/agent-runtimes.md — Claude Code CLI and Copilot CLI runtime configuration
 - @docs/openai-compat.md — OpenAI-compatible API proxy
+- @docs/anthropic-compat.md — Anthropic-compatible API proxy
 - @docs/cicd-integration.md — CI/CD integration patterns
 - @docs/getting-started.md — Installation and quick start
 - @docs/ui.md — Web dashboard architecture

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ One `helm install`, one LLM secret, and you're chatting with an orchestrator tha
 - 🖥️ **Web Dashboard** — Built-in React UI embedded in the controller binary — zero extra deployments
 - 📦 **Declarative CRDs** — Task, Agent, Tool, and Provider custom resources for GitOps workflows
 - ⏰ **Scheduled Tasks** — Cron-based recurring execution with concurrency policies
-- 🔌 **REST & OpenAI-Compatible API** — Full CRUD + `/v1/chat/completions` endpoint for Continue, Cursor, and any OpenAI-compatible client
+- 🔌 **REST & OpenAI-Compatible API** — Full CRUD + `/openai/v1/chat/completions` endpoint for Continue, Cursor, and any OpenAI-compatible client
+- 🔮 **Anthropic-Compatible API** — `/anthropic/v1/messages` endpoint for Claude Code and other Anthropic-native clients
 - 📊 **Observability** — Prometheus metrics, structured logging, health probes
 - 🔒 **Hardened by Default** — Non-root containers, read-only rootfs, ServiceAccount token auth
 
@@ -86,7 +87,7 @@ kubectl port-forward -n orka-system svc/orka-controller 8080:8080
 open http://localhost:8080
 ```
 
-The built-in orchestrator creates agents, runs tasks, monitors progress, and returns results — all from natural language. See the [OpenAI Compatibility](docs/openai-compat.md) docs for full setup with Continue, Cursor, or other OpenAI-compatible clients.
+The built-in orchestrator creates agents, runs tasks, monitors progress, and returns results — all from natural language. See the [OpenAI Compatibility](docs/openai-compat.md) and [Anthropic Compatibility](docs/anthropic-compat.md) docs for proxy setup with your preferred client.
 
 ## Documentation
 
@@ -100,6 +101,7 @@ The built-in orchestrator creates agents, runs tasks, monitors progress, and ret
 | [Multi-Agent Coordination](docs/multi-agent-coordination.md) | Coordinator agents and task delegation                |
 | [API Reference](docs/api-reference.md)                       | REST API endpoints and usage examples                 |
 | [OpenAI Compatibility](docs/openai-compat.md)                | OpenAI-compatible chat completions API                |
+| [Anthropic Compatibility](docs/anthropic-compat.md)          | Anthropic-compatible Messages API                     |
 | [Web Dashboard](docs/ui.md)                                  | Frontend architecture and pages                       |
 | [Security](docs/security.md)                                 | Security model and hardening                          |
 | [Development](docs/development.md)                           | Building, testing, and contributing                   |

--- a/docs/anthropic-compat.md
+++ b/docs/anthropic-compat.md
@@ -1,0 +1,233 @@
+# Anthropic-Compatible API
+
+Orka exposes an **Anthropic-compatible Messages API** at `/anthropic/v1/messages`, enabling Anthropic-compatible clients (Claude Code, etc.) to use Orka as a transparent proxy.
+
+Orka acts as a **proxy** to whichever LLM provider is configured in your cluster, with credentials managed securely via Kubernetes Secrets and Provider CRDs. See also [OpenAI Compatibility](openai-compat.md) for the OpenAI-compatible proxy.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/anthropic/v1/messages` | Create a message (streaming & non-streaming) |
+| `GET` | `/anthropic/v1/models` | List available models from configured providers |
+
+## Authentication
+
+Two authentication methods are supported:
+
+- **`x-api-key: <orka-token>`** — Anthropic convention (recommended for Anthropic clients)
+- **`Authorization: Bearer <orka-token>`** — Standard Bearer token
+
+Both use a Kubernetes ServiceAccount token as the value.
+
+## Model Name Format
+
+The `model` field supports two formats:
+
+- **`provider/model`** — e.g., `anthropic/claude-sonnet-4-20250514`. The part before `/` matches a Provider CRD name, and the part after is the model name sent to that provider.
+- **`model`** — e.g., `claude-sonnet-4-20250514`. Uses the default provider (from `--chat-provider` flag or a Provider CRD named `default`).
+
+## Prerequisites
+
+1. **Provider CRD** configured in the cluster:
+
+```yaml
+apiVersion: core.orka.ai/v1alpha1
+kind: Provider
+metadata:
+  name: anthropic
+  namespace: default
+spec:
+  type: anthropic
+  secretRef:
+    name: anthropic-secret
+    key: api-key
+  defaultModel: claude-sonnet-4-20250514
+```
+
+2. **Secret** with the API key:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: anthropic-secret
+  namespace: default
+type: Opaque
+stringData:
+  api-key: sk-ant-...
+```
+
+3. **ServiceAccount token** for authentication:
+
+```bash
+# Create a service account
+kubectl create serviceaccount orka-client
+
+# Bind it to the orka viewer role (or a custom role)
+kubectl create clusterrolebinding orka-client-binding \
+  --clusterrole=orka-task-viewer \
+  --serviceaccount=default:orka-client
+
+# Get a token
+export ORKA_TOKEN=$(kubectl create token orka-client)
+```
+
+## Using with Claude Code
+
+Configure Claude Code to route all API calls through Orka:
+
+```bash
+export ANTHROPIC_BASE_URL=https://orka.example.com/anthropic
+export ANTHROPIC_API_KEY=$(kubectl create token orka-client)
+# Claude Code will now route all API calls through Orka
+```
+
+## Using with curl
+
+### Non-streaming
+
+```bash
+curl -X POST https://orka.example.com/anthropic/v1/messages \
+  -H "x-api-key: $ORKA_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "anthropic/claude-sonnet-4-20250514",
+    "max_tokens": 1024,
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+### Streaming
+
+```bash
+curl -X POST https://orka.example.com/anthropic/v1/messages \
+  -H "x-api-key: $ORKA_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "anthropic/claude-sonnet-4-20250514",
+    "max_tokens": 1024,
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "stream": true
+  }'
+```
+
+### List models
+
+```bash
+curl https://orka.example.com/anthropic/v1/models \
+  -H "x-api-key: $ORKA_TOKEN"
+```
+
+## Supported Features
+
+| Feature | Supported |
+|---------|-----------|
+| Messages API | Yes |
+| Streaming (SSE) | Yes |
+| Tool use (function calling) | Yes |
+| Extended thinking (`thinking` content blocks with `budget_tokens`) | Yes |
+| System messages (string format) | Yes |
+| System messages (content block array format) | Yes |
+| `max_tokens` | Yes |
+| `temperature` | Yes |
+| `stop_sequences` | Yes |
+| Image inputs | Not yet |
+| PDF inputs | Not supported |
+
+## Server-Side Tool Execution
+
+The Anthropic proxy includes a built-in agent loop that executes tools server-side. When the LLM returns `tool_use` content blocks, the proxy intercepts them, executes the tools, feeds results back to the LLM, and repeats until a final text response is produced. Clients (e.g., Claude Code) never need to execute tools locally — they only receive the final response with progress updates streamed in real-time.
+
+### Available Tools
+
+The proxy automatically injects these built-in tools into every request:
+
+| Tool | Description |
+|------|-------------|
+| `web_search` | Search the web for information |
+| `code_exec` | Execute code snippets in a sandbox |
+| `file_read` | Read file contents from workspace |
+| `file_write` | Write files to workspace |
+| `web_fetch` | Fetch and extract content from URLs |
+
+Additionally, any [Tool CRDs](configuration.md) defined in the user's namespace are automatically included as custom HTTP tools.
+
+Client-provided tools in the request are preserved and merged with the injected tools.
+
+### How It Works
+
+1. Client sends a `POST /anthropic/v1/messages` request
+2. Proxy injects Orka tools into the request and forwards to the LLM
+3. If the LLM returns `tool_use` blocks:
+   - Proxy executes each tool server-side
+   - Tool results are appended to the conversation
+   - Proxy calls the LLM again with updated context
+4. Steps 2-3 repeat until the LLM returns a text-only response
+5. Final response is returned to the client
+
+### Streaming Behavior
+
+When `stream: true`, the proxy streams Anthropic SSE events throughout the entire tool loop:
+
+- **`message_start`**: Emitted once at the beginning
+- **`content_block_start/delta/stop`**: Streamed for each text and `tool_use` block from the LLM
+- **Tool result blocks**: After executing each tool, the result is streamed as a text content block (e.g., `[Tool web_search result]: ...`)
+- **`message_delta` + `message_stop`**: Emitted once at the end
+
+This means clients see real-time progress as tools are called and results are produced, even across multiple LLM round-trips.
+
+### Limits and Timeouts
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Max iterations | 20 | Maximum number of LLM calls per request |
+| Max duration | 5 minutes | Overall request timeout |
+| Tool timeout | 60 seconds | Per-tool execution timeout |
+| Max session size | 500 KB | Conversation size budget (triggers truncation) |
+
+These values come from the chat configuration and apply to both streaming and non-streaming requests.
+
+When the iteration limit is reached, the proxy injects a summary prompt and makes one final LLM call without tools to produce a closing response.
+
+### Repetition Detection
+
+If the LLM calls the same tool with identical arguments 3 or more times, the proxy injects a warning message asking it to try a different approach. This prevents infinite loops where the LLM repeatedly calls a failing tool.
+
+### Error Handling
+
+- **Tool execution errors**: Wrapped as JSON results (`{"success": false, "error": "..."}`) and fed back to the LLM, which can decide how to recover
+- **LLM errors**: If the LLM returns a context-too-long error, the proxy truncates the conversation to ~50% and retries once. Other LLM errors terminate the loop and return an Anthropic error response
+- **Timeout**: If the overall request timeout is reached, the proxy returns whatever progress has been made
+
+### Example: Claude Code with Server-Side Tools
+
+Configure Claude Code to use Orka as a custom provider:
+
+```json
+{
+  "apiUrl": "https://orka.example.com/anthropic/v1",
+  "apiKey": "<orka-service-account-token>"
+}
+```
+
+Claude Code sends requests normally. The proxy handles all tool execution server-side — Claude Code only sees the final text responses with streamed progress.
+
+## Architecture
+
+```
+┌──────────────┐     ┌──────────────────────────────┐     ┌──────────────────┐
+│  Claude Code │────▶│  Orka API Server             │────▶│  Anthropic API   │
+│  (or any     │     │  /anthropic/v1/messages       │     │  OpenAI API      │
+│  Anthropic   │◀────│                               │◀────│  Azure OpenAI    │
+│   client)    │     │  Provider resolution:         │     └──────────────────┘
+└──────────────┘     │  - Provider CRD lookup        │
+                     │  - Secret-based API keys      │
+                     │  - Model routing              │
+                     │  - Server-side tool execution  │
+                     └──────────────────────────────┘
+```
+
+Orka transparently proxies requests to the backend LLM provider. For simple requests, the client manages its own tool execution loop. When server-side tool execution is active, Orka intercepts tool calls, executes them, and returns only the final response — see [Server-Side Tool Execution](#server-side-tool-execution) above.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -91,10 +91,19 @@ See [Interactive Chat](chat.md) for full chat documentation.
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/v1/chat/completions` | POST | Chat completions (streaming & non-streaming) |
-| `/v1/models` | GET | List available models |
+| `/openai/v1/chat/completions` | POST | Chat completions (streaming & non-streaming) |
+| `/openai/v1/models` | GET | List available models |
 
 See [OpenAI Compatibility](openai-compat.md) for details.
+
+## Anthropic-Compatible API
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/anthropic/v1/messages` | POST | Create a message (streaming & non-streaming) |
+| `/anthropic/v1/models` | GET | List available models |
+
+See [Anthropic Compatibility](anthropic-compat.md) for details.
 
 ## Internal API (Worker Communication)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -210,5 +210,7 @@ The CLI supports token extraction from bearer tokens, token files, exec-based au
 - [Agent Runtimes](agent-runtimes.md) — Claude Code CLI and Copilot CLI configuration
 - [Interactive Chat](chat.md) — Chat endpoint with tool execution
 - [Multi-Agent Coordination](multi-agent-coordination.md) — Coordinator agents and delegation
+- [OpenAI Compatibility](openai-compat.md) — Use any OpenAI-compatible client via `/openai/v1/`
+- [Anthropic Compatibility](anthropic-compat.md) — Use Anthropic clients (Claude Code, etc.) via `/anthropic/v1/`
 - [API Reference](api-reference.md) — REST API endpoints
 - [Configuration](configuration.md) — Helm values, controller flags, and metrics

--- a/docs/openai-compat.md
+++ b/docs/openai-compat.md
@@ -1,15 +1,17 @@
 # OpenAI-Compatible API
 
-Orka exposes an **OpenAI-compatible API** at `/v1/chat/completions` and `/v1/models`, allowing any OpenAI-compatible client to use Orka as a provider. This includes tools like [Continue](https://continue.dev/), [Cursor](https://cursor.sh/), and others.
+Orka exposes an **OpenAI-compatible API** at `/openai/v1/chat/completions` and `/openai/v1/models`, allowing any OpenAI-compatible client to use Orka as a provider. This includes tools like [Continue](https://continue.dev/), [Cursor](https://cursor.sh/), and others.
 
 Orka acts as a **proxy** to whichever LLM provider is configured in your cluster (Anthropic, OpenAI, Azure OpenAI, etc.), with credentials managed securely via Kubernetes Secrets and Provider CRDs.
+
+> **Breaking change:** These endpoints moved from `/v1/` to `/openai/v1/` — update your client configurations accordingly. See also [Anthropic Compatibility](anthropic-compat.md) for the Anthropic-native proxy.
 
 ## Endpoints
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/v1/chat/completions` | Chat completions (streaming & non-streaming) |
-| `GET` | `/v1/models` | List available models from configured providers |
+| `POST` | `/openai/v1/chat/completions` | Chat completions (streaming & non-streaming) |
+| `GET` | `/openai/v1/models` | List available models from configured providers |
 
 Both endpoints require authentication via `Authorization: Bearer <token>` using a Kubernetes ServiceAccount token.
 
@@ -101,7 +103,7 @@ Configure Continue to use Orka as an OpenAI-compatible provider. Add to your Con
       "title": "Claude Sonnet 4 (via Orka)",
       "provider": "openai",
       "model": "anthropic/claude-sonnet-4-20250514",
-      "apiBase": "https://orka.example.com/v1",
+      "apiBase": "https://orka.example.com/openai/v1",
       "apiKey": "YOUR_ORKA_TOKEN"
     }
   ]
@@ -121,20 +123,7 @@ export ORKA_TOKEN=$(kubectl create token orka-client)
 ### Non-streaming
 
 ```bash
-curl -X POST https://orka.example.com/v1/chat/completions \
-  -H "Authorization: Bearer $ORKA_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "anthropic/claude-sonnet-4-20250514",
-    "messages": [{"role": "user", "content": "Hello!"}],
-    "max_tokens": 1024
-  }'
-```
-
-### Streaming
-
-```bash
-curl -X POST https://orka.example.com/v1/chat/completions \
+curl -X POST https://orka.example.com/openai/v1/chat/completions \
   -H "Authorization: Bearer $ORKA_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -148,7 +137,7 @@ curl -X POST https://orka.example.com/v1/chat/completions \
 ### List models
 
 ```bash
-curl https://orka.example.com/v1/models \
+curl https://orka.example.com/openai/v1/models \
   -H "Authorization: Bearer $ORKA_TOKEN"
 ```
 
@@ -174,7 +163,7 @@ curl https://orka.example.com/v1/models \
 ```
 ┌──────────────┐     ┌─────────────────────────┐     ┌──────────────────┐
 │  Continue    │────▶│  Orka API Server       │────▶│  Anthropic API   │
-│  (or any     │     │  /v1/chat/completions    │     │  OpenAI API      │
+│  (or any     │     │  /openai/v1/chat/completions│     │  OpenAI API      │
 │   OAI client)│◀────│                          │◀────│  Azure OpenAI    │
 └──────────────┘     │  Provider resolution:    │     └──────────────────┘
                      │  - Provider CRD lookup   │

--- a/internal/api/anthropic_compat.go
+++ b/internal/api/anthropic_compat.go
@@ -1,0 +1,601 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
+	"github.com/sozercan/orka/internal/llm"
+)
+
+var anthropicLog = logf.Log.WithName("anthropic-compat")
+
+// AnthropicCompatHandler implements Anthropic-compatible /v1/messages endpoints.
+// This allows Anthropic-compatible clients to use Orka as a custom provider.
+type AnthropicCompatHandler struct {
+	client                    client.Client
+	watchNamespace            string
+	enforceNamespaceIsolation bool
+	config                    ChatConfig
+}
+
+// NewAnthropicCompatHandler creates an Anthropic-compatible API handler.
+func NewAnthropicCompatHandler(c client.Client, watchNamespace string, enforceNamespaceIsolation bool, config ChatConfig) *AnthropicCompatHandler {
+	return &AnthropicCompatHandler{
+		client:                    c,
+		watchNamespace:            watchNamespace,
+		enforceNamespaceIsolation: enforceNamespaceIsolation,
+		config:                    config,
+	}
+}
+
+// AnthropicRequest represents an incoming Anthropic Messages API request.
+type AnthropicRequest struct {
+	Model         string             `json:"model"`
+	Messages      []AnthropicMessage `json:"messages"`
+	MaxTokens     int                `json:"max_tokens"`
+	System        json.RawMessage    `json:"system,omitempty"`
+	Stream        bool               `json:"stream,omitempty"`
+	Temperature   *float64           `json:"temperature,omitempty"`
+	TopP          *float64           `json:"top_p,omitempty"`
+	TopK          *int               `json:"top_k,omitempty"`
+	StopSequences []string           `json:"stop_sequences,omitempty"`
+	Tools         []AnthropicTool    `json:"tools,omitempty"`
+	ToolChoice    json.RawMessage    `json:"tool_choice,omitempty"`
+	Metadata      *AnthropicMetadata `json:"metadata,omitempty"`
+	Thinking      *AnthropicThinking `json:"thinking,omitempty"`
+}
+
+// AnthropicMessage is a single message in an Anthropic conversation.
+// Content is json.RawMessage because it can be a string or []ContentBlock.
+type AnthropicMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+// AnthropicContentBlock represents a typed content block in Anthropic messages.
+// The Type field determines which other fields are populated.
+type AnthropicContentBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty"`
+	Thinking  string          `json:"thinking,omitempty"`
+	Source    *ImageSource    `json:"source,omitempty"`
+}
+
+// ImageSource represents a base64-encoded image source in an Anthropic content block.
+type ImageSource struct {
+	Type      string `json:"type"`
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
+}
+
+// AnthropicTool defines a tool available for the model to call.
+type AnthropicTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// AnthropicThinking configures extended thinking.
+type AnthropicThinking struct {
+	Type         string `json:"type"`
+	BudgetTokens int    `json:"budget_tokens,omitempty"`
+}
+
+// AnthropicMetadata contains request metadata.
+type AnthropicMetadata struct {
+	UserID string `json:"user_id,omitempty"`
+}
+
+// AnthropicResponse is the non-streaming response from the Anthropic Messages API.
+type AnthropicResponse struct {
+	ID           string                  `json:"id"`
+	Type         string                  `json:"type"`
+	Role         string                  `json:"role"`
+	Content      []AnthropicContentBlock `json:"content"`
+	Model        string                  `json:"model"`
+	StopReason   *string                 `json:"stop_reason"`
+	StopSequence *string                 `json:"stop_sequence"`
+	Usage        AnthropicUsage          `json:"usage"`
+}
+
+// AnthropicUsage contains token usage statistics.
+type AnthropicUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+// AnthropicStreamEvent is a single SSE event in an Anthropic streaming response.
+type AnthropicStreamEvent struct {
+	Type         string                 `json:"type"`
+	Message      *AnthropicResponse     `json:"message,omitempty"`
+	Index        int                    `json:"index,omitempty"`
+	ContentBlock *AnthropicContentBlock `json:"content_block,omitempty"`
+	Delta        *AnthropicDelta        `json:"delta,omitempty"`
+	Usage        *AnthropicUsage        `json:"usage,omitempty"`
+}
+
+// AnthropicDelta carries incremental updates within a streaming event.
+type AnthropicDelta struct {
+	Type         string  `json:"type,omitempty"`
+	Text         string  `json:"text,omitempty"`
+	PartialJSON  string  `json:"partial_json,omitempty"`
+	Thinking     string  `json:"thinking,omitempty"`
+	StopReason   *string `json:"stop_reason,omitempty"`
+	StopSequence *string `json:"stop_sequence,omitempty"`
+}
+
+// AnthropicError is the standard error response format for the Anthropic API.
+type AnthropicError struct {
+	Type  string               `json:"type"`
+	Error AnthropicErrorDetail `json:"error"`
+}
+
+// AnthropicErrorDetail contains the error type and message.
+type AnthropicErrorDetail struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+// parseAnthropicContent handles both string and []ContentBlock formats for message content.
+func parseAnthropicContent(raw json.RawMessage) ([]AnthropicContentBlock, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	// Try string first
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return []AnthropicContentBlock{
+			{Type: "text", Text: s},
+		}, nil
+	}
+
+	// Try []ContentBlock
+	var blocks []AnthropicContentBlock
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return nil, fmt.Errorf("content must be a string or array of content blocks: %w", err)
+	}
+	return blocks, nil
+}
+
+// parseAnthropicSystem handles both string and []ContentBlock formats for the system field.
+func parseAnthropicSystem(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 {
+		return "", nil
+	}
+
+	// Try string first
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s, nil
+	}
+
+	// Try []ContentBlock and concatenate text blocks
+	var blocks []AnthropicContentBlock
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return "", fmt.Errorf("system must be a string or array of content blocks: %w", err)
+	}
+
+	var parts []string
+	for _, b := range blocks {
+		if b.Type == "text" && b.Text != "" {
+			parts = append(parts, b.Text)
+		}
+	}
+	return strings.Join(parts, "\n"), nil
+}
+
+// HandleMessages handles POST /anthropic/v1/messages.
+func (h *AnthropicCompatHandler) HandleMessages(c fiber.Ctx) error {
+	start := time.Now()
+
+	var req AnthropicRequest
+	if err := c.Bind().JSON(&req); err != nil {
+		return anthropicError(c, 400, "invalid_request_error", "invalid request body: "+err.Error())
+	}
+
+	if req.Model == "" {
+		return anthropicError(c, 400, "invalid_request_error", "model is required")
+	}
+	if len(req.Messages) == 0 {
+		return anthropicError(c, 400, "invalid_request_error", "messages is required and must be non-empty")
+	}
+	if req.MaxTokens <= 0 {
+		return anthropicError(c, 400, "invalid_request_error", "max_tokens is required and must be greater than 0")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), h.config.MaxDuration)
+	defer cancel()
+
+	namespace := GetEffectiveNamespace(c, "")
+	if h.watchNamespace != "" {
+		namespace = h.watchNamespace
+	}
+	if h.enforceNamespaceIsolation {
+		ui := GetUserInfo(c)
+		if ui != nil && ui.Namespace != "" && namespace != ui.Namespace {
+			return anthropicError(c, 403, "permission_error", fmt.Sprintf("namespace %q not allowed", namespace))
+		}
+	}
+
+	provider, model, err := h.resolveProviderFromModel(ctx, req.Model, namespace)
+	if err != nil {
+		anthropicLog.Error(err, "failed to resolve provider", "model", req.Model)
+		return anthropicError(c, 400, "invalid_request_error", "failed to resolve provider: "+err.Error())
+	}
+
+	messages, err := convertAnthropicMessages(req.Messages)
+	if err != nil {
+		return anthropicError(c, 400, "invalid_request_error", "failed to convert messages: "+err.Error())
+	}
+
+	tools := convertAnthropicTools(req.Tools)
+
+	systemPrompt, err := parseAnthropicSystem(req.System)
+	if err != nil {
+		return anthropicError(c, 400, "invalid_request_error", "failed to parse system prompt: "+err.Error())
+	}
+
+	compReq := &llm.CompletionRequest{
+		Model:         model,
+		Messages:      messages,
+		SystemPrompt:  systemPrompt,
+		MaxTokens:     req.MaxTokens,
+		Tools:         tools,
+		StopSequences: req.StopSequences,
+	}
+	if req.Temperature != nil {
+		compReq.Temperature = *req.Temperature
+	}
+
+	// Inject Orka's built-in tools and namespace Tool CRDs for server-side execution
+	h.injectOrkaTools(ctx, compReq, namespace)
+
+	if req.Stream {
+		return h.handleStreamingMessages(c, provider, compReq, model, 0)
+	}
+
+	// Run the agentic tool loop (executes tools server-side until final text response)
+	resp, err := h.runNonStreamingToolLoop(ctx, provider, compReq, model)
+	if err != nil {
+		anthropicLog.Error(err, "tool loop failed")
+		return anthropicError(c, 500, "api_error", "completion failed: "+err.Error())
+	}
+
+	user := ""
+	if ui := GetUserInfo(c); ui != nil {
+		user = ui.Username
+	}
+	anthropicLog.Info("messages completed",
+		"user", user,
+		"model", model,
+		"input_tokens", resp.InputTokens,
+		"output_tokens", resp.OutputTokens,
+		"stop_reason", resp.StopReason,
+		"duration", time.Since(start).String(),
+	)
+
+	result := convertToAnthropicResponse(resp, model)
+	return c.JSON(result)
+}
+
+// HandleListModels handles GET /anthropic/v1/models.
+func (h *AnthropicCompatHandler) HandleListModels(c fiber.Ctx) error {
+	ctx := c.Context()
+
+	namespace := GetEffectiveNamespace(c, "")
+	if h.watchNamespace != "" {
+		namespace = h.watchNamespace
+	}
+
+	providerList := &corev1alpha1.ProviderList{}
+	listOpts := []client.ListOption{}
+	if namespace != "" {
+		listOpts = append(listOpts, client.InNamespace(namespace))
+	}
+	if err := h.client.List(ctx, providerList, listOpts...); err != nil {
+		anthropicLog.Error(err, "failed to list providers")
+		return anthropicError(c, 500, "api_error", "failed to list providers")
+	}
+
+	now := time.Now().Unix()
+	models := []OAIModel{}
+	seen := make(map[string]bool)
+
+	for _, p := range providerList.Items {
+		if p.Spec.DefaultModel != "" {
+			modelID := fmt.Sprintf("%s/%s", p.Name, p.Spec.DefaultModel)
+			if !seen[modelID] {
+				models = append(models, OAIModel{
+					ID:      modelID,
+					Object:  "model",
+					Created: now,
+					OwnedBy: string(p.Spec.Type),
+				})
+				seen[modelID] = true
+			}
+			if !seen[p.Spec.DefaultModel] {
+				models = append(models, OAIModel{
+					ID:      p.Spec.DefaultModel,
+					Object:  "model",
+					Created: now,
+					OwnedBy: string(p.Spec.Type),
+				})
+				seen[p.Spec.DefaultModel] = true
+			}
+		}
+	}
+
+	return c.JSON(OAIModelList{
+		Object: "list",
+		Data:   models,
+	})
+}
+
+// resolveProviderFromModel resolves the LLM provider from the model string.
+// Supports "provider-name/model-name" format or plain "model-name" (uses default provider).
+func (h *AnthropicCompatHandler) resolveProviderFromModel(ctx context.Context, modelStr, namespace string) (llm.Provider, string, error) {
+	var providerName, model string
+
+	if idx := strings.Index(modelStr, "/"); idx > 0 {
+		providerName = modelStr[:idx]
+		model = modelStr[idx+1:]
+	} else {
+		model = modelStr
+	}
+
+	var providerCRD *corev1alpha1.Provider
+
+	if providerName != "" {
+		p := &corev1alpha1.Provider{}
+		if err := h.client.Get(ctx, types.NamespacedName{Name: providerName, Namespace: namespace}, p); err == nil {
+			providerCRD = p
+		}
+	}
+
+	if providerCRD == nil && h.config.Provider != "" {
+		p := &corev1alpha1.Provider{}
+		if err := h.client.Get(ctx, types.NamespacedName{Name: h.config.Provider, Namespace: namespace}, p); err == nil {
+			providerCRD = p
+		}
+	}
+
+	if providerCRD == nil {
+		p := &corev1alpha1.Provider{}
+		if err := h.client.Get(ctx, types.NamespacedName{Name: "default", Namespace: namespace}, p); err != nil {
+			return nil, "", fmt.Errorf("no provider %q found and no 'default' Provider CRD exists", providerName)
+		}
+		providerCRD = p
+	}
+
+	secretName := providerCRD.Spec.SecretRef.Name
+	secretKey := providerCRD.Spec.SecretRef.Key
+	if secretKey == "" {
+		secretKey = "api-key"
+	}
+
+	secret := &corev1.Secret{}
+	if err := h.client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: providerCRD.Namespace}, secret); err != nil {
+		return nil, "", fmt.Errorf("failed to get provider secret %q: %w", secretName, err)
+	}
+	apiKeyBytes, ok := secret.Data[secretKey]
+	if !ok {
+		return nil, "", fmt.Errorf("secret %q has no key %q", secretName, secretKey)
+	}
+
+	if model == "" {
+		model = providerCRD.Spec.DefaultModel
+	}
+	if model == "" {
+		model = h.config.Model
+	}
+	if model == "" {
+		return nil, "", fmt.Errorf("no model specified and no default model configured")
+	}
+
+	providerConfig := llm.ProviderConfig{
+		APIKey:       string(apiKeyBytes),
+		BaseURL:      providerCRD.Spec.BaseURL,
+		ProviderType: string(providerCRD.Spec.Type),
+	}
+	if providerCRD.Spec.Azure != nil {
+		providerConfig.AzureAPIVersion = providerCRD.Spec.Azure.APIVersion
+	}
+
+	p, err := llm.NewProvider(string(providerCRD.Spec.Type), providerConfig)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create LLM provider: %w", err)
+	}
+
+	return p, model, nil
+}
+
+// convertAnthropicMessages converts Anthropic messages to internal llm.Message format.
+func convertAnthropicMessages(msgs []AnthropicMessage) ([]llm.Message, error) {
+	var messages []llm.Message
+
+	for _, m := range msgs {
+		blocks, err := parseAnthropicContent(m.Content)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse content for role %q: %w", m.Role, err)
+		}
+
+		switch m.Role {
+		case "user":
+			// Separate tool_result blocks from other content
+			var textParts []string
+			for _, b := range blocks {
+				switch b.Type {
+				case "tool_result":
+					resultContent := ""
+					if b.Content != nil {
+						// tool_result content can be string or []ContentBlock
+						var s string
+						if json.Unmarshal(b.Content, &s) == nil {
+							resultContent = s
+						} else {
+							var innerBlocks []AnthropicContentBlock
+							if json.Unmarshal(b.Content, &innerBlocks) == nil {
+								var parts []string
+								for _, ib := range innerBlocks {
+									if ib.Type == "text" {
+										parts = append(parts, ib.Text)
+									}
+								}
+								resultContent = strings.Join(parts, "\n")
+							}
+						}
+					}
+					messages = append(messages, llm.Message{
+						Role:       "tool",
+						ToolCallID: b.ToolUseID,
+						Content:    resultContent,
+					})
+				case "text":
+					textParts = append(textParts, b.Text)
+				}
+			}
+			if len(textParts) > 0 {
+				messages = append(messages, llm.Message{
+					Role:    "user",
+					Content: strings.Join(textParts, "\n"),
+				})
+			}
+
+		case "assistant":
+			msg := llm.Message{Role: "assistant"}
+			var textParts []string
+			for _, b := range blocks {
+				switch b.Type {
+				case "text":
+					textParts = append(textParts, b.Text)
+				case "tool_use":
+					msg.ToolCalls = append(msg.ToolCalls, llm.ToolCall{
+						ID:        b.ID,
+						Name:      b.Name,
+						Arguments: b.Input,
+					})
+				}
+			}
+			if len(textParts) > 0 {
+				msg.Content = strings.Join(textParts, "\n")
+			}
+			messages = append(messages, msg)
+
+		default:
+			// Pass through unknown roles
+			var textParts []string
+			for _, b := range blocks {
+				if b.Type == "text" {
+					textParts = append(textParts, b.Text)
+				}
+			}
+			messages = append(messages, llm.Message{
+				Role:    m.Role,
+				Content: strings.Join(textParts, "\n"),
+			})
+		}
+	}
+
+	return messages, nil
+}
+
+// convertAnthropicTools converts Anthropic tool definitions to internal llm.Tool format.
+func convertAnthropicTools(tools []AnthropicTool) []llm.Tool {
+	if len(tools) == 0 {
+		return nil
+	}
+
+	result := make([]llm.Tool, 0, len(tools))
+	for _, t := range tools {
+		result = append(result, llm.Tool{
+			Name:        t.Name,
+			Description: t.Description,
+			Parameters:  t.InputSchema,
+		})
+	}
+	return result
+}
+
+// convertToAnthropicResponse converts an internal CompletionResponse to Anthropic format.
+func convertToAnthropicResponse(resp *llm.CompletionResponse, model string) AnthropicResponse {
+	id := "msg_" + uuid.New().String()
+
+	var content []AnthropicContentBlock
+	if resp.Content != "" {
+		content = append(content, AnthropicContentBlock{
+			Type: "text",
+			Text: resp.Content,
+		})
+	}
+	for _, tc := range resp.ToolCalls {
+		content = append(content, AnthropicContentBlock{
+			Type:  "tool_use",
+			ID:    tc.ID,
+			Name:  tc.Name,
+			Input: tc.Arguments,
+		})
+	}
+
+	stopReason := mapAnthropicStopReason(resp.StopReason)
+
+	return AnthropicResponse{
+		ID:         id,
+		Type:       "message",
+		Role:       "assistant",
+		Content:    content,
+		Model:      model,
+		StopReason: &stopReason,
+		Usage: AnthropicUsage{
+			InputTokens:  resp.InputTokens,
+			OutputTokens: resp.OutputTokens,
+		},
+	}
+}
+
+// mapAnthropicStopReason maps internal stop reasons to Anthropic stop_reason values.
+func mapAnthropicStopReason(reason string) string {
+	switch strings.ToLower(reason) {
+	case "stop", "end_turn", "":
+		return "end_turn"
+	case "tool_calls", "tool_use":
+		return "tool_use"
+	case "max_tokens", "length":
+		return "max_tokens"
+	default:
+		return "end_turn"
+	}
+}
+
+// anthropicError returns an error in Anthropic API format.
+func anthropicError(c fiber.Ctx, status int, errType, message string) error {
+	return c.Status(status).JSON(AnthropicError{
+		Type: "error",
+		Error: AnthropicErrorDetail{
+			Type:    errType,
+			Message: message,
+		},
+	})
+}

--- a/internal/api/anthropic_compat_test.go
+++ b/internal/api/anthropic_compat_test.go
@@ -1,0 +1,1218 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
+	"github.com/sozercan/orka/internal/llm"
+
+	_ "github.com/sozercan/orka/internal/llm/anthropic"
+	_ "github.com/sozercan/orka/internal/llm/openai"
+)
+
+func setupTestAnthropicHandler(objs ...runtime.Object) (*AnthropicCompatHandler, *fiber.App) {
+	scheme := runtime.NewScheme()
+	_ = corev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+	handler := NewAnthropicCompatHandler(fakeClient, "default", false, DefaultChatConfig())
+
+	app := fiber.New()
+	return handler, app
+}
+
+// --- Tests: parseAnthropicContent ---
+
+func TestParseAnthropicContent(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       json.RawMessage
+		wantLen   int
+		wantFirst string
+		wantErr   bool
+	}{
+		{
+			name:      "string content",
+			raw:       json.RawMessage(`"hello world"`),
+			wantLen:   1,
+			wantFirst: "hello world",
+		},
+		{
+			name:    "array of content blocks",
+			raw:     json.RawMessage(`[{"type":"text","text":"first"},{"type":"text","text":"second"}]`),
+			wantLen: 2,
+		},
+		{
+			name:    "empty content",
+			raw:     nil,
+			wantLen: 0,
+		},
+		{
+			name:    "empty raw message",
+			raw:     json.RawMessage(``),
+			wantLen: 0,
+		},
+		{
+			name:    "invalid JSON",
+			raw:     json.RawMessage(`{not valid`),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blocks, err := parseAnthropicContent(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(blocks) != tt.wantLen {
+				t.Fatalf("expected %d blocks, got %d", tt.wantLen, len(blocks))
+			}
+			if tt.wantFirst != "" && len(blocks) > 0 {
+				if blocks[0].Text != tt.wantFirst {
+					t.Errorf("expected first block text %q, got %q", tt.wantFirst, blocks[0].Text)
+				}
+				if blocks[0].Type != "text" {
+					t.Errorf("expected first block type 'text', got %q", blocks[0].Type)
+				}
+			}
+		})
+	}
+}
+
+func TestParseAnthropicContent_ArrayDetails(t *testing.T) {
+	raw := json.RawMessage(`[{"type":"text","text":"hello"},{"type":"tool_use","id":"tu_1","name":"search","input":{"q":"test"}}]`)
+	blocks, err := parseAnthropicContent(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(blocks))
+	}
+	if blocks[0].Type != "text" || blocks[0].Text != "hello" {
+		t.Errorf("block 0: type=%q text=%q", blocks[0].Type, blocks[0].Text)
+	}
+	if blocks[1].Type != "tool_use" || blocks[1].ID != "tu_1" || blocks[1].Name != "search" {
+		t.Errorf("block 1: type=%q id=%q name=%q", blocks[1].Type, blocks[1].ID, blocks[1].Name)
+	}
+}
+
+// --- Tests: parseAnthropicSystem ---
+
+func TestParseAnthropicSystem(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     json.RawMessage
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "string system",
+			raw:  json.RawMessage(`"You are a helpful assistant."`),
+			want: "You are a helpful assistant.",
+		},
+		{
+			name: "array of text blocks",
+			raw:  json.RawMessage(`[{"type":"text","text":"First instruction."},{"type":"text","text":"Second instruction."}]`),
+			want: "First instruction.\nSecond instruction.",
+		},
+		{
+			name: "empty",
+			raw:  nil,
+			want: "",
+		},
+		{
+			name: "empty raw message",
+			raw:  json.RawMessage(``),
+			want: "",
+		},
+		{
+			name: "single text block array",
+			raw:  json.RawMessage(`[{"type":"text","text":"Only one."}]`),
+			want: "Only one.",
+		},
+		{
+			name:    "invalid JSON",
+			raw:     json.RawMessage(`{invalid`),
+			wantErr: true,
+		},
+		{
+			name: "array with non-text blocks ignored",
+			raw:  json.RawMessage(`[{"type":"image","text":"ignored"},{"type":"text","text":"kept"}]`),
+			want: "kept",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAnthropicSystem(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+// --- Tests: convertAnthropicMessages ---
+
+func TestConvertAnthropicMessages(t *testing.T) {
+	tests := []struct {
+		name     string
+		messages []AnthropicMessage
+		wantLen  int
+		check    func(t *testing.T, msgs []llm.Message)
+	}{
+		{
+			name: "user text message",
+			messages: []AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"Hello!"`)},
+			},
+			wantLen: 1,
+			check: func(t *testing.T, msgs []llm.Message) {
+				if msgs[0].Role != "user" {
+					t.Errorf("role = %q, want user", msgs[0].Role)
+				}
+				if msgs[0].Content != "Hello!" {
+					t.Errorf("content = %q, want Hello!", msgs[0].Content)
+				}
+			},
+		},
+		{
+			name: "user with tool_result blocks",
+			messages: []AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`[{"type":"tool_result","tool_use_id":"tu_1","content":"result text"}]`)},
+			},
+			wantLen: 1,
+			check: func(t *testing.T, msgs []llm.Message) {
+				if msgs[0].Role != "tool" {
+					t.Errorf("role = %q, want tool", msgs[0].Role)
+				}
+				if msgs[0].ToolCallID != "tu_1" {
+					t.Errorf("tool_call_id = %q, want tu_1", msgs[0].ToolCallID)
+				}
+				if msgs[0].Content != "result text" {
+					t.Errorf("content = %q, want 'result text'", msgs[0].Content)
+				}
+			},
+		},
+		{
+			name: "user with tool_result with nested content blocks",
+			messages: []AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`[{"type":"tool_result","tool_use_id":"tu_2","content":[{"type":"text","text":"line1"},{"type":"text","text":"line2"}]}]`)},
+			},
+			wantLen: 1,
+			check: func(t *testing.T, msgs []llm.Message) {
+				if msgs[0].Role != "tool" {
+					t.Errorf("role = %q, want tool", msgs[0].Role)
+				}
+				if msgs[0].Content != "line1\nline2" {
+					t.Errorf("content = %q, want 'line1\\nline2'", msgs[0].Content)
+				}
+			},
+		},
+		{
+			name: "assistant with text blocks",
+			messages: []AnthropicMessage{
+				{Role: "assistant", Content: json.RawMessage(`[{"type":"text","text":"I can help."}]`)},
+			},
+			wantLen: 1,
+			check: func(t *testing.T, msgs []llm.Message) {
+				if msgs[0].Role != "assistant" {
+					t.Errorf("role = %q, want assistant", msgs[0].Role)
+				}
+				if msgs[0].Content != "I can help." {
+					t.Errorf("content = %q, want 'I can help.'", msgs[0].Content)
+				}
+			},
+		},
+		{
+			name: "assistant with tool_use blocks",
+			messages: []AnthropicMessage{
+				{Role: "assistant", Content: json.RawMessage(`[{"type":"tool_use","id":"tu_1","name":"search","input":{"q":"test"}}]`)},
+			},
+			wantLen: 1,
+			check: func(t *testing.T, msgs []llm.Message) {
+				if msgs[0].Role != "assistant" {
+					t.Errorf("role = %q, want assistant", msgs[0].Role)
+				}
+				if len(msgs[0].ToolCalls) != 1 {
+					t.Fatalf("expected 1 tool call, got %d", len(msgs[0].ToolCalls))
+				}
+				if msgs[0].ToolCalls[0].ID != "tu_1" {
+					t.Errorf("tool call ID = %q, want tu_1", msgs[0].ToolCalls[0].ID)
+				}
+				if msgs[0].ToolCalls[0].Name != "search" {
+					t.Errorf("tool call name = %q, want search", msgs[0].ToolCalls[0].Name)
+				}
+			},
+		},
+		{
+			name: "mixed assistant message text and tool_use",
+			messages: []AnthropicMessage{
+				{Role: "assistant", Content: json.RawMessage(`[{"type":"text","text":"Let me search."},{"type":"tool_use","id":"tu_1","name":"search","input":{"q":"test"}}]`)},
+			},
+			wantLen: 1,
+			check: func(t *testing.T, msgs []llm.Message) {
+				if msgs[0].Content != "Let me search." {
+					t.Errorf("content = %q, want 'Let me search.'", msgs[0].Content)
+				}
+				if len(msgs[0].ToolCalls) != 1 {
+					t.Fatalf("expected 1 tool call, got %d", len(msgs[0].ToolCalls))
+				}
+				if msgs[0].ToolCalls[0].Name != "search" {
+					t.Errorf("tool call name = %q", msgs[0].ToolCalls[0].Name)
+				}
+			},
+		},
+		{
+			name: "multiple messages in conversation",
+			messages: []AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"Hello"`)},
+				{Role: "assistant", Content: json.RawMessage(`"Hi there!"`)},
+				{Role: "user", Content: json.RawMessage(`"How are you?"`)},
+			},
+			wantLen: 3,
+			check: func(t *testing.T, msgs []llm.Message) {
+				if msgs[0].Role != "user" || msgs[0].Content != "Hello" {
+					t.Errorf("msg 0: role=%q content=%q", msgs[0].Role, msgs[0].Content)
+				}
+				if msgs[1].Role != "assistant" || msgs[1].Content != "Hi there!" {
+					t.Errorf("msg 1: role=%q content=%q", msgs[1].Role, msgs[1].Content)
+				}
+				if msgs[2].Role != "user" || msgs[2].Content != "How are you?" {
+					t.Errorf("msg 2: role=%q content=%q", msgs[2].Role, msgs[2].Content)
+				}
+			},
+		},
+		{
+			name: "user with mixed text and tool_result",
+			messages: []AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`[{"type":"text","text":"Here is context."},{"type":"tool_result","tool_use_id":"tu_1","content":"tool output"}]`)},
+			},
+			wantLen: 2,
+			check: func(t *testing.T, msgs []llm.Message) {
+				// tool_result messages come first, then text
+				toolMsg := msgs[0]
+				textMsg := msgs[1]
+				if toolMsg.Role != "tool" || toolMsg.ToolCallID != "tu_1" {
+					t.Errorf("tool msg: role=%q id=%q", toolMsg.Role, toolMsg.ToolCallID)
+				}
+				if textMsg.Role != "user" || textMsg.Content != "Here is context." {
+					t.Errorf("text msg: role=%q content=%q", textMsg.Role, textMsg.Content)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msgs, err := convertAnthropicMessages(tt.messages)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(msgs) != tt.wantLen {
+				t.Fatalf("expected %d messages, got %d", tt.wantLen, len(msgs))
+			}
+			if tt.check != nil {
+				tt.check(t, msgs)
+			}
+		})
+	}
+}
+
+func TestConvertAnthropicMessages_InvalidContent(t *testing.T) {
+	msgs := []AnthropicMessage{
+		{Role: "user", Content: json.RawMessage(`{invalid}`)},
+	}
+	_, err := convertAnthropicMessages(msgs)
+	if err == nil {
+		t.Fatal("expected error for invalid content")
+	}
+}
+
+// --- Tests: convertAnthropicTools ---
+
+func TestConvertAnthropicTools(t *testing.T) {
+	tests := []struct {
+		name    string
+		tools   []AnthropicTool
+		wantLen int
+	}{
+		{
+			name: "single tool with input_schema",
+			tools: []AnthropicTool{
+				{
+					Name:        "get_weather",
+					Description: "Get weather info",
+					InputSchema: json.RawMessage(`{"type":"object","properties":{"location":{"type":"string"}}}`),
+				},
+			},
+			wantLen: 1,
+		},
+		{
+			name: "multiple tools",
+			tools: []AnthropicTool{
+				{Name: "tool_a", Description: "First tool", InputSchema: json.RawMessage(`{"type":"object"}`)},
+				{Name: "tool_b", Description: "Second tool", InputSchema: json.RawMessage(`{"type":"object"}`)},
+			},
+			wantLen: 2,
+		},
+		{
+			name:    "empty tools",
+			tools:   nil,
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertAnthropicTools(tt.tools)
+			if tt.wantLen == 0 {
+				if result != nil {
+					t.Errorf("expected nil, got %v", result)
+				}
+				return
+			}
+			if len(result) != tt.wantLen {
+				t.Fatalf("expected %d tools, got %d", tt.wantLen, len(result))
+			}
+		})
+	}
+}
+
+func TestConvertAnthropicTools_FieldMapping(t *testing.T) {
+	tools := []AnthropicTool{
+		{
+			Name:        "search",
+			Description: "Search the web",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}`),
+		},
+	}
+	result := convertAnthropicTools(tools)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(result))
+	}
+	if result[0].Name != "search" {
+		t.Errorf("name = %q, want search", result[0].Name)
+	}
+	if result[0].Description != "Search the web" {
+		t.Errorf("description = %q", result[0].Description)
+	}
+	if string(result[0].Parameters) != string(tools[0].InputSchema) {
+		t.Errorf("parameters = %s, want %s", result[0].Parameters, tools[0].InputSchema)
+	}
+}
+
+// --- Tests: convertToAnthropicResponse ---
+
+func TestConvertToAnthropicResponse(t *testing.T) {
+	tests := []struct {
+		name             string
+		resp             *llm.CompletionResponse
+		model            string
+		wantContentLen   int
+		wantStopReason   string
+		wantInputTokens  int
+		wantOutputTokens int
+		checkContent     func(t *testing.T, content []AnthropicContentBlock)
+	}{
+		{
+			name: "text-only response",
+			resp: &llm.CompletionResponse{
+				Content:      "Hello!",
+				StopReason:   "stop",
+				InputTokens:  10,
+				OutputTokens: 5,
+			},
+			model:            "claude-sonnet-4-20250514",
+			wantContentLen:   1,
+			wantStopReason:   "end_turn",
+			wantInputTokens:  10,
+			wantOutputTokens: 5,
+			checkContent: func(t *testing.T, content []AnthropicContentBlock) {
+				if content[0].Type != "text" {
+					t.Errorf("type = %q, want text", content[0].Type)
+				}
+				if content[0].Text != "Hello!" {
+					t.Errorf("text = %q, want Hello!", content[0].Text)
+				}
+			},
+		},
+		{
+			name: "tool calls response",
+			resp: &llm.CompletionResponse{
+				StopReason: "tool_calls",
+				ToolCalls: []llm.ToolCall{
+					{ID: "tu_1", Name: "search", Arguments: json.RawMessage(`{"q":"test"}`)},
+				},
+			},
+			model:          "claude-sonnet-4-20250514",
+			wantContentLen: 1,
+			wantStopReason: "tool_use",
+			checkContent: func(t *testing.T, content []AnthropicContentBlock) {
+				if content[0].Type != "tool_use" {
+					t.Errorf("type = %q, want tool_use", content[0].Type)
+				}
+				if content[0].ID != "tu_1" {
+					t.Errorf("id = %q, want tu_1", content[0].ID)
+				}
+				if content[0].Name != "search" {
+					t.Errorf("name = %q, want search", content[0].Name)
+				}
+			},
+		},
+		{
+			name: "mixed text and tool calls",
+			resp: &llm.CompletionResponse{
+				Content:    "Let me search.",
+				StopReason: "tool_use",
+				ToolCalls: []llm.ToolCall{
+					{ID: "tu_1", Name: "search", Arguments: json.RawMessage(`{"q":"test"}`)},
+				},
+			},
+			model:          "claude-sonnet-4-20250514",
+			wantContentLen: 2,
+			wantStopReason: "tool_use",
+			checkContent: func(t *testing.T, content []AnthropicContentBlock) {
+				if content[0].Type != "text" || content[0].Text != "Let me search." {
+					t.Errorf("block 0: type=%q text=%q", content[0].Type, content[0].Text)
+				}
+				if content[1].Type != "tool_use" || content[1].Name != "search" {
+					t.Errorf("block 1: type=%q name=%q", content[1].Type, content[1].Name)
+				}
+			},
+		},
+		{
+			name: "stop reason mapping - max_tokens",
+			resp: &llm.CompletionResponse{
+				Content:    "Truncated...",
+				StopReason: "max_tokens",
+			},
+			model:          "claude-sonnet-4-20250514",
+			wantContentLen: 1,
+			wantStopReason: "max_tokens",
+		},
+		{
+			name: "empty content with no tool calls",
+			resp: &llm.CompletionResponse{
+				StopReason: "stop",
+			},
+			model:          "claude-sonnet-4-20250514",
+			wantContentLen: 0,
+			wantStopReason: "end_turn",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertToAnthropicResponse(tt.resp, tt.model)
+
+			if result.Type != "message" {
+				t.Errorf("type = %q, want message", result.Type)
+			}
+			if result.Role != "assistant" {
+				t.Errorf("role = %q, want assistant", result.Role)
+			}
+			if result.Model != tt.model {
+				t.Errorf("model = %q, want %q", result.Model, tt.model)
+			}
+			if !strings.HasPrefix(result.ID, "msg_") {
+				t.Errorf("ID = %q, expected msg_ prefix", result.ID)
+			}
+			if len(result.Content) != tt.wantContentLen {
+				t.Fatalf("content len = %d, want %d", len(result.Content), tt.wantContentLen)
+			}
+			if result.StopReason == nil {
+				t.Fatal("stop_reason is nil")
+			}
+			if *result.StopReason != tt.wantStopReason {
+				t.Errorf("stop_reason = %q, want %q", *result.StopReason, tt.wantStopReason)
+			}
+			if tt.wantInputTokens > 0 && result.Usage.InputTokens != tt.wantInputTokens {
+				t.Errorf("input_tokens = %d, want %d", result.Usage.InputTokens, tt.wantInputTokens)
+			}
+			if tt.wantOutputTokens > 0 && result.Usage.OutputTokens != tt.wantOutputTokens {
+				t.Errorf("output_tokens = %d, want %d", result.Usage.OutputTokens, tt.wantOutputTokens)
+			}
+			if tt.checkContent != nil {
+				tt.checkContent(t, result.Content)
+			}
+		})
+	}
+}
+
+// --- Tests: mapAnthropicStopReason ---
+
+func TestMapAnthropicStopReason(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"stop", "end_turn"},
+		{"end_turn", "end_turn"},
+		{"", "end_turn"},
+		{"tool_calls", "tool_use"},
+		{"tool_use", "tool_use"},
+		{"max_tokens", "max_tokens"},
+		{"length", "max_tokens"},
+		{"unknown_reason", "end_turn"},
+		{"STOP", "end_turn"},       // case insensitive
+		{"Tool_Calls", "tool_use"}, // case insensitive
+		{"MAX_TOKENS", "max_tokens"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := mapAnthropicStopReason(tt.input)
+			if got != tt.want {
+				t.Errorf("mapAnthropicStopReason(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Tests: anthropicError ---
+
+func TestAnthropicError(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		errType    string
+		message    string
+		wantStatus int
+	}{
+		{
+			name:       "400 invalid request",
+			status:     400,
+			errType:    "invalid_request_error",
+			message:    "model is required",
+			wantStatus: 400,
+		},
+		{
+			name:       "500 api error",
+			status:     500,
+			errType:    "api_error",
+			message:    "completion failed",
+			wantStatus: 500,
+		},
+		{
+			name:       "403 permission error",
+			status:     403,
+			errType:    "permission_error",
+			message:    "namespace not allowed",
+			wantStatus: 403,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := fiber.New()
+			app.Get("/test", func(c fiber.Ctx) error {
+				return anthropicError(c, tt.status, tt.errType, tt.message)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if resp.StatusCode != tt.wantStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+
+			var errResp AnthropicError
+			if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if errResp.Type != "error" {
+				t.Errorf("type = %q, want 'error'", errResp.Type)
+			}
+			if errResp.Error.Type != tt.errType {
+				t.Errorf("error.type = %q, want %q", errResp.Error.Type, tt.errType)
+			}
+			if errResp.Error.Message != tt.message {
+				t.Errorf("error.message = %q, want %q", errResp.Error.Message, tt.message)
+			}
+		})
+	}
+}
+
+// --- Tests: HandleMessages validation ---
+
+func TestHandleMessages_MissingModel(t *testing.T) {
+	handler, app := setupTestAnthropicHandler()
+	app.Post("/anthropic/v1/messages", handler.HandleMessages)
+
+	body := `{"messages":[{"role":"user","content":"hello"}],"max_tokens":100}`
+	req := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 400 {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+
+	var errResp AnthropicError
+	json.NewDecoder(resp.Body).Decode(&errResp) //nolint:errcheck
+	if errResp.Error.Type != "invalid_request_error" {
+		t.Errorf("error type = %q", errResp.Error.Type)
+	}
+	if !strings.Contains(errResp.Error.Message, "model") {
+		t.Errorf("error message = %q, expected mention of model", errResp.Error.Message)
+	}
+}
+
+func TestHandleMessages_EmptyMessages(t *testing.T) {
+	handler, app := setupTestAnthropicHandler()
+	app.Post("/anthropic/v1/messages", handler.HandleMessages)
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[],"max_tokens":100}`
+	req := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 400 {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+
+	var errResp AnthropicError
+	json.NewDecoder(resp.Body).Decode(&errResp) //nolint:errcheck
+	if !strings.Contains(errResp.Error.Message, "messages") {
+		t.Errorf("error message = %q, expected mention of messages", errResp.Error.Message)
+	}
+}
+
+func TestHandleMessages_MissingMaxTokens(t *testing.T) {
+	handler, app := setupTestAnthropicHandler()
+	app.Post("/anthropic/v1/messages", handler.HandleMessages)
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hello"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 400 {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+
+	var errResp AnthropicError
+	json.NewDecoder(resp.Body).Decode(&errResp) //nolint:errcheck
+	if !strings.Contains(errResp.Error.Message, "max_tokens") {
+		t.Errorf("error message = %q, expected mention of max_tokens", errResp.Error.Message)
+	}
+}
+
+func TestHandleMessages_InvalidBody(t *testing.T) {
+	handler, app := setupTestAnthropicHandler()
+	app.Post("/anthropic/v1/messages", handler.HandleMessages)
+
+	req := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 400 {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleMessages_NoProvider(t *testing.T) {
+	handler, app := setupTestAnthropicHandler()
+	app.Post("/anthropic/v1/messages", handler.HandleMessages)
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hello"}],"max_tokens":100}`
+	req := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 400 {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+
+	var errResp AnthropicError
+	json.NewDecoder(resp.Body).Decode(&errResp) //nolint:errcheck
+	if !strings.Contains(errResp.Error.Message, "provider") {
+		t.Errorf("error message = %q, expected mention of provider", errResp.Error.Message)
+	}
+}
+
+func TestHandleMessages_ProviderSlashModel(t *testing.T) {
+	mockAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"authentication_error","message":"invalid key"}}`))
+	}))
+	defer mockAPI.Close()
+
+	provider := &corev1alpha1.Provider{
+		ObjectMeta: metav1.ObjectMeta{Name: "anthropic", Namespace: "default"},
+		Spec: corev1alpha1.ProviderSpec{
+			Type:         corev1alpha1.ProviderTypeAnthropic,
+			DefaultModel: "claude-sonnet-4-20250514",
+			BaseURL:      mockAPI.URL,
+			SecretRef:    corev1alpha1.ProviderSecretRef{Name: "anthropic-secret", Key: "api-key"},
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "anthropic-secret", Namespace: "default"},
+		Data:       map[string][]byte{"api-key": []byte("test-key")},
+	}
+
+	handler, app := setupTestAnthropicHandler(provider, secret)
+	app.Post("/anthropic/v1/messages", handler.HandleMessages)
+
+	body := `{"model":"anthropic/claude-sonnet-4-20250514","messages":[{"role":"user","content":"hello"}],"max_tokens":100}`
+	req := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should get past provider resolution (not 400)
+	if resp.StatusCode == 400 {
+		t.Errorf("did not expect 400; provider/model resolution should have succeeded")
+	}
+}
+
+// --- Tests: HandleListModels ---
+
+func TestAnthropicHandleListModels_Empty(t *testing.T) {
+	handler, app := setupTestAnthropicHandler()
+	app.Get("/anthropic/v1/models", handler.HandleListModels)
+
+	req := httptest.NewRequest(http.MethodGet, "/anthropic/v1/models", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var modelList OAIModelList
+	json.NewDecoder(resp.Body).Decode(&modelList) //nolint:errcheck
+	if modelList.Object != "list" {
+		t.Errorf("object = %q, want list", modelList.Object)
+	}
+	if len(modelList.Data) != 0 {
+		t.Errorf("expected 0 models, got %d", len(modelList.Data))
+	}
+}
+
+func TestAnthropicHandleListModels_WithProviders(t *testing.T) {
+	provider := &corev1alpha1.Provider{
+		ObjectMeta: metav1.ObjectMeta{Name: "anthropic", Namespace: "default"},
+		Spec: corev1alpha1.ProviderSpec{
+			Type:         corev1alpha1.ProviderTypeAnthropic,
+			DefaultModel: "claude-sonnet-4-20250514",
+			SecretRef:    corev1alpha1.ProviderSecretRef{Name: "secret"},
+		},
+	}
+
+	handler, app := setupTestAnthropicHandler(provider)
+	app.Get("/anthropic/v1/models", handler.HandleListModels)
+
+	req := httptest.NewRequest(http.MethodGet, "/anthropic/v1/models", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var modelList OAIModelList
+	json.NewDecoder(resp.Body).Decode(&modelList) //nolint:errcheck
+	if len(modelList.Data) != 2 {
+		t.Fatalf("expected 2 models (prefixed and plain), got %d", len(modelList.Data))
+	}
+
+	ids := map[string]bool{}
+	for _, m := range modelList.Data {
+		ids[m.ID] = true
+	}
+	if !ids["anthropic/claude-sonnet-4-20250514"] {
+		t.Error("expected model 'anthropic/claude-sonnet-4-20250514' not found")
+	}
+	if !ids["claude-sonnet-4-20250514"] {
+		t.Error("expected model 'claude-sonnet-4-20250514' not found")
+	}
+}
+
+// --- Mock provider for tool loop tests ---
+
+type mockAnthropicProvider struct {
+	responses []*llm.CompletionResponse
+	errors    []error
+	callIdx   int
+}
+
+func (m *mockAnthropicProvider) Complete(_ context.Context, _ *llm.CompletionRequest) (*llm.CompletionResponse, error) {
+	if m.callIdx >= len(m.responses) {
+		return nil, fmt.Errorf("unexpected call %d", m.callIdx)
+	}
+	idx := m.callIdx
+	m.callIdx++
+	if m.errors != nil && idx < len(m.errors) && m.errors[idx] != nil {
+		return nil, m.errors[idx]
+	}
+	return m.responses[idx], nil
+}
+
+func (m *mockAnthropicProvider) Stream(_ context.Context, _ *llm.CompletionRequest) (<-chan llm.StreamChunk, error) {
+	return nil, fmt.Errorf("streaming not supported by mock")
+}
+
+func (m *mockAnthropicProvider) Name() string {
+	return "mock-anthropic"
+}
+
+// --- Tests: injectOrkaTools ---
+
+func TestInjectOrkaTools_BuiltinTools(t *testing.T) {
+	handler, _ := setupTestAnthropicHandler()
+	req := &llm.CompletionRequest{}
+	handler.injectOrkaTools(context.Background(), req, "default")
+
+	if len(req.Tools) < len(builtinProxyTools) {
+		t.Fatalf("expected at least %d tools, got %d", len(builtinProxyTools), len(req.Tools))
+	}
+
+	names := map[string]bool{}
+	for _, tool := range req.Tools {
+		names[tool.Name] = true
+	}
+	for _, expected := range builtinProxyTools {
+		if !names[expected] {
+			t.Errorf("expected built-in tool %q not found", expected)
+		}
+	}
+}
+
+func TestInjectOrkaTools_PreservesClientTools(t *testing.T) {
+	handler, _ := setupTestAnthropicHandler()
+	clientTool := llm.Tool{
+		Name:        "my_custom_tool",
+		Description: "A client-provided tool",
+		Parameters:  json.RawMessage(`{"type":"object"}`),
+	}
+	req := &llm.CompletionRequest{Tools: []llm.Tool{clientTool}}
+
+	handler.injectOrkaTools(context.Background(), req, "default")
+
+	// Client tool should still be first
+	if req.Tools[0].Name != "my_custom_tool" {
+		t.Errorf("first tool = %q, want my_custom_tool", req.Tools[0].Name)
+	}
+	// Built-in tools should also be present
+	names := map[string]bool{}
+	for _, tool := range req.Tools {
+		names[tool.Name] = true
+	}
+	for _, expected := range builtinProxyTools {
+		if !names[expected] {
+			t.Errorf("expected built-in tool %q not found after injection", expected)
+		}
+	}
+	// Total should be client + builtins
+	if len(req.Tools) < 1+len(builtinProxyTools) {
+		t.Errorf("expected at least %d tools, got %d", 1+len(builtinProxyTools), len(req.Tools))
+	}
+}
+
+func TestInjectOrkaTools_WithToolCRDs(t *testing.T) {
+	toolCRD := &corev1alpha1.Tool{
+		ObjectMeta: metav1.ObjectMeta{Name: "custom-tool", Namespace: "default"},
+		Spec: corev1alpha1.ToolSpec{
+			Description: "A custom tool",
+			Parameters:  &apiextensionsv1.JSON{Raw: json.RawMessage(`{"type":"object"}`)},
+			HTTP:        corev1alpha1.HTTPExecution{URL: "http://example.com/tool"},
+		},
+	}
+
+	handler, _ := setupTestAnthropicHandler(toolCRD)
+	req := &llm.CompletionRequest{}
+	handler.injectOrkaTools(context.Background(), req, "default")
+
+	names := map[string]bool{}
+	for _, tool := range req.Tools {
+		names[tool.Name] = true
+	}
+	if !names["custom-tool"] {
+		t.Error("expected Tool CRD 'custom-tool' not found in injected tools")
+	}
+	for _, expected := range builtinProxyTools {
+		if !names[expected] {
+			t.Errorf("expected built-in tool %q not found", expected)
+		}
+	}
+}
+
+// --- Tests: runNonStreamingToolLoop ---
+
+func TestRunNonStreamingToolLoop_NoToolCalls(t *testing.T) {
+	handler, _ := setupTestAnthropicHandler()
+	mock := &mockAnthropicProvider{
+		responses: []*llm.CompletionResponse{
+			{Content: "Hello!", StopReason: "end_turn"},
+		},
+	}
+	req := &llm.CompletionRequest{
+		Model:    "test-model",
+		Messages: []llm.Message{{Role: "user", Content: "Hi"}},
+	}
+
+	resp, err := handler.runNonStreamingToolLoop(context.Background(), mock, req, "test-model")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "Hello!" {
+		t.Errorf("content = %q, want Hello!", resp.Content)
+	}
+	if mock.callIdx != 1 {
+		t.Errorf("expected 1 LLM call, got %d", mock.callIdx)
+	}
+}
+
+func TestRunNonStreamingToolLoop_SingleToolCall(t *testing.T) {
+	handler, _ := setupTestAnthropicHandler()
+	mock := &mockAnthropicProvider{
+		responses: []*llm.CompletionResponse{
+			{
+				Content:    "Let me read the file.",
+				StopReason: "tool_use",
+				ToolCalls: []llm.ToolCall{
+					{ID: "tc_1", Name: "file_read", Arguments: json.RawMessage(`{"path":"test.txt"}`)},
+				},
+			},
+			{Content: "The file contains: hello world", StopReason: "end_turn"},
+		},
+	}
+	req := &llm.CompletionRequest{
+		Model:    "test-model",
+		Messages: []llm.Message{{Role: "user", Content: "Read test.txt"}},
+	}
+
+	resp, err := handler.runNonStreamingToolLoop(context.Background(), mock, req, "test-model")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "The file contains: hello world" {
+		t.Errorf("content = %q, want final response", resp.Content)
+	}
+	if mock.callIdx != 2 {
+		t.Errorf("expected 2 LLM calls, got %d", mock.callIdx)
+	}
+}
+
+func TestRunNonStreamingToolLoop_MultiStepToolLoop(t *testing.T) {
+	handler, _ := setupTestAnthropicHandler()
+	mock := &mockAnthropicProvider{
+		responses: []*llm.CompletionResponse{
+			{
+				StopReason: "tool_use",
+				ToolCalls:  []llm.ToolCall{{ID: "tc_1", Name: "web_search", Arguments: json.RawMessage(`{"query":"test"}`)}},
+			},
+			{
+				StopReason: "tool_use",
+				ToolCalls:  []llm.ToolCall{{ID: "tc_2", Name: "file_read", Arguments: json.RawMessage(`{"path":"result.txt"}`)}},
+			},
+			{Content: "Here is the final answer.", StopReason: "end_turn"},
+		},
+	}
+	req := &llm.CompletionRequest{
+		Model:    "test-model",
+		Messages: []llm.Message{{Role: "user", Content: "Search and read"}},
+	}
+
+	resp, err := handler.runNonStreamingToolLoop(context.Background(), mock, req, "test-model")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "Here is the final answer." {
+		t.Errorf("content = %q, want final answer", resp.Content)
+	}
+	if mock.callIdx != 3 {
+		t.Errorf("expected 3 LLM calls, got %d", mock.callIdx)
+	}
+}
+
+func TestRunNonStreamingToolLoop_IterationLimit(t *testing.T) {
+	config := DefaultChatConfig()
+	config.MaxIterations = 2
+
+	scheme := runtime.NewScheme()
+	_ = corev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	handler := NewAnthropicCompatHandler(fakeClient, "default", false, config)
+
+	mock := &mockAnthropicProvider{
+		responses: []*llm.CompletionResponse{
+			// Iteration 0: tool call
+			{StopReason: "tool_use", ToolCalls: []llm.ToolCall{{ID: "tc_1", Name: "web_search", Arguments: json.RawMessage(`{"query":"a"}`)}}},
+			// Iteration 1: tool call
+			{StopReason: "tool_use", ToolCalls: []llm.ToolCall{{ID: "tc_2", Name: "web_search", Arguments: json.RawMessage(`{"query":"b"}`)}}},
+			// Iteration 2: hits limit, summary call
+			{Content: "Summary of work done.", StopReason: "end_turn"},
+		},
+	}
+	req := &llm.CompletionRequest{
+		Model:    "test-model",
+		Messages: []llm.Message{{Role: "user", Content: "Do many things"}},
+	}
+
+	resp, err := handler.runNonStreamingToolLoop(context.Background(), mock, req, "test-model")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "Summary of work done." {
+		t.Errorf("content = %q, want summary", resp.Content)
+	}
+	if mock.callIdx != 3 {
+		t.Errorf("expected 3 LLM calls (2 iterations + 1 summary), got %d", mock.callIdx)
+	}
+}
+
+func TestRunNonStreamingToolLoop_LLMError(t *testing.T) {
+	handler, _ := setupTestAnthropicHandler()
+	mock := &mockAnthropicProvider{
+		responses: []*llm.CompletionResponse{nil},
+		errors:    []error{fmt.Errorf("provider unavailable")},
+	}
+	req := &llm.CompletionRequest{
+		Model:    "test-model",
+		Messages: []llm.Message{{Role: "user", Content: "Hi"}},
+	}
+
+	_, err := handler.runNonStreamingToolLoop(context.Background(), mock, req, "test-model")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "provider unavailable") {
+		t.Errorf("error = %q, want 'provider unavailable'", err.Error())
+	}
+}
+
+func TestRunNonStreamingToolLoop_ToolExecutionError(t *testing.T) {
+	handler, _ := setupTestAnthropicHandler()
+	mock := &mockAnthropicProvider{
+		responses: []*llm.CompletionResponse{
+			{
+				StopReason: "tool_use",
+				ToolCalls:  []llm.ToolCall{{ID: "tc_1", Name: "nonexistent_tool", Arguments: json.RawMessage(`{}`)}},
+			},
+			{Content: "I encountered an error but here is my response.", StopReason: "end_turn"},
+		},
+	}
+	req := &llm.CompletionRequest{
+		Model:    "test-model",
+		Messages: []llm.Message{{Role: "user", Content: "Use a bad tool"}},
+	}
+
+	resp, err := handler.runNonStreamingToolLoop(context.Background(), mock, req, "test-model")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "I encountered an error but here is my response." {
+		t.Errorf("content = %q, want error recovery response", resp.Content)
+	}
+	if mock.callIdx != 2 {
+		t.Errorf("expected 2 LLM calls, got %d", mock.callIdx)
+	}
+}
+
+// --- Tests: executeToolCall ---
+
+func TestExecuteToolCall_UnknownTool(t *testing.T) {
+	result := executeToolCall(context.Background(), llm.ToolCall{
+		ID:        "tc_1",
+		Name:      "nonexistent_tool",
+		Arguments: json.RawMessage(`{}`),
+	}, 10*time.Second)
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	if parsed["success"] != false {
+		t.Errorf("expected success=false, got %v", parsed["success"])
+	}
+	errMsg, ok := parsed["error"].(string)
+	if !ok || errMsg == "" {
+		t.Errorf("expected non-empty error message, got %v", parsed["error"])
+	}
+}
+
+func TestExecuteToolCall_Timeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	// Use an unknown tool so the registry returns an error, validating the timeout/error path
+	result := executeToolCall(ctx, llm.ToolCall{
+		ID:        "tc_1",
+		Name:      "nonexistent_timeout_tool",
+		Arguments: json.RawMessage(`{}`),
+	}, 1*time.Millisecond)
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	if parsed["success"] != false {
+		t.Errorf("expected success=false, got %v", parsed["success"])
+	}
+}

--- a/internal/api/anthropic_streaming.go
+++ b/internal/api/anthropic_streaming.go
@@ -1,0 +1,438 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package api
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+
+	"github.com/sozercan/orka/internal/llm"
+)
+
+// handleStreamingMessages handles an Anthropic Messages API request with streaming and tool execution.
+// It runs an agentic tool loop: stream LLM response → execute tools → stream results → repeat.
+// The full Anthropic SSE envelope (message_start → ... → message_stop) spans all iterations.
+func (h *AnthropicCompatHandler) handleStreamingMessages(
+	c fiber.Ctx,
+	provider llm.Provider,
+	req *llm.CompletionRequest,
+	model string,
+	inputTokens int,
+) error {
+	c.Set("Content-Type", "text/event-stream")
+	c.Set("Cache-Control", "no-cache")
+	c.Set("Connection", "keep-alive")
+	c.Set("X-Accel-Buffering", "no")
+
+	capturedProvider := provider
+	capturedReq := req
+
+	return c.SendStreamWriter(func(w *bufio.Writer) {
+		msgID := "msg_" + uuid.New().String()
+
+		streamCtx, streamCancel := context.WithTimeout(context.Background(), h.config.MaxDuration)
+		defer streamCancel()
+
+		// Emit message_start once for the entire tool loop
+		if err := writeMessageStart(w, msgID, model, inputTokens); err != nil {
+			anthropicLog.Error(err, "failed to write message_start")
+			return
+		}
+
+		blockIndex := 0
+		messages := make([]llm.Message, len(capturedReq.Messages))
+		copy(messages, capturedReq.Messages)
+		totalOutputTokens := 0
+		repetitionTracker := make(map[string]int)
+
+		for iteration := 0; iteration < h.config.MaxIterations; iteration++ {
+			// Check context cancellation
+			select {
+			case <-streamCtx.Done():
+				// Emit timeout message and close
+				if err := writeContentBlockStart(w, blockIndex, AnthropicContentBlock{Type: "text", Text: ""}); err == nil {
+					_ = writeContentBlockDelta(w, blockIndex, AnthropicDelta{Type: "text_delta", Text: "Request timed out during tool execution."})
+					_ = writeContentBlockStop(w, blockIndex)
+				}
+				_ = writeMessageDelta(w, "end_turn", totalOutputTokens)
+				_ = writeMessageStop(w)
+				return
+			default:
+			}
+
+			// Progress check every 5 iterations
+			if iteration > 0 && iteration%5 == 0 {
+				messages = append(messages, llm.Message{
+					Role:    "user",
+					Content: "[System: Progress check — summarize what you've done so far and what remains.]",
+				})
+			}
+
+			// Truncate conversation if needed
+			if h.config.MaxSessionSize > 0 {
+				tokenBudget := h.config.MaxSessionSize / 4
+				messages = llm.TruncateMessages(messages, tokenBudget)
+			}
+
+			// Build request for this iteration
+			compReq := &llm.CompletionRequest{
+				Model:        model,
+				Messages:     messages,
+				SystemPrompt: capturedReq.SystemPrompt,
+				Tools:        capturedReq.Tools,
+				MaxTokens:    capturedReq.MaxTokens,
+				Temperature:  capturedReq.Temperature,
+			}
+
+			// Try streaming from provider
+			var toolCalls []llm.ToolCall
+			var textContent string
+
+			streamCh, err := capturedProvider.Stream(streamCtx, compReq)
+			if err != nil {
+				// Fallback to Complete
+				resp, completeErr := capturedProvider.Complete(streamCtx, compReq)
+				if completeErr != nil {
+					anthropicLog.Error(completeErr, "completion failed in tool loop")
+					if err := writeContentBlockStart(w, blockIndex, AnthropicContentBlock{Type: "text", Text: ""}); err == nil {
+						_ = writeContentBlockDelta(w, blockIndex, AnthropicDelta{Type: "text_delta", Text: "Error: " + completeErr.Error()})
+						_ = writeContentBlockStop(w, blockIndex)
+					}
+					_ = writeMessageDelta(w, "end_turn", totalOutputTokens)
+					_ = writeMessageStop(w)
+					return
+				}
+
+				totalOutputTokens += resp.OutputTokens
+
+				// Emit text content
+				if resp.Content != "" {
+					textContent = resp.Content
+					if err := writeContentBlockStart(w, blockIndex, AnthropicContentBlock{Type: "text", Text: ""}); err == nil {
+						_ = writeContentBlockDelta(w, blockIndex, AnthropicDelta{Type: "text_delta", Text: resp.Content})
+						_ = writeContentBlockStop(w, blockIndex)
+						blockIndex++
+					}
+				}
+
+				// Emit tool calls
+				for _, tc := range resp.ToolCalls {
+					if err := writeContentBlockStart(w, blockIndex, AnthropicContentBlock{
+						Type: "tool_use", ID: tc.ID, Name: tc.Name, Input: json.RawMessage(""),
+					}); err == nil {
+						_ = writeContentBlockDelta(w, blockIndex, AnthropicDelta{
+							Type: "input_json_delta", PartialJSON: string(tc.Arguments),
+						})
+						_ = writeContentBlockStop(w, blockIndex)
+						blockIndex++
+					}
+				}
+				toolCalls = resp.ToolCalls
+			} else {
+				// Consume stream chunks
+				inTextBlock := false
+				for chunk := range streamCh {
+					if chunk.Error != nil {
+						anthropicLog.Error(chunk.Error, "stream chunk error in tool loop")
+						break
+					}
+
+					// Handle text content
+					if chunk.Content != "" {
+						if !inTextBlock {
+							if err := writeContentBlockStart(w, blockIndex, AnthropicContentBlock{
+								Type: "text", Text: "",
+							}); err != nil {
+								break
+							}
+							inTextBlock = true
+						}
+						if err := writeContentBlockDelta(w, blockIndex, AnthropicDelta{
+							Type: "text_delta", Text: chunk.Content,
+						}); err != nil {
+							break
+						}
+						textContent += chunk.Content
+					}
+
+					// Handle tool calls
+					if chunk.ToolCall != nil {
+						if inTextBlock {
+							_ = writeContentBlockStop(w, blockIndex)
+							blockIndex++
+							inTextBlock = false
+						}
+
+						tc := chunk.ToolCall
+						if err := writeContentBlockStart(w, blockIndex, AnthropicContentBlock{
+							Type: "tool_use", ID: tc.ID, Name: tc.Name, Input: json.RawMessage(""),
+						}); err == nil {
+							_ = writeContentBlockDelta(w, blockIndex, AnthropicDelta{
+								Type: "input_json_delta", PartialJSON: string(tc.Arguments),
+							})
+							_ = writeContentBlockStop(w, blockIndex)
+							blockIndex++
+						}
+						toolCalls = append(toolCalls, *tc)
+					}
+
+					if chunk.Done {
+						if inTextBlock {
+							_ = writeContentBlockStop(w, blockIndex)
+							blockIndex++
+							inTextBlock = false
+						}
+						totalOutputTokens += estimateTokens(textContent)
+						break
+					}
+				}
+
+				// Close text block if stream ended without Done
+				if inTextBlock {
+					_ = writeContentBlockStop(w, blockIndex)
+					blockIndex++
+				}
+			}
+
+			// No tool calls → final response, close the stream
+			if len(toolCalls) == 0 {
+				stopReason := "end_turn"
+				_ = writeMessageDelta(w, stopReason, totalOutputTokens)
+				_ = writeMessageStop(w)
+				return
+			}
+
+			anthropicLog.Info("streaming tool loop iteration",
+				"iteration", iteration,
+				"tool_calls", len(toolCalls),
+			)
+
+			// Append assistant message with tool calls
+			messages = append(messages, llm.Message{
+				Role:      "assistant",
+				Content:   textContent,
+				ToolCalls: toolCalls,
+			})
+
+			// Execute tools and emit results
+			var repetitionWarning string
+			for _, tc := range toolCalls {
+				// Check repetition
+				argsHash := hashArgs(tc.Name, tc.Arguments)
+				repetitionTracker[argsHash]++
+				if repetitionTracker[argsHash] >= 3 {
+					repetitionWarning = fmt.Sprintf("[System: Warning — you have called %s with the same arguments %d times. Try a different approach.]", tc.Name, repetitionTracker[argsHash])
+					iteration += 5
+				}
+
+				result := executeToolCall(streamCtx, tc, h.config.ToolTimeout)
+
+				// Emit tool result as a text content block so the user sees what happened
+				resultPreview := result
+				if len(resultPreview) > 2000 {
+					resultPreview = resultPreview[:2000] + "..."
+				}
+				if err := writeContentBlockStart(w, blockIndex, AnthropicContentBlock{
+					Type: "text", Text: "",
+				}); err == nil {
+					_ = writeContentBlockDelta(w, blockIndex, AnthropicDelta{
+						Type: "text_delta",
+						Text: fmt.Sprintf("[Tool %s result]: %s", tc.Name, resultPreview),
+					})
+					_ = writeContentBlockStop(w, blockIndex)
+					blockIndex++
+				}
+
+				messages = append(messages, llm.Message{
+					Role:       "tool",
+					ToolCallID: tc.ID,
+					Name:       tc.Name,
+					Content:    result,
+				})
+			}
+
+			if repetitionWarning != "" {
+				messages = append(messages, llm.Message{
+					Role:    "user",
+					Content: repetitionWarning,
+				})
+			}
+		}
+
+		// Reached iteration limit — emit final message and close
+		_ = writeMessageDelta(w, "end_turn", totalOutputTokens)
+		_ = writeMessageStop(w)
+	})
+}
+
+// estimateTokens provides a rough token count estimate from text length.
+func estimateTokens(text string) int {
+	return len(text) / 4
+}
+
+// handleStreamingFallback uses provider.Complete() and emits the result as a complete SSE sequence.
+func (h *AnthropicCompatHandler) handleStreamingFallback(
+	w *bufio.Writer,
+	ctx context.Context,
+	provider llm.Provider,
+	req *llm.CompletionRequest,
+	msgID, model string,
+) {
+	resp, err := provider.Complete(ctx, req)
+	if err != nil {
+		anthropicLog.Error(err, "fallback complete failed")
+		// Emit an error as text content and close
+		_ = writeContentBlockStart(w, 0, AnthropicContentBlock{Type: "text", Text: ""})
+		_ = writeContentBlockDelta(w, 0, AnthropicDelta{Type: "text_delta", Text: "Error: " + err.Error()})
+		_ = writeContentBlockStop(w, 0)
+		stopReason := "end_turn"
+		_ = writeMessageDelta(w, stopReason, 0)
+		_ = writeMessageStop(w)
+		return
+	}
+
+	blockIndex := 0
+
+	// Emit text content
+	if resp.Content != "" {
+		if err := writeContentBlockStart(w, blockIndex, AnthropicContentBlock{
+			Type: "text",
+			Text: "",
+		}); err != nil {
+			anthropicLog.Error(err, "fallback: failed to write content_block_start")
+			return
+		}
+		if err := writeContentBlockDelta(w, blockIndex, AnthropicDelta{
+			Type: "text_delta",
+			Text: resp.Content,
+		}); err != nil {
+			anthropicLog.Error(err, "fallback: failed to write content_block_delta")
+			return
+		}
+		if err := writeContentBlockStop(w, blockIndex); err != nil {
+			anthropicLog.Error(err, "fallback: failed to write content_block_stop")
+			return
+		}
+		blockIndex++
+	}
+
+	// Emit tool calls
+	for _, tc := range resp.ToolCalls {
+		if err := writeContentBlockStart(w, blockIndex, AnthropicContentBlock{
+			Type:  "tool_use",
+			ID:    tc.ID,
+			Name:  tc.Name,
+			Input: json.RawMessage(""),
+		}); err != nil {
+			anthropicLog.Error(err, "fallback: failed to write tool content_block_start")
+			return
+		}
+		if err := writeContentBlockDelta(w, blockIndex, AnthropicDelta{
+			Type:        "input_json_delta",
+			PartialJSON: string(tc.Arguments),
+		}); err != nil {
+			anthropicLog.Error(err, "fallback: failed to write tool content_block_delta")
+			return
+		}
+		if err := writeContentBlockStop(w, blockIndex); err != nil {
+			anthropicLog.Error(err, "fallback: failed to write tool content_block_stop")
+			return
+		}
+		blockIndex++
+	}
+
+	stopReason := resp.StopReason
+	if stopReason == "" {
+		stopReason = "end_turn"
+	}
+	if len(resp.ToolCalls) > 0 && stopReason == "end_turn" {
+		stopReason = "tool_use"
+	}
+
+	_ = writeMessageDelta(w, stopReason, resp.OutputTokens)
+	_ = writeMessageStop(w)
+}
+
+// writeAnthropicSSE writes a named SSE event in Anthropic format.
+func writeAnthropicSSE(w *bufio.Writer, eventType string, data any) error {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, jsonData)
+	return w.Flush()
+}
+
+// writeMessageStart emits the message_start event.
+func writeMessageStart(w *bufio.Writer, id, model string, inputTokens int) error {
+	return writeAnthropicSSE(w, "message_start", AnthropicStreamEvent{
+		Type: "message_start",
+		Message: &AnthropicResponse{
+			ID:         id,
+			Type:       "message",
+			Role:       "assistant",
+			Content:    []AnthropicContentBlock{},
+			Model:      model,
+			StopReason: nil,
+			Usage: AnthropicUsage{
+				InputTokens:  inputTokens,
+				OutputTokens: 0,
+			},
+		},
+	})
+}
+
+// writeMessageDelta emits the message_delta event with stop_reason and usage.
+func writeMessageDelta(w *bufio.Writer, stopReason string, outputTokens int) error {
+	return writeAnthropicSSE(w, "message_delta", AnthropicStreamEvent{
+		Type: "message_delta",
+		Delta: &AnthropicDelta{
+			StopReason: &stopReason,
+		},
+		Usage: &AnthropicUsage{
+			OutputTokens: outputTokens,
+		},
+	})
+}
+
+// writeMessageStop emits the message_stop event.
+func writeMessageStop(w *bufio.Writer) error {
+	return writeAnthropicSSE(w, "message_stop", AnthropicStreamEvent{
+		Type: "message_stop",
+	})
+}
+
+// writeContentBlockStart emits a content_block_start event.
+func writeContentBlockStart(w *bufio.Writer, index int, block AnthropicContentBlock) error {
+	return writeAnthropicSSE(w, "content_block_start", AnthropicStreamEvent{
+		Type:         "content_block_start",
+		Index:        index,
+		ContentBlock: &block,
+	})
+}
+
+// writeContentBlockDelta emits a content_block_delta event.
+func writeContentBlockDelta(w *bufio.Writer, index int, delta AnthropicDelta) error {
+	return writeAnthropicSSE(w, "content_block_delta", AnthropicStreamEvent{
+		Type:  "content_block_delta",
+		Index: index,
+		Delta: &delta,
+	})
+}
+
+// writeContentBlockStop emits a content_block_stop event.
+func writeContentBlockStop(w *bufio.Writer, index int) error {
+	return writeAnthropicSSE(w, "content_block_stop", AnthropicStreamEvent{
+		Type:  "content_block_stop",
+		Index: index,
+	})
+}

--- a/internal/api/anthropic_tool_loop.go
+++ b/internal/api/anthropic_tool_loop.go
@@ -1,0 +1,188 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
+	"github.com/sozercan/orka/internal/llm"
+	"github.com/sozercan/orka/internal/tools"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// builtinProxyTools are the tool names injected by the proxy for server-side execution.
+var builtinProxyTools = []string{"web_search", "code_exec", "file_read", "file_write", "web_fetch"}
+
+// injectOrkaTools appends Orka's built-in tools and namespace Tool CRDs to the completion request.
+// Client-provided tools (if any) are preserved.
+func (h *AnthropicCompatHandler) injectOrkaTools(ctx context.Context, req *llm.CompletionRequest, namespace string) {
+	builtinTools := tools.DefaultRegistry.ToLLMTools(builtinProxyTools)
+	req.Tools = append(req.Tools, builtinTools...)
+
+	// Load Tool CRDs from namespace for custom HTTP tools
+	var toolList corev1alpha1.ToolList
+	if err := h.client.List(ctx, &toolList, client.InNamespace(namespace)); err == nil {
+		for _, t := range toolList.Items {
+			if t.Spec.Parameters != nil {
+				req.Tools = append(req.Tools, llm.Tool{
+					Name:        t.Name,
+					Description: t.Spec.Description,
+					Parameters:  t.Spec.Parameters.Raw,
+				})
+			}
+		}
+	}
+}
+
+// executeToolCall executes a single tool call via the default registry with a timeout.
+func executeToolCall(ctx context.Context, tc llm.ToolCall, timeout time.Duration) string {
+	toolCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	result, err := tools.DefaultRegistry.Execute(toolCtx, tc.Name, tc.Arguments)
+	if err != nil {
+		errResult, _ := json.Marshal(map[string]any{"success": false, "error": err.Error()})
+		return string(errResult)
+	}
+	return result
+}
+
+// runNonStreamingToolLoop runs the agentic tool loop using non-streaming Complete() calls.
+// It loops until the LLM produces a response with no tool calls, or limits are reached.
+// Returns the final CompletionResponse and all intermediate content blocks.
+func (h *AnthropicCompatHandler) runNonStreamingToolLoop(
+	ctx context.Context,
+	provider llm.Provider,
+	req *llm.CompletionRequest,
+	model string,
+) (*llm.CompletionResponse, error) {
+	repetitionTracker := make(map[string]int)
+	messages := make([]llm.Message, len(req.Messages))
+	copy(messages, req.Messages)
+
+	for iteration := 0; ; iteration++ {
+		// Check context cancellation
+		select {
+		case <-ctx.Done():
+			return &llm.CompletionResponse{
+				Content:    "Request timed out during tool execution.",
+				StopReason: "end_turn",
+			}, nil
+		default:
+		}
+
+		// Check iteration limit — do one final call without tools
+		if iteration >= h.config.MaxIterations {
+			messages = append(messages, llm.Message{
+				Role:    "user",
+				Content: "[System: You have reached the maximum number of iterations. Please provide a final summary of what you accomplished.]",
+			})
+			resp, err := provider.Complete(ctx, &llm.CompletionRequest{
+				Model:        model,
+				Messages:     messages,
+				SystemPrompt: req.SystemPrompt,
+				MaxTokens:    req.MaxTokens,
+				Temperature:  req.Temperature,
+			})
+			if err != nil {
+				return &llm.CompletionResponse{
+					Content:    "Reached iteration limit.",
+					StopReason: "end_turn",
+				}, nil
+			}
+			return resp, nil
+		}
+
+		// Progress check every 5 iterations
+		if iteration > 0 && iteration%5 == 0 {
+			messages = append(messages, llm.Message{
+				Role:    "user",
+				Content: "[System: Progress check — summarize what you've done so far and what remains.]",
+			})
+		}
+
+		// Truncate conversation if it exceeds the session size budget
+		if h.config.MaxSessionSize > 0 {
+			tokenBudget := h.config.MaxSessionSize / 4
+			messages = llm.TruncateMessages(messages, tokenBudget)
+		}
+
+		// Call LLM with tools
+		compReq := &llm.CompletionRequest{
+			Model:        model,
+			Messages:     messages,
+			SystemPrompt: req.SystemPrompt,
+			Tools:        req.Tools,
+			MaxTokens:    req.MaxTokens,
+			Temperature:  req.Temperature,
+		}
+
+		resp, err := provider.Complete(ctx, compReq)
+		if err != nil && llm.IsContextTooLongErr(err) {
+			tokenEstimate := 0
+			for _, m := range messages {
+				tokenEstimate += len(m.Content) / 4
+			}
+			messages = llm.TruncateMessages(messages, tokenEstimate/2)
+			compReq.Messages = messages
+			resp, err = provider.Complete(ctx, compReq)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("LLM completion failed: %w", err)
+		}
+
+		// No tool calls → final response
+		if len(resp.ToolCalls) == 0 {
+			return resp, nil
+		}
+
+		anthropicLog.Info("tool loop iteration",
+			"iteration", iteration,
+			"tool_calls", len(resp.ToolCalls),
+		)
+
+		// Append assistant message with tool calls
+		messages = append(messages, llm.Message{
+			Role:      "assistant",
+			Content:   resp.Content,
+			ToolCalls: resp.ToolCalls,
+		})
+
+		// Execute each tool and append results
+		var repetitionWarning string
+		for _, tc := range resp.ToolCalls {
+			// Check repetition
+			argsHash := hashArgs(tc.Name, tc.Arguments)
+			repetitionTracker[argsHash]++
+			if repetitionTracker[argsHash] >= 3 {
+				repetitionWarning = fmt.Sprintf("[System: Warning — you have called %s with the same arguments %d times. Try a different approach.]", tc.Name, repetitionTracker[argsHash])
+				iteration += 5
+			}
+
+			result := executeToolCall(ctx, tc, h.config.ToolTimeout)
+
+			messages = append(messages, llm.Message{
+				Role:       "tool",
+				ToolCallID: tc.ID,
+				Name:       tc.Name,
+				Content:    result,
+			})
+		}
+
+		// Append repetition warning if triggered
+		if repetitionWarning != "" {
+			messages = append(messages, llm.Message{
+				Role:    "user",
+				Content: repetitionWarning,
+			})
+		}
+	}
+}

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -25,6 +25,9 @@ const (
 	// AuthHeader is the header name for authorization
 	AuthHeader = "Authorization"
 
+	// XAPIKeyHeader is the header name for the Anthropic-style API key
+	XAPIKeyHeader = "x-api-key"
+
 	// BearerPrefix is the prefix for bearer tokens
 	BearerPrefix = "Bearer "
 
@@ -89,23 +92,24 @@ func parseServiceAccountNamespace(username string) string {
 // NewAuthMiddleware creates a new authentication middleware
 func NewAuthMiddleware(c client.Client) fiber.Handler {
 	return func(ctx fiber.Ctx) error {
-		// Get the authorization header
+		// Extract token from Authorization header or x-api-key fallback
+		var token string
 		authHeader := ctx.Get(AuthHeader)
-		if authHeader == "" {
+		if authHeader != "" {
+			// Check for bearer token
+			if !strings.HasPrefix(authHeader, BearerPrefix) {
+				log.Info("authentication failed: invalid authorization header format", "ip", ctx.IP())
+				return fiber.NewError(fiber.StatusUnauthorized, "invalid authorization header format")
+			}
+			token = strings.TrimPrefix(authHeader, BearerPrefix)
+		}
+		if token == "" {
+			// Fallback to x-api-key header (Anthropic convention)
+			token = ctx.Get(XAPIKeyHeader)
+		}
+		if token == "" {
 			log.Info("authentication failed: missing authorization header", "ip", ctx.IP())
 			return fiber.NewError(fiber.StatusUnauthorized, "missing authorization header")
-		}
-
-		// Check for bearer token
-		if !strings.HasPrefix(authHeader, BearerPrefix) {
-			log.Info("authentication failed: invalid authorization header format", "ip", ctx.IP())
-			return fiber.NewError(fiber.StatusUnauthorized, "invalid authorization header format")
-		}
-
-		token := strings.TrimPrefix(authHeader, BearerPrefix)
-		if token == "" {
-			log.Info("authentication failed: empty bearer token", "ip", ctx.IP())
-			return fiber.NewError(fiber.StatusUnauthorized, "empty bearer token")
 		}
 
 		// Validate the token using TokenReview

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -435,6 +435,122 @@ func TestNewAuthMiddleware_ValidToken(t *testing.T) {
 	}
 }
 
+func TestNewAuthMiddleware_XAPIKeyOnly(t *testing.T) {
+	tokenCache.Range(func(key, _ any) bool {
+		tokenCache.Delete(key)
+		return true
+	})
+
+	scheme := runtime.NewScheme()
+	_ = authenticationv1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if tr, ok := obj.(*authenticationv1.TokenReview); ok {
+					tr.Status.Authenticated = true
+					tr.Status.User = authenticationv1.UserInfo{
+						Username: "system:serviceaccount:ns1:worker",
+						UID:      "uid-xapi",
+						Groups:   []string{"system:serviceaccounts"},
+					}
+				}
+				return nil
+			},
+		}).
+		Build()
+
+	app := setupTestApp(fakeClient)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("x-api-key", "xapi-test-token")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestNewAuthMiddleware_BothHeadersPrefersAuthorization(t *testing.T) {
+	tokenCache.Range(func(key, _ any) bool {
+		tokenCache.Delete(key)
+		return true
+	})
+
+	scheme := runtime.NewScheme()
+	_ = authenticationv1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if tr, ok := obj.(*authenticationv1.TokenReview); ok {
+					// Return different UIDs based on token to verify which was used
+					if tr.Spec.Token == "bearer-token" {
+						tr.Status.Authenticated = true
+						tr.Status.User = authenticationv1.UserInfo{
+							Username: "system:serviceaccount:ns1:bearer-sa",
+							UID:      "uid-bearer",
+						}
+					} else if tr.Spec.Token == "xapi-token" {
+						tr.Status.Authenticated = true
+						tr.Status.User = authenticationv1.UserInfo{
+							Username: "system:serviceaccount:ns1:xapi-sa",
+							UID:      "uid-xapi",
+						}
+					}
+				}
+				return nil
+			},
+		}).
+		Build()
+
+	var capturedUserInfo *UserInfo
+	app := fiber.New()
+	app.Use(NewAuthMiddleware(fakeClient))
+	app.Get("/test", func(ctx fiber.Ctx) error {
+		capturedUserInfo = GetUserInfo(ctx)
+		return ctx.SendString("OK")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer bearer-token")
+	req.Header.Set("x-api-key", "xapi-token")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if capturedUserInfo == nil {
+		t.Fatal("expected UserInfo to be set in context")
+	}
+	if capturedUserInfo.UID != "uid-bearer" {
+		t.Errorf("UID = %s, want uid-bearer (Authorization header should take priority)", capturedUserInfo.UID)
+	}
+}
+
+func TestNewAuthMiddleware_NeitherHeader(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = authenticationv1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	app := setupTestApp(fakeClient)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
 func TestNewAuthMiddleware_TokenValidationFails(t *testing.T) {
 	tokenCache.Range(func(key, _ any) bool {
 		tokenCache.Delete(key)

--- a/internal/api/openai_compat.go
+++ b/internal/api/openai_compat.go
@@ -31,7 +31,7 @@ const (
 	finishReasonToolCalls = "tool_calls"
 )
 
-// OpenAICompatHandler implements OpenAI-compatible /v1/chat/completions and /v1/models endpoints.
+// OpenAICompatHandler implements OpenAI-compatible /openai/v1/chat/completions and /openai/v1/models endpoints.
 // This allows OpenAI-compatible clients to use Orka as a custom provider.
 type OpenAICompatHandler struct {
 	client                    client.Client
@@ -153,7 +153,7 @@ type OAIUsage struct {
 	TotalTokens      int `json:"total_tokens"`
 }
 
-// OAIModel is the model object for /v1/models.
+// OAIModel is the model object for /openai/v1/models.
 type OAIModel struct {
 	ID      string `json:"id"`
 	Object  string `json:"object"`
@@ -161,7 +161,7 @@ type OAIModel struct {
 	OwnedBy string `json:"owned_by"`
 }
 
-// OAIModelList is the response for GET /v1/models.
+// OAIModelList is the response for GET /openai/v1/models.
 type OAIModelList struct {
 	Object string     `json:"object"`
 	Data   []OAIModel `json:"data"`
@@ -180,7 +180,7 @@ type OAIErrorDetail struct {
 	Code    *string `json:"code"`
 }
 
-// HandleChatCompletions handles POST /v1/chat/completions.
+// HandleChatCompletions handles POST /openai/v1/chat/completions.
 func (h *OpenAICompatHandler) HandleChatCompletions(c fiber.Ctx) error {
 	var req OAIRequest
 	if err := c.Bind().JSON(&req); err != nil {
@@ -588,7 +588,7 @@ func (h *OpenAICompatHandler) handleStreamingCompletion(
 	})
 }
 
-// HandleListModels handles GET /v1/models.
+// HandleListModels handles GET /openai/v1/models.
 func (h *OpenAICompatHandler) HandleListModels(c fiber.Ctx) error {
 	ctx := c.Context()
 

--- a/internal/api/openai_compat_test.go
+++ b/internal/api/openai_compat_test.go
@@ -46,10 +46,10 @@ func setupTestOpenAIHandler(objs ...runtime.Object) (*OpenAICompatHandler, *fibe
 
 func TestHandleChatCompletions_MissingMessages(t *testing.T) {
 	handler, app := setupTestOpenAIHandler()
-	app.Post("/v1/chat/completions", handler.HandleChatCompletions)
+	app.Post("/openai/v1/chat/completions", handler.HandleChatCompletions)
 
 	body := `{"model":"test-model","messages":[]}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)
@@ -70,10 +70,10 @@ func TestHandleChatCompletions_MissingMessages(t *testing.T) {
 
 func TestHandleChatCompletions_NGreaterThanOne(t *testing.T) {
 	handler, app := setupTestOpenAIHandler()
-	app.Post("/v1/chat/completions", handler.HandleChatCompletions)
+	app.Post("/openai/v1/chat/completions", handler.HandleChatCompletions)
 
 	body := `{"model":"test-model","messages":[{"role":"user","content":"hello"}],"n":2}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)
@@ -97,9 +97,9 @@ func TestHandleChatCompletions_NGreaterThanOne(t *testing.T) {
 
 func TestHandleChatCompletions_InvalidBody(t *testing.T) {
 	handler, app := setupTestOpenAIHandler()
-	app.Post("/v1/chat/completions", handler.HandleChatCompletions)
+	app.Post("/openai/v1/chat/completions", handler.HandleChatCompletions)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("not json"))
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)
@@ -114,10 +114,10 @@ func TestHandleChatCompletions_InvalidBody(t *testing.T) {
 
 func TestHandleChatCompletions_NoProvider(t *testing.T) {
 	handler, app := setupTestOpenAIHandler()
-	app.Post("/v1/chat/completions", handler.HandleChatCompletions)
+	app.Post("/openai/v1/chat/completions", handler.HandleChatCompletions)
 
 	body := `{"model":"test-model","messages":[{"role":"user","content":"hello"}]}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)
@@ -138,9 +138,9 @@ func TestHandleChatCompletions_NoProvider(t *testing.T) {
 
 func TestHandleListModels_Empty(t *testing.T) {
 	handler, app := setupTestOpenAIHandler()
-	app.Get("/v1/models", handler.HandleListModels)
+	app.Get("/openai/v1/models", handler.HandleListModels)
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req := httptest.NewRequest(http.MethodGet, "/openai/v1/models", nil)
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -176,9 +176,9 @@ func TestHandleListModels_WithProviders(t *testing.T) {
 	}
 
 	handler, app := setupTestOpenAIHandler(provider)
-	app.Get("/v1/models", handler.HandleListModels)
+	app.Get("/openai/v1/models", handler.HandleListModels)
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req := httptest.NewRequest(http.MethodGet, "/openai/v1/models", nil)
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -392,7 +392,7 @@ func TestHandleChatCompletions_NonStreamingResponse(t *testing.T) {
 	}
 
 	handler, app := setupTestOpenAIHandler(provider, secret)
-	app.Post("/v1/chat/completions", handler.HandleChatCompletions)
+	app.Post("/openai/v1/chat/completions", handler.HandleChatCompletions)
 
 	reqBody := OAIRequest{
 		Model: "gpt-4",
@@ -402,7 +402,7 @@ func TestHandleChatCompletions_NonStreamingResponse(t *testing.T) {
 	}
 	body, _ := json.Marshal(reqBody)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)
@@ -905,10 +905,10 @@ func TestHandleChatCompletions_MaxTokensTooSmall(t *testing.T) {
 	}
 
 	handler, app := setupTestOpenAIHandler(provider, secret)
-	app.Post("/v1/chat/completions", handler.HandleChatCompletions)
+	app.Post("/openai/v1/chat/completions", handler.HandleChatCompletions)
 
 	body := `{"model":"gpt-4","messages":[{"role":"user","content":"hello"}],"max_tokens":5}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)
@@ -963,7 +963,7 @@ func TestHandleChatCompletions_ProviderSlashModel(t *testing.T) {
 	}
 
 	handler, app := setupTestOpenAIHandler(provider, secret)
-	app.Post("/v1/chat/completions", handler.HandleChatCompletions)
+	app.Post("/openai/v1/chat/completions", handler.HandleChatCompletions)
 
 	// Use "provider/model" format
 	reqBody := OAIRequest{
@@ -974,7 +974,7 @@ func TestHandleChatCompletions_ProviderSlashModel(t *testing.T) {
 	}
 	body, _ := json.Marshal(reqBody)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -52,6 +52,7 @@ type Server struct {
 	handlers         *Handlers
 	chatHandler      *ChatHandler
 	openaiHandler    *OpenAICompatHandler
+	anthropicHandler *AnthropicCompatHandler
 	internalHandlers *InternalHandlers
 	ResultStore      store.ResultStore
 	SessionStore     store.SessionStore
@@ -80,6 +81,7 @@ func NewServer(c client.Client, sessionManager *controller.SessionManager, confi
 	server.handlers = NewHandlers(c, sessionManager, config.WatchNamespace, config.EnforceNamespaceIsolation, config.ResultStore, config.SessionStore, config.PlanStore, config.Clientset, config.HealthChecker)
 	server.chatHandler = NewChatHandler(c, sessionManager, config.Chat, config.WatchNamespace, config.EnforceNamespaceIsolation, config.SessionStore, config.ResultStore)
 	server.openaiHandler = NewOpenAICompatHandler(c, config.WatchNamespace, config.EnforceNamespaceIsolation, config.Chat)
+	server.anthropicHandler = NewAnthropicCompatHandler(c, config.WatchNamespace, config.EnforceNamespaceIsolation, config.Chat)
 	server.setupMiddleware()
 	server.setupRoutes()
 	server.setupStaticFiles()
@@ -171,12 +173,18 @@ func (s *Server) setupRoutes() {
 		api.Delete("/chat/:sessionId", s.chatHandler.HandleCancelChat)
 	}
 
-	// OpenAI-compatible API (under /v1, separate from /api/v1)
+	// OpenAI-compatible API (under /openai/v1, separate from /api/v1)
 	// This allows OpenAI-compatible clients to use Orka as a custom provider.
-	oai := s.app.Group("/v1")
+	oai := s.app.Group("/openai/v1")
 	oai.Use(NewAuthMiddleware(s.client))
 	oai.Post("/chat/completions", s.openaiHandler.HandleChatCompletions)
 	oai.Get("/models", s.openaiHandler.HandleListModels)
+
+	// Anthropic-compatible API
+	anthropic := s.app.Group("/anthropic/v1")
+	anthropic.Use(NewAuthMiddleware(s.client))
+	anthropic.Post("/messages", s.anthropicHandler.HandleMessages)
+	anthropic.Get("/models", s.anthropicHandler.HandleListModels)
 
 	// Internal API for worker communication
 	if s.ResultStore != nil && s.SessionStore != nil {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -395,8 +395,8 @@ func TestServer_SetupRoutes_OpenAI(t *testing.T) {
 		method string
 		path   string
 	}{
-		{http.MethodPost, "/v1/chat/completions"},
-		{http.MethodGet, "/v1/models"},
+		{http.MethodPost, "/openai/v1/chat/completions"},
+		{http.MethodGet, "/openai/v1/models"},
 	}
 
 	for _, ep := range endpoints {

--- a/test/e2e/chat_api_test.go
+++ b/test/e2e/chat_api_test.go
@@ -142,10 +142,10 @@ var _ = Describe("Chat and OpenAI-Compatible API", Ordered, func() {
 		Expect(events).To(ContainElement("done"), "Should receive a 'done' event")
 	})
 
-	// --- OpenAI-Compatible: /v1/models ---
+	// --- OpenAI-Compatible: /openai/v1/models ---
 
-	It("should list models via GET /v1/models", func() {
-		req, err := http.NewRequest("GET", apiBaseURL+"/v1/models", nil)
+	It("should list models via GET /openai/v1/models", func() {
+		req, err := http.NewRequest("GET", apiBaseURL+"/openai/openai/v1/models", nil)
 		Expect(err).NotTo(HaveOccurred())
 		req.Header.Set("Authorization", "Bearer "+token)
 
@@ -161,9 +161,9 @@ var _ = Describe("Chat and OpenAI-Compatible API", Ordered, func() {
 		Expect(bodyStr).To(ContainSubstring("object"))
 	})
 
-	// --- OpenAI-Compatible: /v1/chat/completions ---
+	// --- OpenAI-Compatible: /openai/v1/chat/completions ---
 
-	It("should proxy chat completions via POST /v1/chat/completions", func() {
+	It("should proxy chat completions via POST /openai/v1/chat/completions", func() {
 		skipIfNoKey("E2E_OPENAI_API_KEY")
 
 		By("ensuring an OpenAI provider exists")
@@ -186,7 +186,7 @@ var _ = Describe("Chat and OpenAI-Compatible API", Ordered, func() {
 			"max_tokens": 50
 		}`, model)
 
-		req, err := http.NewRequest("POST", apiBaseURL+"/v1/chat/completions",
+		req, err := http.NewRequest("POST", apiBaseURL+"/openai/openai/v1/chat/completions",
 			strings.NewReader(oaiBody))
 		Expect(err).NotTo(HaveOccurred())
 		req.Header.Set("Authorization", "Bearer "+token)


### PR DESCRIPTION
## Summary

Adds an Anthropic-compatible API proxy at `/anthropic/v1/messages` with a server-side agent loop that executes tools in the K8s cluster. Claude Code and other Anthropic SDK clients can use Orka as a custom provider — all tool execution happens server-side, clients only receive final text responses with streamed progress.

### Phase 1: Anthropic Proxy + Route Reorganization
- Anthropic Messages API at `/anthropic/v1/messages` (streaming + non-streaming)
- OpenAI proxy moved from `/v1/` to `/openai/v1/`
- Auth middleware extended to accept `x-api-key` header (Anthropic convention)
- Full Anthropic SSE streaming with extended thinking support
- Model resolution: `provider/model` and plain model formats

### Phase 2: Server-Side Tool Execution (Agent Loop)
- Proxy intercepts `tool_use` responses and executes tools server-side via `tools.DefaultRegistry`
- Built-in tools injected automatically: `web_search`, `code_exec`, `file_read`, `file_write`, `web_fetch`
- Tool CRDs from the user's namespace included as custom HTTP tools
- Iteration limit (20), per-tool timeout (60s), overall timeout (5min)
- Repetition detection, progress checks every 5 iterations, context truncation
- Streaming: real-time SSE events across multiple LLM round-trips
- Clients never see `tool_use` — only final text + streamed progress

### Files Changed
| File | Change |
|------|--------|
| `internal/api/anthropic_tool_loop.go` | **New** — Tool injection, execution, and non-streaming agent loop |
| `internal/api/anthropic_streaming.go` | **New** — Streaming handler with tool loop and SSE events |
| `internal/api/anthropic_compat.go` | **New** — Handler, types, message/tool conversion |
| `internal/api/anthropic_compat_test.go` | **New** — 11 unit tests for tool injection, loop, and error handling |
| `docs/anthropic-compat.md` | **New** — Full documentation |
| `internal/api/server.go` | Route reorganization + Anthropic route group |
| `internal/api/auth.go` | `x-api-key` header support |
| Other docs/tests | Updated paths from `/v1/` to `/openai/v1/` |

### Testing
- All existing tests pass
- 11 new unit tests covering tool injection, single/multi-step loops, iteration limits, error handling, repetition detection
- Manually verified with Claude Code on AKS cluster — all tools (web_search, code_exec) executed server-side in K8s pod, confirmed via controller logs