### PR TITLE
add codex agent runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 IMG ?= controller:latest
 COPILOT_WORKER_IMG ?= ghcr.io/sozercan/orka/agent-worker-copilot:latest
 CLAUDE_WORKER_IMG ?= ghcr.io/sozercan/orka/agent-worker-claude:latest
+CODEX_WORKER_IMG ?= ghcr.io/sozercan/orka/agent-worker-codex:latest
 AI_WORKER_IMG ?= ghcr.io/sozercan/orka/ai-worker:latest
 GENERAL_WORKER_IMG ?= ghcr.io/sozercan/orka/general-worker:latest
 
@@ -108,6 +109,7 @@ test-e2e-setup-only: setup-test-e2e docker-build-all ## Set up Kind cluster and 
 	$(KIND) load docker-image $(IMG) --name $(KIND_CLUSTER)
 	$(KIND) load docker-image $(COPILOT_WORKER_IMG) --name $(KIND_CLUSTER)
 	$(KIND) load docker-image $(CLAUDE_WORKER_IMG) --name $(KIND_CLUSTER)
+	$(KIND) load docker-image $(CODEX_WORKER_IMG) --name $(KIND_CLUSTER)
 	$(KIND) load docker-image $(AI_WORKER_IMG) --name $(KIND_CLUSTER)
 	$(KIND) load docker-image $(GENERAL_WORKER_IMG) --name $(KIND_CLUSTER)
 
@@ -195,6 +197,10 @@ bundle-copilot-cli: ## Bundle the Copilot CLI binary for the current platform (f
 docker-build-claude-worker: ## Build docker image for the Claude agent worker.
 	$(CONTAINER_TOOL) build -t ${CLAUDE_WORKER_IMG} -f workers/agent/claude/Dockerfile .
 
+.PHONY: docker-build-codex-worker
+docker-build-codex-worker: ## Build docker image for the Codex agent worker.
+	$(CONTAINER_TOOL) build -t ${CODEX_WORKER_IMG} -f workers/agent/codex/Dockerfile .
+
 .PHONY: docker-build-ai-worker
 docker-build-ai-worker: ## Build docker image for the AI worker.
 	$(CONTAINER_TOOL) build -t ${AI_WORKER_IMG} -f workers/ai/Dockerfile .
@@ -211,11 +217,15 @@ docker-push-copilot-worker: ## Push docker image for the Copilot agent worker.
 docker-push-claude-worker: ## Push docker image for the Claude agent worker.
 	$(CONTAINER_TOOL) push ${CLAUDE_WORKER_IMG}
 
+.PHONY: docker-push-codex-worker
+docker-push-codex-worker: ## Push docker image for the Codex agent worker.
+	$(CONTAINER_TOOL) push ${CODEX_WORKER_IMG}
+
 .PHONY: docker-build-all
-docker-build-all: docker-build docker-build-copilot-worker docker-build-claude-worker docker-build-ai-worker docker-build-general-worker ## Build all docker images.
+docker-build-all: docker-build docker-build-copilot-worker docker-build-claude-worker docker-build-codex-worker docker-build-ai-worker docker-build-general-worker ## Build all docker images.
 
 .PHONY: docker-push-all
-docker-push-all: docker-push docker-push-copilot-worker docker-push-claude-worker ## Push all docker images.
+docker-push-all: docker-push docker-push-copilot-worker docker-push-claude-worker docker-push-codex-worker ## Push all docker images.
 
 # PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ One `helm install`, one LLM secret, and you're chatting with an orchestrator tha
 ## Features
 
 - 🤖 **AI Agents** — Anthropic, OpenAI, or Azure OpenAI with tools, skills, and session persistence
-- 🛠️ **Agent Runtimes** — Delegate to Claude Code CLI or GitHub Copilot CLI for full autonomous coding
+- 🛠️ **Agent Runtimes** — Delegate to Codex CLI, Claude Code CLI, or GitHub Copilot CLI for full autonomous coding
 - 🔀 **Multi-Agent Coordination** — Coordinators delegate to specialists with depth and concurrency controls
 - 💬 **Interactive Chat** — Agentic orchestrator with SSE streaming that creates and manages agents and tasks for you
 - 🖥️ **Web Dashboard** — Built-in React UI embedded in the controller binary — zero extra deployments
@@ -96,7 +96,7 @@ The built-in orchestrator creates agents, runs tasks, monitors progress, and ret
 | [Getting Started](docs/getting-started.md)                   | Installation, quick start, CLI setup                  |
 | [Architecture](docs/architecture.md)                         | System design, components, and data flow              |
 | [Configuration](docs/configuration.md)                       | CRD reference, Helm values, controller flags, metrics |
-| [Agent Runtimes](docs/agent-runtimes.md)                     | Claude Code CLI and Copilot CLI runtimes              |
+| [Agent Runtimes](docs/agent-runtimes.md)                     | Codex CLI, Claude Code CLI, and Copilot CLI runtimes  |
 | [Interactive Chat](docs/chat.md)                             | Chat endpoint, tools, and SSE streaming               |
 | [Multi-Agent Coordination](docs/multi-agent-coordination.md) | Coordinator agents and task delegation                |
 | [API Reference](docs/api-reference.md)                       | REST API endpoints and usage examples                 |

--- a/api/v1alpha1/agent_runtime_types_test.go
+++ b/api/v1alpha1/agent_runtime_types_test.go
@@ -45,6 +45,7 @@ func TestAgentRuntimeTypeConstants(t *testing.T) {
 	}{
 		{"copilot", AgentRuntimeCopilot, "copilot"},
 		{"claude", AgentRuntimeClaude, "claude"},
+		{"codex", AgentRuntimeCodex, "codex"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -279,6 +280,7 @@ func TestAgentRuntimeTypeAssignment(t *testing.T) {
 	}{
 		{"copilot runtime", AgentRuntimeCopilot},
 		{"claude runtime", AgentRuntimeClaude},
+		{"codex runtime", AgentRuntimeCodex},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/api/v1alpha1/task_types.go
+++ b/api/v1alpha1/task_types.go
@@ -20,7 +20,7 @@ const (
 	TaskTypeContainer TaskType = "container"
 	// TaskTypeAI runs AI agent tasks with LLM integration
 	TaskTypeAI TaskType = "ai"
-	// TaskTypeAgent runs external agent CLI runtimes (e.g., Copilot CLI, Claude Code CLI)
+	// TaskTypeAgent runs external agent CLI runtimes (e.g., Copilot CLI, Claude Code CLI, Codex CLI)
 	TaskTypeAgent TaskType = "agent"
 )
 
@@ -403,7 +403,7 @@ type TaskList struct {
 }
 
 // AgentRuntimeType defines the agent runtime to use
-// +kubebuilder:validation:Enum=copilot;claude
+// +kubebuilder:validation:Enum=copilot;claude;codex
 type AgentRuntimeType string
 
 const (
@@ -411,6 +411,8 @@ const (
 	AgentRuntimeCopilot AgentRuntimeType = "copilot"
 	// AgentRuntimeClaude uses Claude Code CLI as the agent runtime
 	AgentRuntimeClaude AgentRuntimeType = "claude"
+	// AgentRuntimeCodex uses OpenAI Codex CLI as the agent runtime
+	AgentRuntimeCodex AgentRuntimeType = "codex"
 )
 
 // AgentRuntimeSpec defines task-level overrides for agent runtime configuration.

--- a/charts/orka/templates/deployment.yaml
+++ b/charts/orka/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
             - --ai-worker-image={{ .Values.workers.ai.image.repository }}:{{ .Values.workers.ai.image.tag }}
             - --copilot-worker-image={{ .Values.workers.copilot.image.repository | default "ghcr.io/sozercan/orka/agent-worker-copilot" }}:{{ .Values.workers.copilot.image.tag | default "latest" }}
             - --claude-worker-image={{ .Values.workers.claude.image.repository | default "ghcr.io/sozercan/orka/agent-worker-claude" }}:{{ .Values.workers.claude.image.tag | default "latest" }}
+            - --codex-worker-image={{ .Values.workers.codex.image.repository | default "ghcr.io/sozercan/orka/agent-worker-codex" }}:{{ .Values.workers.codex.image.tag | default "latest" }}
             {{- if .Values.controller.enforceNamespaceIsolation }}
             - --enforce-namespace-isolation=true
             {{- end }}

--- a/charts/orka/values.yaml
+++ b/charts/orka/values.yaml
@@ -52,6 +52,24 @@ workers:
       tag: latest
       pullPolicy: IfNotPresent
 
+  copilot:
+    image:
+      repository: ghcr.io/sozercan/orka/agent-worker-copilot
+      tag: latest
+      pullPolicy: IfNotPresent
+
+  claude:
+    image:
+      repository: ghcr.io/sozercan/orka/agent-worker-claude
+      tag: latest
+      pullPolicy: IfNotPresent
+
+  codex:
+    image:
+      repository: ghcr.io/sozercan/orka/agent-worker-codex
+      tag: latest
+      pullPolicy: IfNotPresent
+
   # Default resources for workers
   resources:
     limits:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -67,6 +67,7 @@ func main() {
 	var watchNamespace string
 	var copilotWorkerImage string
 	var claudeWorkerImage string
+	var codexWorkerImage string
 	var generalWorkerImage string
 	var chatEnabled bool
 	var chatProvider string
@@ -109,6 +110,8 @@ func main() {
 		controller.DefaultCopilotWorkerImage, "Container image for Copilot agent worker.")
 	flag.StringVar(&claudeWorkerImage, "claude-worker-image",
 		controller.DefaultClaudeWorkerImage, "Container image for Claude agent worker.")
+	flag.StringVar(&codexWorkerImage, "codex-worker-image",
+		controller.DefaultCodexWorkerImage, "Container image for Codex agent worker.")
 	flag.StringVar(&aiWorkerImage, "ai-worker-image",
 		controller.DefaultAIWorkerImage, "Container image for AI worker.")
 	flag.StringVar(&generalWorkerImage, "general-worker-image",
@@ -261,9 +264,16 @@ func main() {
 	jobBuilder := controller.NewJobBuilder(mgr.GetClient())
 	jobBuilder.CopilotWorkerImage = copilotWorkerImage
 	jobBuilder.ClaudeWorkerImage = claudeWorkerImage
+	jobBuilder.CodexWorkerImage = codexWorkerImage
 	jobBuilder.AIWorkerImage = aiWorkerImage
 	jobBuilder.GeneralWorkerImage = generalWorkerImage
-	setupLog.Info("worker images configured", "ai", aiWorkerImage, "copilot", copilotWorkerImage)
+	setupLog.Info("worker images configured",
+		"ai", aiWorkerImage,
+		"copilot", copilotWorkerImage,
+		"claude", claudeWorkerImage,
+		"codex", codexWorkerImage,
+		"general", generalWorkerImage,
+	)
 	jobBuilder.ControllerURL = controllerURL
 	// Auto-discover controller URL from in-cluster service if not explicitly set
 	if jobBuilder.ControllerURL == "" {

--- a/config/crd/bases/core.orka.ai_agents.yaml
+++ b/config/crd/bases/core.orka.ai_agents.yaml
@@ -270,6 +270,7 @@ spec:
                     enum:
                     - copilot
                     - claude
+                    - codex
                     type: string
                 required:
                 - type

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,6 +70,7 @@ spec:
           - --ai-worker-image=ghcr.io/sozercan/orka/ai-worker:latest
           - --copilot-worker-image=ghcr.io/sozercan/orka/agent-worker-copilot:latest
           - --claude-worker-image=ghcr.io/sozercan/orka/agent-worker-claude:latest
+          - --codex-worker-image=ghcr.io/sozercan/orka/agent-worker-codex:latest
           - --general-worker-image=ghcr.io/sozercan/orka/general-worker:latest
         image: controller:latest
         name: manager

--- a/config/samples/core_v1alpha1_agent_claude.yaml
+++ b/config/samples/core_v1alpha1_agent_claude.yaml
@@ -18,7 +18,7 @@ spec:
   # runtime marks this Agent for type: agent tasks using Claude Code CLI
   # (mutually exclusive with providerRef, which is for type: ai tasks)
   runtime:
-    # type selects the CLI runtime: "claude" or "copilot"
+    # type selects the CLI runtime: "claude", "copilot", or "codex"
     type: claude
     # defaultMaxTurns is the default max agent loop iterations per task
     defaultMaxTurns: 50

--- a/config/samples/core_v1alpha1_agent_codex.yaml
+++ b/config/samples/core_v1alpha1_agent_codex.yaml
@@ -1,0 +1,24 @@
+apiVersion: core.orka.ai/v1alpha1
+kind: Agent
+metadata:
+  name: codex-agent
+  labels:
+    app.kubernetes.io/name: orka
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  model:
+    name: "gpt-5.4"
+  systemPrompt:
+    inline: "You are a helpful coding assistant."
+  secretRef:
+    name: codex-api-key
+  runtime:
+    type: codex
+    defaultMaxTurns: 50
+    defaultAllowBash: true
+    defaultAllowedTools:
+      - Read
+      - Write
+      - Edit
+      - Bash
+      - WebSearch

--- a/config/samples/core_v1alpha1_task_agent.yaml
+++ b/config/samples/core_v1alpha1_task_agent.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: orka
     app.kubernetes.io/managed-by: kustomize
 spec:
-  # type: agent delegates work to an external CLI runtime (e.g., Claude Code CLI)
+  # type: agent delegates work to an external CLI runtime (e.g., Claude Code CLI or Codex CLI)
   type: agent
   # agentRef references an Agent CRD that defines runtime type and credentials
   agentRef:

--- a/config/samples/core_v1alpha1_task_agent_copilot.yaml
+++ b/config/samples/core_v1alpha1_task_agent_copilot.yaml
@@ -19,6 +19,3 @@ spec:
   # Maximum time before the task is terminated
   timeout: "20m"
   priority: 500
-  # NOTE: The Copilot CLI worker implementation is pending.
-  # This manifest is valid per the API schema and will work
-  # once the copilot worker is available.

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
 - core_v1alpha1_tool.yaml
 - core_v1alpha1_agent.yaml
 - core_v1alpha1_agent_claude.yaml
+- core_v1alpha1_agent_codex.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/docs/agent-runtimes.md
+++ b/docs/agent-runtimes.md
@@ -286,6 +286,8 @@ agentRuntime:
 
 > **Note**: For the Copilot runtime, `GITHUB_TOKEN` from the Agent's `secretRef` can authenticate both the CLI and git clone operations. For the Claude and Codex runtimes, a separate `gitSecretRef` is usually needed because their API keys do not authenticate git operations.
 
+> **Codex caveat**: The current Codex runtime implementation requires `defaultAllowBash: true` (or task-level `allowBash: true`). If bash is disabled, the worker fails fast instead of launching Codex, because the current Codex CLI does not expose a reliable shell-disable mode.
+
 ### SubPath
 
 Restrict the agent's workspace to a subdirectory of the cloned repository:
@@ -394,6 +396,8 @@ Writable directories are provided via `emptyDir` volumes:
 | Bash | Allowed | High |
 
 All tools are allowed by default for autonomous operation. To restrict high-risk tools, set `defaultAllowBash: false` on the Agent or `allowBash: false` on individual Tasks.
+
+For Codex specifically, bash-disabled tasks are not currently supported. Use `defaultAllowBash: true` for Codex Agents until the upstream CLI exposes a reliable shell-disable mode.
 
 ### Secrets
 

--- a/docs/agent-runtimes.md
+++ b/docs/agent-runtimes.md
@@ -1,11 +1,12 @@
 # Agent Runtimes
 
-Agent runtimes let Orka delegate task execution to external agent CLIs—such as Claude Code CLI and GitHub Copilot CLI—instead of running tasks through Orka's built-in AI worker. This gives your tasks access to full autonomous coding capabilities (file read/write/edit, bash execution, git operations) provided by battle-tested agent runtimes, while Orka handles scheduling, lifecycle management, secrets, sessions, and Kubernetes-native orchestration.
+Agent runtimes let Orka delegate task execution to external agent CLIs—such as Codex CLI, Claude Code CLI, and GitHub Copilot CLI—instead of running tasks through Orka's built-in AI worker. This gives your tasks access to full autonomous coding capabilities (file read/write/edit, bash execution, git operations) provided by battle-tested agent runtimes, while Orka handles scheduling, lifecycle management, secrets, sessions, and Kubernetes-native orchestration.
 
 ## Supported Runtimes
 
 | Runtime | `runtime.type` | Secret Key | Status |
 |---------|---------------|------------|--------|
+| Codex CLI | `codex` | `OPENAI_API_KEY` or `CODEX_API_KEY` | GA |
 | Claude Code CLI | `claude` | `ANTHROPIC_API_KEY` (direct) or `ANTHROPIC_FOUNDRY_API_KEY` (Azure AI Foundry) | GA |
 | GitHub Copilot CLI | `copilot` | `GITHUB_TOKEN` | Technical Preview |
 
@@ -14,6 +15,10 @@ Agent runtimes let Orka delegate task execution to external agent CLIs—such as
 ### 1. Create a Secret
 
 ```bash
+# For Codex CLI
+kubectl create secret generic codex-api-key \
+  --from-literal=OPENAI_API_KEY=sk-proj-...
+
 # For Claude Code CLI
 kubectl create secret generic claude-api-key \
   --from-literal=ANTHROPIC_API_KEY=sk-ant-...
@@ -112,7 +117,7 @@ spec:
   # runtime marks this Agent for type: agent tasks
   runtime:
     # type: which CLI runtime to use (required)
-    # Valid values: "copilot", "claude"
+    # Valid values: "copilot", "claude", "codex"
     type: claude
 
     # defaultMaxTurns: default max agent loop iterations per task
@@ -131,6 +136,7 @@ spec:
     defaultAllowBash: true
 
   # secretRef: Secret containing API credentials
+  # Codex runtime expects: OPENAI_API_KEY or CODEX_API_KEY
   # Claude runtime expects: ANTHROPIC_API_KEY
   # Copilot runtime expects: GITHUB_TOKEN
   secretRef:
@@ -278,7 +284,7 @@ agentRuntime:
       name: git-credentials
 ```
 
-> **Note**: For the Copilot runtime, `GITHUB_TOKEN` from the Agent's `secretRef` can authenticate both the CLI and git clone operations. For the Claude runtime, a separate `gitSecretRef` is needed since `ANTHROPIC_API_KEY` cannot authenticate git operations.
+> **Note**: For the Copilot runtime, `GITHUB_TOKEN` from the Agent's `secretRef` can authenticate both the CLI and git clone operations. For the Claude and Codex runtimes, a separate `gitSecretRef` is usually needed because their API keys do not authenticate git operations.
 
 ### SubPath
 
@@ -398,6 +404,10 @@ API keys are injected as environment variables from Kubernetes Secrets. They are
 kubectl create secret generic claude-api-key \
   --from-literal=ANTHROPIC_API_KEY=sk-ant-...
 
+# Codex runtime
+kubectl create secret generic codex-api-key \
+  --from-literal=OPENAI_API_KEY=sk-proj-...
+
 # Copilot runtime
 kubectl create secret generic copilot-token \
   --from-literal=GITHUB_TOKEN=ghp_...
@@ -411,13 +421,15 @@ The controller accepts flags to configure agent worker images:
 |------|---------|-------------|
 | `--copilot-worker-image` | `ghcr.io/sozercan/orka/agent-worker-copilot:latest` | Container image for Copilot agent workers |
 | `--claude-worker-image` | `ghcr.io/sozercan/orka/agent-worker-claude:latest` | Container image for Claude agent workers |
+| `--codex-worker-image` | `ghcr.io/sozercan/orka/agent-worker-codex:latest` | Container image for Codex agent workers |
 
 Example:
 
 ```bash
 orka-controller \
   --copilot-worker-image=ghcr.io/sozercan/orka/agent-worker-copilot:v1.0.0 \
-  --claude-worker-image=ghcr.io/sozercan/orka/agent-worker-claude:v1.0.0
+  --claude-worker-image=ghcr.io/sozercan/orka/agent-worker-claude:v1.0.0 \
+  --codex-worker-image=ghcr.io/sozercan/orka/agent-worker-codex:v1.0.0
 ```
 
 ## Optimizing Agent Performance
@@ -434,6 +446,7 @@ Complete sample manifests are available in [`config/samples/`](../config/samples
 
 | File | Description |
 |------|-------------|
+| `core_v1alpha1_agent_codex.yaml` | Agent configured for Codex CLI |
 | `core_v1alpha1_agent_claude.yaml` | Agent configured for Claude Code CLI |
 | `core_v1alpha1_task_agent.yaml` | Basic agent task with workspace |
 | `core_v1alpha1_task_agent_copilot.yaml` | Agent task using Copilot runtime |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,6 +65,7 @@ Orka uses four CRDs:
 | **AI Worker** (`workers/ai/`) | Runs LLM agent tasks with built-in tools (web search, code exec, file read) and coordination tools (delegate_task, wait_for_tasks, create_pull_request, merge_pull_request, review_pull_request, post_review_comment, create_agent, delete_agent) |
 | **Copilot Agent Worker** (`workers/agent/copilot/`) | Runs tasks via GitHub Copilot CLI using the Go SDK |
 | **Claude Agent Worker** (`workers/agent/claude/`) | Runs tasks via Claude Code CLI |
+| **Codex Agent Worker** (`workers/agent/codex/`) | Runs tasks via OpenAI Codex CLI |
 
 ## Design Decisions
 
@@ -109,7 +110,8 @@ orka/
 │   ├── general/            # General worker (container commands)
 │   └── agent/
 │       ├── copilot/        # Copilot CLI agent worker
-│       └── claude/         # Claude Code CLI agent worker
+│       ├── claude/         # Claude Code CLI agent worker
+│       └── codex/          # Codex CLI agent worker
 ├── ui/                     # React SPA (Vite + TanStack Router + shadcn/ui)
 ├── config/                 # Kustomize manifests (CRDs, RBAC, samples)
 ├── charts/orka/          # Helm chart

--- a/docs/cicd-integration.md
+++ b/docs/cicd-integration.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-`delegate_task` hardcodes `Type: TaskTypeAI` on child tasks. A coordinator agent cannot delegate to `type: agent` tasks (Claude Code, Copilot CLI). This means agents that can natively create branches, write code, commit, push, and open PRs via `gh` are unreachable from the coordination system.
+`delegate_task` hardcodes `Type: TaskTypeAI` on child tasks. A coordinator agent cannot delegate to `type: agent` tasks (Claude Code, Copilot CLI, Codex). This means agents that can natively create branches, write code, commit, push, and open PRs via `gh` are unreachable from the coordination system.
 
 Additionally, the Tool CRD HTTP executor sends all parameters as JSON body — it cannot do URL path interpolation (e.g., `/repos/{owner}/{repo}/pulls/{number}/merge`). This blocks lightweight GitHub/GitLab API calls from Tool CRDs.
 
@@ -10,7 +10,7 @@ Fixing these two issues — plus shipping sample YAML — gives Orka a full CI/C
 
 ## Key Insight
 
-Orka doesn't need built-in PR lifecycle tools. The `type: agent` tasks run Claude Code or Copilot CLI, which natively know how to create branches, write code, commit, push, and run `gh pr create`. These are full coding agents with filesystem access, bash, and git — they do PR creation **better than any custom tool we'd build**.
+Orka doesn't need built-in PR lifecycle tools. The `type: agent` tasks run Claude Code, Copilot CLI, or Codex, which natively know how to create branches, write code, commit, push, and run `gh pr create`. These are full coding agents with filesystem access, bash, and git — they do PR creation **better than any custom tool we'd build**.
 
 What's needed is:
 1. Let `delegate_task` create agent tasks (not just AI tasks)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,7 +133,7 @@ spec:
 
 ### Agent (with Runtime)
 
-Agent configuration for external CLI runtimes (Claude Code CLI or GitHub Copilot CLI).
+Agent configuration for external CLI runtimes (Claude Code CLI, GitHub Copilot CLI, or Codex CLI).
 
 ```yaml
 apiVersion: core.orka.ai/v1alpha1
@@ -148,7 +148,7 @@ spec:
   systemPrompt:
     inline: "You are a senior software engineer."
   runtime:
-    type: claude         # or "copilot"
+    type: claude         # or "copilot" / "codex"
     defaultMaxTurns: 50
     defaultAllowBash: true
     defaultAllowedTools:
@@ -313,6 +313,7 @@ See [charts/orka/values.yaml](../charts/orka/values.yaml) for the full list.
 | `--ai-worker-image` | `ghcr.io/sozercan/orka/ai-worker:latest` | AI worker container image |
 | `--copilot-worker-image` | `ghcr.io/sozercan/orka/agent-worker-copilot:latest` | Copilot agent worker image |
 | `--claude-worker-image` | `ghcr.io/sozercan/orka/agent-worker-claude:latest` | Claude agent worker image |
+| `--codex-worker-image` | `ghcr.io/sozercan/orka/agent-worker-codex:latest` | Codex agent worker image |
 | `--general-worker-image` | `ghcr.io/sozercan/orka/general-worker:latest` | General worker container image |
 | `--store-backend` | `sqlite` | Storage backend (sqlite) |
 | `--store-path` | `/data/orka.db` | Path to SQLite database file |

--- a/docs/development.md
+++ b/docs/development.md
@@ -59,6 +59,7 @@ make ui-test-coverage   # Run UI tests with coverage
 make docker-build                  # Controller image
 make docker-build-claude-worker    # Claude agent worker
 make docker-build-copilot-worker   # Copilot agent worker
+make docker-build-codex-worker     # Codex agent worker
 make docker-build-ai-worker        # AI worker
 make docker-build-general-worker   # General worker
 make docker-build-all              # All images
@@ -67,6 +68,7 @@ make docker-build-all              # All images
 make docker-push
 make docker-push-claude-worker
 make docker-push-copilot-worker
+make docker-push-codex-worker
 make docker-push-all
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -162,6 +162,8 @@ spec:
 EOF
 ```
 
+For Codex Agents, keep `defaultAllowBash: true` for now. The current Codex runtime implementation fails fast when bash is disabled because the upstream Codex CLI does not yet expose a reliable shell-disable mode.
+
 ### 3. Run an Agent Task
 
 ```yaml

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,7 +118,7 @@ orka task download <task-name> [filename] -o <path>
 
 ## Agent Runtimes Quick Start
 
-Agent runtimes let you run tasks via Claude Code CLI or GitHub Copilot CLI with full autonomous coding capabilities.
+Agent runtimes let you run tasks via Codex CLI, Claude Code CLI, or GitHub Copilot CLI with full autonomous coding capabilities.
 
 ### 1. Create Credentials
 
@@ -133,6 +133,10 @@ kubectl create secret generic claude-credentials \
   --from-literal=ANTHROPIC_FOUNDRY_API_KEY=your-key \
   --from-literal=ANTHROPIC_FOUNDRY_RESOURCE=your-resource \
   --from-literal=ANTHROPIC_DEFAULT_SONNET_MODEL=claude-sonnet-4-5
+
+# For Codex CLI
+kubectl create secret generic codex-api-key \
+  --from-literal=OPENAI_API_KEY=sk-proj-your-key
 ```
 
 ### 2. Create an Agent with Runtime
@@ -224,7 +228,7 @@ The CLI supports token extraction from bearer tokens, token files, exec-based au
 
 ## Next Steps
 
-- [Agent Runtimes](agent-runtimes.md) — Claude Code CLI and Copilot CLI configuration
+- [Agent Runtimes](agent-runtimes.md) — Codex CLI, Claude Code CLI, and Copilot CLI configuration
 - [Interactive Chat](chat.md) — Chat endpoint with tool execution
 - [Multi-Agent Coordination](multi-agent-coordination.md) — Coordinator agents and delegation
 - [OpenAI Compatibility](openai-compat.md) — Use any OpenAI-compatible client via `/openai/v1/`

--- a/docs/security.md
+++ b/docs/security.md
@@ -16,7 +16,7 @@ Only three paths are writable (mounted as EmptyDir volumes):
 | Path | Purpose |
 |------|---------|
 | `/tmp` | Container runtime temporary files |
-| `/home/worker` | CLI config/cache (Claude, Copilot) |
+| `/home/worker` | CLI config/cache (Claude, Copilot, Codex) |
 | `/workspace` | Git clone and working directory |
 
 All other filesystem paths are read-only. Workers that write outside these paths will fail.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -45,6 +45,7 @@ Tests use **Ginkgo + Gomega** (BDD style) for controller/integration tests and s
 | `workers/general/` | `main_test.go` | General worker functions |
 | `workers/agent/copilot/` | `main_test.go` | Copilot agent worker |
 | `workers/agent/claude/` | `main_test.go` | Claude agent worker |
+| `workers/agent/codex/` | `main_test.go` | Codex agent worker |
 
 ### E2E Tests
 

--- a/internal/api/chat_system_prompt.go
+++ b/internal/api/chat_system_prompt.go
@@ -145,7 +145,7 @@ call in the SAME response. If you need to create a task AND fetch its result,
 call create_*_task, then wait_for_task, then fetch_task_output all in sequence
 without stopping to narrate between steps. Act first, summarize after.
 
-LONG-RUNNING TASKS: Agent tasks (Copilot, Claude Code) typically run for 5-20 minutes.
+LONG-RUNNING TASKS: Agent tasks (Copilot, Claude Code, Codex) typically run for 5-20 minutes.
 You MUST keep calling wait_for_task in a loop until the task reaches a terminal state
 (Succeeded or Failed). Do NOT give up after a few polls — keep waiting. If wait_for_task
 returns "still running", immediately call wait_for_task again. Only stop when the task
@@ -188,7 +188,7 @@ func buildTaskTypesSection(mode PromptMode) string {
   answering questions about data. The AI worker has built-in tools (code_exec,
   web_search, file_read, web_fetch, file_write) but runs in a minimal container without CLI tools.
   Do NOT use for infrastructure commands.
-- agent: Run an external CLI runtime (Copilot, Claude Code). Use create_agent_task.
+- agent: Run an external CLI runtime (Copilot, Claude Code, Codex). Use create_agent_task.
   Use for: code changes in a git repo, multi-file refactoring.
   IMPORTANT: When the user specifies an agent (via --agent or agentRef) that has a
   runtime configured, ALWAYS use create_agent_task with that agent name.
@@ -196,7 +196,7 @@ func buildTaskTypesSection(mode PromptMode) string {
   workspace config so credentials are automatically mounted:
     create_agent_task(agent: "coder", prompt: "...", gitRepo: "https://github.com/org/repo", timeout: "15m")
   When creating new agents for coding tasks, check the agent_runtimes in the Runtime line above.
-  Use whichever runtime is available. If both are available, prefer copilot.
+  Use whichever runtime is available. If multiple runtimes are available, prefer codex, then copilot.
   If no agent runtimes are available, use create_ai_task with workspace config instead.
   Agent tasks need more time than AI tasks. Set timeout to at least 15m.
   Do NOT use create_container_task or create_ai_task for runtime agents.
@@ -414,6 +414,9 @@ func (b *SystemPromptBuilder) buildDynamicContext(ctx context.Context) (agentsSe
 		secretNames := make(map[string]bool, len(secretList.Items))
 		for i := range secretList.Items {
 			secretNames[secretList.Items[i].Name] = true
+		}
+		if chattools.FirstPresentSecretName(secretNames, chattools.RuntimeSecretCandidates(corev1alpha1.AgentRuntimeCodex)) != "" {
+			availableRuntimes = append(availableRuntimes, "codex")
 		}
 		if chattools.FirstPresentSecretName(secretNames, chattools.RuntimeSecretCandidates(corev1alpha1.AgentRuntimeCopilot)) != "" {
 			availableRuntimes = append(availableRuntimes, "copilot")

--- a/internal/api/chat_system_prompt_test.go
+++ b/internal/api/chat_system_prompt_test.go
@@ -548,6 +548,22 @@ func TestBuildDynamicContext(t *testing.T) {
 		}
 	})
 
+	t.Run("codex runtime detected from codex-api-key secret", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "codex-api-key", Namespace: "default"},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+		b := NewSystemPromptBuilder(c, "default")
+
+		_, _, providers, _, err := b.buildDynamicContext(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(providers, "codex") {
+			t.Errorf("providers = %q, expected codex runtime", providers)
+		}
+	})
+
 	t.Run("no runtime secrets means agent_runtimes=none", func(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 		b := NewSystemPromptBuilder(c, "default")

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -42,6 +42,9 @@ const (
 	// DefaultClaudeWorkerImage is the default image for Claude agent tasks
 	DefaultClaudeWorkerImage = "ghcr.io/sozercan/orka/agent-worker-claude:latest"
 
+	// DefaultCodexWorkerImage is the default image for Codex agent tasks
+	DefaultCodexWorkerImage = "ghcr.io/sozercan/orka/agent-worker-codex:latest"
+
 	// DefaultInitImage is the default image for init containers
 	DefaultInitImage = "busybox:1.37"
 
@@ -68,6 +71,7 @@ type JobBuilder struct {
 	GeneralWorkerImage string
 	CopilotWorkerImage string
 	ClaudeWorkerImage  string
+	CodexWorkerImage   string
 	InitImage          string
 	ControllerURL      string // e.g. http://orka-controller.orka-system.svc:8080
 }
@@ -80,6 +84,7 @@ func NewJobBuilder(c client.Client) *JobBuilder {
 		GeneralWorkerImage: DefaultGeneralWorkerImage,
 		CopilotWorkerImage: DefaultCopilotWorkerImage,
 		ClaudeWorkerImage:  DefaultClaudeWorkerImage,
+		CodexWorkerImage:   DefaultCodexWorkerImage,
 		InitImage:          DefaultInitImage,
 	}
 }
@@ -739,6 +744,8 @@ func (b *JobBuilder) getAgentWorkerImage(agent *corev1alpha1.Agent) string {
 		return b.CopilotWorkerImage
 	case corev1alpha1.AgentRuntimeClaude:
 		return b.ClaudeWorkerImage
+	case corev1alpha1.AgentRuntimeCodex:
+		return b.CodexWorkerImage
 	default:
 		return b.ClaudeWorkerImage
 	}

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -56,6 +56,9 @@ func TestNewJobBuilder(t *testing.T) {
 	if builder.GeneralWorkerImage != DefaultGeneralWorkerImage {
 		t.Errorf("GeneralWorkerImage = %s, want %s", builder.GeneralWorkerImage, DefaultGeneralWorkerImage)
 	}
+	if builder.CodexWorkerImage != DefaultCodexWorkerImage {
+		t.Errorf("CodexWorkerImage = %s, want %s", builder.CodexWorkerImage, DefaultCodexWorkerImage)
+	}
 }
 
 func TestJobBuilder_Build_ContainerTask(t *testing.T) {
@@ -819,6 +822,38 @@ func TestJobBuilder_Build_AgentTask_ClaudeRuntime(t *testing.T) {
 	container := job.Spec.Template.Spec.Containers[0]
 	if container.Image != DefaultClaudeWorkerImage {
 		t.Errorf("Image = %s, want %s", container.Image, DefaultClaudeWorkerImage)
+	}
+}
+
+func TestJobBuilder_Build_AgentTask_CodexRuntime(t *testing.T) {
+	builder := setupJobBuilder()
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent-task",
+			Namespace: defaultNS,
+			UID:       types.UID("12345678-1234-1234-1234-123456789012"),
+		},
+		Spec: corev1alpha1.TaskSpec{
+			Type:   corev1alpha1.TaskTypeAgent,
+			Prompt: "Fix the bug",
+		},
+	}
+	agent := &corev1alpha1.Agent{
+		Spec: corev1alpha1.AgentSpec{
+			Runtime: &corev1alpha1.AgentCLIRuntime{
+				Type: corev1alpha1.AgentRuntimeCodex,
+			},
+		},
+	}
+
+	job, err := builder.Build(context.Background(), task, agent, nil)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	container := job.Spec.Template.Spec.Containers[0]
+	if container.Image != DefaultCodexWorkerImage {
+		t.Errorf("Image = %s, want %s", container.Image, DefaultCodexWorkerImage)
 	}
 }
 
@@ -1960,6 +1995,15 @@ func TestGetAgentWorkerImage(t *testing.T) {
 				},
 			},
 			expected: DefaultClaudeWorkerImage,
+		},
+		{
+			name: "codex runtime",
+			agent: &corev1alpha1.Agent{
+				Spec: corev1alpha1.AgentSpec{
+					Runtime: &corev1alpha1.AgentCLIRuntime{Type: corev1alpha1.AgentRuntimeCodex},
+				},
+			},
+			expected: DefaultCodexWorkerImage,
 		},
 		{
 			name: "unknown runtime type",

--- a/internal/tools/chat_create_agent.go
+++ b/internal/tools/chat_create_agent.go
@@ -48,7 +48,7 @@ func (t *ChatCreateAgentTool) Parameters() json.RawMessage {
 			"runtime": map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"type":            map[string]any{"type": "string", "description": "Runtime type: copilot or claude"},
+					"type":            map[string]any{"type": "string", "description": "Runtime type: copilot, claude, or codex"},
 					"defaultMaxTurns": map[string]any{"type": "integer", "description": "Default max agent loop iterations"},
 					"secretRef":       map[string]any{"type": "string", "description": "Optional secret name containing runtime credentials. Omit to auto-discover the standard secret for this runtime."},
 				},

--- a/internal/tools/chat_create_agent_test.go
+++ b/internal/tools/chat_create_agent_test.go
@@ -89,6 +89,43 @@ func TestParseRuntimeConfig_AutoDiscoversSecretRef(t *testing.T) {
 	}
 }
 
+func TestParseRuntimeConfig_AutoDiscoversCodexSecretRef(t *testing.T) {
+	fc := newFakeClient(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "codex-api-key",
+			Namespace: defaultNamespace,
+		},
+	})
+	agent := &corev1alpha1.Agent{
+		Spec: corev1alpha1.AgentSpec{
+			ProviderRef: &corev1alpha1.ProviderReference{Name: "openai"},
+		},
+	}
+
+	args := map[string]any{
+		"runtime": map[string]any{
+			"type": "codex",
+		},
+	}
+
+	if errResult, ok := parseRuntimeConfig(context.Background(), fc, defaultNamespace, args, agent); !ok {
+		t.Fatalf("parseRuntimeConfig returned error: %s", errResult)
+	}
+
+	if agent.Spec.Runtime == nil {
+		t.Fatal("agent.Spec.Runtime is nil")
+	}
+	if agent.Spec.Runtime.Type != corev1alpha1.AgentRuntimeType("codex") {
+		t.Errorf("runtime.type = %q, want %q", agent.Spec.Runtime.Type, "codex")
+	}
+	if agent.Spec.SecretRef == nil {
+		t.Fatal("agent.Spec.SecretRef is nil")
+	}
+	if agent.Spec.SecretRef.Name != "codex-api-key" {
+		t.Errorf("secretRef.name = %q, want %q", agent.Spec.SecretRef.Name, "codex-api-key")
+	}
+}
+
 func TestParseRuntimeConfig_RejectsUnsupportedSecretRef(t *testing.T) {
 	fc := newFakeClient(&corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/tools/create_agent.go
+++ b/internal/tools/create_agent.go
@@ -162,11 +162,11 @@ func (t *CreateAgentTool) Parameters() json.RawMessage {
 			},
 			"runtime": {
 				"type": "object",
-				"description": "Set to make this a CLI runtime agent (copilot or claude). Runtime agents run code, edit files, and use git. Do NOT set runtime on coordinator agents.",
+				"description": "Set to make this a CLI runtime agent (copilot, claude, or codex). Runtime agents run code, edit files, and use git. Do NOT set runtime on coordinator agents.",
 				"properties": {
 					"type": {
 						"type": "string",
-						"description": "Runtime type: copilot or claude"
+						"description": "Runtime type: copilot, claude, or codex"
 					},
 					"secretRef": {
 						"type": "string",
@@ -297,7 +297,7 @@ func (t *CreateAgentTool) Execute(ctx context.Context, args json.RawMessage) (st
 		agent.Spec.Coordination = coord
 	}
 
-	// Set runtime if provided (makes this a CLI agent like copilot/claude)
+	// Set runtime if provided (makes this a CLI agent like copilot/claude/codex)
 	if a.Runtime != nil && a.Runtime.Type != "" {
 		agent.Spec.Runtime = &corev1alpha1.AgentCLIRuntime{
 			Type: corev1alpha1.AgentRuntimeType(a.Runtime.Type),

--- a/internal/tools/create_agent_task.go
+++ b/internal/tools/create_agent_task.go
@@ -22,7 +22,7 @@ type CreateAgentTaskTool struct{}
 func (t *CreateAgentTaskTool) Name() string { return "create_agent_task" }
 
 func (t *CreateAgentTaskTool) Description() string {
-	return "Create a task using an external CLI runtime (Copilot, Claude Code) for code changes in a git repo. Do NOT use for simple container commands or direct LLM reasoning."
+	return "Create a task using an external CLI runtime (Copilot, Claude Code, Codex) for code changes in a git repo. Do NOT use for simple container commands or direct LLM reasoning."
 }
 
 func (t *CreateAgentTaskTool) Parameters() json.RawMessage {

--- a/internal/tools/create_agent_test.go
+++ b/internal/tools/create_agent_test.go
@@ -515,6 +515,56 @@ func TestCreateAgentTool_Execute_AutoDiscoversRuntimeSecretRefWhenOmitted(t *tes
 	}
 }
 
+func TestCreateAgentTool_Execute_AutoDiscoversCodexRuntimeSecretRefWhenOmitted(t *testing.T) {
+	t.Setenv("ORKA_TASK_NAME", parentTaskName)
+	t.Setenv("ORKA_TASK_NAMESPACE", defaultNamespace)
+
+	k8sClient := newFakeClient(
+		parentTask(),
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "codex-api-key", Namespace: defaultNamespace}},
+	)
+	tool := NewCreateAgentTool(k8sClient)
+
+	args := json.RawMessage(`{
+		"role": "coder",
+		"systemPrompt": "You write code",
+		"runtime": {
+			"type": "codex"
+		}
+	}`)
+
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var agentResult CreateAgentResult
+	if err := json.Unmarshal([]byte(result), &agentResult); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	agent := &corev1alpha1.Agent{}
+	if err := k8sClient.Get(context.Background(), apitypes.NamespacedName{
+		Name:      agentResult.AgentName,
+		Namespace: agentResult.Namespace,
+	}, agent); err != nil {
+		t.Fatalf("failed to get agent: %v", err)
+	}
+
+	if agent.Spec.Runtime == nil {
+		t.Fatal("agent.Spec.Runtime is nil")
+	}
+	if agent.Spec.Runtime.Type != corev1alpha1.AgentRuntimeType("codex") {
+		t.Errorf("runtime.type = %q, want %q", agent.Spec.Runtime.Type, "codex")
+	}
+	if agent.Spec.SecretRef == nil {
+		t.Fatal("agent.Spec.SecretRef is nil")
+	}
+	if agent.Spec.SecretRef.Name != "codex-api-key" {
+		t.Errorf("secretRef.name = %q, want %q", agent.Spec.SecretRef.Name, "codex-api-key")
+	}
+}
+
 func TestCreateAgentTool_Execute_RejectsUnsupportedRuntimeSecretRef(t *testing.T) {
 	t.Setenv("ORKA_TASK_NAME", parentTaskName)
 	t.Setenv("ORKA_TASK_NAMESPACE", defaultNamespace)

--- a/internal/tools/secret_resolution.go
+++ b/internal/tools/secret_resolution.go
@@ -23,6 +23,7 @@ import (
 var (
 	copilotRuntimeSecretCandidates = []string{"copilot-token"}
 	claudeRuntimeSecretCandidates  = []string{"claude-credentials", "claude-api-key"}
+	codexRuntimeSecretCandidates   = []string{"codex-credentials", "codex-api-key", "openai-api-key"}
 	gitCredentialSecretCandidates  = []string{"git-credentials", "github-credentials", "copilot-token", "github-token", "git-token"}
 )
 
@@ -33,6 +34,8 @@ func RuntimeSecretCandidates(runtimeType corev1alpha1.AgentRuntimeType) []string
 		return append([]string(nil), copilotRuntimeSecretCandidates...)
 	case corev1alpha1.AgentRuntimeClaude:
 		return append([]string(nil), claudeRuntimeSecretCandidates...)
+	case corev1alpha1.AgentRuntimeCodex:
+		return append([]string(nil), codexRuntimeSecretCandidates...)
 	default:
 		return nil
 	}

--- a/test/e2e/api_coverage_test.go
+++ b/test/e2e/api_coverage_test.go
@@ -41,39 +41,16 @@ var _ = Describe("API Coverage", Ordered, func() {
 
 	BeforeAll(func() {
 		By("setting up port-forward to controller API")
-		ctx, cancel := context.WithCancel(context.Background())
-		cancelPF = cancel
-
-		cmd := exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
-			"-o", "jsonpath={.items[0].metadata.name}", "-n", namespace)
-		podName, err := utils.Run(cmd)
+		var err error
+		apiBaseURL, cancelPF, portForwardCmd, err = startControllerAPIPortForward(18085)
 		Expect(err).NotTo(HaveOccurred())
-
-		portForwardCmd = exec.CommandContext(ctx, "kubectl", "port-forward",
-			strings.TrimSpace(podName), "18085:8080", "-n", namespace)
-		err = portForwardCmd.Start()
-		Expect(err).NotTo(HaveOccurred())
-
-		apiBaseURL = "http://localhost:18085"
-
-		Eventually(func(g Gomega) {
-			resp, err := http.Get(apiBaseURL + "/healthz")
-			g.Expect(err).NotTo(HaveOccurred())
-			defer resp.Body.Close()
-			g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		}, 30*time.Second, time.Second).Should(Succeed())
 
 		token, err = serviceAccountToken()
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterAll(func() {
-		if cancelPF != nil {
-			cancelPF()
-		}
-		if portForwardCmd != nil && portForwardCmd.Process != nil {
-			_ = portForwardCmd.Wait()
-		}
+		stopPortForward(cancelPF, portForwardCmd)
 
 		// Clean up all resources with e2e-api-cov- prefix
 		for _, res := range []struct{ kind, name string }{

--- a/test/e2e/api_extended_test.go
+++ b/test/e2e/api_extended_test.go
@@ -42,27 +42,9 @@ var _ = Describe("API Extended Coverage", Ordered, func() {
 		skipIfNoKey("E2E_OPENAI_API_KEY")
 
 		By("setting up port-forward to controller API")
-		ctx, cancel := context.WithCancel(context.Background())
-		cancelPF = cancel
-
-		cmd := exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
-			"-o", "jsonpath={.items[0].metadata.name}", "-n", namespace)
-		podName, err := utils.Run(cmd)
+		var err error
+		apiBaseURL, cancelPF, portForwardCmd, err = startControllerAPIPortForward(18082)
 		Expect(err).NotTo(HaveOccurred())
-
-		portForwardCmd = exec.CommandContext(ctx, "kubectl", "port-forward",
-			strings.TrimSpace(podName), "18082:8080", "-n", namespace)
-		err = portForwardCmd.Start()
-		Expect(err).NotTo(HaveOccurred())
-
-		apiBaseURL = "http://localhost:18082"
-
-		Eventually(func(g Gomega) {
-			resp, err := http.Get(apiBaseURL + "/healthz")
-			g.Expect(err).NotTo(HaveOccurred())
-			defer resp.Body.Close()
-			g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		}, 30*time.Second, time.Second).Should(Succeed())
 
 		By("getting a service account token")
 		token, err = serviceAccountToken()
@@ -70,12 +52,7 @@ var _ = Describe("API Extended Coverage", Ordered, func() {
 	})
 
 	AfterAll(func() {
-		if cancelPF != nil {
-			cancelPF()
-		}
-		if portForwardCmd != nil && portForwardCmd.Process != nil {
-			_ = portForwardCmd.Wait()
-		}
+		stopPortForward(cancelPF, portForwardCmd)
 		cmd := exec.Command("kubectl", "delete", "task", taskName, "-n", namespace, "--ignore-not-found")
 		_, _ = utils.Run(cmd)
 		cmd = exec.Command("kubectl", "delete", "provider", providerName, "-n", namespace, "--ignore-not-found")

--- a/test/e2e/api_test.go
+++ b/test/e2e/api_test.go
@@ -33,41 +33,14 @@ var _ = Describe("REST API Endpoints", Ordered, func() {
 
 	BeforeAll(func() {
 		By("setting up port-forward to controller API")
-		ctx, cancel := context.WithCancel(context.Background())
-		cancelPF = cancel
-
-		// Find the controller pod
-		cmd := exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
-			"-o", "jsonpath={.items[0].metadata.name}", "-n", namespace)
-		podName, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to find controller pod")
-		Expect(strings.TrimSpace(podName)).NotTo(BeEmpty())
-
-		// Start port-forward
-		portForwardCmd = exec.CommandContext(ctx, "kubectl", "port-forward",
-			strings.TrimSpace(podName), "18080:8080", "-n", namespace)
-		err = portForwardCmd.Start()
-		Expect(err).NotTo(HaveOccurred(), "Failed to start port-forward")
-
-		apiBaseURL = "http://localhost:18080"
-
-		// Wait for port-forward to be ready
-		Eventually(func(g Gomega) {
-			resp, err := http.Get(apiBaseURL + "/healthz")
-			g.Expect(err).NotTo(HaveOccurred())
-			defer resp.Body.Close()
-			g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		}, 30*time.Second, time.Second).Should(Succeed())
+		var err error
+		apiBaseURL, cancelPF, portForwardCmd, err = startControllerAPIPortForward(18080)
+		Expect(err).NotTo(HaveOccurred(), "Failed to start controller API port-forward")
 	})
 
 	AfterAll(func() {
 		By("stopping port-forward")
-		if cancelPF != nil {
-			cancelPF()
-		}
-		if portForwardCmd != nil && portForwardCmd.Process != nil {
-			_ = portForwardCmd.Wait()
-		}
+		stopPortForward(cancelPF, portForwardCmd)
 	})
 
 	It("should return healthy status from /healthz", func() {

--- a/test/e2e/autonomous_mode_test.go
+++ b/test/e2e/autonomous_mode_test.go
@@ -206,28 +206,9 @@ var _ = Describe("Autonomous Mode", Ordered, func() {
 		skipIfNoKey("E2E_OPENAI_API_KEY")
 
 		By("setting up port-forward to controller API")
-		ctx, cancel := context.WithCancel(context.Background())
-		cancelPF = cancel
-
-		cmd := exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
-			"-o", "jsonpath={.items[0].metadata.name}", "-n", namespace)
-		podName, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to find controller pod")
-		Expect(strings.TrimSpace(podName)).NotTo(BeEmpty())
-
-		portForwardCmd = exec.CommandContext(ctx, "kubectl", "port-forward",
-			strings.TrimSpace(podName), "18084:8080", "-n", namespace)
-		err = portForwardCmd.Start()
-		Expect(err).NotTo(HaveOccurred(), "Failed to start port-forward")
-
-		apiBaseURL = "http://localhost:18084"
-
-		Eventually(func(g Gomega) {
-			resp, err := http.Get(apiBaseURL + "/healthz")
-			g.Expect(err).NotTo(HaveOccurred())
-			defer resp.Body.Close()
-			g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		}, 30*time.Second, time.Second).Should(Succeed())
+		var err error
+		apiBaseURL, cancelPF, portForwardCmd, err = startControllerAPIPortForward(18084)
+		Expect(err).NotTo(HaveOccurred(), "Failed to start controller API port-forward")
 
 		By("getting a service account token for auth")
 		token, err := serviceAccountToken()
@@ -480,28 +461,9 @@ var _ = Describe("Autonomous Mode", Ordered, func() {
 		// Ensure port-forward is available (may have been set up in earlier test)
 		if apiBaseURL == "" {
 			By("setting up port-forward to controller API")
-			ctx, cancel := context.WithCancel(context.Background())
-			cancelPF = cancel
-
-			cmd = exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
-				"-o", "jsonpath={.items[0].metadata.name}", "-n", namespace)
-			podName, pfErr := utils.Run(cmd)
+			var pfErr error
+			apiBaseURL, cancelPF, portForwardCmd, pfErr = startControllerAPIPortForward(18084)
 			Expect(pfErr).NotTo(HaveOccurred())
-			Expect(strings.TrimSpace(podName)).NotTo(BeEmpty())
-
-			portForwardCmd = exec.CommandContext(ctx, "kubectl", "port-forward",
-				strings.TrimSpace(podName), "18084:8080", "-n", namespace)
-			pfErr = portForwardCmd.Start()
-			Expect(pfErr).NotTo(HaveOccurred())
-
-			apiBaseURL = "http://localhost:18084"
-
-			Eventually(func(g Gomega) {
-				resp, err := http.Get(apiBaseURL + "/healthz")
-				g.Expect(err).NotTo(HaveOccurred())
-				defer resp.Body.Close()
-				g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
-			}, 30*time.Second, time.Second).Should(Succeed())
 		}
 
 		By("getting a service account token for auth")

--- a/test/e2e/chat_advanced_test.go
+++ b/test/e2e/chat_advanced_test.go
@@ -41,28 +41,9 @@ var _ = Describe("Chat Advanced Features", Ordered, func() {
 		skipIfNoKey("E2E_OPENAI_API_KEY")
 
 		By("setting up port-forward to controller API")
-		ctx, cancel := context.WithCancel(context.Background())
-		cancelPF = cancel
-
-		cmd := exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
-			"-o", "jsonpath={.items[0].metadata.name}", "-n", namespace)
-		podName, err := utils.Run(cmd)
+		var err error
+		apiBaseURL, cancelPF, portForwardCmd, err = startControllerAPIPortForward(18086)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(strings.TrimSpace(podName)).NotTo(BeEmpty())
-
-		portForwardCmd = exec.CommandContext(ctx, "kubectl", "port-forward",
-			strings.TrimSpace(podName), "18086:8080", "-n", namespace)
-		err = portForwardCmd.Start()
-		Expect(err).NotTo(HaveOccurred())
-
-		apiBaseURL = "http://localhost:18086"
-
-		Eventually(func(g Gomega) {
-			resp, err := http.Get(apiBaseURL + "/healthz")
-			g.Expect(err).NotTo(HaveOccurred())
-			defer resp.Body.Close()
-			g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		}, 30*time.Second, time.Second).Should(Succeed())
 
 		By("getting a service account token")
 		token, err = serviceAccountToken()
@@ -75,12 +56,7 @@ var _ = Describe("Chat Advanced Features", Ordered, func() {
 	})
 
 	AfterAll(func() {
-		if cancelPF != nil {
-			cancelPF()
-		}
-		if portForwardCmd != nil && portForwardCmd.Process != nil {
-			_ = portForwardCmd.Wait()
-		}
+		stopPortForward(cancelPF, portForwardCmd)
 		cmd := exec.Command("kubectl", "delete", "provider", providerName, "-n", namespace, "--ignore-not-found")
 		_, _ = utils.Run(cmd)
 		cmd = exec.Command("kubectl", "delete", "agent", agentName, "-n", namespace, "--ignore-not-found")

--- a/test/e2e/chat_api_test.go
+++ b/test/e2e/chat_api_test.go
@@ -35,28 +35,9 @@ var _ = Describe("Chat and OpenAI-Compatible API", Ordered, func() {
 
 	BeforeAll(func() {
 		By("setting up port-forward to controller API")
-		ctx, cancel := context.WithCancel(context.Background())
-		cancelPF = cancel
-
-		cmd := exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
-			"-o", "jsonpath={.items[0].metadata.name}", "-n", namespace)
-		podName, err := utils.Run(cmd)
+		var err error
+		apiBaseURL, cancelPF, portForwardCmd, err = startControllerAPIPortForward(18081)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(strings.TrimSpace(podName)).NotTo(BeEmpty())
-
-		portForwardCmd = exec.CommandContext(ctx, "kubectl", "port-forward",
-			strings.TrimSpace(podName), "18081:8080", "-n", namespace)
-		err = portForwardCmd.Start()
-		Expect(err).NotTo(HaveOccurred())
-
-		apiBaseURL = "http://localhost:18081"
-
-		Eventually(func(g Gomega) {
-			resp, err := http.Get(apiBaseURL + "/healthz")
-			g.Expect(err).NotTo(HaveOccurred())
-			defer resp.Body.Close()
-			g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		}, 30*time.Second, time.Second).Should(Succeed())
 
 		By("getting a service account token")
 		token, err = serviceAccountToken()
@@ -65,12 +46,7 @@ var _ = Describe("Chat and OpenAI-Compatible API", Ordered, func() {
 	})
 
 	AfterAll(func() {
-		if cancelPF != nil {
-			cancelPF()
-		}
-		if portForwardCmd != nil && portForwardCmd.Process != nil {
-			_ = portForwardCmd.Wait()
-		}
+		stopPortForward(cancelPF, portForwardCmd)
 	})
 
 	// --- Chat Config Endpoint ---

--- a/test/e2e/chat_tools_test.go
+++ b/test/e2e/chat_tools_test.go
@@ -38,27 +38,9 @@ var _ = Describe("Chat with Tool Execution", Ordered, func() {
 		skipIfNoKey("E2E_OPENAI_API_KEY")
 
 		By("setting up port-forward to controller API")
-		ctx, cancel := context.WithCancel(context.Background())
-		cancelPF = cancel
-
-		cmd := exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
-			"-o", "jsonpath={.items[0].metadata.name}", "-n", namespace)
-		podName, err := utils.Run(cmd)
+		var err error
+		apiBaseURL, cancelPF, portForwardCmd, err = startControllerAPIPortForward(18083)
 		Expect(err).NotTo(HaveOccurred())
-
-		portForwardCmd = exec.CommandContext(ctx, "kubectl", "port-forward",
-			strings.TrimSpace(podName), "18083:8080", "-n", namespace)
-		err = portForwardCmd.Start()
-		Expect(err).NotTo(HaveOccurred())
-
-		apiBaseURL = "http://localhost:18083"
-
-		Eventually(func(g Gomega) {
-			resp, err := http.Get(apiBaseURL + "/healthz")
-			g.Expect(err).NotTo(HaveOccurred())
-			defer resp.Body.Close()
-			g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		}, 30*time.Second, time.Second).Should(Succeed())
 
 		By("getting a service account token")
 		token, err = serviceAccountToken()
@@ -69,12 +51,7 @@ var _ = Describe("Chat with Tool Execution", Ordered, func() {
 	})
 
 	AfterAll(func() {
-		if cancelPF != nil {
-			cancelPF()
-		}
-		if portForwardCmd != nil && portForwardCmd.Process != nil {
-			_ = portForwardCmd.Wait()
-		}
+		stopPortForward(cancelPF, portForwardCmd)
 		cmd := exec.Command("kubectl", "delete", "provider", providerName, "-n", namespace, "--ignore-not-found")
 		_, _ = utils.Run(cmd)
 	})

--- a/test/e2e/coordination_advanced_test.go
+++ b/test/e2e/coordination_advanced_test.go
@@ -439,36 +439,12 @@ var _ = Describe("Advanced Coordination Tools", Ordered, func() {
 		)
 
 		By("setting up port-forward to controller API")
-		ctx, cancel := context.WithCancel(context.Background())
-		cancelPF = cancel
-
-		cmd := exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
-			"-o", "jsonpath={.items[0].metadata.name}", "-n", namespace)
-		podName, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(strings.TrimSpace(podName)).NotTo(BeEmpty())
-
-		portForwardCmd = exec.CommandContext(ctx, "kubectl", "port-forward",
-			strings.TrimSpace(podName), "18089:8080", "-n", namespace)
-		err = portForwardCmd.Start()
-		Expect(err).NotTo(HaveOccurred(), "Failed to start port-forward")
-
-		apiBaseURL = "http://localhost:18089"
-
-		Eventually(func(g Gomega) {
-			resp, err := http.Get(apiBaseURL + "/healthz")
-			g.Expect(err).NotTo(HaveOccurred())
-			defer resp.Body.Close()
-			g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		}, 30*time.Second, time.Second).Should(Succeed())
+		var err error
+		apiBaseURL, cancelPF, portForwardCmd, err = startControllerAPIPortForward(18089)
+		Expect(err).NotTo(HaveOccurred(), "Failed to start controller API port-forward")
 
 		defer func() {
-			if cancelPF != nil {
-				cancelPF()
-			}
-			if portForwardCmd != nil && portForwardCmd.Process != nil {
-				_ = portForwardCmd.Wait()
-			}
+			stopPortForward(cancelPF, portForwardCmd)
 		}()
 
 		By("getting a service account token for auth")

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -37,6 +37,7 @@ var (
 	generalWorkerImage = "ghcr.io/sozercan/orka/general-worker:latest"
 	copilotWorkerImage = "ghcr.io/sozercan/orka/agent-worker-copilot:latest"
 	claudeWorkerImage  = "ghcr.io/sozercan/orka/agent-worker-claude:latest"
+	codexWorkerImage   = "ghcr.io/sozercan/orka/agent-worker-codex:latest"
 
 	// E2E environment configuration (loaded from .env or environment)
 	e2eOpenAIAPIKey     string
@@ -66,12 +67,20 @@ var _ = BeforeSuite(func() {
 		fmt.Sprintf("GENERAL_WORKER_IMG=%s", generalWorkerImage),
 		fmt.Sprintf("COPILOT_WORKER_IMG=%s", copilotWorkerImage),
 		fmt.Sprintf("CLAUDE_WORKER_IMG=%s", claudeWorkerImage),
+		fmt.Sprintf("CODEX_WORKER_IMG=%s", codexWorkerImage),
 	)
 	_, err := utils.Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build Docker images")
 
 	By("loading all images into Kind cluster")
-	for _, img := range []string{managerImage, aiWorkerImage, generalWorkerImage, copilotWorkerImage, claudeWorkerImage} {
+	for _, img := range []string{
+		managerImage,
+		aiWorkerImage,
+		generalWorkerImage,
+		copilotWorkerImage,
+		claudeWorkerImage,
+		codexWorkerImage,
+	} {
 		err = utils.LoadImageToKindClusterWithName(img)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to load image %s into Kind", img))
 	}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -10,7 +10,9 @@ MIT License - see LICENSE file for details.
 package e2e
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"time"
@@ -20,6 +22,8 @@ import (
 
 	"github.com/sozercan/orka/test/utils"
 )
+
+const controllerAPIService = "orka-api"
 
 // skipIfNoKey skips the current test if the given environment variable is not set or empty.
 func skipIfNoKey(envVar string) {
@@ -144,6 +148,42 @@ func createProviderCRD(name, providerType, secretName, secretKey, baseURL, model
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(output).To(Equal("true"), "Provider %s should be ready", name)
 	}, 30*time.Second, time.Second).Should(Succeed())
+}
+
+func startControllerAPIPortForward(localPort int) (string, context.CancelFunc, *exec.Cmd, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", localPort)
+
+	cmd := exec.CommandContext(ctx, "kubectl", "port-forward",
+		"-n", namespace,
+		"svc/"+controllerAPIService,
+		fmt.Sprintf("%d:8080", localPort),
+	)
+	cmd.Stdout = GinkgoWriter
+	cmd.Stderr = GinkgoWriter
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return "", nil, nil, err
+	}
+
+	Eventually(func(g Gomega) {
+		resp, err := http.Get(baseURL + "/healthz")
+		g.Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	}, 60*time.Second, time.Second).Should(Succeed())
+
+	return baseURL, cancel, cmd, nil
+}
+
+func stopPortForward(cancel context.CancelFunc, cmd *exec.Cmd) {
+	if cancel != nil {
+		cancel()
+	}
+	if cmd != nil && cmd.Process != nil {
+		_ = cmd.Wait()
+	}
 }
 
 // dumpDebugInfo collects and prints debug information on test failure.

--- a/test/e2e/pr_workflow_test.go
+++ b/test/e2e/pr_workflow_test.go
@@ -107,28 +107,8 @@ var _ = Describe("PR Workflow Tools", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred(), "Failed to create coordinator agent")
 
 		By("setting up port-forward to controller API")
-		ctx, cancel := context.WithCancel(context.Background())
-		cancelPF = cancel
-
-		cmd = exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
-			"-o", "jsonpath={.items[0].metadata.name}", "-n", namespace)
-		podName, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to find controller pod")
-		Expect(strings.TrimSpace(podName)).NotTo(BeEmpty())
-
-		portForwardCmd = exec.CommandContext(ctx, "kubectl", "port-forward",
-			strings.TrimSpace(podName), "18087:8080", "-n", namespace)
-		err = portForwardCmd.Start()
-		Expect(err).NotTo(HaveOccurred(), "Failed to start port-forward")
-
-		apiBaseURL = "http://localhost:18087"
-
-		Eventually(func(g Gomega) {
-			resp, err := http.Get(apiBaseURL + "/healthz")
-			g.Expect(err).NotTo(HaveOccurred())
-			defer resp.Body.Close()
-			g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		}, 30*time.Second, time.Second).Should(Succeed())
+		apiBaseURL, cancelPF, portForwardCmd, err = startControllerAPIPortForward(18087)
+		Expect(err).NotTo(HaveOccurred(), "Failed to start controller API port-forward")
 
 		By("getting a service account token")
 		token, err = serviceAccountToken()

--- a/test/e2e/security_enforcement_test.go
+++ b/test/e2e/security_enforcement_test.go
@@ -159,37 +159,15 @@ var _ = Describe("Security Enforcement", Ordered, func() {
 			portForwardCmd *exec.Cmd
 			cancelPF       context.CancelFunc
 			token          string
+			err            error
 		)
 
 		By("setting up port-forward to controller API")
-		ctx, cancel := context.WithCancel(context.Background())
-		cancelPF = cancel
-
-		cmd := exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
-			"-o", "jsonpath={.items[0].metadata.name}", "-n", namespace)
-		podName, err := utils.Run(cmd)
+		apiBaseURL, cancelPF, portForwardCmd, err = startControllerAPIPortForward(18088)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(strings.TrimSpace(podName)).NotTo(BeEmpty())
-
-		portForwardCmd = exec.CommandContext(ctx, "kubectl", "port-forward",
-			strings.TrimSpace(podName), "18088:8080", "-n", namespace)
-		err = portForwardCmd.Start()
-		Expect(err).NotTo(HaveOccurred())
-
-		apiBaseURL = "http://localhost:18088"
-
-		Eventually(func(g Gomega) {
-			resp, err := http.Get(apiBaseURL + "/healthz")
-			g.Expect(err).NotTo(HaveOccurred())
-			defer resp.Body.Close()
-			g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		}, 30*time.Second, time.Second).Should(Succeed())
 
 		defer func() {
-			cancelPF()
-			if portForwardCmd != nil && portForwardCmd.Process != nil {
-				_ = portForwardCmd.Wait()
-			}
+			stopPortForward(cancelPF, portForwardCmd)
 		}()
 
 		By("getting a service account token")

--- a/ui/src/components/agents/agent-create-form.test.tsx
+++ b/ui/src/components/agents/agent-create-form.test.tsx
@@ -44,6 +44,21 @@ if (typeof globalThis.ResizeObserver === 'undefined') {
   } as any
 }
 
+if (typeof HTMLElement !== 'undefined') {
+  if (!HTMLElement.prototype.hasPointerCapture) {
+    HTMLElement.prototype.hasPointerCapture = () => false
+  }
+  if (!HTMLElement.prototype.setPointerCapture) {
+    HTMLElement.prototype.setPointerCapture = () => {}
+  }
+  if (!HTMLElement.prototype.releasePointerCapture) {
+    HTMLElement.prototype.releasePointerCapture = () => {}
+  }
+  if (!HTMLElement.prototype.scrollIntoView) {
+    HTMLElement.prototype.scrollIntoView = () => {}
+  }
+}
+
 import { render, screen, waitFor } from '@/test/test-utils'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
@@ -86,6 +101,16 @@ describe('AgentCreateForm', () => {
     expect(screen.getByText('Max Turns')).toBeInTheDocument()
     expect(screen.getByText('Allowed Tools')).toBeInTheDocument()
     expect(screen.getByText('Allow Bash')).toBeInTheDocument()
+  })
+
+  it('Runtime mode includes Codex as an available runtime option', async () => {
+    useStateModeOverride = 'runtime'
+    const user = userEvent.setup()
+    render(<AgentCreateForm />)
+
+    const selects = screen.getAllByRole('combobox')
+    await user.click(selects[1])
+    expect(screen.getAllByText('OpenAI Codex').length).toBeGreaterThan(0)
   })
 
   it('secret reference select is shown', () => {

--- a/ui/src/components/agents/agent-create-form.tsx
+++ b/ui/src/components/agents/agent-create-form.tsx
@@ -28,7 +28,7 @@ export function AgentCreateForm() {
   const [systemPrompt, setSystemPrompt] = useState('')
 
   // Runtime mode fields
-  const [runtimeType, setRuntimeType] = useState<'claude' | 'copilot'>('claude')
+  const [runtimeType, setRuntimeType] = useState<'claude' | 'copilot' | 'codex'>('claude')
   const [maxTurns, setMaxTurns] = useState('50')
   const [allowBash, setAllowBash] = useState(true)
   const [allowedTools, setAllowedTools] = useState('Read,Glob,Grep,Bash,LS')
@@ -93,7 +93,7 @@ export function AgentCreateForm() {
                   <SelectTrigger><SelectValue /></SelectTrigger>
                   <SelectContent>
                     <SelectItem value="ai">AI (LLM Provider)</SelectItem>
-                    <SelectItem value="runtime">CLI Runtime (Copilot / Claude)</SelectItem>
+                    <SelectItem value="runtime">CLI Runtime (Copilot / Claude / Codex)</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -144,11 +144,12 @@ export function AgentCreateForm() {
                 <div className="grid gap-4 md:grid-cols-2">
                   <div className="space-y-2">
                     <label className="text-sm font-medium">Runtime Type</label>
-                    <Select value={runtimeType} onValueChange={(v) => setRuntimeType(v as 'claude' | 'copilot')}>
+                    <Select value={runtimeType} onValueChange={(v) => setRuntimeType(v as 'claude' | 'copilot' | 'codex')}>
                       <SelectTrigger><SelectValue /></SelectTrigger>
                       <SelectContent>
                         <SelectItem value="claude">Claude Code</SelectItem>
                         <SelectItem value="copilot">GitHub Copilot</SelectItem>
+                        <SelectItem value="codex">OpenAI Codex</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>

--- a/ui/src/schemas/agent.test.ts
+++ b/ui/src/schemas/agent.test.ts
@@ -62,6 +62,11 @@ describe('agentCLIRuntimeSchema', () => {
     expect(agentCLIRuntimeSchema.parse(data)).toEqual(data)
   })
 
+  it('parses valid codex runtime', () => {
+    const data = { type: 'codex' }
+    expect(agentCLIRuntimeSchema.parse(data)).toEqual(data)
+  })
+
   it('rejects invalid type', () => {
     expect(() => agentCLIRuntimeSchema.parse({ type: 'invalid' })).toThrow()
     expect(() => agentCLIRuntimeSchema.parse({ type: '' })).toThrow()

--- a/ui/src/schemas/agent.ts
+++ b/ui/src/schemas/agent.ts
@@ -14,7 +14,7 @@ export const toolRefSchema = z.object({
 })
 
 export const agentCLIRuntimeSchema = z.object({
-  type: z.enum(['copilot', 'claude']),
+  type: z.enum(['copilot', 'claude', 'codex']),
   defaultMaxTurns: z.number().optional(),
   defaultAllowedTools: z.array(z.string()).optional(),
   defaultAllowBash: z.boolean().optional(),

--- a/workers/agent/codex/Dockerfile
+++ b/workers/agent/codex/Dockerfile
@@ -18,22 +18,15 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} go build -a -o worker .
 # Runtime stage — Node.js required for Codex CLI
 FROM node:22-slim
 
-ARG TARGETARCH
-
 # Install git (needed for workspace cloning)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Codex CLI globally with the matching platform package
-RUN arch="${TARGETARCH:-$(dpkg --print-architecture)}" \
-    && case "$arch" in \
-        amd64) codex_pkg='@openai/codex-linux-x64' ;; \
-        arm64) codex_pkg='@openai/codex-linux-arm64' ;; \
-        *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
-      esac \
-    && npm install -g @openai/codex "$codex_pkg" \
+# Install the published Codex CLI package. It resolves the correct optional
+# platform dependency for the target linux architecture during install.
+RUN npm install -g @openai/codex \
     && npm cache clean --force
 
 # Create a simple token-echo script for git auth

--- a/workers/agent/codex/Dockerfile
+++ b/workers/agent/codex/Dockerfile
@@ -1,0 +1,55 @@
+# Build the Go worker binary
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
+
+ARG TARGETARCH
+
+WORKDIR /workspace
+
+# Copy go mod files
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source
+COPY . .
+
+# Build the worker
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} go build -a -o worker ./workers/agent/codex
+
+# Runtime stage — Node.js required for Codex CLI
+FROM node:22-slim
+
+ARG TARGETARCH
+
+# Install git (needed for workspace cloning)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Codex CLI globally with the matching platform package
+RUN arch="${TARGETARCH:-$(dpkg --print-architecture)}" \
+    && case "$arch" in \
+        amd64) codex_pkg='@openai/codex-linux-x64' ;; \
+        arm64) codex_pkg='@openai/codex-linux-arm64' ;; \
+        *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
+      esac \
+    && npm install -g @openai/codex "$codex_pkg" \
+    && npm cache clean --force
+
+# Create a simple token-echo script for git auth
+RUN printf '#!/bin/sh\necho "$GIT_TOKEN"\n' > /bin/echo-token \
+    && chmod +x /bin/echo-token
+
+# Copy the Go worker binary
+COPY --from=builder /workspace/worker /worker
+
+# Create writable directories for readOnlyRootFilesystem compatibility
+# node:22-slim already has uid 1000 as the 'node' user
+RUN mkdir -p /workspace /home/node /tmp \
+    && ln -s /home/node /home/worker \
+    && chown -R 1000:1000 /workspace /home/node /tmp
+
+USER 1000:1000
+ENV HOME=/home/worker
+
+ENTRYPOINT ["/worker"]

--- a/workers/agent/codex/main.go
+++ b/workers/agent/codex/main.go
@@ -22,9 +22,10 @@ import (
 )
 
 const (
-	defaultMaxTurns  = 50
-	workspaceDir     = "/workspace"
-	defaultCodexPath = "codex"
+	defaultMaxTurns        = 50
+	workspaceDir           = "/workspace"
+	defaultCodexPath       = "codex"
+	codexWebSearchDisabled = "disabled"
 )
 
 var errCodexRequiresBash = errors.New(
@@ -52,7 +53,9 @@ func executeCodex(ctx context.Context, cfg *common.AgentConfig) (string, error) 
 	if err := outputFile.Close(); err != nil {
 		return "", fmt.Errorf("close output temp file: %w", err)
 	}
-	defer os.Remove(outputPath)
+	defer func() {
+		_ = os.Remove(outputPath)
+	}()
 
 	instructionsPath, cleanupInstructions, err := writeCodexInstructionsFile(cfg)
 	if err != nil {
@@ -145,12 +148,18 @@ func buildCodexInstructions(cfg *common.AgentConfig) string {
 		guidance = append(guidance, fmt.Sprintf("Try to complete this task within %d turns.", cfg.MaxTurns))
 	}
 	if !allowBashEnabled() {
-		guidance = append(guidance, "Do not use shell commands unless absolutely necessary. Prefer built-in file inspection and editing tools.")
+		guidance = append(guidance,
+			"Do not use shell commands unless absolutely necessary. "+
+				"Prefer built-in file inspection and editing tools.",
+		)
 	}
 
 	allowedTools := trimmedTools(cfg.AllowedTools)
 	if len(allowedTools) > 0 {
-		guidance = append(guidance, fmt.Sprintf("Respect this requested tool allowlist when possible: %s.", strings.Join(allowedTools, ", ")))
+		guidance = append(guidance, fmt.Sprintf(
+			"Respect this requested tool allowlist when possible: %s.",
+			strings.Join(allowedTools, ", "),
+		))
 	}
 
 	disallowedTools := trimmedTools(cfg.DisallowedTools)
@@ -159,7 +168,7 @@ func buildCodexInstructions(cfg *common.AgentConfig) string {
 	}
 
 	if webSearchSetting, ok := codexWebSearchSetting(cfg); ok {
-		if webSearchSetting == "disabled" {
+		if webSearchSetting == codexWebSearchDisabled {
 			guidance = append(guidance, "Web search is disabled for this task.")
 		} else {
 			guidance = append(guidance, "Web search is available for this task when needed.")
@@ -184,12 +193,12 @@ func writeCodexInstructionsFile(cfg *common.AgentConfig) (string, func(), error)
 		return "", func() {}, fmt.Errorf("create instructions temp file: %w", err)
 	}
 	if _, err := f.WriteString(instructions); err != nil {
-		f.Close()
-		os.Remove(f.Name())
+		_ = f.Close()
+		_ = os.Remove(f.Name())
 		return "", func() {}, fmt.Errorf("write instructions temp file: %w", err)
 	}
 	if err := f.Close(); err != nil {
-		os.Remove(f.Name())
+		_ = os.Remove(f.Name())
 		return "", func() {}, fmt.Errorf("close instructions temp file: %w", err)
 	}
 
@@ -230,13 +239,13 @@ func allowBashEnabled() bool {
 
 func codexWebSearchSetting(cfg *common.AgentConfig) (string, bool) {
 	if hasWebSearchTool(cfg.DisallowedTools) {
-		return "disabled", true
+		return codexWebSearchDisabled, true
 	}
 	if len(cfg.AllowedTools) > 0 {
 		if hasWebSearchTool(cfg.AllowedTools) {
 			return "live", true
 		}
-		return "disabled", true
+		return codexWebSearchDisabled, true
 	}
 	return "", false
 }

--- a/workers/agent/codex/main.go
+++ b/workers/agent/codex/main.go
@@ -1,0 +1,269 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sozercan/orka/workers/common"
+)
+
+const (
+	defaultMaxTurns  = 50
+	workspaceDir     = "/workspace"
+	defaultCodexPath = "codex"
+)
+
+func main() {
+	if err := common.RunAgent("codex", workspaceDir, defaultMaxTurns, executeCodex); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// executeCodex invokes the Codex CLI and returns its final response.
+func executeCodex(ctx context.Context, cfg *common.AgentConfig) (string, error) {
+	outputFile, err := os.CreateTemp("", "codex-last-message-*")
+	if err != nil {
+		return "", fmt.Errorf("create output temp file: %w", err)
+	}
+	outputPath := outputFile.Name()
+	if err := outputFile.Close(); err != nil {
+		return "", fmt.Errorf("close output temp file: %w", err)
+	}
+	defer os.Remove(outputPath)
+
+	instructionsPath, cleanupInstructions, err := writeCodexInstructionsFile(cfg)
+	if err != nil {
+		return "", err
+	}
+	defer cleanupInstructions()
+
+	args := buildCodexArgs(cfg, outputPath, instructionsPath)
+	fmt.Printf("Executing: %s %s\n", codexPath(), strings.Join(args, " "))
+
+	execCtx := ctx
+	if cfg.TimeoutSeconds > 0 {
+		var timeoutCancel context.CancelFunc
+		execCtx, timeoutCancel = context.WithTimeout(ctx, time.Duration(cfg.TimeoutSeconds)*time.Second)
+		defer timeoutCancel()
+	}
+
+	cmd := exec.CommandContext(execCtx, codexPath(), args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = io.MultiWriter(&stdout, os.Stdout)
+	cmd.Stderr = io.MultiWriter(&stderr, os.Stderr)
+
+	dir := workspaceDir
+	if cfg.SubPath != "" {
+		dir = filepath.Join(workspaceDir, cfg.SubPath)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("stat workspace directory: %w", err)
+		}
+		fallbackDir, fallbackErr := os.Getwd()
+		if fallbackErr != nil {
+			return "", fmt.Errorf("determine fallback workspace directory: %w", fallbackErr)
+		}
+		dir = fallbackDir
+	}
+	cmd.Dir = dir
+	cmd.Env = buildCodexEnv()
+
+	if err := cmd.Run(); err != nil {
+		result := readCodexResult(outputPath, stdout.String())
+		if stderrStr := stderr.String(); stderrStr != "" {
+			return result, fmt.Errorf("%w: %s", err, stderrStr)
+		}
+		return result, err
+	}
+
+	return readCodexResult(outputPath, stdout.String()), nil
+}
+
+func buildCodexArgs(cfg *common.AgentConfig, outputPath, instructionsPath string) []string {
+	args := []string{
+		"exec",
+		"--skip-git-repo-check",
+		"--color", "never",
+		"--output-last-message", outputPath,
+		"--config", "approval_policy=never",
+		"--sandbox", "workspace-write",
+	}
+
+	if cfg.Model != "" {
+		args = append(args, "--model", cfg.Model)
+	}
+	if instructionsPath != "" {
+		args = append(args, "--config", "model_instructions_file="+instructionsPath)
+	}
+	if baseURL := strings.TrimSpace(os.Getenv("OPENAI_BASE_URL")); baseURL != "" {
+		args = append(args, "--config", "openai_base_url="+baseURL)
+	}
+	if os.Getenv("ORKA_ALLOW_BASH") == "true" {
+		args = append(args, "--config", "sandbox_workspace_write.network_access=true")
+	} else {
+		args = append(args, "--config", "sandbox_workspace_write.network_access=false")
+	}
+	if webSearchSetting, ok := codexWebSearchSetting(cfg); ok {
+		args = append(args, "--config", "web_search="+webSearchSetting)
+	}
+
+	args = append(args, cfg.Prompt)
+	return args
+}
+
+func buildCodexInstructions(cfg *common.AgentConfig) string {
+	var sections []string
+
+	if systemPrompt := strings.TrimSpace(cfg.SystemPrompt); systemPrompt != "" {
+		sections = append(sections, systemPrompt)
+	}
+
+	var guidance []string
+	if cfg.MaxTurns > 0 {
+		guidance = append(guidance, fmt.Sprintf("Try to complete this task within %d turns.", cfg.MaxTurns))
+	}
+	if os.Getenv("ORKA_ALLOW_BASH") != "true" {
+		guidance = append(guidance, "Do not use shell commands unless absolutely necessary. Prefer built-in file inspection and editing tools.")
+	}
+
+	allowedTools := trimmedTools(cfg.AllowedTools)
+	if len(allowedTools) > 0 {
+		guidance = append(guidance, fmt.Sprintf("Respect this requested tool allowlist when possible: %s.", strings.Join(allowedTools, ", ")))
+	}
+
+	disallowedTools := trimmedTools(cfg.DisallowedTools)
+	if len(disallowedTools) > 0 {
+		guidance = append(guidance, fmt.Sprintf("Do not use these tools: %s.", strings.Join(disallowedTools, ", ")))
+	}
+
+	if webSearchSetting, ok := codexWebSearchSetting(cfg); ok {
+		if webSearchSetting == "disabled" {
+			guidance = append(guidance, "Web search is disabled for this task.")
+		} else {
+			guidance = append(guidance, "Web search is available for this task when needed.")
+		}
+	}
+
+	if len(guidance) > 0 {
+		sections = append(sections, "Additional runtime guidance:\n- "+strings.Join(guidance, "\n- "))
+	}
+
+	return strings.TrimSpace(strings.Join(sections, "\n\n"))
+}
+
+func writeCodexInstructionsFile(cfg *common.AgentConfig) (string, func(), error) {
+	instructions := buildCodexInstructions(cfg)
+	if instructions == "" {
+		return "", func() {}, nil
+	}
+
+	f, err := os.CreateTemp("", "codex-instructions-*.md")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create instructions temp file: %w", err)
+	}
+	if _, err := f.WriteString(instructions); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", func() {}, fmt.Errorf("write instructions temp file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", func() {}, fmt.Errorf("close instructions temp file: %w", err)
+	}
+
+	return f.Name(), func() { _ = os.Remove(f.Name()) }, nil
+}
+
+func buildCodexEnv() []string {
+	env := os.Environ()
+	env = setEnvVar(env, "HOME", "/home/worker")
+
+	if os.Getenv("CODEX_API_KEY") == "" {
+		if apiKey := strings.TrimSpace(os.Getenv("OPENAI_API_KEY")); apiKey != "" {
+			env = setEnvVar(env, "CODEX_API_KEY", apiKey)
+		}
+	}
+
+	return env
+}
+
+func readCodexResult(outputPath, fallback string) string {
+	data, err := os.ReadFile(outputPath)
+	if err == nil && len(data) > 0 {
+		return string(data)
+	}
+	return fallback
+}
+
+func codexPath() string {
+	if p := os.Getenv("CODEX_CLI_PATH"); p != "" {
+		return p
+	}
+	return defaultCodexPath
+}
+
+func codexWebSearchSetting(cfg *common.AgentConfig) (string, bool) {
+	if hasWebSearchTool(cfg.DisallowedTools) {
+		return "disabled", true
+	}
+	if len(cfg.AllowedTools) > 0 {
+		if hasWebSearchTool(cfg.AllowedTools) {
+			return "live", true
+		}
+		return "disabled", true
+	}
+	return "", false
+}
+
+func hasWebSearchTool(tools []string) bool {
+	for _, tool := range tools {
+		if normalizeToolName(tool) == "websearch" {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeToolName(tool string) string {
+	replacer := strings.NewReplacer("_", "", "-", "", " ", "")
+	return replacer.Replace(strings.ToLower(strings.TrimSpace(tool)))
+}
+
+func trimmedTools(tools []string) []string {
+	trimmed := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		tool = strings.TrimSpace(tool)
+		if tool == "" {
+			continue
+		}
+		trimmed = append(trimmed, tool)
+	}
+	return trimmed
+}
+
+func setEnvVar(env []string, key, value string) []string {
+	prefix := key + "="
+	for i, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			env[i] = prefix + value
+			return env
+		}
+	}
+	return append(env, prefix+value)
+}

--- a/workers/agent/codex/main.go
+++ b/workers/agent/codex/main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -26,6 +27,10 @@ const (
 	defaultCodexPath = "codex"
 )
 
+var errCodexRequiresBash = errors.New(
+	"codex runtime requires allowBash=true because the Codex CLI cannot disable shell execution",
+)
+
 func main() {
 	if err := common.RunAgent("codex", workspaceDir, defaultMaxTurns, executeCodex); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -35,6 +40,10 @@ func main() {
 
 // executeCodex invokes the Codex CLI and returns its final response.
 func executeCodex(ctx context.Context, cfg *common.AgentConfig) (string, error) {
+	if !allowBashEnabled() {
+		return "", errCodexRequiresBash
+	}
+
 	outputFile, err := os.CreateTemp("", "codex-last-message-*")
 	if err != nil {
 		return "", fmt.Errorf("create output temp file: %w", err)
@@ -66,6 +75,7 @@ func executeCodex(ctx context.Context, cfg *common.AgentConfig) (string, error) 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = io.MultiWriter(&stdout, os.Stdout)
 	cmd.Stderr = io.MultiWriter(&stderr, os.Stderr)
+	cmd.Stdin = strings.NewReader(cfg.Prompt)
 
 	dir := workspaceDir
 	if cfg.SubPath != "" {
@@ -114,16 +124,12 @@ func buildCodexArgs(cfg *common.AgentConfig, outputPath, instructionsPath string
 	if baseURL := strings.TrimSpace(os.Getenv("OPENAI_BASE_URL")); baseURL != "" {
 		args = append(args, "--config", "openai_base_url="+baseURL)
 	}
-	if os.Getenv("ORKA_ALLOW_BASH") == "true" {
-		args = append(args, "--config", "sandbox_workspace_write.network_access=true")
-	} else {
-		args = append(args, "--config", "sandbox_workspace_write.network_access=false")
-	}
+	args = append(args, "--config", "sandbox_workspace_write.network_access=true")
 	if webSearchSetting, ok := codexWebSearchSetting(cfg); ok {
 		args = append(args, "--config", "web_search="+webSearchSetting)
 	}
 
-	args = append(args, cfg.Prompt)
+	args = append(args, "-")
 	return args
 }
 
@@ -138,7 +144,7 @@ func buildCodexInstructions(cfg *common.AgentConfig) string {
 	if cfg.MaxTurns > 0 {
 		guidance = append(guidance, fmt.Sprintf("Try to complete this task within %d turns.", cfg.MaxTurns))
 	}
-	if os.Getenv("ORKA_ALLOW_BASH") != "true" {
+	if !allowBashEnabled() {
 		guidance = append(guidance, "Do not use shell commands unless absolutely necessary. Prefer built-in file inspection and editing tools.")
 	}
 
@@ -216,6 +222,10 @@ func codexPath() string {
 		return p
 	}
 	return defaultCodexPath
+}
+
+func allowBashEnabled() bool {
+	return os.Getenv("ORKA_ALLOW_BASH") == "true"
 }
 
 func codexWebSearchSetting(cfg *common.AgentConfig) (string, bool) {

--- a/workers/agent/codex/main_test.go
+++ b/workers/agent/codex/main_test.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -18,7 +19,7 @@ import (
 )
 
 func TestBuildCodexArgs_Minimal(t *testing.T) {
-	t.Setenv("ORKA_ALLOW_BASH", "")
+	t.Setenv("ORKA_ALLOW_BASH", "true")
 	t.Setenv("OPENAI_BASE_URL", "")
 
 	cfg := &common.AgentConfig{
@@ -36,10 +37,10 @@ func TestBuildCodexArgs_Minimal(t *testing.T) {
 	assertContains(t, args, "workspace-write")
 	assertContains(t, args, "--config")
 	assertContains(t, args, "approval_policy=never")
-	assertContains(t, args, "sandbox_workspace_write.network_access=false")
+	assertContains(t, args, "sandbox_workspace_write.network_access=true")
 
-	if args[len(args)-1] != "hello world" {
-		t.Errorf("prompt should be last arg, got %q", args[len(args)-1])
+	if args[len(args)-1] != "-" {
+		t.Errorf("prompt sentinel should be last arg, got %q", args[len(args)-1])
 	}
 }
 
@@ -67,7 +68,7 @@ func TestBuildCodexArgs_Full(t *testing.T) {
 }
 
 func TestBuildCodexArgs_WebSearchDisabled(t *testing.T) {
-	t.Setenv("ORKA_ALLOW_BASH", "")
+	t.Setenv("ORKA_ALLOW_BASH", "true")
 
 	cfg := &common.AgentConfig{
 		Prompt:       "test",
@@ -135,7 +136,7 @@ func TestBuildCodexEnv_UsesOpenAIAPIKeyWhenCodexUnset(t *testing.T) {
 
 func TestExecuteCodex_NonexistentBinary(t *testing.T) {
 	t.Setenv("CODEX_CLI_PATH", "/nonexistent/codex-cli")
-	t.Setenv("ORKA_ALLOW_BASH", "")
+	t.Setenv("ORKA_ALLOW_BASH", "true")
 
 	cfg := &common.AgentConfig{
 		Prompt:   "test prompt",
@@ -145,6 +146,20 @@ func TestExecuteCodex_NonexistentBinary(t *testing.T) {
 	_, err := executeCodex(context.Background(), cfg)
 	if err == nil {
 		t.Fatal("expected error when codex binary doesn't exist")
+	}
+}
+
+func TestExecuteCodex_RejectsBashDisabledConfig(t *testing.T) {
+	t.Setenv("ORKA_ALLOW_BASH", "")
+
+	cfg := &common.AgentConfig{
+		Prompt:   "test prompt",
+		MaxTurns: 5,
+	}
+
+	_, err := executeCodex(context.Background(), cfg)
+	if !errors.Is(err, errCodexRequiresBash) {
+		t.Fatalf("executeCodex() error = %v, want %v", err, errCodexRequiresBash)
 	}
 }
 
@@ -164,7 +179,7 @@ printf 'ignored-stdout'
 `)
 
 	t.Setenv("CODEX_CLI_PATH", scriptPath)
-	t.Setenv("ORKA_ALLOW_BASH", "")
+	t.Setenv("ORKA_ALLOW_BASH", "true")
 
 	cfg := &common.AgentConfig{
 		Prompt:   "test prompt",
@@ -186,7 +201,7 @@ printf 'stdout-result'
 `)
 
 	t.Setenv("CODEX_CLI_PATH", scriptPath)
-	t.Setenv("ORKA_ALLOW_BASH", "")
+	t.Setenv("ORKA_ALLOW_BASH", "true")
 
 	cfg := &common.AgentConfig{
 		Prompt:   "test prompt",
@@ -199,6 +214,43 @@ printf 'stdout-result'
 	}
 	if result != "stdout-result" {
 		t.Fatalf("executeCodex() = %q, want %q", result, "stdout-result")
+	}
+}
+
+func TestExecuteCodex_SendsPromptViaStdin(t *testing.T) {
+	scriptPath := writeCodexStub(t, `#!/bin/sh
+OUTPUT=""
+LAST_ARG=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output-last-message" ]; then
+    OUTPUT="$2"
+    shift 2
+    continue
+  fi
+  LAST_ARG="$1"
+  shift
+done
+INPUT="$(cat)"
+printf 'arg=%s\nstdin=%s\n' "$LAST_ARG" "$INPUT" > "$OUTPUT"
+`)
+
+	t.Setenv("CODEX_CLI_PATH", scriptPath)
+	t.Setenv("ORKA_ALLOW_BASH", "true")
+
+	cfg := &common.AgentConfig{
+		Prompt:   "--help",
+		MaxTurns: 5,
+	}
+
+	result, err := executeCodex(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("executeCodex() error = %v", err)
+	}
+	if !strings.Contains(result, "arg=-") {
+		t.Fatalf("executeCodex() = %q, want prompt sentinel", result)
+	}
+	if !strings.Contains(result, "stdin=--help") {
+		t.Fatalf("executeCodex() = %q, want stdin prompt", result)
 	}
 }
 

--- a/workers/agent/codex/main_test.go
+++ b/workers/agent/codex/main_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/sozercan/orka/workers/common"
+)
+
+func TestBuildCodexArgs_Minimal(t *testing.T) {
+	t.Setenv("ORKA_ALLOW_BASH", "")
+	t.Setenv("OPENAI_BASE_URL", "")
+
+	cfg := &common.AgentConfig{
+		Prompt:   "hello world",
+		MaxTurns: 50,
+	}
+
+	args := buildCodexArgs(cfg, "/tmp/result.txt", "")
+
+	assertContains(t, args, "exec")
+	assertContains(t, args, "--skip-git-repo-check")
+	assertContains(t, args, "--output-last-message")
+	assertContains(t, args, "/tmp/result.txt")
+	assertContains(t, args, "--sandbox")
+	assertContains(t, args, "workspace-write")
+	assertContains(t, args, "--config")
+	assertContains(t, args, "approval_policy=never")
+	assertContains(t, args, "sandbox_workspace_write.network_access=false")
+
+	if args[len(args)-1] != "hello world" {
+		t.Errorf("prompt should be last arg, got %q", args[len(args)-1])
+	}
+}
+
+func TestBuildCodexArgs_Full(t *testing.T) {
+	t.Setenv("ORKA_ALLOW_BASH", "true")
+	t.Setenv("OPENAI_BASE_URL", "https://example.invalid/v1")
+
+	cfg := &common.AgentConfig{
+		Prompt:          "fix bugs",
+		Model:           "gpt-5.4",
+		SystemPrompt:    "You are a code reviewer",
+		MaxTurns:        100,
+		AllowedTools:    []string{"Read", "WebSearch"},
+		DisallowedTools: []string{"Shell"},
+	}
+
+	args := buildCodexArgs(cfg, "/tmp/result.txt", "/tmp/instructions.md")
+
+	assertContains(t, args, "--model")
+	assertContains(t, args, "gpt-5.4")
+	assertContains(t, args, "model_instructions_file=/tmp/instructions.md")
+	assertContains(t, args, "openai_base_url=https://example.invalid/v1")
+	assertContains(t, args, "sandbox_workspace_write.network_access=true")
+	assertContains(t, args, "web_search=live")
+}
+
+func TestBuildCodexArgs_WebSearchDisabled(t *testing.T) {
+	t.Setenv("ORKA_ALLOW_BASH", "")
+
+	cfg := &common.AgentConfig{
+		Prompt:       "test",
+		AllowedTools: []string{"Read", "Write"},
+	}
+
+	args := buildCodexArgs(cfg, "/tmp/result.txt", "")
+	assertContains(t, args, "web_search=disabled")
+}
+
+func TestBuildCodexInstructions(t *testing.T) {
+	t.Setenv("ORKA_ALLOW_BASH", "")
+
+	cfg := &common.AgentConfig{
+		SystemPrompt:    "You are helpful.",
+		MaxTurns:        12,
+		AllowedTools:    []string{" Read ", "Write"},
+		DisallowedTools: []string{" Bash "},
+	}
+
+	instructions := buildCodexInstructions(cfg)
+
+	if !strings.Contains(instructions, "You are helpful.") {
+		t.Fatalf("expected system prompt in instructions, got %q", instructions)
+	}
+	if !strings.Contains(instructions, "within 12 turns") {
+		t.Errorf("expected max turns guidance, got %q", instructions)
+	}
+	if !strings.Contains(instructions, "Read, Write") {
+		t.Errorf("expected allowlist guidance, got %q", instructions)
+	}
+	if !strings.Contains(instructions, "Do not use these tools: Bash.") {
+		t.Errorf("expected disallow guidance, got %q", instructions)
+	}
+}
+
+func TestCodexPath_Default(t *testing.T) {
+	t.Setenv("CODEX_CLI_PATH", "")
+
+	if p := codexPath(); p != defaultCodexPath {
+		t.Errorf("codexPath() = %q, want %q", p, defaultCodexPath)
+	}
+}
+
+func TestCodexPath_Override(t *testing.T) {
+	t.Setenv("CODEX_CLI_PATH", "/usr/local/bin/codex")
+
+	if p := codexPath(); p != "/usr/local/bin/codex" {
+		t.Errorf("codexPath() = %q, want /usr/local/bin/codex", p)
+	}
+}
+
+func TestBuildCodexEnv_UsesOpenAIAPIKeyWhenCodexUnset(t *testing.T) {
+	t.Setenv("CODEX_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "openai-test-key")
+
+	env := buildCodexEnv()
+	if !slices.Contains(env, "CODEX_API_KEY=openai-test-key") {
+		t.Fatalf("expected CODEX_API_KEY to be populated from OPENAI_API_KEY, got %v", env)
+	}
+	if !slices.Contains(env, "HOME=/home/worker") {
+		t.Fatalf("expected HOME override, got %v", env)
+	}
+}
+
+func TestExecuteCodex_NonexistentBinary(t *testing.T) {
+	t.Setenv("CODEX_CLI_PATH", "/nonexistent/codex-cli")
+	t.Setenv("ORKA_ALLOW_BASH", "")
+
+	cfg := &common.AgentConfig{
+		Prompt:   "test prompt",
+		MaxTurns: 5,
+	}
+
+	_, err := executeCodex(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected error when codex binary doesn't exist")
+	}
+}
+
+func TestExecuteCodex_UsesOutputFileWhenPresent(t *testing.T) {
+	scriptPath := writeCodexStub(t, `#!/bin/sh
+OUTPUT=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output-last-message" ]; then
+    OUTPUT="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+printf 'codex-ok' > "$OUTPUT"
+printf 'ignored-stdout'
+`)
+
+	t.Setenv("CODEX_CLI_PATH", scriptPath)
+	t.Setenv("ORKA_ALLOW_BASH", "")
+
+	cfg := &common.AgentConfig{
+		Prompt:   "test prompt",
+		MaxTurns: 5,
+	}
+
+	result, err := executeCodex(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("executeCodex() error = %v", err)
+	}
+	if result != "codex-ok" {
+		t.Fatalf("executeCodex() = %q, want %q", result, "codex-ok")
+	}
+}
+
+func TestExecuteCodex_FallsBackToStdoutWhenOutputFileMissing(t *testing.T) {
+	scriptPath := writeCodexStub(t, `#!/bin/sh
+printf 'stdout-result'
+`)
+
+	t.Setenv("CODEX_CLI_PATH", scriptPath)
+	t.Setenv("ORKA_ALLOW_BASH", "")
+
+	cfg := &common.AgentConfig{
+		Prompt:   "test prompt",
+		MaxTurns: 5,
+	}
+
+	result, err := executeCodex(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("executeCodex() error = %v", err)
+	}
+	if result != "stdout-result" {
+		t.Fatalf("executeCodex() = %q, want %q", result, "stdout-result")
+	}
+}
+
+func assertContains(t *testing.T, values []string, want string) {
+	t.Helper()
+	if slices.Contains(values, want) {
+		return
+	}
+	t.Fatalf("expected args to contain %q, got %v", want, values)
+}
+
+func writeCodexStub(t *testing.T, content string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex-stub")
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	return path
+}


### PR DESCRIPTION
## Summary
Add Codex as a supported agent runtime alongside Claude Code and Copilot.

This wires the new `runtime.type: codex` option through the API, controller, worker image selection, secret autodiscovery, chat/runtime guidance, UI, docs, and samples.

## What Changed
- added `codex` to the agent runtime enum and regenerated the Agent CRD
- added controller/config wiring for a dedicated Codex worker image
- implemented a new Codex worker that runs `codex exec`, captures the final message, maps OpenAI credentials, and applies best-effort runtime/tool guidance
- updated runtime secret detection, chat prompts, and task/agent creation tool descriptions to include Codex
- added UI support for selecting Codex when creating runtime agents
- added tests for runtime parsing, worker image selection, secret autodiscovery, system prompt runtime discovery, and the new Codex worker
- updated docs, Helm values, manager manifests, and sample configs, including a new Codex agent sample

## Why
Orka already supported Claude Code and Copilot runtimes. Adding Codex makes OpenAI's coding runtime available through the same Kubernetes-native agent workflow, with the same task lifecycle, workspace, and secret-management model.

## Impact
Users can now create `type: agent` tasks backed by Codex and configure them through CRDs, chat tools, the embedded UI, Helm values, and sample manifests.

## Validation
- `make manifests`
- `go test ./api/v1alpha1 ./internal/tools ./internal/api`
- `go test ./internal/controller -run 'Test(NewJobBuilder|JobBuilder_Build_AgentTask_CodexRuntime|GetAgentWorkerImage)$'
- `go test ./workers/agent/codex`
- `cd ui && bun run test src/schemas/agent.test.ts src/components/agents/agent-create-form.test.tsx`

## Notes
The full `internal/controller` envtest suite was not run in this environment because the Kubebuilder envtest binaries were not installed locally (`etcd` under `/usr/local/kubebuilder/bin`).
