### PR TITLE
add repo-local deploy skills

### DIFF
--- a/.claude/skills/copilot-proxy-kind-deploy
+++ b/.claude/skills/copilot-proxy-kind-deploy
@@ -1,0 +1,1 @@
+../../.codex/skills/copilot-proxy-kind-deploy

--- a/.claude/skills/orka-kind-deploy
+++ b/.claude/skills/orka-kind-deploy
@@ -1,0 +1,1 @@
+../../.codex/skills/orka-kind-deploy

--- a/.codex/skills/copilot-proxy-kind-deploy/SKILL.md
+++ b/.codex/skills/copilot-proxy-kind-deploy/SKILL.md
@@ -9,11 +9,12 @@ Use the bundled script for the normal local cluster flow instead of rebuilding t
 
 ## Workflow
 
-1. Confirm the `copilot-proxy` repository path. Default to `/Users/sozercan/projects/copilot-proxy` when it exists.
-2. Prefer the active `kubectl` context. If it starts with `kind-`, derive the cluster name from it. Otherwise require `--cluster`.
+1. Confirm the `copilot-proxy` repository path. Prefer `--repo` when the user gives one. Otherwise let the script auto-discover from `COPILOT_PROXY_REPO`, the current repo, or a sibling `../copilot-proxy` checkout; if discovery fails, ask the user for `--repo`.
+2. Prefer the active `kubectl` context. If it targets a kind cluster, derive the cluster name from it. Otherwise require `--cluster`; when `--context` is omitted, the script uses `kind-<cluster>`.
 3. Run the script:
    - Default: `scripts/deploy_copilot_proxy_kind.sh`
    - Explicit repo or namespace: `scripts/deploy_copilot_proxy_kind.sh --repo /path/to/copilot-proxy --namespace default`
+   - Environment override: `COPILOT_PROXY_REPO=/path/to/copilot-proxy scripts/deploy_copilot_proxy_kind.sh`
    - Safe preview: `scripts/deploy_copilot_proxy_kind.sh --dry-run`
 4. Let the script:
    - build a local `copilot-proxy:kind` image

--- a/.codex/skills/copilot-proxy-kind-deploy/SKILL.md
+++ b/.codex/skills/copilot-proxy-kind-deploy/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: copilot-proxy-kind-deploy
+description: Build and deploy the local copilot-proxy checkout into a kind Kubernetes cluster using the repo's Dockerfile and `k8s/copilot-proxy.yaml` manifest. Use when the user wants to rebuild copilot-proxy, load it into the current kind cluster, or roll out the proxy service for local cluster testing.
+---
+
+# Copilot Proxy Kind Deploy
+
+Use the bundled script for the normal local cluster flow instead of rebuilding the Docker and kubectl steps manually.
+
+## Workflow
+
+1. Confirm the `copilot-proxy` repository path. Default to `/Users/sozercan/projects/copilot-proxy` when it exists.
+2. Prefer the active `kubectl` context. If it starts with `kind-`, derive the cluster name from it. Otherwise require `--cluster`.
+3. Run the script:
+   - Default: `scripts/deploy_copilot_proxy_kind.sh`
+   - Explicit repo or namespace: `scripts/deploy_copilot_proxy_kind.sh --repo /path/to/copilot-proxy --namespace default`
+   - Safe preview: `scripts/deploy_copilot_proxy_kind.sh --dry-run`
+4. Let the script:
+   - build a local `copilot-proxy:kind` image
+   - load it into the target kind cluster
+   - patch the manifest to use the local image with `imagePullPolicy: IfNotPresent`
+   - create the target namespace when needed
+   - apply the manifest and wait for `deployment/copilot-proxy`
+   - print either the GitHub device-login URL and user code from pod logs or a message that the pod is already authenticated
+5. If the script prints a login URL and code, relay them to the user exactly and stop to wait for their confirmation that login is complete.
+6. If the script reports that the pod is already authenticated, tell the user no manual login step is needed.
+7. After the user confirms login, verify success with `kubectl --context <context> -n <namespace> logs deployment/copilot-proxy --tail=50` and summarize the resulting `pods`, `services`, and `deployments` for `copilot-proxy`.
+
+## Guardrails
+
+- Use this for local kind-based deployment. Do not assume it is appropriate for remote clusters unless the image distribution path is explicitly changed.
+- The stock manifest mounts the token cache as `emptyDir`, so Copilot authentication inside the pod is ephemeral unless the user changes the volume strategy.
+- When the script prints a device code, do not keep going as if login is done. Pause and wait for the user's confirmation.
+- If rollout fails, inspect `kubectl -n <namespace> describe deployment/copilot-proxy`, `kubectl -n <namespace> get pods -l app=copilot-proxy`, and `kubectl -n <namespace> logs deployment/copilot-proxy`.

--- a/.codex/skills/copilot-proxy-kind-deploy/agents/openai.yaml
+++ b/.codex/skills/copilot-proxy-kind-deploy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Copilot Proxy Deploy"
+  short_description: "Deploy copilot-proxy to kind"
+  default_prompt: "Use $copilot-proxy-kind-deploy to build copilot-proxy, load it into the current kind cluster, and roll it out with the Kubernetes manifest."

--- a/.codex/skills/copilot-proxy-kind-deploy/scripts/deploy_copilot_proxy_kind.sh
+++ b/.codex/skills/copilot-proxy-kind-deploy/scripts/deploy_copilot_proxy_kind.sh
@@ -8,6 +8,12 @@ Usage: deploy_copilot_proxy_kind.sh [--repo PATH] [--context NAME] [--cluster NA
 Build the local copilot-proxy image, load it into a kind cluster, patch the
 Kubernetes manifest to use that image, apply it, wait for rollout, and print
 the current login state from the pod logs.
+
+When --cluster is provided without --context, the script uses the standard
+kind context name: kind-<cluster>.
+
+When --repo is omitted, the script tries COPILOT_PROXY_REPO, the current git
+repository, and a sibling ../copilot-proxy checkout before failing.
 EOF
 }
 
@@ -19,6 +25,13 @@ require_cmd() {
   fi
 }
 
+context_cluster_for() {
+  local context="$1"
+
+  kubectl config view -o jsonpath='{range .contexts[*]}{.name}{"\t"}{.context.cluster}{"\n"}{end}' \
+    | awk -F'\t' -v context="$context" '$1 == context { print $2; exit }'
+}
+
 run_cmd() {
   printf '+'
   printf ' %q' "$@"
@@ -27,6 +40,37 @@ run_cmd() {
     return 0
   fi
   "$@"
+}
+
+is_copilot_proxy_repo() {
+  local candidate="${1:-}"
+  [[ -n "$candidate" ]] || return 1
+  [[ -f "$candidate/Dockerfile" && -f "$candidate/k8s/copilot-proxy.yaml" ]]
+}
+
+discover_repo_root() {
+  local git_root=""
+  local candidate=""
+  local -a candidates=()
+
+  if [[ -n "${COPILOT_PROXY_REPO:-}" ]]; then
+    candidates+=("$COPILOT_PROXY_REPO")
+  fi
+
+  if git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    candidates+=("$git_root" "$git_root/../copilot-proxy")
+  fi
+
+  candidates+=("$(pwd)" "$(pwd)/../copilot-proxy")
+
+  for candidate in "${candidates[@]}"; do
+    if is_copilot_proxy_repo "$candidate"; then
+      repo_root="$(cd "$candidate" && pwd)"
+      return 0
+    fi
+  done
+
+  return 1
 }
 
 print_login_status() {
@@ -62,7 +106,6 @@ print_login_status() {
   echo "$logs"
 }
 
-default_repo="/Users/sozercan/projects/copilot-proxy"
 repo_root=""
 context_name=""
 cluster_name=""
@@ -123,12 +166,10 @@ for cmd in docker git kind kubectl sed mktemp; do
 done
 
 if [[ -z "$repo_root" ]]; then
-  if [[ -d "$default_repo" ]]; then
-    repo_root="$default_repo"
-  elif git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
-    repo_root="$git_root"
-  else
-    repo_root="$(pwd)"
+  if ! discover_repo_root; then
+    echo "Unable to locate a copilot-proxy repository automatically." >&2
+    echo "Pass --repo PATH or set COPILOT_PROXY_REPO to a checkout containing Dockerfile and k8s/copilot-proxy.yaml." >&2
+    exit 1
   fi
 fi
 repo_root="$(cd "$repo_root" && pwd)"
@@ -147,16 +188,35 @@ if [[ ! -f "$manifest_path" ]]; then
 fi
 
 if [[ -z "$context_name" ]]; then
-  context_name="$(kubectl config current-context)"
+  if [[ -n "$cluster_name" ]]; then
+    context_name="kind-$cluster_name"
+  else
+    context_name="$(kubectl config current-context)"
+  fi
+fi
+
+context_cluster="$(context_cluster_for "$context_name")"
+if [[ -z "$context_cluster" ]]; then
+  echo "kubectl context '$context_name' not found" >&2
+  exit 1
+fi
+
+if [[ "$context_cluster" == kind-* ]]; then
+  context_kind_cluster="${context_cluster#kind-}"
+else
+  context_kind_cluster=""
 fi
 
 if [[ -z "$cluster_name" ]]; then
-  if [[ "$context_name" == kind-* ]]; then
-    cluster_name="${context_name#kind-}"
+  if [[ -n "$context_kind_cluster" ]]; then
+    cluster_name="$context_kind_cluster"
   else
-    echo "Current context '$context_name' is not a kind context. Pass --cluster explicitly." >&2
+    echo "Context '$context_name' targets '$context_cluster', not a kind cluster. Pass --cluster explicitly." >&2
     exit 1
   fi
+elif [[ -z "$context_kind_cluster" || "$context_kind_cluster" != "$cluster_name" ]]; then
+  echo "Context '$context_name' targets '$context_cluster', which does not match kind cluster '$cluster_name'." >&2
+  exit 1
 fi
 
 if ! kind get clusters | grep -Fxq "$cluster_name"; then

--- a/.codex/skills/copilot-proxy-kind-deploy/scripts/deploy_copilot_proxy_kind.sh
+++ b/.codex/skills/copilot-proxy-kind-deploy/scripts/deploy_copilot_proxy_kind.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: deploy_copilot_proxy_kind.sh [--repo PATH] [--context NAME] [--cluster NAME] [--namespace NAME] [--image IMAGE] [--manifest PATH] [--skip-build] [--dry-run]
+
+Build the local copilot-proxy image, load it into a kind cluster, patch the
+Kubernetes manifest to use that image, apply it, wait for rollout, and print
+the current login state from the pod logs.
+EOF
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: $cmd" >&2
+    exit 1
+  fi
+}
+
+run_cmd() {
+  printf '+'
+  printf ' %q' "$@"
+  printf '\n'
+  if [[ "$dry_run" == true ]]; then
+    return 0
+  fi
+  "$@"
+}
+
+print_login_status() {
+  local logs line url code
+
+  if [[ "$dry_run" == true ]]; then
+    echo "Login status: skipped during dry-run"
+    return
+  fi
+
+  logs="$(kubectl --context "$context_name" -n "$namespace" logs deployment/copilot-proxy --tail=50 2>&1 || true)"
+  if [[ -z "$logs" ]]; then
+    echo "Login status: no recent copilot-proxy logs found"
+    return
+  fi
+
+  if grep -Fq "authenticated successfully" <<<"$logs"; then
+    echo "Login status: copilot-proxy reports authenticated successfully"
+    return
+  fi
+
+  line="$(grep -E 'Please visit .* and enter code: ' <<<"$logs" | tail -n 1 || true)"
+  if [[ -n "$line" ]]; then
+    url="$(sed -E 's/Please visit ([^ ]+) and enter code: .*/\1/' <<<"$line")"
+    code="$(sed -E 's/Please visit [^ ]+ and enter code: (.*)/\1/' <<<"$line")"
+    echo "Login status: login required"
+    echo "Verification URL: $url"
+    echo "User code: $code"
+    return
+  fi
+
+  echo "Login status: no explicit login line found in recent logs"
+  echo "$logs"
+}
+
+default_repo="/Users/sozercan/projects/copilot-proxy"
+repo_root=""
+context_name=""
+cluster_name=""
+namespace="default"
+image="copilot-proxy:kind"
+manifest_path=""
+skip_build=false
+dry_run=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo_root="${2:?missing value for --repo}"
+      shift 2
+      ;;
+    --context)
+      context_name="${2:?missing value for --context}"
+      shift 2
+      ;;
+    --cluster)
+      cluster_name="${2:?missing value for --cluster}"
+      shift 2
+      ;;
+    --namespace)
+      namespace="${2:?missing value for --namespace}"
+      shift 2
+      ;;
+    --image)
+      image="${2:?missing value for --image}"
+      shift 2
+      ;;
+    --manifest)
+      manifest_path="${2:?missing value for --manifest}"
+      shift 2
+      ;;
+    --skip-build)
+      skip_build=true
+      shift
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+for cmd in docker git kind kubectl sed mktemp; do
+  require_cmd "$cmd"
+done
+
+if [[ -z "$repo_root" ]]; then
+  if [[ -d "$default_repo" ]]; then
+    repo_root="$default_repo"
+  elif git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    repo_root="$git_root"
+  else
+    repo_root="$(pwd)"
+  fi
+fi
+repo_root="$(cd "$repo_root" && pwd)"
+
+if [[ ! -f "$repo_root/Dockerfile" ]]; then
+  echo "Not a copilot-proxy repository root: missing Dockerfile in $repo_root" >&2
+  exit 1
+fi
+
+if [[ -z "$manifest_path" ]]; then
+  manifest_path="$repo_root/k8s/copilot-proxy.yaml"
+fi
+if [[ ! -f "$manifest_path" ]]; then
+  echo "Missing manifest: $manifest_path" >&2
+  exit 1
+fi
+
+if [[ -z "$context_name" ]]; then
+  context_name="$(kubectl config current-context)"
+fi
+
+if [[ -z "$cluster_name" ]]; then
+  if [[ "$context_name" == kind-* ]]; then
+    cluster_name="${context_name#kind-}"
+  else
+    echo "Current context '$context_name' is not a kind context. Pass --cluster explicitly." >&2
+    exit 1
+  fi
+fi
+
+if ! kind get clusters | grep -Fxq "$cluster_name"; then
+  echo "kind cluster '$cluster_name' not found" >&2
+  exit 1
+fi
+
+tmp_manifest="$(mktemp)"
+cleanup() {
+  rm -f "$tmp_manifest"
+}
+trap cleanup EXIT
+
+sed \
+  -e "s|^\([[:space:]]*image:[[:space:]]*\).*|\1${image}|" \
+  -e "s|^\([[:space:]]*imagePullPolicy:[[:space:]]*\).*|\1IfNotPresent|" \
+  "$manifest_path" >"$tmp_manifest"
+
+echo "Repository: $repo_root"
+echo "Context: $context_name"
+echo "Kind cluster: $cluster_name"
+echo "Namespace: $namespace"
+echo "Image: $image"
+echo "Manifest: $manifest_path"
+
+if [[ "$skip_build" != true ]]; then
+  run_cmd docker build -t "$image" "$repo_root"
+fi
+
+run_cmd kind load docker-image "$image" --name "$cluster_name"
+
+if ! kubectl --context "$context_name" get namespace "$namespace" >/dev/null 2>&1; then
+  run_cmd kubectl --context "$context_name" create namespace "$namespace"
+fi
+
+run_cmd kubectl --context "$context_name" apply -n "$namespace" -f "$tmp_manifest"
+run_cmd kubectl --context "$context_name" -n "$namespace" rollout status deployment/copilot-proxy --timeout=180s
+run_cmd kubectl --context "$context_name" -n "$namespace" get deploy,svc,pods -l app=copilot-proxy
+print_login_status

--- a/.codex/skills/orka-kind-deploy/SKILL.md
+++ b/.codex/skills/orka-kind-deploy/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: orka-kind-deploy
+description: Rebuild and redeploy the Orka controller and all worker images into a local kind cluster from an Orka repository checkout. Use when the user asks to rebuild Orka, redeploy all components, refresh the local cluster after code changes, or roll out the full local stack for verification.
+---
+
+# Orka Kind Deploy
+
+Use the bundled script for the standard local deploy path instead of retyping the Makefile sequence.
+
+## Workflow
+
+1. Ensure the working directory is an Orka repository checkout with `Makefile`, `config/manager/kustomization.yaml`, and the `workers/` tree.
+2. Prefer the active `kubectl` context. If it starts with `kind-`, derive the cluster name from it. If not, pass `--cluster` explicitly.
+3. Run the script:
+   - Default: `scripts/deploy_orka_kind.sh`
+   - Explicit repo or cluster: `scripts/deploy_orka_kind.sh --repo /path/to/repo --cluster codex`
+4. Let the script:
+   - build `controller:kind` plus all worker images
+   - load them into the target kind cluster with `make test-e2e-setup-only`
+   - install CRDs and deploy the controller with `make install deploy IMG=controller:kind`
+   - wait for `deployment/orka-controller-manager` in `orka-system`
+   - restore `config/manager/kustomization.yaml` after the deploy so the worktree stays clean
+5. Summarize the resulting `pods`, `services`, and `deployments` in `orka-system`.
+
+## Guardrails
+
+- Use this skill for local kind-based Orka deployments. For remote or shared clusters, inspect the intended registry and tag flow before deploying.
+- If the active context is not a kind context and no explicit cluster is provided, stop and explain the mismatch instead of guessing.
+- If rollout fails, inspect `kubectl -n orka-system describe deployment/orka-controller-manager`, `kubectl -n orka-system get pods`, and `kubectl -n orka-system logs deployment/orka-controller-manager`.

--- a/.codex/skills/orka-kind-deploy/SKILL.md
+++ b/.codex/skills/orka-kind-deploy/SKILL.md
@@ -10,7 +10,7 @@ Use the bundled script for the standard local deploy path instead of retyping th
 ## Workflow
 
 1. Ensure the working directory is an Orka repository checkout with `Makefile`, `config/manager/kustomization.yaml`, and the `workers/` tree.
-2. Prefer the active `kubectl` context. If it starts with `kind-`, derive the cluster name from it. If not, pass `--cluster` explicitly.
+2. Prefer the active `kubectl` context. If it targets a kind cluster, derive the cluster name from it. If not, pass `--cluster` explicitly; when `--context` is omitted, the script uses `kind-<cluster>`.
 3. Run the script:
    - Default: `scripts/deploy_orka_kind.sh`
    - Explicit repo or cluster: `scripts/deploy_orka_kind.sh --repo /path/to/repo --cluster codex`

--- a/.codex/skills/orka-kind-deploy/agents/openai.yaml
+++ b/.codex/skills/orka-kind-deploy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Orka Kind Deploy"
+  short_description: "Rebuild and deploy Orka to kind"
+  default_prompt: "Use $orka-kind-deploy to rebuild all Orka images, load them into the active kind cluster, and roll out the controller."

--- a/.codex/skills/orka-kind-deploy/scripts/deploy_orka_kind.sh
+++ b/.codex/skills/orka-kind-deploy/scripts/deploy_orka_kind.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: deploy_orka_kind.sh [--repo PATH] [--cluster NAME] [--context NAME] [--controller-image IMAGE]
+
+Rebuild all Orka images, load them into a local kind cluster, install CRDs,
+deploy the controller, and wait for the rollout to finish.
+EOF
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: $cmd" >&2
+    exit 1
+  fi
+}
+
+repo_root=""
+cluster_name=""
+context_name=""
+controller_image="controller:kind"
+namespace="orka-system"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo_root="${2:?missing value for --repo}"
+      shift 2
+      ;;
+    --cluster)
+      cluster_name="${2:?missing value for --cluster}"
+      shift 2
+      ;;
+    --context)
+      context_name="${2:?missing value for --context}"
+      shift 2
+      ;;
+    --controller-image)
+      controller_image="${2:?missing value for --controller-image}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+for cmd in docker git kind kubectl make; do
+  require_cmd "$cmd"
+done
+
+if [[ -z "$repo_root" ]]; then
+  if git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    repo_root="$git_root"
+  else
+    repo_root="$(pwd)"
+  fi
+fi
+repo_root="$(cd "$repo_root" && pwd)"
+
+if [[ ! -f "$repo_root/Makefile" ]]; then
+  echo "Not an Orka repository root: missing Makefile in $repo_root" >&2
+  exit 1
+fi
+
+kustomization_file="$repo_root/config/manager/kustomization.yaml"
+if [[ ! -f "$kustomization_file" ]]; then
+  echo "Not an Orka repository root: missing $kustomization_file" >&2
+  exit 1
+fi
+
+if [[ -z "$context_name" ]]; then
+  context_name="$(kubectl config current-context)"
+fi
+
+if [[ -z "$cluster_name" ]]; then
+  if [[ "$context_name" == kind-* ]]; then
+    cluster_name="${context_name#kind-}"
+  else
+    echo "Current context '$context_name' is not a kind context. Pass --cluster explicitly." >&2
+    exit 1
+  fi
+fi
+
+if ! kind get clusters | grep -Fxq "$cluster_name"; then
+  echo "kind cluster '$cluster_name' not found" >&2
+  exit 1
+fi
+
+backup_file="$(mktemp)"
+kubectl_wrapper="$(mktemp)"
+cp "$kustomization_file" "$backup_file"
+cat >"$kubectl_wrapper" <<EOF
+#!/usr/bin/env bash
+exec kubectl --context "$context_name" "\$@"
+EOF
+chmod +x "$kubectl_wrapper"
+
+kube_cmd=("$kubectl_wrapper")
+
+restore_kustomization() {
+  if [[ -f "$backup_file" ]]; then
+    cp "$backup_file" "$kustomization_file"
+    rm -f "$backup_file"
+  fi
+  if [[ -f "$kubectl_wrapper" ]]; then
+    rm -f "$kubectl_wrapper"
+  fi
+}
+
+trap restore_kustomization EXIT
+
+echo "Repository: $repo_root"
+echo "Context: $context_name"
+echo "Kind cluster: $cluster_name"
+echo "Controller image: $controller_image"
+
+(
+  cd "$repo_root"
+  KIND_CLUSTER="$cluster_name" IMG="$controller_image" make test-e2e-setup-only
+)
+
+(
+  cd "$repo_root"
+  KUBECTL="$kubectl_wrapper" make install deploy IMG="$controller_image"
+)
+
+"${kube_cmd[@]}" -n "$namespace" rollout status deployment/orka-controller-manager --timeout=180s
+"${kube_cmd[@]}" -n "$namespace" get pods,svc,deploy

--- a/.codex/skills/orka-kind-deploy/scripts/deploy_orka_kind.sh
+++ b/.codex/skills/orka-kind-deploy/scripts/deploy_orka_kind.sh
@@ -7,6 +7,9 @@ Usage: deploy_orka_kind.sh [--repo PATH] [--cluster NAME] [--context NAME] [--co
 
 Rebuild all Orka images, load them into a local kind cluster, install CRDs,
 deploy the controller, and wait for the rollout to finish.
+
+When --cluster is provided without --context, the script uses the standard
+kind context name: kind-<cluster>.
 EOF
 }
 
@@ -16,6 +19,13 @@ require_cmd() {
     echo "Missing required command: $cmd" >&2
     exit 1
   fi
+}
+
+context_cluster_for() {
+  local context="$1"
+
+  kubectl config view -o jsonpath='{range .contexts[*]}{.name}{"\t"}{.context.cluster}{"\n"}{end}' \
+    | awk -F'\t' -v context="$context" '$1 == context { print $2; exit }'
 }
 
 repo_root=""
@@ -79,16 +89,35 @@ if [[ ! -f "$kustomization_file" ]]; then
 fi
 
 if [[ -z "$context_name" ]]; then
-  context_name="$(kubectl config current-context)"
+  if [[ -n "$cluster_name" ]]; then
+    context_name="kind-$cluster_name"
+  else
+    context_name="$(kubectl config current-context)"
+  fi
+fi
+
+context_cluster="$(context_cluster_for "$context_name")"
+if [[ -z "$context_cluster" ]]; then
+  echo "kubectl context '$context_name' not found" >&2
+  exit 1
+fi
+
+if [[ "$context_cluster" == kind-* ]]; then
+  context_kind_cluster="${context_cluster#kind-}"
+else
+  context_kind_cluster=""
 fi
 
 if [[ -z "$cluster_name" ]]; then
-  if [[ "$context_name" == kind-* ]]; then
-    cluster_name="${context_name#kind-}"
+  if [[ -n "$context_kind_cluster" ]]; then
+    cluster_name="$context_kind_cluster"
   else
-    echo "Current context '$context_name' is not a kind context. Pass --cluster explicitly." >&2
+    echo "Context '$context_name' targets '$context_cluster', not a kind cluster. Pass --cluster explicitly." >&2
     exit 1
   fi
+elif [[ -z "$context_kind_cluster" || "$context_kind_cluster" != "$cluster_name" ]]; then
+  echo "Context '$context_name' targets '$context_cluster', which does not match kind cluster '$cluster_name'." >&2
+  exit 1
 fi
 
 if ! kind get clusters | grep -Fxq "$cluster_name"; then

--- a/.copilot/skills/copilot-proxy-kind-deploy
+++ b/.copilot/skills/copilot-proxy-kind-deploy
@@ -1,0 +1,1 @@
+../../.codex/skills/copilot-proxy-kind-deploy

--- a/.copilot/skills/orka-kind-deploy
+++ b/.copilot/skills/orka-kind-deploy
@@ -1,0 +1,1 @@
+../../.codex/skills/orka-kind-deploy


### PR DESCRIPTION
## What changed

This adds two repo-local Codex skills under `.codex/skills/`:

- `orka-kind-deploy` to rebuild Orka, load all local images into a kind cluster, and roll out the controller
- `copilot-proxy-kind-deploy` to build and deploy the local `copilot-proxy` checkout into kind and surface device-login status from the pod logs

## Why

These workflows came up repeatedly while testing the new runtime locally, so moving them into repo-local skills makes them easy to invoke directly from this checkout without repeating the deployment steps by hand.

## User impact

Developers working in this repo can ask Codex to:

- rebuild and redeploy Orka to the active kind cluster
- deploy `copilot-proxy` to kind
- pause after printing the GitHub device code and wait for login confirmation before continuing

## Validation

- `bash -n .codex/skills/orka-kind-deploy/scripts/deploy_orka_kind.sh`
- `bash -n .codex/skills/copilot-proxy-kind-deploy/scripts/deploy_copilot_proxy_kind.sh`
