### PR TITLE
fix: stub out browser opener in CLI tests

### DIFF
--- a/cmd/cli/login_test.go
+++ b/cmd/cli/login_test.go
@@ -36,6 +36,11 @@ func TestNewLoginCmd_WithTokenFlag(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 
+	// Stub out the browser opener so we never launch a real browser.
+	orig := openBrowserFunc
+	openBrowserFunc = func(string) error { return nil }
+	t.Cleanup(func() { openBrowserFunc = orig })
+
 	cmd := newLoginCmd()
 
 	// Create a root command to provide persistent flags
@@ -43,11 +48,9 @@ func TestNewLoginCmd_WithTokenFlag(t *testing.T) {
 	root.AddCommand(cmd)
 
 	// With --token provided, it should try to construct URL and open browser.
-	// The openBrowser will fail in test, but the command should return nil.
 	root.SetArgs([]string{"login", "--server", "http://test-server:8080", "--token", "test-token-123"})
 
 	err := root.Execute()
-	// openBrowser may fail, but the cmd returns nil on browser error
 	if err != nil {
 		t.Fatalf("Execute() error: %v", err)
 	}
@@ -76,6 +79,11 @@ func TestNewLoginCmd_DefaultServerFromConfig(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 
+	// Stub out the browser opener so we never launch a real browser.
+	orig := openBrowserFunc
+	openBrowserFunc = func(string) error { return nil }
+	t.Cleanup(func() { openBrowserFunc = orig })
+
 	// Save a config with server
 	cfg := orkaConfig{Server: "http://configured-server:9090"}
 	if err := saveConfig(cfg); err != nil {
@@ -88,7 +96,6 @@ func TestNewLoginCmd_DefaultServerFromConfig(t *testing.T) {
 
 	root.SetArgs([]string{"login", "--token", "my-token"})
 
-	// Should use configured server. openBrowser may fail but command returns nil.
 	if err := root.Execute(); err != nil {
 		t.Fatalf("Execute() error: %v", err)
 	}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -196,8 +196,16 @@ func extractToken(kubeconfigPath string) (string, error) {
 	return "", fmt.Errorf("no token, token file, exec, or auth provider found for user %q", ctx.AuthInfo)
 }
 
+// openBrowserFunc is the function used to open URLs in the default browser.
+// Tests can replace this to avoid launching a real browser.
+var openBrowserFunc = openBrowserDefault
+
 // openBrowser opens the given URL in the default browser.
 func openBrowser(url string) error {
+	return openBrowserFunc(url)
+}
+
+func openBrowserDefault(url string) error {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -348,10 +348,15 @@ func TestExtractToken_MissingContext(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestOpenBrowser_DoesNotPanic(t *testing.T) { //nolint:unparam
-	// We can't really test browser opening, but ensure it doesn't panic
+	// Stub out the browser opener so we never launch a real browser.
+	orig := openBrowserFunc
+	openBrowserFunc = func(string) error { return nil }
+	t.Cleanup(func() { openBrowserFunc = orig })
+
 	err := openBrowser("http://example.com")
-	// May succeed or fail depending on platform — just check no panic
-	_ = err
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- CLI tests (`TestOpenBrowser_DoesNotPanic`, `TestNewLoginCmd_WithTokenFlag`, `TestNewLoginCmd_DefaultServerFromConfig`) were actually launching a real browser via `open`/`xdg-open`/`rundll32` as a side effect
- Introduced a `openBrowserFunc` package-level variable so tests can swap the real implementation with a no-op
- Each test stubs the function and restores it via `t.Cleanup`

## Test plan
- [x] `go test ./cmd/cli/ -run "TestOpenBrowser|TestNewLoginCmd" -v` — all pass
- [x] `make lint-fix` — 0 issues
- [x] `make test` — all pass (pre-existing flaky `internal/api` test unrelated)