### PR TITLE
Harden security patch result handling

### DIFF
--- a/internal/api/chat_tool_executor.go
+++ b/internal/api/chat_tool_executor.go
@@ -8,8 +8,12 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -157,11 +161,25 @@ func (e *ToolExecutor) Execute(ctx context.Context, toolCall llm.ToolCall) (stri
 
 func (e *ToolExecutor) generateTaskName() string {
 	seq := e.taskSeq.Add(1)
-	prefix := e.sessionID
-	if len(prefix) > 8 {
-		prefix = prefix[:8]
+	prefix := sanitizeTaskNameComponent(e.sessionID)
+	if prefix == "" {
+		prefix = "session"
 	}
-	return fmt.Sprintf("chat-%s-%d", prefix, seq)
+	hash := sha256.Sum256([]byte(e.sessionID))
+	hashSuffix := hex.EncodeToString(hash[:])[:8]
+	seqSuffix := strconv.FormatInt(int64(seq), 10)
+
+	// Kubernetes task names must fit DNS label rules (max 63 chars).
+	const taskNameOverhead = len("chat-") + len("-") + len("-")
+	maxPrefixLen := max(63-taskNameOverhead-len(hashSuffix)-len(seqSuffix), 1)
+	if len(prefix) > maxPrefixLen {
+		prefix = strings.Trim(prefix[:maxPrefixLen], "-")
+		if prefix == "" {
+			prefix = "session"
+		}
+	}
+
+	return fmt.Sprintf("chat-%s-%s-%s", prefix, hashSuffix, seqSuffix)
 }
 
 func (e *ToolExecutor) taskLabels() map[string]string {
@@ -169,6 +187,29 @@ func (e *ToolExecutor) taskLabels() map[string]string {
 		labels.LabelCreatedBy:   "orchestrator",
 		labels.LabelChatSession: e.sessionID,
 	}
+}
+
+func sanitizeTaskNameComponent(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	lastDash := false
+
+	for _, r := range s {
+		isLower := r >= 'a' && r <= 'z'
+		isDigit := r >= '0' && r <= '9'
+		if isLower || isDigit {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+
+	return strings.Trim(b.String(), "-")
 }
 
 // ---- Error handling helpers ----

--- a/internal/api/chat_tool_executor_test.go
+++ b/internal/api/chat_tool_executor_test.go
@@ -471,11 +471,62 @@ func TestGenerateTaskName(t *testing.T) {
 	name1 := e.generateTaskName()
 	name2 := e.generateTaskName()
 
-	if !strings.HasPrefix(name1, "chat-sess-123-") {
-		t.Errorf("name1 = %q, expected prefix chat-sess-123-", name1)
+	if !strings.HasPrefix(name1, "chat-sess-12345678-") {
+		t.Errorf("name1 = %q, expected prefix chat-sess-12345678-", name1)
 	}
 	if name1 == name2 {
 		t.Errorf("expected unique names, got %q twice", name1)
+	}
+}
+
+func TestGenerateTaskName_AvoidsCrossSessionCollisions(t *testing.T) {
+	e1 := newTestExecutor()
+	e1.sessionID = "demo-magic-chat-pr-one"
+	e2 := newTestExecutor()
+	e2.sessionID = "demo-magic-chat-pr-two"
+
+	name1 := e1.generateTaskName()
+	name2 := e2.generateTaskName()
+
+	if name1 == name2 {
+		t.Fatalf("expected distinct names for different sessions, got %q", name1)
+	}
+	if !strings.HasPrefix(name1, "chat-demo-magic-chat-pr-") {
+		t.Fatalf("name1 = %q, expected sanitized session prefix", name1)
+	}
+	if !strings.HasPrefix(name2, "chat-demo-magic-chat-pr-") {
+		t.Fatalf("name2 = %q, expected sanitized session prefix", name2)
+	}
+}
+
+func TestGenerateTaskNameTruncatesLongSessionToDNSLabelLimit(t *testing.T) {
+	e := newTestExecutor()
+	e.sessionID = strings.Repeat("a", 80)
+
+	name := e.generateTaskName()
+
+	if len(name) > 63 {
+		t.Fatalf("len(name) = %d, want <= 63: %q", len(name), name)
+	}
+	if !strings.HasPrefix(name, "chat-") {
+		t.Fatalf("name = %q, expected chat prefix", name)
+	}
+	if strings.Contains(name, "--") {
+		t.Fatalf("name = %q, expected no empty DNS label components", name)
+	}
+}
+
+func TestSanitizeTaskNameComponent(t *testing.T) {
+	tests := map[string]string{
+		"Demo Session/ABC": "demo-session-abc",
+		"---already---":    "already",
+		"MiXeD___123":      "mixed-123",
+	}
+
+	for input, want := range tests {
+		if got := sanitizeTaskNameComponent(input); got != want {
+			t.Fatalf("sanitizeTaskNameComponent(%q) = %q, want %q", input, got, want)
+		}
 	}
 }
 

--- a/internal/api/security_handlers.go
+++ b/internal/api/security_handlers.go
@@ -254,7 +254,7 @@ func (h *Handlers) createSecurityPatchTask(ctx context.Context, scan *corev1alph
 
 	taskName := security.PatchTaskName(scan.Name, finding.ID)
 	proposalID := security.PatchProposalID(taskName)
-	branch := security.PatchBranch(finding.ID)
+	branch := security.PatchBranch(finding.ID, taskName)
 	timeout := metav1.Duration{Duration: 2 * time.Hour}
 	priority := int32(750)
 
@@ -276,7 +276,7 @@ func (h *Handlers) createSecurityPatchTask(ctx context.Context, scan *corev1alph
 		Spec: corev1alpha1.TaskSpec{
 			Type:     corev1alpha1.TaskTypeAgent,
 			AgentRef: &agentRef,
-			Prompt:   security.BuildPatchPrompt(scan, finding),
+			Prompt:   security.BuildPatchPrompt(scan, finding, branch),
 			Timeout:  &timeout,
 			Priority: &priority,
 			Env: []corev1.EnvVar{

--- a/internal/api/security_handlers_test.go
+++ b/internal/api/security_handlers_test.go
@@ -187,7 +187,7 @@ func TestCreateSecurityPatchTaskRequiresPushedBranch(t *testing.T) {
 
 	proposal, err := handlers.createSecurityPatchTask(context.Background(), scan, finding)
 	require.NoError(t, err)
-	require.Equal(t, "orka/security/fnd-123", proposal.Branch)
+	require.Regexp(t, `^orka/security/fnd-123-[a-f0-9]{12}$`, proposal.Branch)
 
 	task := &corev1alpha1.Task{}
 	require.NoError(t, fakeClient.Get(context.Background(), clientObjectKey("demo", proposal.TaskName), task))

--- a/internal/controller/repositoryscan_controller.go
+++ b/internal/controller/repositoryscan_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/sozercan/orka/internal/labels"
 	"github.com/sozercan/orka/internal/security"
 	"github.com/sozercan/orka/internal/store"
+	"github.com/sozercan/orka/workers/common"
 )
 
 const (
@@ -48,6 +49,8 @@ const (
 	scanRunPhaseFailed    = "failed"
 
 	findingStateOpen                 = "open"
+	findingStatePatchPending         = "patch_pending"
+	findingStatePatchReady           = "patch_ready"
 	findingValidationStatusPending   = "pending"
 	findingValidationStatusValidated = "validated"
 	findingValidationStatusFailed    = "failed"
@@ -488,7 +491,7 @@ func (r *RepositoryScanReconciler) progressLatestScanRun(ctx context.Context, sc
 	timeout := metav1.Duration{Duration: 2 * time.Hour}
 	priority := int32(700)
 	for index, scope := range security.DiscoveryScopes() {
-		taskName := fmt.Sprintf("%s-%d", security.ScanStageTaskName(scan.Name, run.Mode, security.StageDiscovery, scope.Name), index)
+		taskName := security.ScanStageTaskName(scan.Name, run.Mode, security.StageDiscovery, fmt.Sprintf("%s-%d", scope.Name, index))
 		task := &corev1alpha1.Task{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      taskName,
@@ -1563,10 +1566,43 @@ func (r *RepositoryScanReconciler) ingestPatchTask(ctx context.Context, scan *co
 	}
 
 	proposal.Status = taskPhaseToSecurityPhase(task.Status.Phase)
+	requestedBranch := ""
 	if task.Spec.Workspace != nil {
-		proposal.Branch = task.Spec.Workspace.PushBranch
+		requestedBranch = strings.TrimSpace(task.Spec.Workspace.PushBranch)
 	} else if task.Spec.AgentRuntime != nil && task.Spec.AgentRuntime.Workspace != nil {
-		proposal.Branch = task.Spec.AgentRuntime.Workspace.PushBranch
+		requestedBranch = strings.TrimSpace(task.Spec.AgentRuntime.Workspace.PushBranch)
+	}
+	if requestedBranch != "" && strings.TrimSpace(proposal.Branch) == "" {
+		proposal.Branch = requestedBranch
+	}
+
+	if task.Status.Phase == corev1alpha1.TaskPhaseSucceeded {
+		switch {
+		case r.ResultStore == nil:
+			proposal.Status = scanRunPhasePending
+		case task.Status.ResultRef == nil || !task.Status.ResultRef.Available:
+			proposal.Status = scanRunPhasePending
+		default:
+			result, err := r.ResultStore.GetResult(ctx, task.Namespace, task.Name)
+			if err != nil {
+				if errors.Is(err, store.ErrNotFound) {
+					proposal.Status = scanRunPhasePending
+				} else {
+					return err
+				}
+			} else {
+				sr := common.ParseStructuredResult(string(result))
+				switch {
+				case strings.TrimSpace(sr.PushError) != "":
+					proposal.Status = scanRunPhaseFailed
+				case strings.TrimSpace(sr.PushBranch) != "":
+					proposal.Branch = strings.TrimSpace(sr.PushBranch)
+					proposal.Status = scanRunPhaseSucceeded
+				default:
+					proposal.Status = scanRunPhaseFailed
+				}
+			}
+		}
 	}
 
 	if r.ArtifactStore != nil {
@@ -1592,9 +1628,12 @@ func (r *RepositoryScanReconciler) ingestPatchTask(ctx context.Context, scan *co
 		return err
 	}
 	finding.PatchProposalID = proposal.ID
-	if task.Status.Phase == corev1alpha1.TaskPhaseSucceeded {
-		finding.State = "patch_ready"
-	} else {
+	switch proposal.Status {
+	case scanRunPhaseSucceeded:
+		finding.State = findingStatePatchReady
+	case scanRunPhasePending:
+		finding.State = findingStatePatchPending
+	default:
 		finding.State = findingStateOpen
 	}
 	return r.SecurityStore.UpsertFinding(ctx, finding)

--- a/internal/controller/repositoryscan_controller_test.go
+++ b/internal/controller/repositoryscan_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sozercan/orka/internal/security"
 	storepkg "github.com/sozercan/orka/internal/store"
 	sqlitestore "github.com/sozercan/orka/internal/store/sqlite"
+	"github.com/sozercan/orka/workers/common"
 )
 
 func TestRepositoryScanConditionMessageUsesFallback(t *testing.T) {
@@ -812,6 +813,188 @@ func TestCreateScanRunIsIdempotentWhenTaskAlreadyExists(t *testing.T) {
 	if current.Status.LastScanTaskName != taskName {
 		t.Fatalf("scan.Status.LastScanTaskName = %q, want %q", current.Status.LastScanTaskName, taskName)
 	}
+}
+
+type patchIngestFixture struct {
+	store      *sqlitestore.Store
+	reconciler *RepositoryScanReconciler
+	scan       *corev1alpha1.RepositoryScan
+	finding    *storepkg.Finding
+	proposal   *storepkg.PatchProposal
+}
+
+func newPatchIngestFixture(t *testing.T, id string) patchIngestFixture {
+	t.Helper()
+	ctx := context.Background()
+	securityStore := setupControllerSQLiteStore(t)
+
+	findingID := "fnd_patch_" + id
+	taskName := "kaset-patch-" + id
+	branch := "orka/security/" + findingID
+	fixture := patchIngestFixture{
+		store: securityStore,
+		reconciler: &RepositoryScanReconciler{
+			SecurityStore: securityStore,
+			ArtifactStore: securityStore,
+			ResultStore:   securityStore,
+		},
+		scan: &corev1alpha1.RepositoryScan{
+			ObjectMeta: metav1.ObjectMeta{Name: "kaset", Namespace: "default"},
+		},
+		finding: &storepkg.Finding{
+			ID:               findingID,
+			Namespace:        "default",
+			RepositoryScan:   "kaset",
+			ScanRunID:        "scan_patch",
+			Fingerprint:      "sha256:patch-" + id,
+			Title:            "Patch target",
+			Summary:          "candidate finding",
+			Severity:         "high",
+			Confidence:       "high",
+			ValidationStatus: "validated",
+			State:            findingStatePatchPending,
+		},
+		proposal: &storepkg.PatchProposal{
+			ID:             "patch_" + id,
+			Namespace:      "default",
+			RepositoryScan: "kaset",
+			FindingID:      findingID,
+			TaskName:       taskName,
+			Branch:         branch,
+			Status:         scanRunPhasePending,
+			CreatedAt:      time.Now(),
+			UpdatedAt:      time.Now(),
+		},
+	}
+	if err := securityStore.UpsertFinding(ctx, fixture.finding); err != nil {
+		t.Fatalf("UpsertFinding() error = %v", err)
+	}
+	if err := securityStore.CreatePatchProposal(ctx, fixture.proposal); err != nil {
+		t.Fatalf("CreatePatchProposal() error = %v", err)
+	}
+	return fixture
+}
+
+func patchTaskForFixture(fixture patchIngestFixture, resultAvailable bool) *corev1alpha1.Task {
+	return &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fixture.proposal.TaskName,
+			Namespace: fixture.proposal.Namespace,
+			Labels: map[string]string{
+				labels.LabelSecurityTarget:    fixture.scan.Name,
+				labels.LabelSecurityFindingID: fixture.finding.ID,
+				labels.LabelSecurityStage:     security.StagePatch,
+				labels.LabelSecurityMode:      security.StagePatch,
+			},
+		},
+		Spec: corev1alpha1.TaskSpec{
+			AgentRuntime: &corev1alpha1.AgentRuntimeSpec{
+				Workspace: &corev1alpha1.WorkspaceConfig{
+					PushBranch: fixture.proposal.Branch,
+				},
+			},
+		},
+		Status: corev1alpha1.TaskStatus{
+			Phase:     corev1alpha1.TaskPhaseSucceeded,
+			ResultRef: &corev1alpha1.ResultReference{Available: resultAvailable},
+		},
+	}
+}
+
+func savePatchStructuredResult(t *testing.T, fixture patchIngestFixture, sr *common.StructuredResult) {
+	t.Helper()
+	result, err := common.FormatStructuredResult(sr)
+	if err != nil {
+		t.Fatalf("FormatStructuredResult() error = %v", err)
+	}
+	if err := fixture.store.SaveResult(context.Background(), fixture.proposal.Namespace, fixture.proposal.TaskName, result); err != nil {
+		t.Fatalf("SaveResult() error = %v", err)
+	}
+}
+
+func assertPatchIngestState(t *testing.T, fixture patchIngestFixture, wantProposalStatus, wantFindingState string) {
+	t.Helper()
+	proposals, err := fixture.store.ListPatchProposals(context.Background(), fixture.proposal.Namespace, fixture.finding.ID)
+	if err != nil {
+		t.Fatalf("ListPatchProposals() error = %v", err)
+	}
+	if len(proposals) != 1 {
+		t.Fatalf("len(proposals) = %d, want 1", len(proposals))
+	}
+	if proposals[0].Status != wantProposalStatus {
+		t.Fatalf("proposal.Status = %q, want %q", proposals[0].Status, wantProposalStatus)
+	}
+	updatedFinding, err := fixture.store.GetFinding(context.Background(), fixture.proposal.Namespace, fixture.finding.ID)
+	if err != nil {
+		t.Fatalf("GetFinding() error = %v", err)
+	}
+	if updatedFinding.State != wantFindingState {
+		t.Fatalf("finding.State = %q, want %q", updatedFinding.State, wantFindingState)
+	}
+}
+
+func TestIngestPatchTaskMarksPatchReadyAfterConfirmedPush(t *testing.T) {
+	ctx := context.Background()
+	fixture := newPatchIngestFixture(t, "ready")
+	savePatchStructuredResult(t, fixture, &common.StructuredResult{
+		Summary:    "patched successfully",
+		Diff:       "diff --git a/app.py b/app.py",
+		PushBranch: fixture.proposal.Branch,
+	})
+
+	if err := fixture.reconciler.ingestPatchTask(ctx, fixture.scan, patchTaskForFixture(fixture, true)); err != nil {
+		t.Fatalf("ingestPatchTask() error = %v", err)
+	}
+	assertPatchIngestState(t, fixture, scanRunPhaseSucceeded, findingStatePatchReady)
+}
+
+func TestIngestPatchTaskFailsSucceededTaskWhenPushFails(t *testing.T) {
+	ctx := context.Background()
+	fixture := newPatchIngestFixture(t, "failed")
+	savePatchStructuredResult(t, fixture, &common.StructuredResult{
+		Summary:   "patch created but push failed",
+		Diff:      "diff --git a/app.py b/app.py",
+		PushError: "git push failed: remote rejected",
+	})
+
+	if err := fixture.reconciler.ingestPatchTask(ctx, fixture.scan, patchTaskForFixture(fixture, true)); err != nil {
+		t.Fatalf("ingestPatchTask() error = %v", err)
+	}
+	assertPatchIngestState(t, fixture, scanRunPhaseFailed, findingStateOpen)
+}
+
+func TestIngestPatchTaskFailsSucceededTaskWithoutConfirmedPushBranch(t *testing.T) {
+	ctx := context.Background()
+	fixture := newPatchIngestFixture(t, "missing-push")
+	savePatchStructuredResult(t, fixture, &common.StructuredResult{
+		Summary: "patch created without confirmed push",
+		Diff:    "diff --git a/app.py b/app.py",
+	})
+
+	if err := fixture.reconciler.ingestPatchTask(ctx, fixture.scan, patchTaskForFixture(fixture, true)); err != nil {
+		t.Fatalf("ingestPatchTask() error = %v", err)
+	}
+	assertPatchIngestState(t, fixture, scanRunPhaseFailed, findingStateOpen)
+}
+
+func TestIngestPatchTaskKeepsPatchPendingUntilResultIsAvailable(t *testing.T) {
+	ctx := context.Background()
+	fixture := newPatchIngestFixture(t, "pending-ref")
+
+	if err := fixture.reconciler.ingestPatchTask(ctx, fixture.scan, patchTaskForFixture(fixture, false)); err != nil {
+		t.Fatalf("ingestPatchTask() error = %v", err)
+	}
+	assertPatchIngestState(t, fixture, scanRunPhasePending, findingStatePatchPending)
+}
+
+func TestIngestPatchTaskKeepsPatchPendingUntilResultExists(t *testing.T) {
+	ctx := context.Background()
+	fixture := newPatchIngestFixture(t, "pending-result")
+
+	if err := fixture.reconciler.ingestPatchTask(ctx, fixture.scan, patchTaskForFixture(fixture, true)); err != nil {
+		t.Fatalf("ingestPatchTask() error = %v", err)
+	}
+	assertPatchIngestState(t, fixture, scanRunPhasePending, findingStatePatchPending)
 }
 
 func setupControllerSQLiteStore(t *testing.T) *sqlitestore.Store {

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -22,6 +22,7 @@ const (
 	// ArtifactWorkspaceDir is the repo-root symlink the worker exposes for
 	// writing security artifacts from inside the agent workspace.
 	ArtifactWorkspaceDir = ".orka-artifacts"
+	maxGeneratedTaskName = 63
 )
 
 const (
@@ -135,19 +136,19 @@ func (e *FindingsArtifactEvidenceRefs) UnmarshalJSON(data []byte) error {
 		*e = nil
 		return nil
 	case strings.HasPrefix(trimmed, `"`):
-		var text string
-		if err := json.Unmarshal(data, &text); err != nil {
+		ref, ok, err := findingsArtifactEvidenceRefFromJSON(data)
+		if err != nil {
 			return err
 		}
-		if strings.TrimSpace(text) == "" {
+		if !ok {
 			*e = nil
 			return nil
 		}
-		*e = FindingsArtifactEvidenceRefs{{Kind: "note", Label: text}}
+		*e = FindingsArtifactEvidenceRefs{ref}
 		return nil
 	case strings.HasPrefix(trimmed, "{"):
-		var ref store.FindingEvidenceRef
-		if err := json.Unmarshal(data, &ref); err != nil {
+		ref, _, err := findingsArtifactEvidenceRefFromJSON(data)
+		if err != nil {
 			return err
 		}
 		*e = FindingsArtifactEvidenceRefs{ref}
@@ -159,28 +160,40 @@ func (e *FindingsArtifactEvidenceRefs) UnmarshalJSON(data []byte) error {
 		}
 		refs := make([]store.FindingEvidenceRef, 0, len(items))
 		for _, item := range items {
-			itemTrimmed := strings.TrimSpace(string(item))
-			if itemTrimmed == "" || itemTrimmed == "null" {
-				continue
-			}
-			if strings.HasPrefix(itemTrimmed, `"`) {
-				var text string
-				if err := json.Unmarshal(item, &text); err != nil {
-					return err
-				}
-				if strings.TrimSpace(text) != "" {
-					refs = append(refs, store.FindingEvidenceRef{Kind: "note", Label: text})
-				}
-				continue
-			}
-			var ref store.FindingEvidenceRef
-			if err := json.Unmarshal(item, &ref); err != nil {
+			ref, ok, err := findingsArtifactEvidenceRefFromJSON(item)
+			if err != nil {
 				return err
+			}
+			if !ok {
+				continue
 			}
 			refs = append(refs, ref)
 		}
 		*e = FindingsArtifactEvidenceRefs(refs)
 		return nil
+	}
+}
+
+func findingsArtifactEvidenceRefFromJSON(data []byte) (store.FindingEvidenceRef, bool, error) {
+	trimmed := strings.TrimSpace(string(data))
+	switch {
+	case trimmed == "", trimmed == "null":
+		return store.FindingEvidenceRef{}, false, nil
+	case strings.HasPrefix(trimmed, `"`):
+		var text string
+		if err := json.Unmarshal(data, &text); err != nil {
+			return store.FindingEvidenceRef{}, false, err
+		}
+		if strings.TrimSpace(text) == "" {
+			return store.FindingEvidenceRef{}, false, nil
+		}
+		return store.FindingEvidenceRef{Kind: "note", Label: text}, true, nil
+	default:
+		var ref store.FindingEvidenceRef
+		if err := json.Unmarshal(data, &ref); err != nil {
+			return store.FindingEvidenceRef{}, false, err
+		}
+		return ref, true, nil
 	}
 }
 
@@ -254,7 +267,11 @@ func PatchProposalID(taskName string) string {
 
 // ScanTaskName returns a task name for a scan run.
 func ScanTaskName(repositoryScanName, mode string) string {
-	return fmt.Sprintf("%s-%s-%d", sanitizeName(repositoryScanName), sanitizeName(mode), time.Now().Unix())
+	return boundedTaskName(
+		sanitizeName(repositoryScanName),
+		sanitizeName(mode),
+		fmt.Sprintf("%d", time.Now().Unix()),
+	)
 }
 
 // ScanStageTaskName returns a task name for a specific scan stage and optional scope.
@@ -264,17 +281,45 @@ func ScanStageTaskName(repositoryScanName, mode, stage, scope string) string {
 		parts = append(parts, sanitizeName(scope))
 	}
 	parts = append(parts, fmt.Sprintf("%d", time.Now().Unix()))
-	return strings.Join(parts, "-")
+	return boundedTaskName(parts...)
 }
 
 // PatchTaskName returns a task name for a patch proposal.
 func PatchTaskName(repositoryScanName, findingID string) string {
-	return fmt.Sprintf("%s-patch-%s-%d", sanitizeName(repositoryScanName), sanitizeName(findingID), time.Now().Unix())
+	return boundedTaskName(
+		sanitizeName(repositoryScanName),
+		"patch",
+		sanitizeName(findingID),
+		fmt.Sprintf("%d", time.Now().Unix()),
+	)
 }
 
 // PatchBranch returns the default branch name for a security patch proposal.
-func PatchBranch(findingID string) string {
-	return fmt.Sprintf("orka/security/%s", sanitizeName(findingID))
+func PatchBranch(findingID, taskName string) string {
+	return fmt.Sprintf("orka/security/%s-%s", sanitizeName(findingID), shortHash(taskName))
+}
+
+func boundedTaskName(parts ...string) string {
+	base := strings.Join(parts, "-")
+	if len(base) <= maxGeneratedTaskName {
+		return base
+	}
+
+	visibleParts := parts
+	if len(visibleParts) > 3 {
+		visibleParts = visibleParts[:3]
+	}
+	visible := strings.Join(visibleParts, "-")
+	hash := shortHash(base)
+	maxVisible := max(maxGeneratedTaskName-len(hash)-1, 1)
+	if len(visible) > maxVisible {
+		visible = strings.Trim(visible[:maxVisible], "-")
+		if visible == "" {
+			visible = "security"
+		}
+	}
+
+	return visible + "-" + hash
 }
 
 // EffectiveValidationMode returns the configured validation mode or the v1 default.
@@ -549,10 +594,13 @@ func appendRequiredArtifactsDirective(prompt *strings.Builder, artifacts ...stri
 }
 
 // BuildPatchPrompt returns the prompt for patch proposal tasks.
-func BuildPatchPrompt(scan *corev1alpha1.RepositoryScan, finding *store.Finding) string {
+func BuildPatchPrompt(scan *corev1alpha1.RepositoryScan, finding *store.Finding, patchBranch string) string {
 	var prompt strings.Builder
 	artifactDir := ArtifactWorkspacePath(scan.Spec.SubPath)
 	fmt.Fprintf(&prompt, "Generate a minimal security patch for repository %s on branch %s.\n", scan.Spec.RepoURL, EffectiveBranch(scan))
+	if strings.TrimSpace(patchBranch) != "" {
+		fmt.Fprintf(&prompt, "Orka will push the final diff to patch branch %s after the task finishes.\n", patchBranch)
+	}
 	fmt.Fprintf(&prompt, "Finding ID: %s\nTitle: %s\nSeverity: %s\nConfidence: %s\n", finding.ID, finding.Title, finding.Severity, finding.Confidence)
 	if finding.FilePath != "" {
 		fmt.Fprintf(&prompt, "Primary file: %s:%d\n", finding.FilePath, finding.Line)
@@ -570,7 +618,7 @@ func BuildPatchPrompt(scan *corev1alpha1.RepositoryScan, finding *store.Finding)
 	prompt.WriteString("4. Preserve existing behavior unless the vulnerability requires a behavior change.\n")
 	prompt.WriteString("5. Run focused tests when available.\n")
 	prompt.WriteString("6. The diff artifact must match the actual workspace changes after your edit.\n")
-	prompt.WriteString("7. Do not open a pull request directly. Orka will commit and push the workspace changes for you.\n")
+	prompt.WriteString("7. Do not commit, push, or open a pull request directly. Leave the final file changes in the workspace so Orka can create the commit and push it to the patch branch automatically.\n")
 	fmt.Fprintf(&prompt, "\nWrite these artifacts under %s/:\n", artifactDir)
 	fmt.Fprintf(&prompt, "- %s/security-patch-%s.diff\n", artifactDir, finding.ID)
 	fmt.Fprintf(&prompt, "- %s/security-patch-%s.json\n", artifactDir, finding.ID)

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -39,7 +39,9 @@ func TestFindingsArtifactEvidenceRefsUnmarshalJSON(t *testing.T) {
 	}{
 		{name: "array", raw: `[{"kind":"artifact","name":"file.txt","label":"trace"}]`, want: 1},
 		{name: "string array shorthand", raw: `["inline evidence"]`, want: 1},
+		{name: "array of strings", raw: `["note one","note two"]`, want: 2},
 		{name: "mixed array shorthand", raw: `["inline evidence", {"kind":"artifact","name":"file.txt"}]`, want: 2},
+		{name: "mixed array with blanks", raw: `["inline evidence",{"kind":"artifact","name":"file.txt","label":"trace"},null,"  "]`, want: 2},
 		{name: "string shorthand", raw: `"inline evidence"`, want: 1},
 		{name: "object shorthand", raw: `{"kind":"artifact","name":"file.txt"}`, want: 1},
 		{name: "null", raw: `null`, want: 0},
@@ -55,6 +57,17 @@ func TestFindingsArtifactEvidenceRefsUnmarshalJSON(t *testing.T) {
 				t.Fatalf("len(got) = %d, want %d", len(got), tt.want)
 			}
 		})
+	}
+
+	var got FindingsArtifactEvidenceRefs
+	if err := json.Unmarshal([]byte(`["inline evidence"]`), &got); err != nil {
+		t.Fatalf("json.Unmarshal(array shorthand) error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].Kind != "note" || got[0].Label != "inline evidence" {
+		t.Fatalf("got[0] = %#v, want note shorthand normalization", got[0])
 	}
 }
 
@@ -124,7 +137,7 @@ func TestBuildValidationPromptIncludesAttackPathAnalysis(t *testing.T) {
 	}
 }
 
-func TestBuildPatchPromptRequiresWorkspaceEdit(t *testing.T) {
+func TestBuildPatchPromptRequiresWorkspaceEditAndManagedPush(t *testing.T) {
 	scan := &corev1alpha1.RepositoryScan{
 		Spec: corev1alpha1.RepositoryScanSpec{
 			RepoURL: "https://github.com/example/project",
@@ -135,15 +148,54 @@ func TestBuildPatchPromptRequiresWorkspaceEdit(t *testing.T) {
 	finding := &store.Finding{
 		ID:         "fnd_123",
 		Title:      "Command injection",
-		Severity:   "high",
+		Severity:   "critical",
 		Confidence: "high",
 	}
 
-	got := BuildPatchPrompt(scan, finding)
+	got := BuildPatchPrompt(scan, finding, "orka/security/fnd-123")
+	if !strings.Contains(got, "patch branch orka/security/fnd-123") {
+		t.Fatalf("BuildPatchPrompt() missing patch branch guidance:\n%s", got)
+	}
 	if !strings.Contains(got, "Apply the fix directly to the checked-out workspace files.") {
 		t.Fatalf("BuildPatchPrompt() missing workspace-edit directive:\n%s", got)
 	}
-	if !strings.Contains(got, "Orka will commit and push the workspace changes for you.") {
-		t.Fatalf("BuildPatchPrompt() missing push-handling directive:\n%s", got)
+	if !strings.Contains(got, "Do not commit, push, or open a pull request directly.") {
+		t.Fatalf("BuildPatchPrompt() missing no-manual-push instruction:\n%s", got)
+	}
+	if !strings.Contains(got, "Orka can create the commit and push it to the patch branch automatically.") {
+		t.Fatalf("BuildPatchPrompt() missing Orka-managed push instruction:\n%s", got)
+	}
+}
+
+func TestGeneratedSecurityTaskNamesStayLabelSafe(t *testing.T) {
+	scanName := "demo-security-repository-security1-1776034262"
+
+	names := []string{
+		ScanTaskName(scanName, "initial"),
+		ScanStageTaskName(scanName, "initial", "threat-model", ""),
+		ScanStageTaskName(scanName, "initial", "discovery", "ci-cd-supply-chain"),
+		ScanStageTaskName(scanName, "initial", "discovery", "ci-cd-supply-chain-4"),
+		PatchTaskName(scanName, "fnd_1234567890abcdef"),
+	}
+
+	for _, name := range names {
+		if len(name) > 63 {
+			t.Fatalf("generated task name %q has length %d, want <= 63", name, len(name))
+		}
+		if strings.Contains(name, "--") {
+			t.Fatalf("generated task name %q should not contain duplicate separators", name)
+		}
+	}
+}
+
+func TestPatchBranchUsesUniqueTaskHash(t *testing.T) {
+	branchA := PatchBranch("fnd_1234567890abcdef", "demo-security-repository-patch-a")
+	branchB := PatchBranch("fnd_1234567890abcdef", "demo-security-repository-patch-b")
+
+	if !strings.HasPrefix(branchA, "orka/security/fnd-1234567890abcdef-") {
+		t.Fatalf("PatchBranch() = %q, want finding prefix preserved", branchA)
+	}
+	if branchA == branchB {
+		t.Fatalf("PatchBranch() should vary by task name, got identical branches %q", branchA)
 	}
 }

--- a/internal/store/sqlite/security_store.go
+++ b/internal/store/sqlite/security_store.go
@@ -248,8 +248,50 @@ func (s *Store) UpsertFinding(ctx context.Context, finding *store.Finding) error
 		   summary = excluded.summary,
 		   severity = excluded.severity,
 		   confidence = excluded.confidence,
-		   validation_status = excluded.validation_status,
-		   state = excluded.state,
+		   validation_status = CASE
+		     WHEN security_findings.validation_status = 'validated'
+		       AND excluded.validation_status != 'validated'
+		       THEN security_findings.validation_status
+		     WHEN excluded.validation_status IN ('validated', 'failed', 'skipped', 'pending')
+		       THEN excluded.validation_status
+		     WHEN CASE security_findings.validation_status
+		       WHEN 'validated' THEN 4
+		       WHEN 'failed' THEN 3
+		       WHEN 'skipped' THEN 3
+		       WHEN 'pending' THEN 2
+		       WHEN 'unvalidated' THEN 1
+		       ELSE 0
+		     END >= CASE excluded.validation_status
+		       WHEN 'validated' THEN 4
+		       WHEN 'failed' THEN 3
+		       WHEN 'skipped' THEN 3
+		       WHEN 'pending' THEN 2
+		       WHEN 'unvalidated' THEN 1
+		       ELSE 0
+		     END THEN security_findings.validation_status
+		     ELSE excluded.validation_status
+		   END,
+		   state = CASE
+		     WHEN security_findings.state IN ('fixed', 'resolved', 'dismissed', 'suppressed', 'false_positive')
+		       THEN security_findings.state
+		     WHEN security_findings.state = 'patch_pending'
+		       AND excluded.state = 'open'
+		       THEN excluded.state
+		     WHEN CASE security_findings.state
+		       WHEN 'pr_open' THEN 4
+		       WHEN 'patch_ready' THEN 3
+		       WHEN 'patch_pending' THEN 2
+		       WHEN 'open' THEN 1
+		       ELSE 0
+		     END >= CASE excluded.state
+		       WHEN 'pr_open' THEN 4
+		       WHEN 'patch_ready' THEN 3
+		       WHEN 'patch_pending' THEN 2
+		       WHEN 'open' THEN 1
+		       ELSE 0
+		     END THEN security_findings.state
+		     ELSE excluded.state
+		   END,
 		   file_path = excluded.file_path,
 		   line = excluded.line,
 		   commit_sha = excluded.commit_sha,
@@ -257,10 +299,38 @@ func (s *Store) UpsertFinding(ctx context.Context, finding *store.Finding) error
 		   remediation = excluded.remediation,
 		   suggested_action = excluded.suggested_action,
 		   evidence_json = excluded.evidence_json,
-		   validation_json = excluded.validation_json,
-		   patch_proposal_id = excluded.patch_proposal_id,
-		   pr_number = excluded.pr_number,
-		   pr_url = excluded.pr_url,
+		   validation_json = CASE
+		     WHEN security_findings.validation_status = 'validated'
+		       AND excluded.validation_status != 'validated'
+		       THEN security_findings.validation_json
+		     WHEN excluded.validation_status IN ('validated', 'failed', 'skipped', 'pending')
+		       THEN excluded.validation_json
+		     WHEN CASE security_findings.validation_status
+		       WHEN 'validated' THEN 4
+		       WHEN 'failed' THEN 3
+		       WHEN 'skipped' THEN 3
+		       WHEN 'pending' THEN 2
+		       WHEN 'unvalidated' THEN 1
+		       ELSE 0
+		     END >= CASE excluded.validation_status
+		       WHEN 'validated' THEN 4
+		       WHEN 'failed' THEN 3
+		       WHEN 'skipped' THEN 3
+		       WHEN 'pending' THEN 2
+		       WHEN 'unvalidated' THEN 1
+		       ELSE 0
+		     END THEN security_findings.validation_json
+		     ELSE excluded.validation_json
+		   END,
+		   patch_proposal_id = CASE
+		     WHEN excluded.patch_proposal_id IS NOT NULL AND excluded.patch_proposal_id != '' THEN excluded.patch_proposal_id
+		     ELSE security_findings.patch_proposal_id
+		   END,
+		   pr_number = COALESCE(excluded.pr_number, security_findings.pr_number),
+		   pr_url = CASE
+		     WHEN excluded.pr_url IS NOT NULL AND excluded.pr_url != '' THEN excluded.pr_url
+		     ELSE security_findings.pr_url
+		   END,
 		   updated_at = excluded.updated_at`,
 		finding.ID, finding.Namespace, finding.RepositoryScan, finding.ScanRunID, finding.Fingerprint, finding.Title, finding.Summary,
 		finding.Severity, finding.Confidence, finding.ValidationStatus, finding.State, finding.FilePath, finding.Line, finding.CommitSHA,

--- a/internal/store/sqlite/security_store_test.go
+++ b/internal/store/sqlite/security_store_test.go
@@ -115,3 +115,249 @@ func TestSaveThreatModelCollapsesExistingVersions(t *testing.T) {
 		t.Fatalf("threat model row count = %d, want 1", count)
 	}
 }
+
+func TestUpsertFindingPreservesMostAdvancedStateAndPRMetadata(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	prNumber := 123
+	initial := &store.Finding{
+		ID:               "fnd-123",
+		Namespace:        "ns1",
+		RepositoryScan:   "repo1",
+		ScanRunID:        "scan-1",
+		Fingerprint:      "repo1:file.go:unauthenticated-preview",
+		Title:            "Preview disclosure",
+		Summary:          "initial summary",
+		Severity:         "medium",
+		Confidence:       "high",
+		ValidationStatus: "validated",
+		State:            "pr_open",
+		PatchProposalID:  "patch-123",
+		PRNumber:         &prNumber,
+		PRURL:            "https://github.com/example/repo/pull/123",
+	}
+	if err := s.UpsertFinding(ctx, initial); err != nil {
+		t.Fatalf("UpsertFinding(initial): %v", err)
+	}
+
+	laterStage := &store.Finding{
+		ID:               "fnd-123",
+		Namespace:        "ns1",
+		RepositoryScan:   "repo1",
+		ScanRunID:        "scan-2",
+		Fingerprint:      initial.Fingerprint,
+		Title:            initial.Title,
+		Summary:          "later summary",
+		Severity:         initial.Severity,
+		Confidence:       initial.Confidence,
+		ValidationStatus: "pending",
+		State:            "patch_ready",
+	}
+	if err := s.UpsertFinding(ctx, laterStage); err != nil {
+		t.Fatalf("UpsertFinding(laterStage): %v", err)
+	}
+
+	got, err := s.GetFinding(ctx, "ns1", "fnd-123")
+	if err != nil {
+		t.Fatalf("GetFinding: %v", err)
+	}
+	if got.State != "pr_open" {
+		t.Fatalf("State = %q, want %q", got.State, "pr_open")
+	}
+	if got.ValidationStatus != "validated" {
+		t.Fatalf("ValidationStatus = %q, want %q", got.ValidationStatus, "validated")
+	}
+	if got.PatchProposalID != "patch-123" {
+		t.Fatalf("PatchProposalID = %q, want %q", got.PatchProposalID, "patch-123")
+	}
+	if got.PRNumber == nil || *got.PRNumber != prNumber {
+		t.Fatalf("PRNumber = %#v, want %d", got.PRNumber, prNumber)
+	}
+	if got.PRURL != "https://github.com/example/repo/pull/123" {
+		t.Fatalf("PRURL = %q, want preserved PR URL", got.PRURL)
+	}
+	if got.Summary != "later summary" {
+		t.Fatalf("Summary = %q, want later summary to keep newer descriptive fields", got.Summary)
+	}
+}
+
+func TestUpsertFindingAllowsPendingValidationToBecomeTerminal(t *testing.T) {
+	for _, tc := range []struct {
+		status         string
+		validationJSON string
+	}{
+		{
+			status:         "failed",
+			validationJSON: `{"status":"failed","summary":"validation failed"}`,
+		},
+		{
+			status:         "skipped",
+			validationJSON: `{"status":"skipped","summary":"validation skipped"}`,
+		},
+	} {
+		t.Run(tc.status, func(t *testing.T) {
+			s := setupTestStore(t)
+			ctx := context.Background()
+
+			initial := &store.Finding{
+				ID:               "fnd-" + tc.status,
+				Namespace:        "ns1",
+				RepositoryScan:   "repo1",
+				ScanRunID:        "scan-1",
+				Fingerprint:      "repo1:file.go:" + tc.status,
+				Title:            "Finding",
+				Summary:          "pending validation",
+				Severity:         "high",
+				Confidence:       "medium",
+				ValidationStatus: "pending",
+				State:            "open",
+				ValidationJSON:   `{"status":"pending"}`,
+			}
+			if err := s.UpsertFinding(ctx, initial); err != nil {
+				t.Fatalf("UpsertFinding(initial): %v", err)
+			}
+
+			terminal := *initial
+			terminal.ScanRunID = "scan-2"
+			terminal.Summary = "terminal validation"
+			terminal.ValidationStatus = tc.status
+			terminal.ValidationJSON = tc.validationJSON
+			if err := s.UpsertFinding(ctx, &terminal); err != nil {
+				t.Fatalf("UpsertFinding(terminal): %v", err)
+			}
+
+			got, err := s.GetFinding(ctx, "ns1", initial.ID)
+			if err != nil {
+				t.Fatalf("GetFinding: %v", err)
+			}
+			if got.ValidationStatus != tc.status {
+				t.Fatalf("ValidationStatus = %q, want %q", got.ValidationStatus, tc.status)
+			}
+			if got.ValidationJSON != tc.validationJSON {
+				t.Fatalf("ValidationJSON = %q, want %q", got.ValidationJSON, tc.validationJSON)
+			}
+		})
+	}
+}
+
+func TestUpsertFindingKeepsValidationJSONWhenValidatedStatusIsPreserved(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	initial := &store.Finding{
+		ID:               "fnd-validated",
+		Namespace:        "ns1",
+		RepositoryScan:   "repo1",
+		ScanRunID:        "scan-1",
+		Fingerprint:      "repo1:file.go:validated",
+		Title:            "Finding",
+		Summary:          "validated",
+		Severity:         "high",
+		Confidence:       "medium",
+		ValidationStatus: "validated",
+		State:            "open",
+		ValidationJSON:   `{"status":"validated","summary":"confirmed"}`,
+	}
+	if err := s.UpsertFinding(ctx, initial); err != nil {
+		t.Fatalf("UpsertFinding(initial): %v", err)
+	}
+
+	lowerStatus := *initial
+	lowerStatus.ScanRunID = "scan-2"
+	lowerStatus.ValidationStatus = "failed"
+	lowerStatus.ValidationJSON = `{"status":"failed","summary":"later failure"}`
+	if err := s.UpsertFinding(ctx, &lowerStatus); err != nil {
+		t.Fatalf("UpsertFinding(lowerStatus): %v", err)
+	}
+
+	got, err := s.GetFinding(ctx, "ns1", initial.ID)
+	if err != nil {
+		t.Fatalf("GetFinding: %v", err)
+	}
+	if got.ValidationStatus != "validated" {
+		t.Fatalf("ValidationStatus = %q, want validated", got.ValidationStatus)
+	}
+	if got.ValidationJSON != initial.ValidationJSON {
+		t.Fatalf("ValidationJSON = %q, want %q", got.ValidationJSON, initial.ValidationJSON)
+	}
+}
+
+func TestUpsertFindingAllowsPatchPendingToReturnOpen(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	initial := &store.Finding{
+		ID:               "fnd-patch-pending",
+		Namespace:        "ns1",
+		RepositoryScan:   "repo1",
+		ScanRunID:        "scan-1",
+		Fingerprint:      "repo1:file.go:patch-pending",
+		Title:            "Finding",
+		Summary:          "patch pending",
+		Severity:         "high",
+		Confidence:       "medium",
+		ValidationStatus: "validated",
+		State:            "patch_pending",
+		PatchProposalID:  "patch-123",
+	}
+	if err := s.UpsertFinding(ctx, initial); err != nil {
+		t.Fatalf("UpsertFinding(initial): %v", err)
+	}
+
+	open := *initial
+	open.ScanRunID = "scan-2"
+	open.State = "open"
+	if err := s.UpsertFinding(ctx, &open); err != nil {
+		t.Fatalf("UpsertFinding(open): %v", err)
+	}
+
+	got, err := s.GetFinding(ctx, "ns1", initial.ID)
+	if err != nil {
+		t.Fatalf("GetFinding: %v", err)
+	}
+	if got.State != "open" {
+		t.Fatalf("State = %q, want open", got.State)
+	}
+}
+
+func TestUpsertFindingPreservesFinalStatesOverOpen(t *testing.T) {
+	for _, finalState := range []string{"fixed", "resolved", "dismissed", "suppressed", "false_positive"} {
+		t.Run(finalState, func(t *testing.T) {
+			s := setupTestStore(t)
+			ctx := context.Background()
+
+			initial := &store.Finding{
+				ID:               "fnd-" + finalState,
+				Namespace:        "ns1",
+				RepositoryScan:   "repo1",
+				ScanRunID:        "scan-1",
+				Fingerprint:      "repo1:file.go:" + finalState,
+				Title:            "Finding",
+				Summary:          "final state",
+				Severity:         "high",
+				Confidence:       "medium",
+				ValidationStatus: "validated",
+				State:            finalState,
+			}
+			if err := s.UpsertFinding(ctx, initial); err != nil {
+				t.Fatalf("UpsertFinding(initial): %v", err)
+			}
+
+			reopened := *initial
+			reopened.ScanRunID = "scan-2"
+			reopened.State = "open"
+			if err := s.UpsertFinding(ctx, &reopened); err != nil {
+				t.Fatalf("UpsertFinding(reopened): %v", err)
+			}
+
+			got, err := s.GetFinding(ctx, "ns1", initial.ID)
+			if err != nil {
+				t.Fatalf("GetFinding: %v", err)
+			}
+			if got.State != finalState {
+				t.Fatalf("State = %q, want %q", got.State, finalState)
+			}
+		})
+	}
+}

--- a/internal/store/sqlite/security_store_test.go
+++ b/internal/store/sqlite/security_store_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/sozercan/orka/internal/store"
 )
 
+const (
+	testScanRunID2 = "scan-2"
+	testStateOpen  = "open"
+)
+
 func TestSaveThreatModelReplacesCurrentModel(t *testing.T) {
 	s := setupTestStore(t)
 	ctx := context.Background()
@@ -145,7 +150,7 @@ func TestUpsertFindingPreservesMostAdvancedStateAndPRMetadata(t *testing.T) {
 		ID:               "fnd-123",
 		Namespace:        "ns1",
 		RepositoryScan:   "repo1",
-		ScanRunID:        "scan-2",
+		ScanRunID:        testScanRunID2,
 		Fingerprint:      initial.Fingerprint,
 		Title:            initial.Title,
 		Summary:          "later summary",
@@ -211,7 +216,7 @@ func TestUpsertFindingAllowsPendingValidationToBecomeTerminal(t *testing.T) {
 				Severity:         "high",
 				Confidence:       "medium",
 				ValidationStatus: "pending",
-				State:            "open",
+				State:            testStateOpen,
 				ValidationJSON:   `{"status":"pending"}`,
 			}
 			if err := s.UpsertFinding(ctx, initial); err != nil {
@@ -219,7 +224,7 @@ func TestUpsertFindingAllowsPendingValidationToBecomeTerminal(t *testing.T) {
 			}
 
 			terminal := *initial
-			terminal.ScanRunID = "scan-2"
+			terminal.ScanRunID = testScanRunID2
 			terminal.Summary = "terminal validation"
 			terminal.ValidationStatus = tc.status
 			terminal.ValidationJSON = tc.validationJSON
@@ -256,7 +261,7 @@ func TestUpsertFindingKeepsValidationJSONWhenValidatedStatusIsPreserved(t *testi
 		Severity:         "high",
 		Confidence:       "medium",
 		ValidationStatus: "validated",
-		State:            "open",
+		State:            testStateOpen,
 		ValidationJSON:   `{"status":"validated","summary":"confirmed"}`,
 	}
 	if err := s.UpsertFinding(ctx, initial); err != nil {
@@ -264,7 +269,7 @@ func TestUpsertFindingKeepsValidationJSONWhenValidatedStatusIsPreserved(t *testi
 	}
 
 	lowerStatus := *initial
-	lowerStatus.ScanRunID = "scan-2"
+	lowerStatus.ScanRunID = testScanRunID2
 	lowerStatus.ValidationStatus = "failed"
 	lowerStatus.ValidationJSON = `{"status":"failed","summary":"later failure"}`
 	if err := s.UpsertFinding(ctx, &lowerStatus); err != nil {
@@ -306,8 +311,8 @@ func TestUpsertFindingAllowsPatchPendingToReturnOpen(t *testing.T) {
 	}
 
 	open := *initial
-	open.ScanRunID = "scan-2"
-	open.State = "open"
+	open.ScanRunID = testScanRunID2
+	open.State = testStateOpen
 	if err := s.UpsertFinding(ctx, &open); err != nil {
 		t.Fatalf("UpsertFinding(open): %v", err)
 	}
@@ -316,7 +321,7 @@ func TestUpsertFindingAllowsPatchPendingToReturnOpen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetFinding: %v", err)
 	}
-	if got.State != "open" {
+	if got.State != testStateOpen {
 		t.Fatalf("State = %q, want open", got.State)
 	}
 }
@@ -345,8 +350,8 @@ func TestUpsertFindingPreservesFinalStatesOverOpen(t *testing.T) {
 			}
 
 			reopened := *initial
-			reopened.ScanRunID = "scan-2"
-			reopened.State = "open"
+			reopened.ScanRunID = testScanRunID2
+			reopened.State = testStateOpen
 			if err := s.UpsertFinding(ctx, &reopened); err != nil {
 				t.Fatalf("UpsertFinding(reopened): %v", err)
 			}

--- a/workers/agent/codex/main.go
+++ b/workers/agent/codex/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,11 +29,15 @@ const (
 	defaultCodexSandboxMode = "workspace-write"
 	codexWebSearchDisabled  = "disabled"
 	defaultAutoCompactLimit = "240000"
+	codexBwrapNamespaceErr  = "bwrap: no permissions to create a new namespace"
 )
 
 var errCodexRequiresBash = errors.New(
 	"codex runtime requires allowBash=true because the Codex CLI cannot disable shell execution",
 )
+
+var codexProcSysDir = "/proc/sys"
+var codexUserNamespaceProbe = probeUserNamespaceSupport
 
 func main() {
 	if err := common.RunAgent("codex", workspaceDir, defaultMaxTurns, executeCodex); err != nil {
@@ -82,22 +87,12 @@ func executeCodexPrompt(ctx context.Context, cfg *common.AgentConfig, prompt str
 	}
 	defer cleanupInstructions()
 
-	args := buildCodexArgs(cfg, outputPath, instructionsPath)
-	fmt.Printf("Executing: %s %s\n", codexPath(), strings.Join(args, " "))
-
 	execCtx := ctx
 	if cfg.TimeoutSeconds > 0 {
 		var timeoutCancel context.CancelFunc
 		execCtx, timeoutCancel = context.WithTimeout(ctx, time.Duration(cfg.TimeoutSeconds)*time.Second)
 		defer timeoutCancel()
 	}
-
-	cmd := exec.CommandContext(execCtx, codexPath(), args...)
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = io.MultiWriter(&stdout, os.Stdout)
-	cmd.Stderr = io.MultiWriter(&stderr, os.Stderr)
-	cmd.Stdin = strings.NewReader(prompt)
 
 	dir := workspaceDir
 	if cfg.SubPath != "" {
@@ -113,22 +108,42 @@ func executeCodexPrompt(ctx context.Context, cfg *common.AgentConfig, prompt str
 		}
 		dir = fallbackDir
 	}
-	cmd.Dir = dir
-	cmd.Env = buildCodexEnv()
 
-	if err := cmd.Run(); err != nil {
-		result := readCodexResult(outputPath, stdout.String())
-		if stderrStr := stderr.String(); stderrStr != "" {
-			return result, fmt.Errorf("%w: %s", err, stderrStr)
+	if shouldStartCodexWithoutSandbox() {
+		fmt.Fprintln(
+			os.Stderr,
+			"workspace-write sandbox unavailable on this kernel; starting Codex without sandbox isolation",
+		)
+		retry := runCodex(execCtx, cfg, dir, outputPath, instructionsPath, prompt, true)
+		if retry.err == nil {
+			return retry.result, nil
 		}
-		return result, err
+		return retry.result, fmt.Errorf(
+			"codex without sandbox after kernel capability check: %w",
+			wrapCodexError(retry.err, retry.stderr),
+		)
 	}
 
-	return readCodexResult(outputPath, stdout.String()), nil
+	primary := runCodex(execCtx, cfg, dir, outputPath, instructionsPath, prompt, false)
+	if primary.err != nil && shouldRetryCodexWithoutSandbox(primary.combinedOutput()) {
+		fmt.Fprintln(os.Stderr, "workspace-write sandbox unavailable; retrying Codex without sandbox isolation")
+		retry := runCodex(execCtx, cfg, dir, outputPath, instructionsPath, prompt, true)
+		if retry.err == nil {
+			return retry.result, nil
+		}
+		return retry.result, fmt.Errorf(
+			"codex retry without sandbox after workspace-write failure: %w",
+			wrapCodexError(retry.err, retry.stderr),
+		)
+	}
+	if primary.err == nil {
+		return primary.result, nil
+	}
+
+	return primary.result, wrapCodexError(primary.err, primary.stderr)
 }
 
-func buildCodexArgs(cfg *common.AgentConfig, outputPath, instructionsPath string) []string {
-	sandboxMode := codexSandboxMode()
+func buildCodexArgsForMode(cfg *common.AgentConfig, outputPath, instructionsPath string, bypassSandbox bool) []string {
 	args := []string{
 		"exec",
 		"--skip-git-repo-check",
@@ -137,7 +152,13 @@ func buildCodexArgs(cfg *common.AgentConfig, outputPath, instructionsPath string
 		"--output-last-message", outputPath,
 		"--config", "approval_policy=never",
 		"--config", "model_auto_compact_token_limit=" + codexAutoCompactTokenLimit(),
-		"--sandbox", sandboxMode,
+	}
+
+	sandboxMode := codexSandboxMode()
+	if bypassSandbox {
+		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
+	} else {
+		args = append(args, "--sandbox", sandboxMode)
 	}
 
 	if cfg.Model != "" {
@@ -149,7 +170,7 @@ func buildCodexArgs(cfg *common.AgentConfig, outputPath, instructionsPath string
 	if baseURL := strings.TrimSpace(os.Getenv("OPENAI_BASE_URL")); baseURL != "" {
 		args = append(args, "--config", "openai_base_url="+baseURL)
 	}
-	if sandboxMode == defaultCodexSandboxMode {
+	if !bypassSandbox && sandboxMode == defaultCodexSandboxMode {
 		args = append(args, "--config", "sandbox_workspace_write.network_access=true")
 	}
 	if webSearchSetting, ok := codexWebSearchSetting(cfg); ok {
@@ -256,6 +277,59 @@ func buildCodexEnv() []string {
 	return env
 }
 
+type codexRunResult struct {
+	result string
+	stdout string
+	stderr string
+	err    error
+}
+
+func runCodex(
+	ctx context.Context,
+	cfg *common.AgentConfig,
+	dir, outputPath, instructionsPath string,
+	prompt string,
+	bypassSandbox bool,
+) codexRunResult {
+	if err := os.Truncate(outputPath, 0); err != nil {
+		return codexRunResult{err: fmt.Errorf("reset output temp file: %w", err)}
+	}
+
+	args := buildCodexArgsForMode(cfg, outputPath, instructionsPath, bypassSandbox)
+	fmt.Printf("Executing: %s %s\n", codexPath(), strings.Join(args, " "))
+
+	cmd := exec.CommandContext(ctx, codexPath(), args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = io.MultiWriter(&stdout, os.Stdout)
+	cmd.Stderr = io.MultiWriter(&stderr, os.Stderr)
+	cmd.Stdin = strings.NewReader(prompt)
+	cmd.Dir = dir
+	cmd.Env = buildCodexEnv()
+
+	err := cmd.Run()
+	return codexRunResult{
+		result: readCodexResult(outputPath, stdout.String()),
+		stdout: stdout.String(),
+		stderr: stderr.String(),
+		err:    err,
+	}
+}
+
+func (r codexRunResult) combinedOutput() string {
+	return r.stdout + "\n" + r.stderr
+}
+
+func wrapCodexError(err error, stderr string) error {
+	if err == nil {
+		return nil
+	}
+	if stderrStr := strings.TrimSpace(stderr); stderrStr != "" {
+		return fmt.Errorf("%w: %s", err, stderrStr)
+	}
+	return err
+}
+
 func readCodexResult(outputPath, fallback string) string {
 	data, err := os.ReadFile(outputPath)
 	if err == nil && len(data) > 0 {
@@ -273,6 +347,99 @@ func codexPath() string {
 
 func allowBashEnabled() bool {
 	return os.Getenv("ORKA_ALLOW_BASH") == "true"
+}
+
+func shouldRetryCodexWithoutSandbox(output string) bool {
+	if codexSandboxMode() != defaultCodexSandboxMode {
+		return false
+	}
+
+	normalized := strings.ToLower(output)
+	if strings.Contains(normalized, codexBwrapNamespaceErr) {
+		return true
+	}
+
+	if strings.Contains(normalized, "unshare failed") && strings.Contains(normalized, "operation not permitted") {
+		return true
+	}
+
+	return strings.Contains(normalized, "bwrap: creating new namespace failed") &&
+		strings.Contains(normalized, "operation not permitted")
+}
+
+func shouldStartCodexWithoutSandbox() bool {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("ORKA_CODEX_DISABLE_SANDBOX")), "true") {
+		return true
+	}
+	if codexSandboxMode() != defaultCodexSandboxMode {
+		return false
+	}
+
+	if value, err := readProcSysInt("kernel/unprivileged_userns_clone"); err == nil && value == 0 {
+		return true
+	}
+
+	if value, err := readProcSysInt("user/max_user_namespaces"); err == nil && value == 0 {
+		return true
+	}
+
+	if err := codexUserNamespaceProbe(); isUserNamespacePermissionError(err) {
+		return true
+	}
+
+	return false
+}
+
+func probeUserNamespaceSupport() error {
+	unsharePath, err := exec.LookPath("unshare")
+	if err != nil {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, unsharePath, "-Ur", "true")
+	var stderr bytes.Buffer
+	cmd.Stdout = io.Discard
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+
+	return nil
+}
+
+func isUserNamespacePermissionError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	normalized := strings.ToLower(err.Error())
+	if strings.Contains(normalized, codexBwrapNamespaceErr) {
+		return true
+	}
+	if strings.Contains(normalized, "bwrap: creating new namespace failed") &&
+		strings.Contains(normalized, "operation not permitted") {
+		return true
+	}
+	return strings.Contains(normalized, "unshare failed") &&
+		strings.Contains(normalized, "operation not permitted")
+}
+
+func readProcSysInt(relPath string) (int, error) {
+	path := filepath.Join(codexProcSysDir, filepath.FromSlash(relPath))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+
+	value, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	return value, nil
 }
 
 func codexWebSearchSetting(cfg *common.AgentConfig) (string, bool) {
@@ -298,8 +465,8 @@ func hasWebSearchTool(tools []string) bool {
 }
 
 func normalizeToolName(tool string) string {
-	replacer := strings.NewReplacer("_", "", "-", "", " ", "")
-	return replacer.Replace(strings.ToLower(strings.TrimSpace(tool)))
+	replacer := strings.NewReplacer("_", "-", " ", "")
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(replacer.Replace(tool))), "-", "")
 }
 
 func trimmedTools(tools []string) []string {

--- a/workers/agent/codex/main_test.go
+++ b/workers/agent/codex/main_test.go
@@ -28,7 +28,7 @@ func TestBuildCodexArgs_Minimal(t *testing.T) {
 		MaxTurns: 50,
 	}
 
-	args := buildCodexArgs(cfg, "/tmp/result.txt", "")
+	args := buildCodexArgsForMode(cfg, "/tmp/result.txt", "", false)
 
 	assertContains(t, args, "exec")
 	assertContains(t, args, "--skip-git-repo-check")
@@ -57,7 +57,7 @@ func TestBuildCodexArgs_UsesConfiguredSandboxMode(t *testing.T) {
 		MaxTurns: 50,
 	}
 
-	args := buildCodexArgs(cfg, "/tmp/result.txt", "")
+	args := buildCodexArgsForMode(cfg, "/tmp/result.txt", "", false)
 
 	assertContains(t, args, "--sandbox")
 	assertContains(t, args, "danger-full-access")
@@ -79,7 +79,7 @@ func TestBuildCodexArgs_Full(t *testing.T) {
 		DisallowedTools: []string{"Shell"},
 	}
 
-	args := buildCodexArgs(cfg, "/tmp/result.txt", "/tmp/instructions.md")
+	args := buildCodexArgsForMode(cfg, "/tmp/result.txt", "/tmp/instructions.md", false)
 
 	assertContains(t, args, "--model")
 	assertContains(t, args, "gpt-5.4")
@@ -95,8 +95,24 @@ func TestBuildCodexArgs_UsesConfiguredAutoCompactLimit(t *testing.T) {
 
 	cfg := &common.AgentConfig{Prompt: "test"}
 
-	args := buildCodexArgs(cfg, "/tmp/result.txt", "")
+	args := buildCodexArgsForMode(cfg, "/tmp/result.txt", "", false)
 	assertContains(t, args, "model_auto_compact_token_limit=200000")
+}
+
+func TestBuildCodexArgs_BypassSandbox(t *testing.T) {
+	t.Setenv("ORKA_ALLOW_BASH", "true")
+
+	cfg := &common.AgentConfig{
+		Prompt: "fix bugs",
+		Model:  "gpt-5.4",
+	}
+
+	args := buildCodexArgsForMode(cfg, "/tmp/result.txt", "", true)
+
+	assertContains(t, args, "--dangerously-bypass-approvals-and-sandbox")
+	assertNotContains(t, args, "--sandbox")
+	assertNotContains(t, args, "workspace-write")
+	assertNotContains(t, args, "sandbox_workspace_write.network_access=true")
 }
 
 func TestBuildCodexArgs_WebSearchDisabled(t *testing.T) {
@@ -107,7 +123,7 @@ func TestBuildCodexArgs_WebSearchDisabled(t *testing.T) {
 		AllowedTools: []string{"Read", "Write"},
 	}
 
-	args := buildCodexArgs(cfg, "/tmp/result.txt", "")
+	args := buildCodexArgsForMode(cfg, "/tmp/result.txt", "", false)
 	assertContains(t, args, "web_search=disabled")
 }
 
@@ -283,6 +299,221 @@ printf 'arg=%s\nstdin=%s\n' "$LAST_ARG" "$INPUT" > "$OUTPUT"
 	}
 	if !strings.Contains(result, "stdin=--help") {
 		t.Fatalf("executeCodex() = %q, want stdin prompt", result)
+	}
+}
+
+func TestExecuteCodex_RetriesWithoutSandboxOnNamespaceError(t *testing.T) {
+	scriptPath := writeCodexStub(t, `#!/bin/sh
+OUTPUT=""
+ARGS_FILE=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output-last-message" ]; then
+    OUTPUT="$2"
+    shift 2
+    continue
+  fi
+  if [ "$1" = "--dangerously-bypass-approvals-and-sandbox" ]; then
+    printf '%s\n' "$*" > "$OUTPUT.args"
+    printf 'fallback-ok' > "$OUTPUT"
+    exit 0
+  fi
+  shift
+done
+printf 'bwrap: No permissions to create a new namespace\n' >&2
+exit 1
+`)
+
+	t.Setenv("CODEX_CLI_PATH", scriptPath)
+	t.Setenv("ORKA_ALLOW_BASH", "true")
+
+	cfg := &common.AgentConfig{
+		Prompt:   "make a real edit",
+		MaxTurns: 5,
+	}
+
+	result, err := executeCodex(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("executeCodex() error = %v", err)
+	}
+	if result != "fallback-ok" {
+		t.Fatalf("executeCodex() = %q, want %q", result, "fallback-ok")
+	}
+}
+
+func TestExecuteCodex_DoesNotRetryWithoutSandboxWhenSuccessfulOutputMentionsNamespaceError(t *testing.T) {
+	scriptPath := writeCodexStub(t, `#!/bin/sh
+OUTPUT=""
+BYPASS=0
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output-last-message" ]; then
+    OUTPUT="$2"
+    shift 2
+    continue
+  fi
+  if [ "$1" = "--dangerously-bypass-approvals-and-sandbox" ]; then
+    BYPASS=1
+  fi
+  shift
+done
+
+if [ "$BYPASS" -eq 1 ]; then
+  printf 'unexpected-retry' > "$OUTPUT"
+  exit 0
+fi
+
+printf 'codex summary mentioning sandbox diagnostics
+'
+printf 'bwrap: No permissions to create a new namespace
+'
+printf 'blocked-result' > "$OUTPUT"
+exit 0
+`)
+
+	t.Setenv("CODEX_CLI_PATH", scriptPath)
+	t.Setenv("ORKA_ALLOW_BASH", "true")
+
+	cfg := &common.AgentConfig{
+		Prompt:   "make a real edit",
+		MaxTurns: 5,
+	}
+
+	result, err := executeCodex(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("executeCodex() error = %v", err)
+	}
+	if result != "blocked-result" {
+		t.Fatalf("executeCodex() = %q, want %q", result, "blocked-result")
+	}
+}
+
+func TestShouldRetryCodexWithoutSandbox(t *testing.T) {
+	if !shouldRetryCodexWithoutSandbox("bwrap: No permissions to create a new namespace") {
+		t.Fatal("expected bubblewrap namespace error to trigger retry")
+	}
+	if shouldRetryCodexWithoutSandbox("some other failure") {
+		t.Fatal("expected unrelated stderr to skip retry")
+	}
+}
+
+func TestShouldStartCodexWithoutSandbox_EnvOverride(t *testing.T) {
+	t.Setenv("ORKA_CODEX_DISABLE_SANDBOX", "true")
+
+	if !shouldStartCodexWithoutSandbox() {
+		t.Fatal("expected env override to disable sandbox")
+	}
+}
+
+func TestShouldStartCodexWithoutSandbox_ProcSysSignalsUnsupportedNamespaces(t *testing.T) {
+	originalProcSysDir := codexProcSysDir
+	codexProcSysDir = t.TempDir()
+	t.Cleanup(func() {
+		codexProcSysDir = originalProcSysDir
+	})
+	originalProbe := codexUserNamespaceProbe
+	codexUserNamespaceProbe = func() error {
+		t.Fatal("user namespace probe should not run when proc sys already disables sandbox")
+		return nil
+	}
+	t.Cleanup(func() {
+		codexUserNamespaceProbe = originalProbe
+	})
+	t.Setenv("ORKA_CODEX_DISABLE_SANDBOX", "")
+
+	if err := os.MkdirAll(filepath.Join(codexProcSysDir, "kernel"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(kernel): %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(codexProcSysDir, "kernel", "unprivileged_userns_clone"),
+		[]byte("0\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("WriteFile(unprivileged_userns_clone): %v", err)
+	}
+
+	if !shouldStartCodexWithoutSandbox() {
+		t.Fatal("expected kernel sysctl to disable sandbox")
+	}
+}
+
+func TestShouldStartCodexWithoutSandbox_ProbeSignalsUnsupportedNamespaces(t *testing.T) {
+	originalProcSysDir := codexProcSysDir
+	codexProcSysDir = t.TempDir()
+	t.Cleanup(func() {
+		codexProcSysDir = originalProcSysDir
+	})
+	originalProbe := codexUserNamespaceProbe
+	codexUserNamespaceProbe = func() error {
+		return errors.New("unshare: unshare failed: Operation not permitted")
+	}
+	t.Cleanup(func() {
+		codexUserNamespaceProbe = originalProbe
+	})
+	t.Setenv("ORKA_CODEX_DISABLE_SANDBOX", "")
+
+	if err := os.MkdirAll(filepath.Join(codexProcSysDir, "kernel"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(kernel): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(codexProcSysDir, "user"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(user): %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(codexProcSysDir, "kernel", "unprivileged_userns_clone"),
+		[]byte("1\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("WriteFile(unprivileged_userns_clone): %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(codexProcSysDir, "user", "max_user_namespaces"),
+		[]byte("1024\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("WriteFile(max_user_namespaces): %v", err)
+	}
+
+	if !shouldStartCodexWithoutSandbox() {
+		t.Fatal("expected runtime user namespace probe to disable sandbox")
+	}
+}
+
+func TestShouldStartCodexWithoutSandbox_ProcSysAllowsNamespacesAndProbeSucceeds(t *testing.T) {
+	originalProcSysDir := codexProcSysDir
+	codexProcSysDir = t.TempDir()
+	t.Cleanup(func() {
+		codexProcSysDir = originalProcSysDir
+	})
+	originalProbe := codexUserNamespaceProbe
+	codexUserNamespaceProbe = func() error {
+		return nil
+	}
+	t.Cleanup(func() {
+		codexUserNamespaceProbe = originalProbe
+	})
+	t.Setenv("ORKA_CODEX_DISABLE_SANDBOX", "")
+
+	if err := os.MkdirAll(filepath.Join(codexProcSysDir, "kernel"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(kernel): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(codexProcSysDir, "user"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(user): %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(codexProcSysDir, "kernel", "unprivileged_userns_clone"),
+		[]byte("1\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("WriteFile(unprivileged_userns_clone): %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(codexProcSysDir, "user", "max_user_namespaces"),
+		[]byte("1024\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("WriteFile(max_user_namespaces): %v", err)
+	}
+
+	if shouldStartCodexWithoutSandbox() {
+		t.Fatal("expected sandbox to remain enabled when proc sys and probe both allow user namespaces")
 	}
 }
 

--- a/workers/common/result.go
+++ b/workers/common/result.go
@@ -126,6 +126,7 @@ type StructuredResult struct {
 	Feedback   string   `json:"feedback,omitempty"`
 	Files      []string `json:"files,omitempty"`
 	PushBranch string   `json:"pushBranch,omitempty"`
+	PushError  string   `json:"pushError,omitempty"`
 }
 
 // FormatStructuredResult serializes a StructuredResult to JSON bytes.

--- a/workers/common/workspace.go
+++ b/workers/common/workspace.go
@@ -149,7 +149,17 @@ func FinalizeResult(workDir string, agentOutput string) ([]byte, error) {
 		files = append(files, parseDiffStatFiles(unstagedStat)...)
 	}
 
-	// Auto-push if ORKA_PUSH_BRANCH is set and there are changes
+	sr := &StructuredResult{
+		Summary: TruncateStructuredSummary(agentOutput),
+		BaseSHA: baseSHA,
+		HeadSHA: baseSHA,
+	}
+	if diff != "" {
+		sr.Diff = diff
+		sr.Files = files
+	}
+
+	// Auto-push if ORKA_PUSH_BRANCH is set and there are changes.
 	pushBranch := os.Getenv("ORKA_PUSH_BRANCH")
 	requirePushBranch := strings.EqualFold(os.Getenv(requirePushBranchEnvVar), "true")
 	if requirePushBranch && pushBranch == "" {
@@ -161,29 +171,19 @@ func FinalizeResult(workDir string, agentOutput string) ([]byte, error) {
 				return nil, fmt.Errorf("ORKA_PUSH_BRANCH=%s but no workspace diff was produced", pushBranch)
 			}
 		} else if pushErr := pushChanges(workDir, pushBranch); pushErr != nil {
+			sr.PushError = pushErr.Error()
 			if requirePushBranch {
 				return nil, fmt.Errorf("failed to push to %s: %w", pushBranch, pushErr)
 			}
 			fmt.Fprintf(os.Stderr, "warning: failed to push to %s: %v\n", pushBranch, pushErr)
 		} else {
 			fmt.Fprintf(os.Stderr, "pushed changes to branch %s\n", pushBranch)
+			sr.PushBranch = pushBranch
 		}
 	}
 
-	headSHA := baseSHA
 	if out, err := execGit(workDir, "rev-parse", "HEAD"); err == nil {
-		headSHA = strings.TrimSpace(out)
-	}
-
-	sr := &StructuredResult{
-		Summary:    TruncateStructuredSummary(agentOutput),
-		BaseSHA:    baseSHA,
-		HeadSHA:    headSHA,
-		PushBranch: pushBranch,
-	}
-	if diff != "" {
-		sr.Diff = diff
-		sr.Files = files
+		sr.HeadSHA = strings.TrimSpace(out)
 	}
 
 	return FormatStructuredResult(sr)

--- a/workers/common/workspace_test.go
+++ b/workers/common/workspace_test.go
@@ -362,6 +362,52 @@ func TestFinalizeResult_PushBranchNoRemote(t *testing.T) {
 	if sr.Diff == "" {
 		t.Error("expected diff in result")
 	}
+	if sr.PushBranch != "" {
+		t.Errorf("PushBranch = %q, want empty when push fails", sr.PushBranch)
+	}
+	if !strings.Contains(sr.PushError, "git push failed") {
+		t.Errorf("PushError = %q, want git push failure", sr.PushError)
+	}
+}
+
+func TestFinalizeResult_PushBranchWithRemote(t *testing.T) {
+	bareDir := t.TempDir()
+	runGitWS(t, bareDir, "init", "--bare")
+
+	dir := t.TempDir()
+	runGitWS(t, dir, "init")
+	runGitWS(t, dir, "checkout", "-b", "main")
+	runGitWS(t, dir, "config", "user.email", "test@test.com")
+	runGitWS(t, dir, "config", "user.name", "Test")
+	if err := os.WriteFile(dir+"/file.txt", []byte("content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitWS(t, dir, "add", ".")
+	runGitWS(t, dir, "commit", "-m", "initial")
+	runGitWS(t, dir, "remote", "add", "origin", bareDir)
+	runGitWS(t, dir, "push", "-u", "origin", "main")
+
+	if err := os.WriteFile(dir+"/new.txt", []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("ORKA_PUSH_BRANCH", "feature-branch")
+
+	data, err := FinalizeResult(dir, "agent output")
+	if err != nil {
+		t.Fatalf("FinalizeResult failed: %v", err)
+	}
+
+	var sr StructuredResult
+	if err := json.Unmarshal(data, &sr); err != nil {
+		t.Fatalf("expected JSON result, got: %s", string(data))
+	}
+	if sr.PushBranch != "feature-branch" {
+		t.Errorf("PushBranch = %q, want feature-branch", sr.PushBranch)
+	}
+	if sr.PushError != "" {
+		t.Errorf("PushError = %q, want empty", sr.PushError)
+	}
 }
 
 func TestFinalizeResult_RequirePushBranchNoRemote(t *testing.T) {


### PR DESCRIPTION
## Summary
- harden chat/security scan task and branch naming for Kubernetes/Git constraints
- require structured patch task push confirmation before marking findings patch-ready
- preserve advanced security finding state/PR metadata during SQLite upserts
- capture push failures in structured worker results
- retry Codex without sandbox when bubblewrap/user namespaces are unavailable

## Tests
- go test ./internal/api ./internal/controller ./internal/security ./internal/store/sqlite ./workers/agent/codex ./workers/common
- go test ./...
