### PR TITLE
refactor: centralize worker env contract

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ import (
 	_ "github.com/sozercan/orka/internal/metrics"
 	"github.com/sozercan/orka/internal/store/sqlite"
 	"github.com/sozercan/orka/internal/tracing"
+	"github.com/sozercan/orka/internal/workerenv"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -292,7 +293,7 @@ func main() {
 	jobBuilder.ControllerURL = controllerURL
 	// Auto-discover controller URL from in-cluster service if not explicitly set
 	if jobBuilder.ControllerURL == "" {
-		ns := os.Getenv("POD_NAMESPACE")
+		ns := os.Getenv(workerenv.PodNamespace)
 		if ns == "" {
 			if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 				ns = strings.TrimSpace(string(data))

--- a/internal/api/security_handlers.go
+++ b/internal/api/security_handlers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sozercan/orka/internal/security"
 	"github.com/sozercan/orka/internal/store"
 	"github.com/sozercan/orka/internal/tools"
+	"github.com/sozercan/orka/internal/workerenv"
 )
 
 type CreateRepositoryScanRequest struct {
@@ -280,7 +281,7 @@ func (h *Handlers) createSecurityPatchTask(ctx context.Context, scan *corev1alph
 			Timeout:  &timeout,
 			Priority: &priority,
 			Env: []corev1.EnvVar{
-				{Name: "ORKA_REQUIRE_PUSH_BRANCH", Value: "true"},
+				{Name: workerenv.RequirePushBranch, Value: "true"},
 			},
 			AgentRuntime: &corev1alpha1.AgentRuntimeSpec{
 				Workspace: &corev1alpha1.WorkspaceConfig{
@@ -731,7 +732,7 @@ func (h *Handlers) ListSecurityPatchProposals(c fiber.Ctx) error {
 }
 
 func extractGitToken(secret *corev1.Secret) string {
-	for _, key := range []string{"token", "password", "GITHUB_TOKEN"} {
+	for _, key := range []string{"token", "password", workerenv.GitHubToken} {
 		if value, ok := secret.Data[key]; ok {
 			token := strings.TrimSpace(string(value))
 			if token != "" {

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -28,6 +28,7 @@ import (
 	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
 	"github.com/sozercan/orka/internal/labels"
 	"github.com/sozercan/orka/internal/metrics"
+	"github.com/sozercan/orka/internal/workerenv"
 )
 
 const (
@@ -50,16 +51,16 @@ const (
 	DefaultInitImage = "busybox:1.37"
 
 	// ResultEndpointEnvVar is the env var for the result submission URL
-	ResultEndpointEnvVar = "ORKA_RESULT_ENDPOINT"
+	ResultEndpointEnvVar = workerenv.ResultEndpoint
 
 	// ControllerURLEnvVar is the env var for the controller base URL
-	ControllerURLEnvVar = "ORKA_CONTROLLER_URL"
+	ControllerURLEnvVar = workerenv.ControllerURL
 
 	// TaskNameEnvVar is the env var for the task name
-	TaskNameEnvVar = "ORKA_TASK_NAME"
+	TaskNameEnvVar = workerenv.TaskName
 
 	// TaskNamespaceEnvVar is the env var for the task namespace
-	TaskNamespaceEnvVar = "ORKA_TASK_NAMESPACE"
+	TaskNamespaceEnvVar = workerenv.TaskNamespace
 
 	// defaultSecretKey is the default key name in provider secrets
 	defaultSecretKey = "api-key"
@@ -373,24 +374,12 @@ func (b *JobBuilder) buildResources(task *corev1alpha1.Task, agent *corev1alpha1
 
 // buildEnvVars builds the environment variables for the container
 func (b *JobBuilder) buildEnvVars(ctx context.Context, task *corev1alpha1.Task, agent *corev1alpha1.Agent, provider *corev1alpha1.Provider) []corev1.EnvVar {
-	envVars := []corev1.EnvVar{
-		{
-			Name:  TaskNameEnvVar,
-			Value: task.Name,
-		},
-		{
-			Name:  TaskNamespaceEnvVar,
-			Value: task.Namespace,
-		},
-		{
-			Name:  ResultEndpointEnvVar,
-			Value: fmt.Sprintf("%s/internal/v1/results/%s/%s", b.ControllerURL, task.Namespace, task.Name),
-		},
-		{
-			Name:  ControllerURLEnvVar,
-			Value: b.ControllerURL,
-		},
-	}
+	envVars := workerenv.BaseEnv{
+		TaskName:       task.Name,
+		TaskNamespace:  task.Namespace,
+		ResultEndpoint: fmt.Sprintf("%s/internal/v1/results/%s/%s", b.ControllerURL, task.Namespace, task.Name),
+		ControllerURL:  b.ControllerURL,
+	}.EnvVars()
 
 	// Add task-level env vars
 	envVars = append(envVars, task.Spec.Env...)
@@ -398,21 +387,21 @@ func (b *JobBuilder) buildEnvVars(ctx context.Context, task *corev1alpha1.Task, 
 	// Add prior task env vars for iterative coordination
 	if task.Spec.PriorTaskRef != nil {
 		envVars = append(envVars,
-			corev1.EnvVar{Name: "ORKA_PRIOR_TASK", Value: task.Spec.PriorTaskRef.Name},
+			corev1.EnvVar{Name: workerenv.PriorTask, Value: task.Spec.PriorTaskRef.Name},
 		)
 		priorNS := task.Spec.PriorTaskRef.Namespace
 		if priorNS == "" {
 			priorNS = task.Namespace
 		}
 		envVars = append(envVars,
-			corev1.EnvVar{Name: "ORKA_PRIOR_TASK_NAMESPACE", Value: priorNS},
+			corev1.EnvVar{Name: workerenv.PriorTaskNamespace, Value: priorNS},
 		)
 	}
 
 	// Add parent task env var for inter-agent messaging
 	if parentTask := labels.ParentTaskName(task.Labels, task.Annotations); parentTask != "" {
 		envVars = append(envVars,
-			corev1.EnvVar{Name: "ORKA_PARENT_TASK", Value: parentTask},
+			corev1.EnvVar{Name: workerenv.ParentTask, Value: parentTask},
 		)
 	}
 
@@ -514,48 +503,27 @@ func resolveAIConfig(task *corev1alpha1.Task, agent *corev1alpha1.Agent, provide
 
 // addCoordinationEnvVars appends coordination-related environment variables.
 func (b *JobBuilder) addCoordinationEnvVars(envVars []corev1.EnvVar, task *corev1alpha1.Task, agent *corev1alpha1.Agent) []corev1.EnvVar {
-	envVars = append(envVars,
-		corev1.EnvVar{Name: "ORKA_COORDINATION_ENABLED", Value: "true"},
-		corev1.EnvVar{Name: "ORKA_COORDINATION_MAX_DEPTH",
-			Value: fmt.Sprintf("%d", agent.Spec.Coordination.MaxDepth)},
-		corev1.EnvVar{Name: "ORKA_COORDINATION_MAX_CHILDREN",
-			Value: fmt.Sprintf("%d", agent.Spec.Coordination.MaxConcurrentChildren)},
-	)
-
 	agentNames := make([]string, 0, len(agent.Spec.Coordination.AllowedAgents))
 	for _, a := range agent.Spec.Coordination.AllowedAgents {
 		agentNames = append(agentNames, a.Name)
 	}
-	envVars = append(envVars,
-		corev1.EnvVar{Name: "ORKA_COORDINATION_ALLOWED_AGENTS",
-			Value: strings.Join(agentNames, ",")},
-	)
 
 	// Current depth (0 for top-level coordinator)
 	depth := "0"
 	if d, ok := task.Annotations[labels.AnnotationCoordinationDepth]; ok {
 		depth = d
 	}
-	envVars = append(envVars,
-		corev1.EnvVar{Name: "ORKA_COORDINATION_DEPTH", Value: depth},
-	)
 
-	// Autonomous mode env vars
-	if agent.Spec.Coordination.Autonomous {
-		envVars = append(envVars,
-			corev1.EnvVar{Name: "ORKA_AUTONOMOUS_MODE", Value: "true"},
-			corev1.EnvVar{Name: "ORKA_AUTONOMOUS_ITERATION",
-				Value: fmt.Sprintf("%d", task.Status.Iteration)},
-		)
-		if agent.Spec.Coordination.MaxIterations > 0 {
-			envVars = append(envVars,
-				corev1.EnvVar{Name: "ORKA_AUTONOMOUS_MAX_ITERATIONS",
-					Value: fmt.Sprintf("%d", agent.Spec.Coordination.MaxIterations)},
-			)
-		}
-	}
-
-	return envVars
+	return append(envVars, workerenv.CoordinationEnv{
+		Enabled:                 true,
+		MaxDepth:                int(agent.Spec.Coordination.MaxDepth),
+		MaxChildren:             int(agent.Spec.Coordination.MaxConcurrentChildren),
+		AllowedAgents:           agentNames,
+		Depth:                   depth,
+		AutonomousMode:          agent.Spec.Coordination.Autonomous,
+		AutonomousIteration:     int(task.Status.Iteration),
+		AutonomousMaxIterations: int(agent.Spec.Coordination.MaxIterations),
+	}.EnvVars()...)
 }
 
 // addAIEnvVars adds AI-specific environment variables
@@ -568,19 +536,14 @@ func (b *JobBuilder) addAIEnvVars(ctx context.Context, //nolint:gocyclo
 		cfg.systemPrompt = b.resolveConfigMapValue(ctx, agent.Namespace, agent.Spec.SystemPrompt.ConfigMapRef)
 	}
 
-	envVars = append(envVars,
-		corev1.EnvVar{Name: "ORKA_AI_PROVIDER", Value: cfg.providerType},
-		corev1.EnvVar{Name: "ORKA_AI_MODEL", Value: cfg.model},
-		corev1.EnvVar{Name: "ORKA_AI_PROMPT", Value: cfg.prompt},
-		corev1.EnvVar{Name: "ORKA_AI_SYSTEM_PROMPT", Value: cfg.systemPrompt},
-	)
-
-	if cfg.baseURL != "" {
-		envVars = append(envVars, corev1.EnvVar{Name: "ORKA_AI_BASE_URL", Value: cfg.baseURL})
-	}
-	if cfg.azureAPIVersion != "" {
-		envVars = append(envVars, corev1.EnvVar{Name: "ORKA_AI_AZURE_API_VERSION", Value: cfg.azureAPIVersion})
-	}
+	envVars = append(envVars, workerenv.AIWorkerEnv{
+		Provider:        cfg.providerType,
+		Model:           cfg.model,
+		Prompt:          cfg.prompt,
+		SystemPrompt:    cfg.systemPrompt,
+		BaseURL:         cfg.baseURL,
+		AzureAPIVersion: cfg.azureAPIVersion,
+	}.EnvVars()...)
 
 	// Auto-inject coordination tools when coordination is enabled
 	if agent != nil && agent.Spec.Coordination != nil && agent.Spec.Coordination.Enabled {
@@ -623,7 +586,7 @@ func (b *JobBuilder) addAIEnvVars(ctx context.Context, //nolint:gocyclo
 	}
 
 	if len(cfg.tools) > 0 {
-		envVars = append(envVars, corev1.EnvVar{Name: "ORKA_AI_TOOLS", Value: strings.Join(cfg.tools, ",")})
+		envVars = append(envVars, corev1.EnvVar{Name: workerenv.AITools, Value: strings.Join(cfg.tools, ",")})
 	}
 
 	if agent != nil && agent.Spec.Coordination != nil && agent.Spec.Coordination.Enabled {
@@ -632,13 +595,13 @@ func (b *JobBuilder) addAIEnvVars(ctx context.Context, //nolint:gocyclo
 
 	// Enable coordination in worker for child tasks so messaging tools are registered
 	if isChildTask && (agent == nil || agent.Spec.Coordination == nil || !agent.Spec.Coordination.Enabled) {
-		envVars = append(envVars, corev1.EnvVar{Name: "ORKA_COORDINATION_ENABLED", Value: "true"})
+		envVars = append(envVars, corev1.EnvVar{Name: workerenv.CoordinationEnabled, Value: "true"})
 	}
 
 	// Add fallback provider environment variables
 	if agent != nil && agent.Spec.Model != nil && len(agent.Spec.Model.Fallbacks) > 0 {
 		envVars = append(envVars, corev1.EnvVar{
-			Name:  "ORKA_AI_FALLBACK_COUNT",
+			Name:  workerenv.AIFallbackCount,
 			Value: fmt.Sprintf("%d", len(agent.Spec.Model.Fallbacks)),
 		})
 		for i, fb := range agent.Spec.Model.Fallbacks {
@@ -650,17 +613,16 @@ func (b *JobBuilder) addAIEnvVars(ctx context.Context, //nolint:gocyclo
 			}, fbProvider); err != nil {
 				continue // skip unresolvable fallbacks
 			}
-			prefix := fmt.Sprintf("ORKA_AI_FALLBACK_%d", i)
-			envVars = append(envVars,
-				corev1.EnvVar{Name: prefix + "_PROVIDER", Value: string(fbProvider.Spec.Type)},
-				corev1.EnvVar{Name: prefix + "_MODEL", Value: fb.Model},
-			)
-			if fbProvider.Spec.BaseURL != "" {
-				envVars = append(envVars, corev1.EnvVar{Name: prefix + "_BASE_URL", Value: fbProvider.Spec.BaseURL})
+			fallbackEnv := workerenv.FallbackProviderEnv{
+				Provider: string(fbProvider.Spec.Type),
+				Model:    fb.Model,
+				BaseURL:  fbProvider.Spec.BaseURL,
 			}
 			if fbProvider.Spec.Azure != nil {
-				envVars = append(envVars, corev1.EnvVar{Name: prefix + "_AZURE_API_VERSION", Value: fbProvider.Spec.Azure.APIVersion})
+				fallbackEnv.AzureAPIVersion = fbProvider.Spec.Azure.APIVersion
 			}
+			envVars = append(envVars, fallbackEnv.EnvVars(i)...)
+
 		}
 	}
 
@@ -674,7 +636,7 @@ func (b *JobBuilder) addAIEnvVars(ctx context.Context, //nolint:gocyclo
 	}
 	if allowBash {
 		envVars = append(envVars, corev1.EnvVar{
-			Name: "ORKA_ALLOW_BASH", Value: "true",
+			Name: workerenv.AllowBash, Value: "true",
 		})
 	}
 
@@ -692,9 +654,9 @@ func (b *JobBuilder) addSecretVolumes(ctx context.Context, job *batchv1.Job, tas
 		}
 
 		// Determine the env var name based on provider type
-		envVarName := "ANTHROPIC_API_KEY"
+		envVarName := workerenv.AnthropicAPIKey
 		if provider.Spec.Type == corev1alpha1.ProviderTypeOpenAI || provider.Spec.Type == corev1alpha1.ProviderTypeAzureOpenAI {
-			envVarName = "OPENAI_API_KEY"
+			envVarName = workerenv.OpenAIAPIKey
 		}
 
 		// Add API key as environment variable from secret
@@ -715,9 +677,9 @@ func (b *JobBuilder) addSecretVolumes(ctx context.Context, job *batchv1.Job, tas
 
 		// Set base URL so agent CLIs route through the provider's upstream
 		if provider.Spec.BaseURL != "" {
-			baseURLEnvVar := "ANTHROPIC_BASE_URL"
+			baseURLEnvVar := workerenv.AnthropicBaseURL
 			if provider.Spec.Type == corev1alpha1.ProviderTypeOpenAI || provider.Spec.Type == corev1alpha1.ProviderTypeAzureOpenAI {
-				baseURLEnvVar = "OPENAI_BASE_URL"
+				baseURLEnvVar = workerenv.OpenAIBaseURL
 			}
 			job.Spec.Template.Spec.Containers[0].Env = append(
 				job.Spec.Template.Spec.Containers[0].Env,
@@ -741,7 +703,7 @@ func (b *JobBuilder) addSecretVolumes(ctx context.Context, job *batchv1.Job, tas
 			if secretKey == "" {
 				secretKey = defaultSecretKey
 			}
-			envVarName := fmt.Sprintf("ORKA_AI_FALLBACK_%d_API_KEY", i)
+			envVarName := workerenv.FallbackAPIKeyKey(i)
 			job.Spec.Template.Spec.Containers[0].Env = append(
 				job.Spec.Template.Spec.Containers[0].Env,
 				corev1.EnvVar{
@@ -865,7 +827,7 @@ func (b *JobBuilder) addSessionVolume(job *batchv1.Job, task *corev1alpha1.Task)
 	// Add session env vars
 	job.Spec.Template.Spec.Containers[0].Env = append(
 		job.Spec.Template.Spec.Containers[0].Env,
-		corev1.EnvVar{Name: "ORKA_SESSION_NAME", Value: sessionName},
+		corev1.EnvVar{Name: workerenv.SessionName, Value: sessionName},
 	)
 }
 
@@ -901,11 +863,11 @@ func isCodexAgent(agent *corev1alpha1.Agent) bool {
 
 // addCodexSandboxEnvVars injects controller-configured Codex sandbox mode when set.
 func (b *JobBuilder) addCodexSandboxEnvVars(envVars []corev1.EnvVar, agent *corev1alpha1.Agent) []corev1.EnvVar {
-	if b.CodexSandboxMode == "" || !isCodexAgent(agent) || envVarExists(envVars, "ORKA_CODEX_SANDBOX_MODE") {
+	if b.CodexSandboxMode == "" || !isCodexAgent(agent) || envVarExists(envVars, workerenv.CodexSandboxMode) {
 		return envVars
 	}
 
-	return append(envVars, corev1.EnvVar{Name: "ORKA_CODEX_SANDBOX_MODE", Value: b.CodexSandboxMode})
+	return append(envVars, corev1.EnvVar{Name: workerenv.CodexSandboxMode, Value: b.CodexSandboxMode})
 }
 
 // addAgentEnvVars adds agent-runtime-specific environment variables
@@ -915,7 +877,7 @@ func (b *JobBuilder) addAgentEnvVars(ctx context.Context, envVars []corev1.EnvVa
 	if prompt == "" && task.Spec.AI != nil {
 		prompt = task.Spec.AI.Prompt
 	}
-	envVars = append(envVars, corev1.EnvVar{Name: "ORKA_PROMPT", Value: prompt})
+	envVars = append(envVars, corev1.EnvVar{Name: workerenv.Prompt, Value: prompt})
 
 	envVars = b.addAgentModelEnvVars(ctx, envVars, agent)
 	envVars = b.addAgentToolsEnvVars(envVars, task, agent)
@@ -924,7 +886,7 @@ func (b *JobBuilder) addAgentEnvVars(ctx context.Context, envVars []corev1.EnvVa
 	// Timeout (task level)
 	if task.Spec.Timeout != nil {
 		envVars = append(envVars, corev1.EnvVar{
-			Name:  "ORKA_TIMEOUT_SECONDS",
+			Name:  workerenv.TimeoutSeconds,
 			Value: fmt.Sprintf("%d", int64(task.Spec.Timeout.Seconds())),
 		})
 	}
@@ -954,7 +916,7 @@ func (b *JobBuilder) addAgentModelEnvVars(ctx context.Context, envVars []corev1.
 
 	if model != "" {
 		envVars = append(envVars, corev1.EnvVar{
-			Name: "ORKA_MODEL", Value: model,
+			Name: workerenv.Model, Value: model,
 		})
 	}
 
@@ -967,7 +929,7 @@ func (b *JobBuilder) addAgentModelEnvVars(ctx context.Context, envVars []corev1.
 		}
 		if systemPrompt != "" {
 			envVars = append(envVars, corev1.EnvVar{
-				Name: "ORKA_SYSTEM_PROMPT", Value: systemPrompt,
+				Name: workerenv.SystemPrompt, Value: systemPrompt,
 			})
 		}
 	}
@@ -1000,7 +962,7 @@ func (b *JobBuilder) addAgentToolsEnvVars(
 		maxTurns = *task.Spec.AgentRuntime.MaxTurns
 	}
 	envVars = append(envVars, corev1.EnvVar{
-		Name: "ORKA_MAX_TURNS", Value: fmt.Sprintf("%d", maxTurns),
+		Name: workerenv.MaxTurns, Value: fmt.Sprintf("%d", maxTurns),
 	})
 
 	// AllowedTools: task override > agent default
@@ -1013,14 +975,14 @@ func (b *JobBuilder) addAgentToolsEnvVars(
 	}
 	if len(allowedTools) > 0 {
 		envVars = append(envVars, corev1.EnvVar{
-			Name: "ORKA_ALLOWED_TOOLS", Value: joinStrings(allowedTools),
+			Name: workerenv.AllowedTools, Value: joinStrings(allowedTools),
 		})
 	}
 
 	// DisallowedTools (task only)
 	if task.Spec.AgentRuntime != nil && len(task.Spec.AgentRuntime.DisallowedTools) > 0 {
 		envVars = append(envVars, corev1.EnvVar{
-			Name:  "ORKA_DISALLOWED_TOOLS",
+			Name:  workerenv.DisallowedTools,
 			Value: joinStrings(task.Spec.AgentRuntime.DisallowedTools),
 		})
 	}
@@ -1035,7 +997,7 @@ func (b *JobBuilder) addAgentToolsEnvVars(
 	}
 	if allowBash {
 		envVars = append(envVars, corev1.EnvVar{
-			Name: "ORKA_ALLOW_BASH", Value: "true",
+			Name: workerenv.AllowBash, Value: "true",
 		})
 	}
 
@@ -1053,45 +1015,45 @@ func (b *JobBuilder) addWorkspaceEnvVars(
 	}
 	if ws.GitRepo != "" {
 		envVars = append(envVars, corev1.EnvVar{
-			Name: "ORKA_GIT_REPO", Value: ws.GitRepo,
+			Name: workerenv.GitRepo, Value: ws.GitRepo,
 		})
 	}
 	envVars = append(envVars,
-		corev1.EnvVar{Name: "GIT_CONFIG_COUNT", Value: "1"},
-		corev1.EnvVar{Name: "GIT_CONFIG_KEY_0", Value: "safe.directory"},
-		corev1.EnvVar{Name: "GIT_CONFIG_VALUE_0", Value: "/workspace"},
+		corev1.EnvVar{Name: workerenv.GitConfigCount, Value: "1"},
+		corev1.EnvVar{Name: workerenv.GitConfigKey0, Value: "safe.directory"},
+		corev1.EnvVar{Name: workerenv.GitConfigValue0, Value: "/workspace"},
 	)
 	if ws.Branch != "" {
 		envVars = append(envVars, corev1.EnvVar{
-			Name: "ORKA_GIT_BRANCH", Value: ws.Branch,
+			Name: workerenv.GitBranch, Value: ws.Branch,
 		})
 	}
 	if ws.Ref != "" {
 		envVars = append(envVars, corev1.EnvVar{
-			Name: "ORKA_GIT_REF", Value: ws.Ref,
+			Name: workerenv.GitRef, Value: ws.Ref,
 		})
 	}
 	if ws.SubPath != "" {
 		envVars = append(envVars, corev1.EnvVar{
-			Name: "ORKA_WORKSPACE_SUBPATH", Value: ws.SubPath,
+			Name: workerenv.WorkspaceSubpath, Value: ws.SubPath,
 		})
 	}
 	if ws.ForkRepo != "" {
 		envVars = append(envVars, corev1.EnvVar{
-			Name: "ORKA_FORK_REPO", Value: ws.ForkRepo,
+			Name: workerenv.ForkRepo, Value: ws.ForkRepo,
 		})
 	}
 	if ws.PRBaseBranch != "" {
 		envVars = append(envVars, corev1.EnvVar{
-			Name: "ORKA_PR_BASE_BRANCH", Value: ws.PRBaseBranch,
+			Name: workerenv.PRBaseBranch, Value: ws.PRBaseBranch,
 		})
 	}
 	if ws.PushBranch != "" {
 		envVars = append(envVars, corev1.EnvVar{
-			Name: "ORKA_PUSH_BRANCH", Value: ws.PushBranch,
+			Name: workerenv.PushBranch, Value: ws.PushBranch,
 		})
 		envVars = append(envVars, corev1.EnvVar{
-			Name: "ORKA_REQUIRE_PUSH_BRANCH", Value: "true",
+			Name: workerenv.RequirePushBranch, Value: "true",
 		})
 	}
 	return envVars
@@ -1207,12 +1169,12 @@ func (b *JobBuilder) workspaceInitEnvVars(task *corev1alpha1.Task) []corev1.EnvV
 	}
 	envVars = append(envVars, task.Spec.Env...)
 	if task.Spec.PriorTaskRef != nil {
-		envVars = append(envVars, corev1.EnvVar{Name: "ORKA_PRIOR_TASK", Value: task.Spec.PriorTaskRef.Name})
+		envVars = append(envVars, corev1.EnvVar{Name: workerenv.PriorTask, Value: task.Spec.PriorTaskRef.Name})
 		priorNS := task.Spec.PriorTaskRef.Namespace
 		if priorNS == "" {
 			priorNS = task.Namespace
 		}
-		envVars = append(envVars, corev1.EnvVar{Name: "ORKA_PRIOR_TASK_NAMESPACE", Value: priorNS})
+		envVars = append(envVars, corev1.EnvVar{Name: workerenv.PriorTaskNamespace, Value: priorNS})
 	}
 	return b.addWorkspaceEnvVars(envVars, task)
 }

--- a/internal/tools/code_exec.go
+++ b/internal/tools/code_exec.go
@@ -12,6 +12,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"github.com/sozercan/orka/internal/workerenv"
 	"os"
 	"os/exec"
 	"regexp"
@@ -26,7 +27,7 @@ import (
 const (
 	codeExecToolName = "code_exec"
 
-	codeExecBackendEnv        = "ORKA_CODE_EXEC_BACKEND"
+	codeExecBackendEnv        = workerenv.CodeExecBackend
 	codeExecBackendInProcess  = "in-process"
 	codeExecBackendKubernetes = "kubernetes"
 
@@ -34,9 +35,9 @@ const (
 	maxCodeExecTimeoutSeconds       = 60
 	defaultCodeExecOutputLimitBytes = 64 * 1024
 
-	codeExecLocalCPUSecondsEnv   = "ORKA_CODE_EXEC_LOCAL_CPU_SECONDS"
-	codeExecLocalMemoryKBEnv     = "ORKA_CODE_EXEC_LOCAL_MEMORY_KB"
-	codeExecLocalMaxProcessesEnv = "ORKA_CODE_EXEC_LOCAL_MAX_PROCESSES"
+	codeExecLocalCPUSecondsEnv   = workerenv.CodeExecLocalCPUSeconds
+	codeExecLocalMemoryKBEnv     = workerenv.CodeExecLocalMemoryKB
+	codeExecLocalMaxProcessesEnv = workerenv.CodeExecLocalMaxProcesses
 
 	defaultCodeExecLocalCPUSeconds   = int64(maxCodeExecTimeoutSeconds)
 	defaultCodeExecLocalMemoryKB     = int64(4 * 1024 * 1024)
@@ -118,7 +119,7 @@ type unsupportedCodeExecutor struct {
 
 // NewCodeExecTool creates a new code execution tool.
 func NewCodeExecTool() *CodeExecTool {
-	workDir := os.Getenv("ORKA_WORK_DIR")
+	workDir := os.Getenv(workerenv.WorkDir)
 	if workDir == "" {
 		workDir = "/tmp/orka-exec"
 	}

--- a/internal/tools/code_exec.go
+++ b/internal/tools/code_exec.go
@@ -12,7 +12,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"github.com/sozercan/orka/internal/workerenv"
 	"os"
 	"os/exec"
 	"regexp"
@@ -20,6 +19,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/sozercan/orka/internal/workerenv"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )

--- a/internal/tools/code_exec_kubernetes.go
+++ b/internal/tools/code_exec_kubernetes.go
@@ -11,6 +11,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"github.com/sozercan/orka/internal/workerenv"
 	"io"
 	"os"
 	"sort"
@@ -41,18 +42,18 @@ const (
 	codeExecKubernetesCodeMountPath  = "/orka-code"
 	codeExecKubernetesCodePath       = codeExecKubernetesCodeMountPath + "/code"
 
-	codeExecKubernetesImageEnv       = "ORKA_CODE_EXEC_K8S_IMAGE"
-	codeExecKubernetesPythonImageEnv = "ORKA_CODE_EXEC_K8S_PYTHON_IMAGE"
-	codeExecKubernetesNodeImageEnv   = "ORKA_CODE_EXEC_K8S_NODE_IMAGE"
-	codeExecKubernetesBashImageEnv   = "ORKA_CODE_EXEC_K8S_BASH_IMAGE"
+	codeExecKubernetesImageEnv       = workerenv.CodeExecKubernetesImage
+	codeExecKubernetesPythonImageEnv = workerenv.CodeExecKubernetesPythonImage
+	codeExecKubernetesNodeImageEnv   = workerenv.CodeExecKubernetesNodeImage
+	codeExecKubernetesBashImageEnv   = workerenv.CodeExecKubernetesBashImage
 
-	codeExecKubernetesCPURequestEnv       = "ORKA_CODE_EXEC_K8S_CPU_REQUEST"
-	codeExecKubernetesCPULimitEnv         = "ORKA_CODE_EXEC_K8S_CPU_LIMIT"
-	codeExecKubernetesMemoryRequestEnv    = "ORKA_CODE_EXEC_K8S_MEMORY_REQUEST"
-	codeExecKubernetesMemoryLimitEnv      = "ORKA_CODE_EXEC_K8S_MEMORY_LIMIT"
-	codeExecKubernetesNetworkPolicyEnv    = "ORKA_CODE_EXEC_K8S_NETWORK_POLICY"
-	codeExecKubernetesRuntimeClassNameEnv = "ORKA_CODE_EXEC_K8S_RUNTIME_CLASS_NAME"
-	codeExecKubernetesAppArmorProfileEnv  = "ORKA_CODE_EXEC_K8S_APPARMOR_PROFILE"
+	codeExecKubernetesCPURequestEnv       = workerenv.CodeExecKubernetesCPURequest
+	codeExecKubernetesCPULimitEnv         = workerenv.CodeExecKubernetesCPULimit
+	codeExecKubernetesMemoryRequestEnv    = workerenv.CodeExecKubernetesMemoryRequest
+	codeExecKubernetesMemoryLimitEnv      = workerenv.CodeExecKubernetesMemoryLimit
+	codeExecKubernetesNetworkPolicyEnv    = workerenv.CodeExecKubernetesNetworkPolicy
+	codeExecKubernetesRuntimeClassNameEnv = workerenv.CodeExecKubernetesRuntimeClass
+	codeExecKubernetesAppArmorProfileEnv  = workerenv.CodeExecKubernetesAppArmor
 
 	// Keep completed Jobs long enough for the executor to observe status and stream logs.
 	// The executor still deletes all resources after each run; this TTL is only a
@@ -842,7 +843,7 @@ func codeExecQuantityForScope(envName, provider, tenant, fallback string) (resou
 }
 
 func defaultCodeExecNamespace() string {
-	for _, envName := range []string{"POD_NAMESPACE", "ORKA_NAMESPACE", "NAMESPACE"} {
+	for _, envName := range []string{workerenv.PodNamespace, workerenv.OrkaNamespace, workerenv.Namespace} {
 		if namespace := strings.TrimSpace(os.Getenv(envName)); namespace != "" {
 			return namespace
 		}

--- a/internal/tools/code_exec_kubernetes.go
+++ b/internal/tools/code_exec_kubernetes.go
@@ -11,13 +11,14 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"github.com/sozercan/orka/internal/workerenv"
 	"io"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/sozercan/orka/internal/workerenv"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/internal/tools/common_constants.go
+++ b/internal/tools/common_constants.go
@@ -6,14 +6,16 @@ MIT License - see LICENSE file for details.
 
 package tools
 
+import "github.com/sozercan/orka/internal/workerenv"
+
 const (
-	envOrkaTaskName                  = "ORKA_TASK_NAME"
-	envOrkaTaskNamespace             = "ORKA_TASK_NAMESPACE"
-	envOrkaParentTask                = "ORKA_PARENT_TASK"
-	envOrkaControllerURL             = "ORKA_CONTROLLER_URL"
-	envOrkaCoordinationDepth         = "ORKA_COORDINATION_DEPTH"
-	envOrkaCoordinationAllowedAgents = "ORKA_COORDINATION_ALLOWED_AGENTS"
-	envOrkaCoordinationMaxDepth      = "ORKA_COORDINATION_MAX_DEPTH"
+	envOrkaTaskName                  = workerenv.TaskName
+	envOrkaTaskNamespace             = workerenv.TaskNamespace
+	envOrkaParentTask                = workerenv.ParentTask
+	envOrkaControllerURL             = workerenv.ControllerURL
+	envOrkaCoordinationDepth         = workerenv.CoordinationDepth
+	envOrkaCoordinationAllowedAgents = workerenv.CoordinationAllowedAgents
+	envOrkaCoordinationMaxDepth      = workerenv.CoordinationMaxDepth
 
 	noNewMessagesText               = "No new messages"
 	agentNameDescription            = "Agent name"
@@ -23,7 +25,7 @@ const (
 	workspaceTaskDescription        = "Name of a task whose workspace config has the repo and git credentials"
 	childWorkspaceTaskDescription   = "Name of the child task whose workspace config has the repo and git credentials"
 	timeoutDescription              = "Timeout duration, e.g. \"5m\""
-	missingControllerTaskEnvMessage = "ORKA_CONTROLLER_URL, ORKA_TASK_NAME, and ORKA_TASK_NAMESPACE are required"
+	missingControllerTaskEnvMessage = workerenv.ControllerURL + ", " + workerenv.TaskName + ", and " + workerenv.TaskNamespace + " are required"
 	shortPollIntervalString         = "100ms"
 	taskPhasePendingString          = "Pending"
 	taskPhaseRunningString          = "Running"

--- a/internal/tools/create_agent.go
+++ b/internal/tools/create_agent.go
@@ -11,9 +11,10 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"github.com/sozercan/orka/internal/workerenv"
 	"os"
 	"time"
+
+	"github.com/sozercan/orka/internal/workerenv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/internal/tools/create_agent.go
+++ b/internal/tools/create_agent.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"github.com/sozercan/orka/internal/workerenv"
 	"os"
 	"time"
 
@@ -218,7 +219,7 @@ func (t *CreateAgentTool) Execute(ctx context.Context, args json.RawMessage) (st
 		model.Name = a.Model.Name
 	}
 	if model.Name == "" {
-		model.Name = os.Getenv("ORKA_AI_MODEL")
+		model.Name = os.Getenv(workerenv.AIModel)
 	}
 
 	// Build provider ref — inherit from parent agent's providerRef for reliability,
@@ -240,7 +241,7 @@ func (t *CreateAgentTool) Execute(ctx context.Context, args json.RawMessage) (st
 		providerRefName = a.ProviderRef
 	}
 	if providerRefName == "" {
-		providerRefName = os.Getenv("ORKA_AI_PROVIDER")
+		providerRefName = os.Getenv(workerenv.AIProvider)
 	}
 	if providerRefName == "" {
 		providerRefName = defaultNamespace

--- a/internal/tools/create_container_task.go
+++ b/internal/tools/create_container_task.go
@@ -124,7 +124,7 @@ func (t *CreateContainerTaskTool) executeCoordination(ctx context.Context, args 
 	}
 	parentName := os.Getenv(envOrkaTaskName)
 	if parentName == "" {
-		return ChatToolErrorResult(internalErrorType, "ORKA_TASK_NAME is required for coordinator container tasks", "")
+		return ChatToolErrorResult(internalErrorType, fmt.Sprintf("%s is required for coordinator container tasks", envOrkaTaskName), "")
 	}
 
 	parentTask := &corev1alpha1.Task{}

--- a/internal/tools/file_read.go
+++ b/internal/tools/file_read.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/sozercan/orka/internal/workerenv"
 	"io"
 	"os"
 	"path/filepath"
@@ -41,7 +42,7 @@ type FileReadResult struct {
 
 // NewFileReadTool creates a new file read tool
 func NewFileReadTool() *FileReadTool {
-	workDir := os.Getenv("ORKA_WORK_DIR")
+	workDir := os.Getenv(workerenv.WorkDir)
 	if workDir == "" {
 		workDir = defaultWorkspacePath
 	}

--- a/internal/tools/file_read.go
+++ b/internal/tools/file_read.go
@@ -10,11 +10,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/sozercan/orka/internal/workerenv"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/sozercan/orka/internal/workerenv"
 )
 
 // FileReadTool implements file reading functionality

--- a/internal/tools/file_write.go
+++ b/internal/tools/file_write.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/sozercan/orka/internal/workerenv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,7 +46,7 @@ type FileWriteResult struct {
 
 // NewFileWriteTool creates a new file write tool
 func NewFileWriteTool() *FileWriteTool {
-	workDir := os.Getenv("ORKA_WORK_DIR")
+	workDir := os.Getenv(workerenv.WorkDir)
 	if workDir == "" {
 		workDir = defaultWorkspacePath
 	}

--- a/internal/tools/file_write.go
+++ b/internal/tools/file_write.go
@@ -10,10 +10,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/sozercan/orka/internal/workerenv"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/sozercan/orka/internal/workerenv"
 )
 
 const (

--- a/internal/tools/github_helpers.go
+++ b/internal/tools/github_helpers.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/sozercan/orka/internal/workerenv"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,7 +61,7 @@ func resolveRepoAndToken(ctx context.Context, k8sClient client.Client, taskName,
 
 	default:
 		// Priority 3: ORKA_GIT_REPO env var
-		envRepo := os.Getenv("ORKA_GIT_REPO")
+		envRepo := os.Getenv(workerenv.GitRepo)
 		if envRepo == "" {
 			return "", "", "", "", fmt.Errorf("no repo_url, task_name, or ORKA_GIT_REPO provided")
 		}
@@ -150,5 +152,5 @@ func resolveToken() string {
 	}
 
 	// Fall back to GITHUB_TOKEN env var
-	return os.Getenv("GITHUB_TOKEN")
+	return os.Getenv(workerenv.GitHubToken)
 }

--- a/internal/tools/memory_tools.go
+++ b/internal/tools/memory_tools.go
@@ -11,13 +11,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/sozercan/orka/internal/workerenv"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/sozercan/orka/internal/workerenv"
 )
 
 const internalMemoryToolBodyLimit = 1 << 20 // 1MB

--- a/internal/tools/memory_tools.go
+++ b/internal/tools/memory_tools.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/sozercan/orka/internal/workerenv"
 	"io"
 	"net/http"
 	"net/url"
@@ -547,14 +548,14 @@ type internalControllerConfig struct {
 
 func loadInternalControllerConfig() (internalControllerConfig, error) {
 	cfg := internalControllerConfig{
-		ControllerURL: strings.TrimRight(strings.TrimSpace(os.Getenv("ORKA_CONTROLLER_URL")), "/"),
-		Namespace:     strings.TrimSpace(os.Getenv("ORKA_TASK_NAMESPACE")),
-		TaskName:      strings.TrimSpace(os.Getenv("ORKA_TASK_NAME")),
-		AgentName:     strings.TrimSpace(os.Getenv("ORKA_AGENT_NAME")),
-		Token:         strings.TrimSpace(os.Getenv("ORKA_SA_TOKEN")),
+		ControllerURL: strings.TrimRight(strings.TrimSpace(os.Getenv(workerenv.ControllerURL)), "/"),
+		Namespace:     strings.TrimSpace(os.Getenv(workerenv.TaskNamespace)),
+		TaskName:      strings.TrimSpace(os.Getenv(workerenv.TaskName)),
+		AgentName:     strings.TrimSpace(os.Getenv(workerenv.AgentName)),
+		Token:         strings.TrimSpace(os.Getenv(workerenv.ServiceAccountToken)),
 	}
 	if cfg.ControllerURL == "" || cfg.Namespace == "" || cfg.TaskName == "" {
-		return cfg, fmt.Errorf("ORKA_CONTROLLER_URL, ORKA_TASK_NAME, and ORKA_TASK_NAMESPACE are required")
+		return cfg, fmt.Errorf("%s, %s, and %s are required", workerenv.ControllerURL, workerenv.TaskName, workerenv.TaskNamespace)
 	}
 	if cfg.Token == "" {
 		if data, err := os.ReadFile(saTokenPath); err == nil {

--- a/internal/tools/update_plan.go
+++ b/internal/tools/update_plan.go
@@ -12,9 +12,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/sozercan/orka/internal/workerenv"
 	"net/http"
 	"os"
+
+	"github.com/sozercan/orka/internal/workerenv"
 )
 
 // UpdatePlanTool allows the LLM to update the autonomous plan state.

--- a/internal/tools/update_plan.go
+++ b/internal/tools/update_plan.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/sozercan/orka/internal/workerenv"
 	"net/http"
 	"os"
 )
@@ -85,7 +86,7 @@ func (t *UpdatePlanTool) Execute(ctx context.Context, args json.RawMessage) (str
 	controllerURL := os.Getenv(envOrkaControllerURL)
 	taskName := os.Getenv(envOrkaTaskName)
 	taskNamespace := os.Getenv(envOrkaTaskNamespace)
-	saToken := os.Getenv("ORKA_SA_TOKEN")
+	saToken := os.Getenv(workerenv.ServiceAccountToken)
 
 	if controllerURL == "" || taskName == "" || taskNamespace == "" {
 		return "", errors.New(missingControllerTaskEnvMessage)

--- a/internal/tools/wait_for_tasks.go
+++ b/internal/tools/wait_for_tasks.go
@@ -131,7 +131,7 @@ func (t *WaitForTasksTool) Execute(ctx context.Context, args json.RawMessage) (s
 
 	ns := os.Getenv(envOrkaTaskNamespace)
 	if ns == "" {
-		return "", fmt.Errorf("ORKA_TASK_NAMESPACE environment variable is not set")
+		return "", fmt.Errorf("%s environment variable is not set", envOrkaTaskNamespace)
 	}
 
 	deadline := time.Now().Add(timeout)
@@ -291,7 +291,7 @@ const saTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 func fetchTaskResult(ctx context.Context, taskName string) (string, error) {
 	controllerURL := os.Getenv(envOrkaControllerURL)
 	if controllerURL == "" {
-		return "", fmt.Errorf("ORKA_CONTROLLER_URL is not set")
+		return "", fmt.Errorf("%s is not set", envOrkaControllerURL)
 	}
 
 	controllerURL = strings.TrimRight(controllerURL, "/")

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -17,6 +17,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/sozercan/orka/internal/workerenv"
 )
 
 // WebSearchTool implements web search functionality
@@ -42,8 +44,8 @@ type WebSearchResult struct {
 // NewWebSearchTool creates a new web search tool
 func NewWebSearchTool() *WebSearchTool {
 	return &WebSearchTool{
-		apiKey:  os.Getenv("SEARCH_API_KEY"),
-		baseURL: os.Getenv("SEARCH_API_URL"),
+		apiKey:  os.Getenv(workerenv.SearchAPIKey),
+		baseURL: os.Getenv(workerenv.SearchAPIURL),
 		client: &http.Client{
 			Timeout: 30 * time.Second,
 		},

--- a/internal/worker/tool_executor.go
+++ b/internal/worker/tool_executor.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/sozercan/orka/internal/workerenv"
 	"io"
 	"net/http"
 	neturl "net/url"
@@ -35,7 +36,7 @@ type ToolExecutor struct {
 
 // NewToolExecutor creates a new tool executor
 func NewToolExecutor() *ToolExecutor {
-	namespace := os.Getenv("ORKA_TASK_NAMESPACE")
+	namespace := os.Getenv(workerenv.TaskNamespace)
 	if namespace == "" {
 		namespace = "default"
 	}

--- a/internal/worker/tool_executor.go
+++ b/internal/worker/tool_executor.go
@@ -11,13 +11,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/sozercan/orka/internal/workerenv"
 	"io"
 	"net/http"
 	neturl "net/url"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/sozercan/orka/internal/workerenv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/internal/workerenv/env.go
+++ b/internal/workerenv/env.go
@@ -1,0 +1,397 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+// Package workerenv defines the environment-variable contract shared by the
+// controller job builder and worker binaries.
+package workerenv
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// Base worker env vars used by all worker types.
+	TaskName       = "ORKA_TASK_NAME"
+	TaskNamespace  = "ORKA_TASK_NAMESPACE"
+	ResultEndpoint = "ORKA_RESULT_ENDPOINT"
+	ControllerURL  = "ORKA_CONTROLLER_URL"
+	Command        = "ORKA_COMMAND"
+	AgentName      = "ORKA_AGENT_NAME"
+
+	// Task relationship env vars.
+	PriorTask          = "ORKA_PRIOR_TASK"
+	PriorTaskNamespace = "ORKA_PRIOR_TASK_NAMESPACE"
+	ParentTask         = "ORKA_PARENT_TASK"
+
+	// AI worker env vars.
+	AIProvider        = "ORKA_AI_PROVIDER"
+	AIModel           = "ORKA_AI_MODEL"
+	AIPrompt          = "ORKA_AI_PROMPT"
+	AISystemPrompt    = "ORKA_AI_SYSTEM_PROMPT"
+	AIBaseURL         = "ORKA_AI_BASE_URL"
+	AIAzureAPIVersion = "ORKA_AI_AZURE_API_VERSION"
+	AITools           = "ORKA_AI_TOOLS"
+	AIFallbackCount   = "ORKA_AI_FALLBACK_COUNT"
+
+	// Coordination/autonomous env vars used by AI worker and coordination tools.
+	CoordinationEnabled       = "ORKA_COORDINATION_ENABLED"
+	CoordinationMaxDepth      = "ORKA_COORDINATION_MAX_DEPTH"
+	CoordinationMaxChildren   = "ORKA_COORDINATION_MAX_CHILDREN"
+	CoordinationAllowedAgents = "ORKA_COORDINATION_ALLOWED_AGENTS"
+	CoordinationDepth         = "ORKA_COORDINATION_DEPTH"
+	AutonomousMode            = "ORKA_AUTONOMOUS_MODE"
+	AutonomousIteration       = "ORKA_AUTONOMOUS_ITERATION"
+	AutonomousMaxIterations   = "ORKA_AUTONOMOUS_MAX_ITERATIONS"
+
+	// Agent runtime env vars.
+	Prompt                     = "ORKA_PROMPT"
+	Model                      = "ORKA_MODEL"
+	SystemPrompt               = "ORKA_SYSTEM_PROMPT"
+	MaxTurns                   = "ORKA_MAX_TURNS"
+	AllowedTools               = "ORKA_ALLOWED_TOOLS"
+	DisallowedTools            = "ORKA_DISALLOWED_TOOLS"
+	AllowBash                  = "ORKA_ALLOW_BASH"
+	TimeoutSeconds             = "ORKA_TIMEOUT_SECONDS"
+	SessionName                = "ORKA_SESSION_NAME"
+	CodexSandboxMode           = "ORKA_CODEX_SANDBOX_MODE"
+	CodexAutoCompactTokenLimit = "ORKA_CODEX_AUTO_COMPACT_TOKEN_LIMIT"
+	CodexDisableSandbox        = "ORKA_CODEX_DISABLE_SANDBOX"
+	AnthropicBaseURL           = "ANTHROPIC_BASE_URL"
+	OpenAIBaseURL              = "OPENAI_BASE_URL"
+	AnthropicAPIKey            = "ANTHROPIC_API_KEY"
+	OpenAIAPIKey               = "OPENAI_API_KEY"
+	CodexAPIKey                = "CODEX_API_KEY"
+	GitHubToken                = "GITHUB_TOKEN"
+	GitToken                   = "GIT_TOKEN"
+	GitAskpass                 = "GIT_ASKPASS"
+	GitUsername                = "GIT_USERNAME"
+	ClaudeCLIPath              = "CLAUDE_CLI_PATH"
+	CodexCLIPath               = "CODEX_CLI_PATH"
+	CopilotCLIPath             = "COPILOT_CLI_PATH"
+
+	// Tool integration env vars.
+	SearchAPIKey = "SEARCH_API_KEY"
+	SearchAPIURL = "SEARCH_API_URL"
+
+	// Kubernetes namespace env vars used by workers/tools.
+	PodNamespace = "POD_NAMESPACE"
+	Namespace    = "NAMESPACE"
+
+	// Code execution tool env vars.
+	CodeExecBackend                 = "ORKA_CODE_EXEC_BACKEND"
+	CodeExecLocalCPUSeconds         = "ORKA_CODE_EXEC_LOCAL_CPU_SECONDS"
+	CodeExecLocalMemoryKB           = "ORKA_CODE_EXEC_LOCAL_MEMORY_KB"
+	CodeExecLocalMaxProcesses       = "ORKA_CODE_EXEC_LOCAL_MAX_PROCESSES"
+	CodeExecKubernetesImage         = "ORKA_CODE_EXEC_K8S_IMAGE"
+	CodeExecKubernetesPythonImage   = "ORKA_CODE_EXEC_K8S_PYTHON_IMAGE"
+	CodeExecKubernetesNodeImage     = "ORKA_CODE_EXEC_K8S_NODE_IMAGE"
+	CodeExecKubernetesBashImage     = "ORKA_CODE_EXEC_K8S_BASH_IMAGE"
+	CodeExecKubernetesCPURequest    = "ORKA_CODE_EXEC_K8S_CPU_REQUEST"
+	CodeExecKubernetesCPULimit      = "ORKA_CODE_EXEC_K8S_CPU_LIMIT"
+	CodeExecKubernetesMemoryRequest = "ORKA_CODE_EXEC_K8S_MEMORY_REQUEST"
+	CodeExecKubernetesMemoryLimit   = "ORKA_CODE_EXEC_K8S_MEMORY_LIMIT"
+	CodeExecKubernetesNetworkPolicy = "ORKA_CODE_EXEC_K8S_NETWORK_POLICY"
+	CodeExecKubernetesRuntimeClass  = "ORKA_CODE_EXEC_K8S_RUNTIME_CLASS_NAME"
+	CodeExecKubernetesAppArmor      = "ORKA_CODE_EXEC_K8S_APPARMOR_PROFILE"
+	OrkaNamespace                   = "ORKA_NAMESPACE"
+
+	// Workspace env vars used by general and agent-runtime workers.
+	GitRepo           = "ORKA_GIT_REPO"
+	GitBranch         = "ORKA_GIT_BRANCH"
+	GitRef            = "ORKA_GIT_REF"
+	WorkspaceSubpath  = "ORKA_WORKSPACE_SUBPATH"
+	ForkRepo          = "ORKA_FORK_REPO"
+	PRBaseBranch      = "ORKA_PR_BASE_BRANCH"
+	PushBranch        = "ORKA_PUSH_BRANCH"
+	RequirePushBranch = "ORKA_REQUIRE_PUSH_BRANCH"
+	WorkDir           = "ORKA_WORK_DIR"
+	SkillsDir         = "ORKA_SKILLS_DIR"
+
+	// Git config env vars used to mark the prepared workspace as safe.
+	GitConfigCount  = "GIT_CONFIG_COUNT"
+	GitConfigKey0   = "GIT_CONFIG_KEY_0"
+	GitConfigValue0 = "GIT_CONFIG_VALUE_0"
+
+	// Memory/controller context env vars used by AI worker memory integration.
+	MemoryContextEnabled  = "ORKA_MEMORY_CONTEXT_ENABLED"
+	MemoryContextLimit    = "ORKA_MEMORY_CONTEXT_LIMIT"
+	MemoryContextMaxChars = "ORKA_MEMORY_CONTEXT_MAX_CHARS"
+	ServiceAccountToken   = "ORKA_SA_TOKEN"
+)
+
+const trueString = "true"
+
+// Env returns a simple Kubernetes environment variable.
+func Env(name, value string) corev1.EnvVar {
+	return corev1.EnvVar{Name: name, Value: value}
+}
+
+// EnvIfSet returns an env var and true when value is non-empty.
+func EnvIfSet(name, value string) (corev1.EnvVar, bool) {
+	if value == "" {
+		return corev1.EnvVar{}, false
+	}
+	return Env(name, value), true
+}
+
+// AppendIfSet appends name=value to envVars only when value is non-empty.
+func AppendIfSet(envVars []corev1.EnvVar, name, value string) []corev1.EnvVar {
+	if value == "" {
+		return envVars
+	}
+	return append(envVars, Env(name, value))
+}
+
+// IsTrue returns true when value enables a boolean env flag.
+func IsTrue(value string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), trueString)
+}
+
+// SplitCSV returns trimmed, non-empty items from a comma-separated env value.
+func SplitCSV(value string) []string {
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+// JoinCSV joins values using the comma-separated format used by worker env vars.
+func JoinCSV(values []string) string {
+	return strings.Join(values, ",")
+}
+
+// BaseEnv is the common env contract passed to all Orka worker containers.
+type BaseEnv struct {
+	TaskName       string
+	TaskNamespace  string
+	ResultEndpoint string
+	ControllerURL  string
+}
+
+// EnvVars renders the base worker environment.
+func (e BaseEnv) EnvVars() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		Env(TaskName, e.TaskName),
+		Env(TaskNamespace, e.TaskNamespace),
+		Env(ResultEndpoint, e.ResultEndpoint),
+		Env(ControllerURL, e.ControllerURL),
+	}
+}
+
+// ParseBaseEnv reads the common worker environment.
+func ParseBaseEnv(getenv func(string) string) BaseEnv {
+	return BaseEnv{
+		TaskName:       getenv(TaskName),
+		TaskNamespace:  getenv(TaskNamespace),
+		ResultEndpoint: getenv(ResultEndpoint),
+		ControllerURL:  getenv(ControllerURL),
+	}
+}
+
+// FallbackProviderEnv is one fallback provider entry from the AI worker env contract.
+type FallbackProviderEnv struct {
+	Provider        string
+	APIKey          string
+	Model           string
+	BaseURL         string
+	AzureAPIVersion string
+}
+
+// FallbackPrefix returns the prefix for fallback provider i.
+func FallbackPrefix(i int) string {
+	return fmt.Sprintf("ORKA_AI_FALLBACK_%d", i)
+}
+
+func FallbackProviderKey(i int) string        { return FallbackPrefix(i) + "_PROVIDER" }
+func FallbackAPIKeyKey(i int) string          { return FallbackPrefix(i) + "_API_KEY" }
+func FallbackModelKey(i int) string           { return FallbackPrefix(i) + "_MODEL" }
+func FallbackBaseURLKey(i int) string         { return FallbackPrefix(i) + "_BASE_URL" }
+func FallbackAzureAPIVersionKey(i int) string { return FallbackPrefix(i) + "_AZURE_API_VERSION" }
+
+// EnvVars renders the non-secret fallback metadata env vars for fallback i.
+// API keys should normally be rendered from SecretKeyRef by the caller.
+func (e FallbackProviderEnv) EnvVars(i int) []corev1.EnvVar {
+	envVars := []corev1.EnvVar{
+		Env(FallbackProviderKey(i), e.Provider),
+		Env(FallbackModelKey(i), e.Model),
+	}
+	envVars = AppendIfSet(envVars, FallbackBaseURLKey(i), e.BaseURL)
+	envVars = AppendIfSet(envVars, FallbackAzureAPIVersionKey(i), e.AzureAPIVersion)
+	if e.APIKey != "" {
+		envVars = append(envVars, Env(FallbackAPIKeyKey(i), e.APIKey))
+	}
+	return envVars
+}
+
+// ParseFallbackProviderEnv reads fallback provider i.
+func ParseFallbackProviderEnv(getenv func(string) string, i int) FallbackProviderEnv {
+	return FallbackProviderEnv{
+		Provider:        getenv(FallbackProviderKey(i)),
+		APIKey:          getenv(FallbackAPIKeyKey(i)),
+		Model:           getenv(FallbackModelKey(i)),
+		BaseURL:         getenv(FallbackBaseURLKey(i)),
+		AzureAPIVersion: getenv(FallbackAzureAPIVersionKey(i)),
+	}
+}
+
+// ParseFallbacks reads all fallback provider entries from env. Invalid counts are
+// treated as no fallbacks to preserve historical worker behavior.
+func ParseFallbacks(getenv func(string) string) []FallbackProviderEnv {
+	countStr := strings.TrimSpace(getenv(AIFallbackCount))
+	if countStr == "" {
+		return nil
+	}
+	count, err := strconv.Atoi(countStr)
+	if err != nil || count <= 0 {
+		return nil
+	}
+	fallbacks := make([]FallbackProviderEnv, 0, count)
+	for i := range count {
+		fallbacks = append(fallbacks, ParseFallbackProviderEnv(getenv, i))
+	}
+	return fallbacks
+}
+
+// AIWorkerEnv is the typed AI worker env contract shared by JobBuilder and the
+// AI worker binary.
+type AIWorkerEnv struct {
+	BaseEnv
+	Provider        string
+	Model           string
+	Prompt          string
+	SystemPrompt    string
+	BaseURL         string
+	AzureAPIVersion string
+	Tools           []string
+	Fallbacks       []FallbackProviderEnv
+}
+
+// EnvVars renders AI worker env vars. Fallback API keys are included only when
+// set on the struct; JobBuilder should usually add them separately via secrets.
+func (e AIWorkerEnv) EnvVars() []corev1.EnvVar {
+	envVars := make([]corev1.EnvVar, 0, 8+len(e.Fallbacks)*4)
+	if e.BaseEnv != (BaseEnv{}) {
+		envVars = append(envVars, e.BaseEnv.EnvVars()...)
+	}
+	envVars = append(envVars,
+		Env(AIProvider, e.Provider),
+		Env(AIModel, e.Model),
+		Env(AIPrompt, e.Prompt),
+		Env(AISystemPrompt, e.SystemPrompt),
+	)
+	envVars = AppendIfSet(envVars, AIBaseURL, e.BaseURL)
+	envVars = AppendIfSet(envVars, AIAzureAPIVersion, e.AzureAPIVersion)
+	if len(e.Tools) > 0 {
+		envVars = append(envVars, Env(AITools, JoinCSV(e.Tools)))
+	}
+	if len(e.Fallbacks) > 0 {
+		envVars = append(envVars, Env(AIFallbackCount, strconv.Itoa(len(e.Fallbacks))))
+		for i, fallback := range e.Fallbacks {
+			envVars = append(envVars, fallback.EnvVars(i)...)
+		}
+	}
+	return envVars
+}
+
+// ParseAIWorkerEnv reads the AI worker environment.
+func ParseAIWorkerEnv(getenv func(string) string) AIWorkerEnv {
+	return AIWorkerEnv{
+		BaseEnv:         ParseBaseEnv(getenv),
+		Provider:        getenv(AIProvider),
+		Model:           getenv(AIModel),
+		Prompt:          getenv(AIPrompt),
+		SystemPrompt:    getenv(AISystemPrompt),
+		BaseURL:         getenv(AIBaseURL),
+		AzureAPIVersion: getenv(AIAzureAPIVersion),
+		Tools:           SplitCSV(getenv(AITools)),
+		Fallbacks:       ParseFallbacks(getenv),
+	}
+}
+
+// ValidateRequired returns an error when required AI worker fields are missing.
+func (e AIWorkerEnv) ValidateRequired() error {
+	if e.Provider == "" {
+		return fmt.Errorf("%s is required", AIProvider)
+	}
+	if e.Model == "" {
+		return fmt.Errorf("%s is required", AIModel)
+	}
+	if e.Prompt == "" {
+		return fmt.Errorf("%s is required", AIPrompt)
+	}
+	return nil
+}
+
+// CoordinationEnv is the coordination/autonomous env contract used by AI tasks.
+type CoordinationEnv struct {
+	Enabled       bool
+	MaxDepth      int
+	MaxChildren   int
+	AllowedAgents []string
+	Depth         string
+
+	AutonomousMode          bool
+	AutonomousIteration     int
+	AutonomousMaxIterations int
+}
+
+// EnvVars renders coordination/autonomous env vars.
+func (e CoordinationEnv) EnvVars() []corev1.EnvVar {
+	if !e.Enabled {
+		return nil
+	}
+	envVars := []corev1.EnvVar{
+		Env(CoordinationEnabled, trueString),
+		Env(CoordinationMaxDepth, strconv.Itoa(e.MaxDepth)),
+		Env(CoordinationMaxChildren, strconv.Itoa(e.MaxChildren)),
+	}
+	if len(e.AllowedAgents) > 0 {
+		envVars = append(envVars, Env(CoordinationAllowedAgents, JoinCSV(e.AllowedAgents)))
+	}
+	if e.Depth != "" {
+		envVars = append(envVars, Env(CoordinationDepth, e.Depth))
+	}
+	if e.AutonomousMode {
+		envVars = append(envVars,
+			Env(AutonomousMode, trueString),
+			Env(AutonomousIteration, strconv.Itoa(e.AutonomousIteration)),
+		)
+		if e.AutonomousMaxIterations > 0 {
+			envVars = append(envVars, Env(AutonomousMaxIterations, strconv.Itoa(e.AutonomousMaxIterations)))
+		}
+	}
+	return envVars
+}
+
+// ParseCoordinationEnv reads coordination/autonomous settings.
+func ParseCoordinationEnv(getenv func(string) string) CoordinationEnv {
+	return CoordinationEnv{
+		Enabled:                 IsTrue(getenv(CoordinationEnabled)),
+		MaxDepth:                parsePositiveInt(getenv(CoordinationMaxDepth)),
+		MaxChildren:             parsePositiveInt(getenv(CoordinationMaxChildren)),
+		AllowedAgents:           SplitCSV(getenv(CoordinationAllowedAgents)),
+		Depth:                   getenv(CoordinationDepth),
+		AutonomousMode:          IsTrue(getenv(AutonomousMode)),
+		AutonomousIteration:     parsePositiveInt(getenv(AutonomousIteration)),
+		AutonomousMaxIterations: parsePositiveInt(getenv(AutonomousMaxIterations)),
+	}
+}
+
+func parsePositiveInt(value string) int {
+	parsed, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || parsed <= 0 {
+		return 0
+	}
+	return parsed
+}

--- a/internal/workerenv/env_test.go
+++ b/internal/workerenv/env_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package workerenv
+
+import "testing"
+
+func TestAIWorkerEnvRoundTrip(t *testing.T) {
+	env := AIWorkerEnv{
+		BaseEnv: BaseEnv{
+			TaskName:       "task-1",
+			TaskNamespace:  "default",
+			ResultEndpoint: "http://controller/results/default/task-1",
+			ControllerURL:  "http://controller",
+		},
+		Provider:        "openai",
+		Model:           "gpt-5",
+		Prompt:          "do work",
+		SystemPrompt:    "be concise",
+		BaseURL:         "https://example.test/v1",
+		AzureAPIVersion: "2024-10-21",
+		Tools:           []string{"delegate_task", "wait_for_tasks"},
+		Fallbacks: []FallbackProviderEnv{{
+			Provider:        "anthropic",
+			APIKey:          "secret",
+			Model:           "claude",
+			BaseURL:         "https://anthropic.example",
+			AzureAPIVersion: "ignored",
+		}},
+	}
+
+	values := map[string]string{}
+	for _, envVar := range env.EnvVars() {
+		values[envVar.Name] = envVar.Value
+	}
+
+	parsed := ParseAIWorkerEnv(func(name string) string { return values[name] })
+	if err := parsed.ValidateRequired(); err != nil {
+		t.Fatalf("ValidateRequired() returned error: %v", err)
+	}
+	if parsed.TaskName != env.TaskName || parsed.TaskNamespace != env.TaskNamespace || parsed.ControllerURL != env.ControllerURL {
+		t.Fatalf("base env mismatch: got %#v, want %#v", parsed.BaseEnv, env.BaseEnv)
+	}
+	if parsed.Provider != env.Provider || parsed.Model != env.Model || parsed.Prompt != env.Prompt {
+		t.Fatalf("AI env mismatch: got %#v, want %#v", parsed, env)
+	}
+	if len(parsed.Tools) != 2 || parsed.Tools[0] != "delegate_task" || parsed.Tools[1] != "wait_for_tasks" {
+		t.Fatalf("tools = %#v", parsed.Tools)
+	}
+	if len(parsed.Fallbacks) != 1 {
+		t.Fatalf("fallback count = %d, want 1", len(parsed.Fallbacks))
+	}
+	if parsed.Fallbacks[0] != env.Fallbacks[0] {
+		t.Fatalf("fallback = %#v, want %#v", parsed.Fallbacks[0], env.Fallbacks[0])
+	}
+}
+
+func TestParseFallbacksInvalidCountPreservesLegacyBehavior(t *testing.T) {
+	values := map[string]string{AIFallbackCount: "not-an-int"}
+	fallbacks := ParseFallbacks(func(name string) string { return values[name] })
+	if len(fallbacks) != 0 {
+		t.Fatalf("fallbacks = %#v, want none", fallbacks)
+	}
+}
+
+func TestAIWorkerEnvValidateRequired(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		env  AIWorkerEnv
+		want string
+	}{
+		{name: "missing provider", env: AIWorkerEnv{Model: "m", Prompt: "p"}, want: AIProvider},
+		{name: "missing model", env: AIWorkerEnv{Provider: "p", Prompt: "prompt"}, want: AIModel},
+		{name: "missing prompt", env: AIWorkerEnv{Provider: "p", Model: "m"}, want: AIPrompt},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.env.ValidateRequired()
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if err.Error() != tt.want+" is required" {
+				t.Fatalf("error = %q, want %q", err.Error(), tt.want+" is required")
+			}
+		})
+	}
+}
+
+func TestCoordinationEnvRenderAndParse(t *testing.T) {
+	env := CoordinationEnv{
+		Enabled:                 true,
+		MaxDepth:                3,
+		MaxChildren:             4,
+		AllowedAgents:           []string{"builder", "reviewer"},
+		Depth:                   "1",
+		AutonomousMode:          true,
+		AutonomousIteration:     2,
+		AutonomousMaxIterations: 8,
+	}
+	values := map[string]string{}
+	for _, envVar := range env.EnvVars() {
+		values[envVar.Name] = envVar.Value
+	}
+
+	parsed := ParseCoordinationEnv(func(name string) string { return values[name] })
+	if !parsed.Enabled || !parsed.AutonomousMode {
+		t.Fatalf("parsed flags = %#v", parsed)
+	}
+	if parsed.MaxDepth != 3 || parsed.MaxChildren != 4 || parsed.Depth != "1" || parsed.AutonomousIteration != 2 || parsed.AutonomousMaxIterations != 8 {
+		t.Fatalf("parsed numeric/depth values = %#v", parsed)
+	}
+	if len(parsed.AllowedAgents) != 2 || parsed.AllowedAgents[0] != "builder" || parsed.AllowedAgents[1] != "reviewer" {
+		t.Fatalf("allowed agents = %#v", parsed.AllowedAgents)
+	}
+}

--- a/test/e2e/agent_session_test.go
+++ b/test/e2e/agent_session_test.go
@@ -23,10 +23,10 @@ import (
 
 var _ = Describe("Agent Session Continuity", Ordered, func() {
 	const (
-		taskName1  = "e2e-session-task-1"
-		taskName2  = "e2e-session-task-2"
-		agentName  = "e2e-session-agent"
-		sessionID  = "e2e-test-session"
+		taskName1 = "e2e-session-task-1"
+		taskName2 = "e2e-session-task-2"
+		agentName = "e2e-session-agent"
+		sessionID = "e2e-test-session"
 	)
 
 	AfterAll(func() {

--- a/workers/agent/claude/main.go
+++ b/workers/agent/claude/main.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/sozercan/orka/internal/workerenv"
 	"io"
 	"os"
 	"os/exec"
@@ -18,6 +17,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/sozercan/orka/internal/workerenv"
 
 	"github.com/sozercan/orka/workers/common"
 )

--- a/workers/agent/claude/main.go
+++ b/workers/agent/claude/main.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/sozercan/orka/internal/workerenv"
 	"io"
 	"os"
 	"os/exec"
@@ -119,7 +120,7 @@ func buildClaudeArgs(cfg *common.AgentConfig, prompt string) []string {
 	args = append(args, "--max-turns", strconv.Itoa(cfg.MaxTurns))
 
 	// Tool permissions
-	if os.Getenv("ORKA_ALLOW_BASH") == "true" {
+	if os.Getenv(workerenv.AllowBash) == "true" {
 		args = append(args, "--dangerously-skip-permissions")
 	}
 	for _, tool := range cfg.AllowedTools {
@@ -137,7 +138,7 @@ func buildClaudeArgs(cfg *common.AgentConfig, prompt string) []string {
 
 // claudePath returns the path to the claude CLI binary.
 func claudePath() string {
-	if p := os.Getenv("CLAUDE_CLI_PATH"); p != "" {
+	if p := os.Getenv(workerenv.ClaudeCLIPath); p != "" {
 		return p
 	}
 	return defaultClaudePath

--- a/workers/agent/codex/main.go
+++ b/workers/agent/codex/main.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sozercan/orka/internal/workerenv"
 	"github.com/sozercan/orka/workers/common"
 )
 
@@ -167,7 +168,7 @@ func buildCodexArgsForMode(cfg *common.AgentConfig, outputPath, instructionsPath
 	if instructionsPath != "" {
 		args = append(args, "--config", "model_instructions_file="+instructionsPath)
 	}
-	if baseURL := strings.TrimSpace(os.Getenv("OPENAI_BASE_URL")); baseURL != "" {
+	if baseURL := strings.TrimSpace(os.Getenv(workerenv.OpenAIBaseURL)); baseURL != "" {
 		args = append(args, "--config", "openai_base_url="+baseURL)
 	}
 	if !bypassSandbox && sandboxMode == defaultCodexSandboxMode {
@@ -182,14 +183,14 @@ func buildCodexArgsForMode(cfg *common.AgentConfig, outputPath, instructionsPath
 }
 
 func codexAutoCompactTokenLimit() string {
-	if limit := strings.TrimSpace(os.Getenv("ORKA_CODEX_AUTO_COMPACT_TOKEN_LIMIT")); limit != "" {
+	if limit := strings.TrimSpace(os.Getenv(workerenv.CodexAutoCompactTokenLimit)); limit != "" {
 		return limit
 	}
 	return defaultAutoCompactLimit
 }
 
 func codexSandboxMode() string {
-	if mode := strings.TrimSpace(os.Getenv("ORKA_CODEX_SANDBOX_MODE")); mode != "" {
+	if mode := strings.TrimSpace(os.Getenv(workerenv.CodexSandboxMode)); mode != "" {
 		return mode
 	}
 	return defaultCodexSandboxMode
@@ -268,9 +269,9 @@ func buildCodexEnv() []string {
 	env := os.Environ()
 	env = setEnvVar(env, "HOME", "/home/worker")
 
-	if os.Getenv("CODEX_API_KEY") == "" {
-		if apiKey := strings.TrimSpace(os.Getenv("OPENAI_API_KEY")); apiKey != "" {
-			env = setEnvVar(env, "CODEX_API_KEY", apiKey)
+	if os.Getenv(workerenv.CodexAPIKey) == "" {
+		if apiKey := strings.TrimSpace(os.Getenv(workerenv.OpenAIAPIKey)); apiKey != "" {
+			env = setEnvVar(env, workerenv.CodexAPIKey, apiKey)
 		}
 	}
 
@@ -339,14 +340,14 @@ func readCodexResult(outputPath, fallback string) string {
 }
 
 func codexPath() string {
-	if p := os.Getenv("CODEX_CLI_PATH"); p != "" {
+	if p := os.Getenv(workerenv.CodexCLIPath); p != "" {
 		return p
 	}
 	return defaultCodexPath
 }
 
 func allowBashEnabled() bool {
-	return os.Getenv("ORKA_ALLOW_BASH") == "true"
+	return os.Getenv(workerenv.AllowBash) == "true"
 }
 
 func shouldRetryCodexWithoutSandbox(output string) bool {
@@ -368,7 +369,7 @@ func shouldRetryCodexWithoutSandbox(output string) bool {
 }
 
 func shouldStartCodexWithoutSandbox() bool {
-	if strings.EqualFold(strings.TrimSpace(os.Getenv("ORKA_CODEX_DISABLE_SANDBOX")), "true") {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv(workerenv.CodexDisableSandbox)), "true") {
 		return true
 	}
 	if codexSandboxMode() != defaultCodexSandboxMode {

--- a/workers/agent/copilot/main.go
+++ b/workers/agent/copilot/main.go
@@ -20,6 +20,7 @@ import (
 	copilot "github.com/github/copilot-sdk/go"
 
 	"github.com/sozercan/orka/internal/security"
+	"github.com/sozercan/orka/internal/workerenv"
 	"github.com/sozercan/orka/workers/common"
 )
 
@@ -126,10 +127,10 @@ func executeCopilot(ctx context.Context, cfg *common.AgentConfig) (string, error
 	opts := &copilot.ClientOptions{
 		Cwd: workspaceDir,
 	}
-	if p := os.Getenv("COPILOT_CLI_PATH"); p != "" {
+	if p := os.Getenv(workerenv.CopilotCLIPath); p != "" {
 		opts.CLIPath = p
 	}
-	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+	if token := os.Getenv(workerenv.GitHubToken); token != "" {
 		opts.GithubToken = token
 	}
 	client := copilot.NewClient(opts)

--- a/workers/ai/autonomous_prompt.go
+++ b/workers/ai/autonomous_prompt.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/sozercan/orka/internal/workerenv"
 )
 
 // autonomousSystemPromptSuffix returns additional system prompt instructions
@@ -139,11 +141,11 @@ When you have access to list_issues and list_pull_requests tools, follow this wo
 // inspecting the ORKA_AI_TOOLS env var for known tool names, or by checking
 // if ORKA_GIT_REPO is set (indicating a workspace tied to a GitHub repo).
 func hasGitHubTools() bool {
-	if os.Getenv("ORKA_GIT_REPO") != "" {
+	if os.Getenv(workerenv.GitRepo) != "" {
 		return true
 	}
 
-	toolsStr := os.Getenv("ORKA_AI_TOOLS")
+	toolsStr := os.Getenv(workerenv.AITools)
 	if toolsStr == "" {
 		return false
 	}

--- a/workers/ai/main.go
+++ b/workers/ai/main.go
@@ -35,10 +35,9 @@ import (
 	"github.com/sozercan/orka/internal/store"
 	"github.com/sozercan/orka/internal/tools"
 	"github.com/sozercan/orka/internal/worker"
+	"github.com/sozercan/orka/internal/workerenv"
 	"github.com/sozercan/orka/workers/common"
 )
-
-const trueStr = "true"
 
 const (
 	defaultMemoryContextLimit      = 5
@@ -74,25 +73,19 @@ func run() error {
 	defer cancel()
 
 	// Get configuration from environment
-	taskName := os.Getenv("ORKA_TASK_NAME")
-	taskNamespace := os.Getenv("ORKA_TASK_NAMESPACE")
+	workerEnv := workerenv.ParseAIWorkerEnv(os.Getenv)
+	if err := workerEnv.ValidateRequired(); err != nil {
+		return err
+	}
 
-	provider := os.Getenv("ORKA_AI_PROVIDER")
-	model := os.Getenv("ORKA_AI_MODEL")
-	prompt := os.Getenv("ORKA_AI_PROMPT")
-	systemPrompt := os.Getenv("ORKA_AI_SYSTEM_PROMPT")
-	toolsStr := os.Getenv("ORKA_AI_TOOLS")
-	baseURL := os.Getenv("ORKA_AI_BASE_URL")
-
-	if provider == "" {
-		return fmt.Errorf("ORKA_AI_PROVIDER is required")
-	}
-	if model == "" {
-		return fmt.Errorf("ORKA_AI_MODEL is required")
-	}
-	if prompt == "" {
-		return fmt.Errorf("ORKA_AI_PROMPT is required")
-	}
+	taskName := workerEnv.TaskName
+	taskNamespace := workerEnv.TaskNamespace
+	provider := workerEnv.Provider
+	model := workerEnv.Model
+	prompt := workerEnv.Prompt
+	systemPrompt := workerEnv.SystemPrompt
+	baseURL := workerEnv.BaseURL
+	azureAPIVersion := workerEnv.AzureAPIVersion
 
 	// Get API key
 	apiKey := getAPIKey(provider)
@@ -101,7 +94,6 @@ func run() error {
 	}
 
 	// Create LLM provider
-	azureAPIVersion := os.Getenv("ORKA_AI_AZURE_API_VERSION")
 	llmProvider, err := llm.NewProvider(provider, llm.ProviderConfig{
 		APIKey:          apiKey,
 		BaseURL:         baseURL,
@@ -116,50 +108,39 @@ func run() error {
 	llmProvider = llm.NewRetryProvider(llmProvider, 0)
 
 	// Set up fallback providers if configured
-	fallbackCountStr := os.Getenv("ORKA_AI_FALLBACK_COUNT")
-	if fallbackCountStr != "" {
-		fallbackCount, _ := strconv.Atoi(fallbackCountStr)
-		if fallbackCount > 0 {
-			var fallbacks []llm.FallbackEntry
-			for i := range fallbackCount {
-				prefix := fmt.Sprintf("ORKA_AI_FALLBACK_%d", i)
-				fbProviderType := os.Getenv(prefix + "_PROVIDER")
-				fbAPIKey := os.Getenv(prefix + "_API_KEY")
-				fbModel := os.Getenv(prefix + "_MODEL")
-				fbBaseURL := os.Getenv(prefix + "_BASE_URL")
-				fbAzureAPIVersion := os.Getenv(prefix + "_AZURE_API_VERSION")
-
-				if fbProviderType == "" || fbAPIKey == "" {
-					fmt.Printf("Warning: skipping fallback %d: missing provider or API key\n", i)
-					continue
-				}
-
-				fbProvider, err := llm.NewProvider(fbProviderType, llm.ProviderConfig{
-					APIKey:          fbAPIKey,
-					BaseURL:         fbBaseURL,
-					ProviderType:    fbProviderType,
-					AzureAPIVersion: fbAzureAPIVersion,
-				})
-				if err != nil {
-					fmt.Printf("Warning: skipping fallback %d: %v\n", i, err)
-					continue
-				}
-
-				fallbacks = append(fallbacks, llm.FallbackEntry{
-					Provider: llm.NewRetryProvider(fbProvider, 0),
-					Model:    fbModel,
-				})
+	if len(workerEnv.Fallbacks) > 0 {
+		var fallbacks []llm.FallbackEntry
+		for i, fallbackEnv := range workerEnv.Fallbacks {
+			if fallbackEnv.Provider == "" || fallbackEnv.APIKey == "" {
+				fmt.Printf("Warning: skipping fallback %d: missing provider or API key\n", i)
+				continue
 			}
-			if len(fallbacks) > 0 {
-				fp := llm.NewFallbackProvider(llmProvider, fallbacks)
-				fp.SetCooldownTracker(llm.NewCooldownTracker())
-				llmProvider = fp
+
+			fbProvider, err := llm.NewProvider(fallbackEnv.Provider, llm.ProviderConfig{
+				APIKey:          fallbackEnv.APIKey,
+				BaseURL:         fallbackEnv.BaseURL,
+				ProviderType:    fallbackEnv.Provider,
+				AzureAPIVersion: fallbackEnv.AzureAPIVersion,
+			})
+			if err != nil {
+				fmt.Printf("Warning: skipping fallback %d: %v\n", i, err)
+				continue
 			}
+
+			fallbacks = append(fallbacks, llm.FallbackEntry{
+				Provider: llm.NewRetryProvider(fbProvider, 0),
+				Model:    fallbackEnv.Model,
+			})
+		}
+		if len(fallbacks) > 0 {
+			fp := llm.NewFallbackProvider(llmProvider, fallbacks)
+			fp.SetCooldownTracker(llm.NewCooldownTracker())
+			llmProvider = fp
 		}
 	}
 
 	// Parse enabled tools
-	enabledTools := normalizeEnabledTools(strings.Split(toolsStr, ","))
+	enabledTools := normalizeEnabledTools(workerEnv.Tools)
 
 	// Create Kubernetes client for Tool CRDs
 	k8sClient, err := createK8sClient()
@@ -167,8 +148,10 @@ func run() error {
 		return fmt.Errorf("failed to create k8s client: %w", err)
 	}
 
+	coordinationEnv := workerenv.ParseCoordinationEnv(os.Getenv)
+
 	// Register coordination tools if enabled
-	if os.Getenv("ORKA_COORDINATION_ENABLED") == trueStr {
+	if coordinationEnv.Enabled {
 		tools.RegisterCoordinationTools(k8sClient)
 	}
 
@@ -190,19 +173,9 @@ func run() error {
 	}
 
 	// Autonomous mode: fetch plan state and augment system prompt
-	if os.Getenv("ORKA_AUTONOMOUS_MODE") == trueStr {
-		iteration := 0
-		if v := os.Getenv("ORKA_AUTONOMOUS_ITERATION"); v != "" {
-			if i, err := strconv.Atoi(v); err == nil {
-				iteration = i
-			}
-		}
-		maxIter := 0
-		if v := os.Getenv("ORKA_AUTONOMOUS_MAX_ITERATIONS"); v != "" {
-			if i, err := strconv.Atoi(v); err == nil {
-				maxIter = i
-			}
-		}
+	if coordinationEnv.AutonomousMode {
+		iteration := coordinationEnv.AutonomousIteration
+		maxIter := coordinationEnv.AutonomousMaxIterations
 
 		// Augment system prompt with autonomous instructions
 		systemPrompt += autonomousSystemPromptSuffix(iteration, maxIter)
@@ -377,9 +350,9 @@ func normalizeEnabledTools(toolNames []string) []string {
 }
 
 func memoryControllerConfigPresent() bool {
-	return strings.TrimSpace(os.Getenv("ORKA_CONTROLLER_URL")) != "" &&
-		strings.TrimSpace(os.Getenv("ORKA_TASK_NAMESPACE")) != "" &&
-		strings.TrimSpace(os.Getenv("ORKA_TASK_NAME")) != ""
+	return strings.TrimSpace(os.Getenv(workerenv.ControllerURL)) != "" &&
+		strings.TrimSpace(os.Getenv(workerenv.TaskNamespace)) != "" &&
+		strings.TrimSpace(os.Getenv(workerenv.TaskName)) != ""
 }
 
 func autoEnableMemoryTools(enabled []string) []string {
@@ -413,15 +386,15 @@ func registerMemoryTools() {
 }
 
 func loadDurableMemoryContext(ctx context.Context) string {
-	if strings.EqualFold(strings.TrimSpace(os.Getenv("ORKA_MEMORY_CONTEXT_ENABLED")), "false") {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv(workerenv.MemoryContextEnabled)), "false") {
 		return ""
 	}
 	if !memoryControllerConfigPresent() {
 		return ""
 	}
 
-	controllerURL := strings.TrimRight(strings.TrimSpace(os.Getenv("ORKA_CONTROLLER_URL")), "/")
-	namespace := strings.TrimSpace(os.Getenv("ORKA_TASK_NAMESPACE"))
+	controllerURL := strings.TrimRight(strings.TrimSpace(os.Getenv(workerenv.ControllerURL)), "/")
+	namespace := strings.TrimSpace(os.Getenv(workerenv.TaskNamespace))
 	limit := memoryContextLimit()
 
 	values := url.Values{}
@@ -460,7 +433,7 @@ func loadDurableMemoryContext(ctx context.Context) string {
 }
 
 func workerServiceAccountToken() string {
-	if token := strings.TrimSpace(os.Getenv("ORKA_SA_TOKEN")); token != "" {
+	if token := strings.TrimSpace(os.Getenv(workerenv.ServiceAccountToken)); token != "" {
 		return token
 	}
 	if data, err := os.ReadFile(serviceAccountTokenPath); err == nil {
@@ -471,7 +444,7 @@ func workerServiceAccountToken() string {
 
 func memoryContextLimit() int {
 	limit := defaultMemoryContextLimit
-	if raw := strings.TrimSpace(os.Getenv("ORKA_MEMORY_CONTEXT_LIMIT")); raw != "" {
+	if raw := strings.TrimSpace(os.Getenv(workerenv.MemoryContextLimit)); raw != "" {
 		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
 			limit = parsed
 		}
@@ -484,7 +457,7 @@ func memoryContextLimit() int {
 
 func memoryContextMaxChars() int {
 	maxChars := defaultMemoryContextMaxChars
-	if raw := strings.TrimSpace(os.Getenv("ORKA_MEMORY_CONTEXT_MAX_CHARS")); raw != "" {
+	if raw := strings.TrimSpace(os.Getenv(workerenv.MemoryContextMaxChars)); raw != "" {
 		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
 			maxChars = parsed
 		}
@@ -635,11 +608,11 @@ func getAPIKey(provider string) string {
 	// Check environment variables
 	switch provider {
 	case "anthropic":
-		if key := os.Getenv("ANTHROPIC_API_KEY"); key != "" {
+		if key := os.Getenv(workerenv.AnthropicAPIKey); key != "" {
 			return key
 		}
 	case "openai", "azure-openai":
-		if key := os.Getenv("OPENAI_API_KEY"); key != "" {
+		if key := os.Getenv(workerenv.OpenAIAPIKey); key != "" {
 			return key
 		}
 	}
@@ -703,9 +676,9 @@ func loadSessionContext() []llm.Message {
 
 // loadPlanContext fetches the current plan state from the controller API.
 func loadPlanContext() string {
-	controllerURL := os.Getenv("ORKA_CONTROLLER_URL")
-	taskName := os.Getenv("ORKA_TASK_NAME")
-	taskNamespace := os.Getenv("ORKA_TASK_NAMESPACE")
+	controllerURL := os.Getenv(workerenv.ControllerURL)
+	taskName := os.Getenv(workerenv.TaskName)
+	taskNamespace := os.Getenv(workerenv.TaskNamespace)
 
 	if controllerURL == "" || taskName == "" || taskNamespace == "" {
 		return ""
@@ -778,11 +751,12 @@ func executeAgentLoop(
 		baseToolCtx = baseToolCtxOpt[0]
 	}
 
+	coordinationEnv := workerenv.ParseCoordinationEnv(os.Getenv)
 	maxIterations := 10
-	if os.Getenv("ORKA_COORDINATION_ENABLED") == trueStr {
+	if coordinationEnv.Enabled {
 		maxIterations = 50
 	}
-	if os.Getenv("ORKA_AUTONOMOUS_MODE") == trueStr {
+	if coordinationEnv.AutonomousMode {
 		maxIterations = 100
 	}
 
@@ -869,7 +843,7 @@ func writeResult(result string) error {
 
 // loadSkillsFromVolume reads skill content from the mounted volume at /workspace/.skills/.
 func loadSkillsFromVolume() string {
-	skillsDir := os.Getenv("ORKA_SKILLS_DIR")
+	skillsDir := os.Getenv(workerenv.SkillsDir)
 	if skillsDir == "" {
 		skillsDir = "/workspace/.skills"
 	}

--- a/workers/common/agent_runtime.go
+++ b/workers/common/agent_runtime.go
@@ -9,7 +9,6 @@ package common
 import (
 	"context"
 	"fmt"
-	"github.com/sozercan/orka/internal/workerenv"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -17,6 +16,8 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/sozercan/orka/internal/workerenv"
 )
 
 // AgentConfig holds worker configuration from environment variables.

--- a/workers/common/agent_runtime.go
+++ b/workers/common/agent_runtime.go
@@ -9,6 +9,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"github.com/sozercan/orka/internal/workerenv"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -48,41 +49,41 @@ func LoadWorkspaceConfig() (*AgentConfig, error) {
 
 func loadConfig(defaultMaxTurns int, requirePrompt bool) (*AgentConfig, error) {
 	cfg := &AgentConfig{
-		TaskName:      os.Getenv("ORKA_TASK_NAME"),
-		TaskNamespace: os.Getenv("ORKA_TASK_NAMESPACE"),
-		Prompt:        os.Getenv("ORKA_PROMPT"),
-		Model:         os.Getenv("ORKA_MODEL"),
-		SystemPrompt:  os.Getenv("ORKA_SYSTEM_PROMPT"),
-		GitRepo:       os.Getenv("ORKA_GIT_REPO"),
-		GitBranch:     os.Getenv("ORKA_GIT_BRANCH"),
-		GitRef:        os.Getenv("ORKA_GIT_REF"),
-		SubPath:       os.Getenv("ORKA_WORKSPACE_SUBPATH"),
+		TaskName:      os.Getenv(workerenv.TaskName),
+		TaskNamespace: os.Getenv(workerenv.TaskNamespace),
+		Prompt:        os.Getenv(workerenv.Prompt),
+		Model:         os.Getenv(workerenv.Model),
+		SystemPrompt:  os.Getenv(workerenv.SystemPrompt),
+		GitRepo:       os.Getenv(workerenv.GitRepo),
+		GitBranch:     os.Getenv(workerenv.GitBranch),
+		GitRef:        os.Getenv(workerenv.GitRef),
+		SubPath:       os.Getenv(workerenv.WorkspaceSubpath),
 		MaxTurns:      defaultMaxTurns,
 	}
 
 	if requirePrompt && cfg.Prompt == "" {
-		return nil, fmt.Errorf("ORKA_PROMPT is required")
+		return nil, fmt.Errorf("%s is required", workerenv.Prompt)
 	}
 
-	if v := os.Getenv("ORKA_MAX_TURNS"); v != "" {
+	if v := os.Getenv(workerenv.MaxTurns); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil {
-			return nil, fmt.Errorf("invalid ORKA_MAX_TURNS: %w", err)
+			return nil, fmt.Errorf("invalid %s: %w", workerenv.MaxTurns, err)
 		}
 		cfg.MaxTurns = n
 	}
 
-	if v := os.Getenv("ORKA_ALLOWED_TOOLS"); v != "" {
+	if v := os.Getenv(workerenv.AllowedTools); v != "" {
 		cfg.AllowedTools = strings.Split(v, ",")
 	}
-	if v := os.Getenv("ORKA_DISALLOWED_TOOLS"); v != "" {
+	if v := os.Getenv(workerenv.DisallowedTools); v != "" {
 		cfg.DisallowedTools = strings.Split(v, ",")
 	}
 
-	if v := os.Getenv("ORKA_TIMEOUT_SECONDS"); v != "" {
+	if v := os.Getenv(workerenv.TimeoutSeconds); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil {
-			return nil, fmt.Errorf("invalid ORKA_TIMEOUT_SECONDS: %w", err)
+			return nil, fmt.Errorf("invalid %s: %w", workerenv.TimeoutSeconds, err)
 		}
 		cfg.TimeoutSeconds = n
 	}
@@ -91,7 +92,7 @@ func loadConfig(defaultMaxTurns int, requirePrompt bool) (*AgentConfig, error) {
 	if cfg.SubPath != "" {
 		cleaned := filepath.Clean(cfg.SubPath)
 		if filepath.IsAbs(cleaned) || strings.HasPrefix(cleaned, "..") {
-			return nil, fmt.Errorf("ORKA_WORKSPACE_SUBPATH %q contains path traversal", cfg.SubPath)
+			return nil, fmt.Errorf("%s %q contains path traversal", workerenv.WorkspaceSubpath, cfg.SubPath)
 		}
 		cfg.SubPath = cleaned
 	}
@@ -111,9 +112,9 @@ func SetupGitCredentials() {
 		if data, err := os.ReadFile(path); err == nil {
 			token := strings.TrimSpace(string(data))
 			if token != "" {
-				os.Setenv("GIT_TOKEN", token)               //nolint:errcheck
-				os.Setenv("GITHUB_TOKEN", token)            //nolint:errcheck
-				os.Setenv("GIT_ASKPASS", "/bin/echo-token") //nolint:errcheck
+				os.Setenv(workerenv.GitToken, token)               //nolint:errcheck
+				os.Setenv(workerenv.GitHubToken, token)            //nolint:errcheck
+				os.Setenv(workerenv.GitAskpass, "/bin/echo-token") //nolint:errcheck
 				break
 			}
 		}
@@ -121,7 +122,7 @@ func SetupGitCredentials() {
 	if data, err := os.ReadFile("/secrets/git/username"); err == nil {
 		username := strings.TrimSpace(string(data))
 		if username != "" {
-			os.Setenv("GIT_USERNAME", username) //nolint:errcheck
+			os.Setenv(workerenv.GitUsername, username) //nolint:errcheck
 		}
 	}
 }

--- a/workers/common/artifacts.go
+++ b/workers/common/artifacts.go
@@ -9,6 +9,7 @@ package common
 import (
 	"bytes"
 	"fmt"
+	"github.com/sozercan/orka/internal/workerenv"
 	"io"
 	"net/http"
 	"net/url"
@@ -201,23 +202,23 @@ func UploadArtifacts() error {
 }
 
 func artifactEndpointBase() (string, error) {
-	controllerURL := os.Getenv("ORKA_CONTROLLER_URL")
+	controllerURL := os.Getenv(workerenv.ControllerURL)
 	if controllerURL == "" {
-		return "", fmt.Errorf("ORKA_CONTROLLER_URL must be set")
+		return "", fmt.Errorf("%s must be set", workerenv.ControllerURL)
 	}
 
-	namespace := os.Getenv("ORKA_TASK_NAMESPACE")
+	namespace := os.Getenv(workerenv.TaskNamespace)
 	if namespace == "" {
 		data, err := os.ReadFile(saNamespacePath)
 		if err != nil {
-			return "", fmt.Errorf("ORKA_TASK_NAMESPACE not set and cannot read namespace from SA: %w", err)
+			return "", fmt.Errorf("%s not set and cannot read namespace from SA: %w", workerenv.TaskNamespace, err)
 		}
 		namespace = strings.TrimSpace(string(data))
 	}
 
-	taskName := os.Getenv("ORKA_TASK_NAME")
+	taskName := os.Getenv(workerenv.TaskName)
 	if taskName == "" {
-		return "", fmt.Errorf("ORKA_TASK_NAME must be set")
+		return "", fmt.Errorf("%s must be set", workerenv.TaskName)
 	}
 
 	controllerURL = strings.TrimRight(controllerURL, "/")

--- a/workers/common/artifacts.go
+++ b/workers/common/artifacts.go
@@ -9,7 +9,6 @@ package common
 import (
 	"bytes"
 	"fmt"
-	"github.com/sozercan/orka/internal/workerenv"
 	"io"
 	"net/http"
 	"net/url"
@@ -17,6 +16,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/sozercan/orka/internal/workerenv"
 )
 
 const (

--- a/workers/common/result.go
+++ b/workers/common/result.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/sozercan/orka/internal/workerenv"
 	"io"
 	"net/http"
 	"os"
@@ -59,29 +60,29 @@ func SubmitResult(result []byte) error {
 
 func resultEndpoint() (string, error) {
 	// Prefer explicit endpoint
-	if ep := os.Getenv("ORKA_RESULT_ENDPOINT"); ep != "" {
+	if ep := os.Getenv(workerenv.ResultEndpoint); ep != "" {
 		return ep, nil
 	}
 
 	// Construct from controller URL + task identity
-	controllerURL := os.Getenv("ORKA_CONTROLLER_URL")
+	controllerURL := os.Getenv(workerenv.ControllerURL)
 	if controllerURL == "" {
-		return "", fmt.Errorf("ORKA_RESULT_ENDPOINT or ORKA_CONTROLLER_URL must be set")
+		return "", fmt.Errorf("%s or %s must be set", workerenv.ResultEndpoint, workerenv.ControllerURL)
 	}
 
-	namespace := os.Getenv("ORKA_TASK_NAMESPACE")
+	namespace := os.Getenv(workerenv.TaskNamespace)
 	if namespace == "" {
 		// Fall back to downward API namespace file
 		data, err := os.ReadFile(saNamespacePath)
 		if err != nil {
-			return "", fmt.Errorf("ORKA_TASK_NAMESPACE not set and cannot read namespace from SA: %w", err)
+			return "", fmt.Errorf("%s not set and cannot read namespace from SA: %w", workerenv.TaskNamespace, err)
 		}
 		namespace = strings.TrimSpace(string(data))
 	}
 
-	taskName := os.Getenv("ORKA_TASK_NAME")
+	taskName := os.Getenv(workerenv.TaskName)
 	if taskName == "" {
-		return "", fmt.Errorf("ORKA_TASK_NAME must be set")
+		return "", fmt.Errorf("%s must be set", workerenv.TaskName)
 	}
 
 	controllerURL = strings.TrimRight(controllerURL, "/")

--- a/workers/common/result.go
+++ b/workers/common/result.go
@@ -10,12 +10,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/sozercan/orka/internal/workerenv"
 	"io"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/sozercan/orka/internal/workerenv"
 )
 
 const (

--- a/workers/common/workspace.go
+++ b/workers/common/workspace.go
@@ -9,6 +9,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/sozercan/orka/internal/workerenv"
 	"io"
 	"net/http"
 	"os"
@@ -18,7 +19,7 @@ import (
 	"time"
 )
 
-const requirePushBranchEnvVar = "ORKA_REQUIRE_PUSH_BRANCH"
+const requirePushBranchEnvVar = workerenv.RequirePushBranch
 
 var waitForRemoteBranchVisibility = waitForRemoteBranchVisibilityWithGit
 
@@ -26,19 +27,19 @@ var waitForRemoteBranchVisibility = waitForRemoteBranchVisibilityWithGit
 // directory. It is called after git clone and before the LLM agent starts.
 // If ORKA_PRIOR_TASK is not set the function is a no-op.
 func PrepareWorkspace(workDir string) error {
-	priorTask := os.Getenv("ORKA_PRIOR_TASK")
+	priorTask := os.Getenv(workerenv.PriorTask)
 	if priorTask == "" {
 		return nil
 	}
 
-	ns := os.Getenv("ORKA_PRIOR_TASK_NAMESPACE")
+	ns := os.Getenv(workerenv.PriorTaskNamespace)
 	if ns == "" {
-		ns = os.Getenv("ORKA_TASK_NAMESPACE")
+		ns = os.Getenv(workerenv.TaskNamespace)
 	}
 
-	controllerURL := os.Getenv("ORKA_CONTROLLER_URL")
+	controllerURL := os.Getenv(workerenv.ControllerURL)
 	if controllerURL == "" {
-		return fmt.Errorf("ORKA_CONTROLLER_URL must be set when ORKA_PRIOR_TASK is specified")
+		return fmt.Errorf("%s must be set when %s is specified", workerenv.ControllerURL, workerenv.PriorTask)
 	}
 	controllerURL = strings.TrimRight(controllerURL, "/")
 
@@ -160,15 +161,15 @@ func FinalizeResult(workDir string, agentOutput string) ([]byte, error) {
 	}
 
 	// Auto-push if ORKA_PUSH_BRANCH is set and there are changes.
-	pushBranch := os.Getenv("ORKA_PUSH_BRANCH")
+	pushBranch := os.Getenv(workerenv.PushBranch)
 	requirePushBranch := strings.EqualFold(os.Getenv(requirePushBranchEnvVar), "true")
 	if requirePushBranch && pushBranch == "" {
-		return nil, fmt.Errorf("%s is true but ORKA_PUSH_BRANCH is empty", requirePushBranchEnvVar)
+		return nil, fmt.Errorf("%s is true but %s is empty", requirePushBranchEnvVar, workerenv.PushBranch)
 	}
 	if pushBranch != "" {
 		if diff == "" {
 			if requirePushBranch {
-				return nil, fmt.Errorf("ORKA_PUSH_BRANCH=%s but no workspace diff was produced", pushBranch)
+				return nil, fmt.Errorf("%s=%s but no workspace diff was produced", workerenv.PushBranch, pushBranch)
 			}
 		} else if pushErr := pushChanges(workDir, pushBranch); pushErr != nil {
 			sr.PushError = pushErr.Error()

--- a/workers/common/workspace.go
+++ b/workers/common/workspace.go
@@ -9,7 +9,6 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sozercan/orka/internal/workerenv"
 	"io"
 	"net/http"
 	"os"
@@ -17,6 +16,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/sozercan/orka/internal/workerenv"
 )
 
 const requirePushBranchEnvVar = workerenv.RequirePushBranch

--- a/workers/general/main.go
+++ b/workers/general/main.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/sozercan/orka/internal/workerenv"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -47,7 +48,7 @@ func run() error {
 	if len(os.Args) > 1 {
 		command = os.Args[1:]
 	} else {
-		cmdStr := os.Getenv("ORKA_COMMAND")
+		cmdStr := os.Getenv(workerenv.Command)
 		if cmdStr == "" {
 			return fmt.Errorf("no command specified")
 		}
@@ -95,7 +96,7 @@ func run() error {
 }
 
 func prepareWorkspaceIfConfigured(ctx context.Context) (string, error) {
-	if os.Getenv("ORKA_GIT_REPO") == "" {
+	if os.Getenv(workerenv.GitRepo) == "" {
 		return "", nil
 	}
 	if _, err := os.Stat(filepath.Join(workspaceDir, ".git")); err == nil {
@@ -131,14 +132,14 @@ func prepareWorkspace(ctx context.Context) error {
 }
 
 func workspaceRoot() string {
-	if subPath := os.Getenv("ORKA_WORKSPACE_SUBPATH"); subPath != "" {
+	if subPath := os.Getenv(workerenv.WorkspaceSubpath); subPath != "" {
 		return filepath.Join(workspaceDir, subPath)
 	}
 	return workspaceDir
 }
 
 func submitResult(workDir, output string) error {
-	if os.Getenv("ORKA_RESULT_ENDPOINT") == "" && os.Getenv("ORKA_CONTROLLER_URL") == "" {
+	if os.Getenv(workerenv.ResultEndpoint) == "" && os.Getenv(workerenv.ControllerURL) == "" {
 		return nil
 	}
 	resultDir := ""

--- a/workers/general/main.go
+++ b/workers/general/main.go
@@ -10,13 +10,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/sozercan/orka/internal/workerenv"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	"github.com/sozercan/orka/internal/workerenv"
 
 	"github.com/sozercan/orka/workers/common"
 )


### PR DESCRIPTION
## Summary

- add `internal/workerenv` as the centralized worker environment-variable contract
- replace scattered raw worker/tool env-var strings with shared constants/helpers
- add tests for env rendering/parsing and fallback behavior

## Tests

```bash
go test ./internal/workerenv ./workers/common ./workers/agent/claude ./workers/agent/codex ./workers/agent/copilot ./workers/ai ./internal/tools ./internal/api ./cmd
```