### PR TITLE
Remove broken skill symlink aliases

### DIFF
--- a/.claude/skills/copilot-proxy-kind-deploy
+++ b/.claude/skills/copilot-proxy-kind-deploy
@@ -1,1 +1,0 @@
-../../.codex/skills/copilot-proxy-kind-deploy

--- a/.copilot/skills/copilot-proxy-kind-deploy
+++ b/.copilot/skills/copilot-proxy-kind-deploy
@@ -1,1 +1,0 @@
-../../.codex/skills/copilot-proxy-kind-deploy


### PR DESCRIPTION
## Summary
- Remove stale `.claude` and `.copilot` aliases for the missing `copilot-proxy-kind-deploy` skill
- Keep `orka-kind-deploy` as the only valid deploy skill

## Verification
- Verified no broken symlinks remain under `.claude/skills`, `.copilot/skills`, and `.codex/skills`
