### PR TITLE
Fix terminal task and repository scan cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,6 +23,11 @@
 !ui/public/**
 !ui/src/
 !ui/src/**
+ui/node_modules
+ui/node_modules/**
+ui/dist
+ui/dist/**
+ui/tsconfig.tsbuildinfo
 
 # Re-include pre-built UI assets for embed
 !internal/uiembed/dist/

--- a/Makefile
+++ b/Makefile
@@ -115,11 +115,11 @@ test-e2e-run-only: manifests generate fmt vet ## Run e2e tests without rebuildin
 	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -timeout $(E2E_GO_TEST_TIMEOUT) -v -ginkgo.v
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter
+lint: ensure-ui-embed golangci-lint ## Run golangci-lint linter
 	"$(GOLANGCI_LINT)" run
 
 .PHONY: lint-fix
-lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
+lint-fix: ensure-ui-embed golangci-lint ## Run golangci-lint linter and perform fixes
 	"$(GOLANGCI_LINT)" run --fix
 
 .PHONY: lint-config

--- a/internal/api/security_handlers.go
+++ b/internal/api/security_handlers.go
@@ -680,6 +680,9 @@ func (h *Handlers) ListSecurityFindings(c fiber.Ctx) error {
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to list findings: %v", err))
 	}
+	if findings == nil {
+		findings = []store.Finding{}
+	}
 
 	for i := range findings {
 		if findings[i].ScanRunID == "" {

--- a/internal/api/security_handlers_test.go
+++ b/internal/api/security_handlers_test.go
@@ -689,6 +689,31 @@ func TestSecurityScanRunAndFindingLists_ContextTokenRepositoryScanAuthorizationD
 	}
 }
 
+func TestListSecurityFindingsReturnsEmptyItemsArray(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+	ctxTokenConfig := testContextTokenConfig(t, provider, "")
+	app, _ := setupSecurityHandlersWithAuthzFixture(
+		t,
+		ctxTokenConfig,
+		ContextTokenAuthorizationModeEnforce,
+		securityAuthzTestRepositoryScan("scan-1", securityTestRepoURL),
+	)
+	token := issueTestContextToken(t, provider, nil, map[string]any{
+		"scope": ContextTokenScopeSecurityRead,
+		"tctx":  securityAuthzTestTctx(securityTestRepoURL),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/security/repositories/scan-1/findings?namespace=demo", nil)
+	req.Header.Set(KontxtHeaderName, token)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]json.RawMessage
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	require.JSONEq(t, "[]", string(body["items"]))
+}
+
 func TestGetSecurityFinding_ContextTokenAuthorizesFindingRepositoryScan(t *testing.T) {
 	provider := newTestOIDCProvider(t)
 	ctxTokenConfig := testContextTokenConfig(t, provider, "")

--- a/internal/controller/repositoryscan_controller.go
+++ b/internal/controller/repositoryscan_controller.go
@@ -1354,9 +1354,6 @@ func (r *RepositoryScanReconciler) ingestThreatModelTask(ctx context.Context, sc
 		run.ErrorMessage = r.pipelineTaskSummary(ctx, task, "threat model stage failed")
 	}
 
-	if !updateStatus {
-		return r.refreshScanRunStatus(ctx, scan, run, run.ID, false)
-	}
 	return r.refreshScanRunStatus(ctx, scan, run, run.ID, updateStatus)
 }
 
@@ -1423,9 +1420,6 @@ func (r *RepositoryScanReconciler) ingestDiscoveryTask(ctx context.Context, scan
 		run.ErrorMessage = r.pipelineTaskSummary(ctx, task, "discovery stage failed")
 	}
 
-	if !updateStatus {
-		return r.refreshScanRunStatus(ctx, scan, run, run.ID, false)
-	}
 	return r.refreshScanRunStatus(ctx, scan, run, run.ID, updateStatus)
 }
 

--- a/internal/controller/repositoryscan_controller.go
+++ b/internal/controller/repositoryscan_controller.go
@@ -561,10 +561,14 @@ func (r *RepositoryScanReconciler) ingestOwnedTasks(ctx context.Context, scan *c
 	}
 
 	slices.SortFunc(tasks.Items, func(a, b corev1alpha1.Task) int {
-		return a.CreationTimestamp.Compare(b.CreationTimestamp.Time)
+		if cmp := a.CreationTimestamp.Compare(b.CreationTimestamp.Time); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.Name, b.Name)
 	})
 
 	latestScanRunID := latestOwnedScanPipelineRunID(tasks.Items)
+	refreshLatestScanRun := false
 
 	for i := range tasks.Items {
 		task := &tasks.Items[i]
@@ -588,10 +592,20 @@ func (r *RepositoryScanReconciler) ingestOwnedTasks(ctx context.Context, scan *c
 			continue
 		}
 
-		updateStatus := latestScanRunID != "" && scanTaskRunID(task) == latestScanRunID
-		if err := r.ingestScanTask(ctx, scan, task, updateStatus); err != nil {
+		if latestScanRunID != "" && scanTaskRunID(task) == latestScanRunID {
+			refreshLatestScanRun = true
+		}
+		if err := r.ingestScanTask(ctx, scan, task, false); err != nil {
 			return err
 		}
+	}
+
+	if refreshLatestScanRun {
+		run, err := r.SecurityStore.GetScanRun(ctx, scan.Namespace, latestScanRunID)
+		if err != nil {
+			return err
+		}
+		return r.refreshScanRunStatus(ctx, scan, run, latestScanRunID, true)
 	}
 
 	return nil
@@ -895,19 +909,28 @@ func pipelineTaskDisplayName(task *corev1alpha1.Task) string {
 }
 
 type scanRunProgress struct {
+	hasPipelineTask     bool
 	hasActive           bool
 	hasThreatModelReady bool
 	hasDiscovery        bool
+	hasCombined         bool
 	discoveryCount      int
 	discoverySucceeded  int
 	failedStages        []string
+	failureMessage      string
 	latestCompletion    *time.Time
+}
+
+func recordScanProgressFailure(progress *scanRunProgress, task *corev1alpha1.Task, message string) {
+	progress.failedStages = append(progress.failedStages, pipelineTaskDisplayName(task))
+	if progress.failureMessage == "" {
+		progress.failureMessage = message
+	}
 }
 
 func (r *RepositoryScanReconciler) collectScanRunProgress(
 	ctx context.Context,
 	tasks []corev1alpha1.Task,
-	run *store.ScanRun,
 ) scanRunProgress {
 	progress := scanRunProgress{}
 	for i := range tasks {
@@ -916,6 +939,7 @@ func (r *RepositoryScanReconciler) collectScanRunProgress(
 		if !isScanPipelineStage(stage) {
 			continue
 		}
+		progress.hasPipelineTask = true
 		if isActiveTaskPhase(task.Status.Phase) {
 			progress.hasActive = true
 		}
@@ -931,22 +955,19 @@ func (r *RepositoryScanReconciler) collectScanRunProgress(
 				progress.hasThreatModelReady = true
 			}
 			if task.Status.Phase == corev1alpha1.TaskPhaseFailed {
-				progress.failedStages = append(progress.failedStages, pipelineTaskDisplayName(task))
-				if run.ErrorMessage == "" {
-					run.ErrorMessage = r.pipelineTaskSummary(ctx, task, "threat model stage failed")
-				}
+				recordScanProgressFailure(&progress, task, r.pipelineTaskSummary(ctx, task, "threat model stage failed"))
 			}
 		case security.StageDiscovery, security.StageCombined:
+			if stage == security.StageCombined {
+				progress.hasCombined = true
+			}
 			progress.hasDiscovery = true
 			progress.discoveryCount++
 			if task.Status.Phase == corev1alpha1.TaskPhaseSucceeded {
 				progress.discoverySucceeded++
 			}
 			if task.Status.Phase == corev1alpha1.TaskPhaseFailed {
-				progress.failedStages = append(progress.failedStages, pipelineTaskDisplayName(task))
-				if run.ErrorMessage == "" {
-					run.ErrorMessage = r.pipelineTaskSummary(ctx, task, "discovery stage failed")
-				}
+				recordScanProgressFailure(&progress, task, r.pipelineTaskSummary(ctx, task, "discovery stage failed"))
 			}
 		}
 	}
@@ -967,12 +988,18 @@ func applyScanRunProgress(run *store.ScanRun, progress scanRunProgress) {
 		return
 	}
 
-	if run.ErrorMessage != "" || len(progress.failedStages) > 0 {
+	storedFailureMessage := ""
+	if !progress.hasPipelineTask {
+		storedFailureMessage = run.ErrorMessage
+	}
+	if progress.failureMessage != "" || run.ErrorMessage != "" || storedFailureMessage != "" || len(progress.failedStages) > 0 {
 		run.Phase = scanRunPhaseFailed
 		if progress.latestCompletion != nil {
 			run.CompletedAt = progress.latestCompletion
 		}
-		if run.ErrorMessage == "" {
+		if progress.failureMessage != "" {
+			run.ErrorMessage = progress.failureMessage
+		} else if run.ErrorMessage == "" {
 			run.ErrorMessage = fmt.Sprintf(
 				"scan failed in stages: %s",
 				strings.Join(progress.failedStages, ", "),
@@ -985,8 +1012,24 @@ func applyScanRunProgress(run *store.ScanRun, progress scanRunProgress) {
 	if progress.hasThreatModelReady && !progress.hasDiscovery {
 		run.Phase = scanRunPhaseRunning
 		run.CompletedAt = nil
+		run.ErrorMessage = ""
 		run.Summary = scanSummaryThreatModelPending
 		return
+	}
+
+	if progress.hasThreatModelReady && progress.hasDiscovery && !progress.hasCombined {
+		expectedDiscoveryCount := len(security.DiscoveryScopes())
+		if expectedDiscoveryCount > 0 && progress.discoveryCount < expectedDiscoveryCount {
+			run.Phase = scanRunPhaseRunning
+			run.CompletedAt = nil
+			run.ErrorMessage = ""
+			run.Summary = fmt.Sprintf(
+				"Threat model generated and %d/%d discovery scopes completed successfully",
+				progress.discoverySucceeded,
+				expectedDiscoveryCount,
+			)
+			return
+		}
 	}
 
 	run.Phase = scanRunPhaseSucceeded
@@ -1035,8 +1078,15 @@ func (r *RepositoryScanReconciler) refreshScanRunStatus(
 	); err != nil {
 		return err
 	}
+	slices.SortFunc(tasks.Items, func(a, b corev1alpha1.Task) int {
+		if cmp := a.CreationTimestamp.Compare(b.CreationTimestamp.Time); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
 
-	applyScanRunProgress(run, r.collectScanRunProgress(ctx, tasks.Items, run))
+	progress := r.collectScanRunProgress(ctx, tasks.Items)
+	applyScanRunProgress(run, progress)
 
 	if err := r.SecurityStore.UpdateScanRun(ctx, run); err != nil {
 		return err
@@ -1266,6 +1316,9 @@ func (r *RepositoryScanReconciler) ingestThreatModelTask(ctx context.Context, sc
 		run.ErrorMessage = r.pipelineTaskSummary(ctx, task, "threat model stage failed")
 	}
 
+	if !updateStatus {
+		return r.SecurityStore.UpdateScanRun(ctx, run)
+	}
 	return r.refreshScanRunStatus(ctx, scan, run, run.ID, updateStatus)
 }
 
@@ -1331,6 +1384,9 @@ func (r *RepositoryScanReconciler) ingestDiscoveryTask(ctx context.Context, scan
 		run.ErrorMessage = r.pipelineTaskSummary(ctx, task, "discovery stage failed")
 	}
 
+	if !updateStatus {
+		return r.SecurityStore.UpdateScanRun(ctx, run)
+	}
 	return r.refreshScanRunStatus(ctx, scan, run, run.ID, updateStatus)
 }
 
@@ -1479,10 +1535,23 @@ func applyCombinedScanPhaseStatus(s *corev1alpha1.RepositoryScan, effectivePhase
 	})
 }
 
+func isTerminalScanRun(run *store.ScanRun) bool {
+	if run == nil || run.CompletedAt == nil {
+		return false
+	}
+	return run.Phase == scanRunPhaseSucceeded || run.Phase == scanRunPhaseFailed
+}
+
 func (r *RepositoryScanReconciler) ingestScanTask(ctx context.Context, scan *corev1alpha1.RepositoryScan, task *corev1alpha1.Task, updateStatus bool) error {
 	run, err := r.getOrCreateScanRun(ctx, scan, task)
 	if err != nil {
 		return err
+	}
+	if isTerminalScanRun(run) {
+		if updateStatus {
+			return r.refreshScanRunStatus(ctx, scan, run, run.ID, true)
+		}
+		return nil
 	}
 
 	switch taskSecurityStage(task) {

--- a/internal/controller/repositoryscan_controller.go
+++ b/internal/controller/repositoryscan_controller.go
@@ -1287,6 +1287,44 @@ func (r *RepositoryScanReconciler) enqueueAutoValidationTasks(ctx context.Contex
 	return nil
 }
 
+func clearRunError(run *store.ScanRun) {
+	if run == nil {
+		return
+	}
+	if run.Summary == run.ErrorMessage {
+		run.Summary = ""
+	}
+	run.ErrorMessage = ""
+}
+
+func clearThreatModelRunError(run *store.ScanRun) {
+	if run == nil || run.ErrorMessage == "" {
+		return
+	}
+	if strings.Contains(run.ErrorMessage, security.ArtifactThreatModel) ||
+		strings.Contains(run.ErrorMessage, "threat model stage failed") {
+		clearRunError(run)
+	}
+}
+
+func clearDiscoveryRunError(run *store.ScanRun, scope string) {
+	if run == nil || run.ErrorMessage == "" {
+		return
+	}
+	if scope != "" {
+		if strings.Contains(run.ErrorMessage, fmt.Sprintf("scope %s:", scope)) {
+			clearRunError(run)
+		}
+		if strings.Contains(run.ErrorMessage, "scope ") {
+			return
+		}
+	}
+	if strings.Contains(run.ErrorMessage, security.ArtifactFindings) ||
+		strings.Contains(run.ErrorMessage, "discovery stage failed") {
+		clearRunError(run)
+	}
+}
+
 func (r *RepositoryScanReconciler) ingestThreatModelTask(ctx context.Context, scan *corev1alpha1.RepositoryScan, task *corev1alpha1.Task, run *store.ScanRun, updateStatus bool) error {
 	run.TaskName = task.Name
 	if mode := task.Labels[labels.LabelSecurityMode]; mode != "" {
@@ -1304,6 +1342,7 @@ func (r *RepositoryScanReconciler) ingestThreatModelTask(ctx context.Context, sc
 			if err := r.persistThreatModelIfChanged(ctx, scan, run.ID, run.StartedAt, threatModel); err != nil {
 				return err
 			}
+			clearThreatModelRunError(run)
 			run.Summary = scanSummaryThreatModelPending
 		}
 	} else {
@@ -1311,7 +1350,7 @@ func (r *RepositoryScanReconciler) ingestThreatModelTask(ctx context.Context, sc
 	}
 
 	if !updateStatus {
-		return r.SecurityStore.UpdateScanRun(ctx, run)
+		return r.refreshScanRunStatus(ctx, scan, run, run.ID, false)
 	}
 	return r.refreshScanRunStatus(ctx, scan, run, run.ID, updateStatus)
 }
@@ -1330,6 +1369,7 @@ func (r *RepositoryScanReconciler) ingestDiscoveryTask(ctx context.Context, scan
 				run.ErrorMessage = validationProblem
 			}
 		} else if findingsArtifact != nil {
+			clearDiscoveryRunError(run, strings.TrimSpace(task.Labels[labels.LabelSecurityScope]))
 			if findingsArtifact.Scan.Mode != "" {
 				run.Mode = findingsArtifact.Scan.Mode
 			}
@@ -1379,7 +1419,7 @@ func (r *RepositoryScanReconciler) ingestDiscoveryTask(ctx context.Context, scan
 	}
 
 	if !updateStatus {
-		return r.SecurityStore.UpdateScanRun(ctx, run)
+		return r.refreshScanRunStatus(ctx, scan, run, run.ID, false)
 	}
 	return r.refreshScanRunStatus(ctx, scan, run, run.ID, updateStatus)
 }
@@ -1529,23 +1569,10 @@ func applyCombinedScanPhaseStatus(s *corev1alpha1.RepositoryScan, effectivePhase
 	})
 }
 
-func isTerminalScanRun(run *store.ScanRun) bool {
-	if run == nil || run.CompletedAt == nil {
-		return false
-	}
-	return run.Phase == scanRunPhaseSucceeded || run.Phase == scanRunPhaseFailed
-}
-
 func (r *RepositoryScanReconciler) ingestScanTask(ctx context.Context, scan *corev1alpha1.RepositoryScan, task *corev1alpha1.Task, updateStatus bool) error {
 	run, err := r.getOrCreateScanRun(ctx, scan, task)
 	if err != nil {
 		return err
-	}
-	if isTerminalScanRun(run) {
-		if updateStatus {
-			return r.refreshScanRunStatus(ctx, scan, run, run.ID, true)
-		}
-		return nil
 	}
 
 	switch taskSecurityStage(task) {

--- a/internal/controller/repositoryscan_controller.go
+++ b/internal/controller/repositoryscan_controller.go
@@ -909,7 +909,6 @@ func pipelineTaskDisplayName(task *corev1alpha1.Task) string {
 }
 
 type scanRunProgress struct {
-	hasPipelineTask     bool
 	hasActive           bool
 	hasThreatModelReady bool
 	hasDiscovery        bool
@@ -939,7 +938,6 @@ func (r *RepositoryScanReconciler) collectScanRunProgress(
 		if !isScanPipelineStage(stage) {
 			continue
 		}
-		progress.hasPipelineTask = true
 		if isActiveTaskPhase(task.Status.Phase) {
 			progress.hasActive = true
 		}
@@ -988,11 +986,7 @@ func applyScanRunProgress(run *store.ScanRun, progress scanRunProgress) {
 		return
 	}
 
-	storedFailureMessage := ""
-	if !progress.hasPipelineTask {
-		storedFailureMessage = run.ErrorMessage
-	}
-	if progress.failureMessage != "" || run.ErrorMessage != "" || storedFailureMessage != "" || len(progress.failedStages) > 0 {
+	if progress.failureMessage != "" || run.ErrorMessage != "" || len(progress.failedStages) > 0 {
 		run.Phase = scanRunPhaseFailed
 		if progress.latestCompletion != nil {
 			run.CompletedAt = progress.latestCompletion

--- a/internal/controller/repositoryscan_controller.go
+++ b/internal/controller/repositoryscan_controller.go
@@ -592,10 +592,15 @@ func (r *RepositoryScanReconciler) ingestOwnedTasks(ctx context.Context, scan *c
 			continue
 		}
 
+		updateStatus := false
 		if latestScanRunID != "" && scanTaskRunID(task) == latestScanRunID {
-			refreshLatestScanRun = true
+			if stage == security.StageCombined {
+				updateStatus = true
+			} else {
+				refreshLatestScanRun = true
+			}
 		}
-		if err := r.ingestScanTask(ctx, scan, task, false); err != nil {
+		if err := r.ingestScanTask(ctx, scan, task, updateStatus); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/repositoryscan_controller_test.go
+++ b/internal/controller/repositoryscan_controller_test.go
@@ -177,7 +177,6 @@ func saveTestFindingsArtifact(
 	store storepkg.ArtifactStore,
 	namespace string,
 	taskName string,
-	mode string,
 	headSHA string,
 ) {
 	t.Helper()
@@ -191,7 +190,7 @@ func saveTestFindingsArtifact(
 			BaseSHA: "base-" + headSHA,
 		},
 		Scan: security.FindingsArtifactScan{
-			Mode:    mode,
+			Mode:    "initial",
 			Summary: "No findings",
 		},
 		Findings: []security.FindingsArtifactFinding{},
@@ -202,6 +201,221 @@ func saveTestFindingsArtifact(
 	}
 	if err := store.SaveArtifact(ctx, namespace, taskName, security.ArtifactFindings, "application/json", data); err != nil {
 		t.Fatalf("SaveArtifact(%s) error = %v", taskName, err)
+	}
+}
+
+func saveTestFindingsArtifactWithFinding(
+	t *testing.T,
+	ctx context.Context,
+	store storepkg.ArtifactStore,
+	namespace string,
+	taskName string,
+	headSHA string,
+	fingerprint string,
+) {
+	t.Helper()
+
+	findings := security.FindingsArtifact{
+		Version: 1,
+		Repository: security.FindingsArtifactRepo{
+			RepoURL: "https://github.com/example/repo",
+			Branch:  "main",
+			HeadSHA: headSHA,
+			BaseSHA: "base-" + headSHA,
+		},
+		Scan: security.FindingsArtifactScan{
+			Mode:    "initial",
+			Summary: "One finding",
+		},
+		Findings: []security.FindingsArtifactFinding{{
+			Fingerprint:      fingerprint,
+			Title:            "Late artifact finding",
+			Summary:          "Finding persisted after terminal run re-ingest",
+			Severity:         "high",
+			Confidence:       "high",
+			ValidationStatus: "unvalidated",
+			FilePath:         "app/routes/index.js",
+			Line:             42,
+			RootCause:        "late artifact",
+			Remediation:      "fix it",
+			SuggestedAction:  "patch",
+		}},
+	}
+	data, err := json.Marshal(findings)
+	if err != nil {
+		t.Fatalf("json.Marshal(findings) error = %v", err)
+	}
+	if err := store.SaveArtifact(ctx, namespace, taskName, security.ArtifactFindings, "application/json", data); err != nil {
+		t.Fatalf("SaveArtifact(%s) error = %v", taskName, err)
+	}
+}
+
+func newSucceededSecurityTask(name, scanName, scanID, stage, scope string, completed metav1.Time) *corev1alpha1.Task {
+	labelsMap := map[string]string{
+		labels.LabelSecurityTarget: scanName,
+		labels.LabelSecurityScanID: scanID,
+		labels.LabelSecurityStage:  stage,
+	}
+	if scope != "" {
+		labelsMap[labels.LabelSecurityScope] = scope
+	}
+	return &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    labelsMap,
+		},
+		Status: corev1alpha1.TaskStatus{
+			Phase:          corev1alpha1.TaskPhaseSucceeded,
+			CompletionTime: &completed,
+		},
+	}
+}
+
+func TestIngestScanTaskRefreshesNonLatestSplitRun(t *testing.T) {
+	ctx := context.Background()
+	secStore := setupControllerSQLiteStore(t)
+	scheme := runtime.NewScheme()
+	if err := corev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	scanName := "split-nonlatest"
+	scanID := "scan_split_nonlatest"
+	scan := &corev1alpha1.RepositoryScan{
+		TypeMeta:   metav1.TypeMeta{APIVersion: corev1alpha1.GroupVersion.String(), Kind: "RepositoryScan"},
+		ObjectMeta: metav1.ObjectMeta{Name: scanName, Namespace: "default"},
+		Spec:       corev1alpha1.RepositoryScanSpec{RepoURL: "https://github.com/example/repo", AnalysisAgentRef: corev1alpha1.AgentReference{Name: "a"}},
+	}
+	completed := metav1.NewTime(mustParseTime(t, "2026-05-10T10:00:00Z"))
+	threatTask := newSucceededSecurityTask("split-nonlatest-threat", scanName, scanID, security.StageThreatModel, "", completed)
+	objects := []client.Object{scan, threatTask}
+	discoveryTasks := []*corev1alpha1.Task{}
+	for index, scope := range security.DiscoveryScopes() {
+		task := newSucceededSecurityTask(
+			fmt.Sprintf("split-nonlatest-discovery-%d", index),
+			scanName,
+			scanID,
+			security.StageDiscovery,
+			scope.Name,
+			completed,
+		)
+		objects = append(objects, task)
+		discoveryTasks = append(discoveryTasks, task)
+		saveTestFindingsArtifact(t, ctx, secStore, task.Namespace, task.Name, fmt.Sprintf("head-%d", index))
+	}
+	if err := secStore.SaveArtifact(ctx, threatTask.Namespace, threatTask.Name, security.ArtifactThreatModel, "text/markdown", []byte("# Threat Model")); err != nil {
+		t.Fatalf("SaveArtifact(threat model) error = %v", err)
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&corev1alpha1.RepositoryScan{}).
+		WithObjects(objects...).
+		Build()
+	r := &RepositoryScanReconciler{Client: cl, Scheme: scheme, SecurityStore: secStore, ArtifactStore: secStore}
+	run := &storepkg.ScanRun{ID: scanID, Namespace: "default", RepositoryScan: scanName, TaskName: threatTask.Name, Mode: "initial", Phase: scanRunPhasePending, StartedAt: completed.Time}
+	if err := secStore.CreateScanRun(ctx, run); err != nil {
+		t.Fatalf("CreateScanRun() error = %v", err)
+	}
+
+	if err := r.ingestScanTask(ctx, scan, discoveryTasks[0], false); err != nil {
+		t.Fatalf("ingestScanTask() error = %v", err)
+	}
+
+	updated, err := secStore.GetScanRun(ctx, scan.Namespace, scanID)
+	if err != nil {
+		t.Fatalf("GetScanRun() error = %v", err)
+	}
+	if updated.Phase != scanRunPhaseSucceeded {
+		t.Fatalf("run.Phase = %q, want %q", updated.Phase, scanRunPhaseSucceeded)
+	}
+	if updated.CompletedAt == nil || !updated.CompletedAt.Equal(completed.Time) {
+		t.Fatalf("run.CompletedAt = %v, want %v", updated.CompletedAt, completed.Time)
+	}
+}
+
+func TestIngestOwnedTasksReingestsTerminalRunWhenArtifactsArrive(t *testing.T) {
+	ctx := context.Background()
+	secStore := setupControllerSQLiteStore(t)
+	scheme := runtime.NewScheme()
+	if err := corev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	scanName := "split-terminal-late-artifacts"
+	scanID := "scan_split_terminal_late_artifacts"
+	scan := &corev1alpha1.RepositoryScan{
+		TypeMeta:   metav1.TypeMeta{APIVersion: corev1alpha1.GroupVersion.String(), Kind: "RepositoryScan"},
+		ObjectMeta: metav1.ObjectMeta{Name: scanName, Namespace: "default"},
+		Spec:       corev1alpha1.RepositoryScanSpec{RepoURL: "https://github.com/example/repo", AnalysisAgentRef: corev1alpha1.AgentReference{Name: "a"}},
+	}
+	completed := metav1.NewTime(mustParseTime(t, "2026-05-10T11:00:00Z"))
+	threatTask := newSucceededSecurityTask("split-terminal-late-threat", scanName, scanID, security.StageThreatModel, "", completed)
+	objects := []client.Object{scan, threatTask}
+	if err := secStore.SaveArtifact(ctx, threatTask.Namespace, threatTask.Name, security.ArtifactThreatModel, "text/markdown", []byte("# Threat Model")); err != nil {
+		t.Fatalf("SaveArtifact(threat model) error = %v", err)
+	}
+	lateFingerprint := "late-artifact-finding"
+	for index, scope := range security.DiscoveryScopes() {
+		task := newSucceededSecurityTask(
+			fmt.Sprintf("split-terminal-late-discovery-%d", index),
+			scanName,
+			scanID,
+			security.StageDiscovery,
+			scope.Name,
+			completed,
+		)
+		objects = append(objects, task)
+		if index == 0 {
+			saveTestFindingsArtifactWithFinding(t, ctx, secStore, task.Namespace, task.Name, fmt.Sprintf("head-%d", index), lateFingerprint)
+			continue
+		}
+		saveTestFindingsArtifact(t, ctx, secStore, task.Namespace, task.Name, fmt.Sprintf("head-%d", index))
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&corev1alpha1.RepositoryScan{}).
+		WithObjects(objects...).
+		Build()
+	r := &RepositoryScanReconciler{Client: cl, Scheme: scheme, SecurityStore: secStore, ArtifactStore: secStore}
+	completedTime := completed.Time
+	run := &storepkg.ScanRun{
+		ID:             scanID,
+		Namespace:      "default",
+		RepositoryScan: scanName,
+		TaskName:       threatTask.Name,
+		Mode:           "initial",
+		Phase:          scanRunPhaseFailed,
+		StartedAt:      completed.Add(-5 * time.Minute),
+		CompletedAt:    &completedTime,
+		ErrorMessage:   security.ArtifactFindings + " is missing",
+		Summary:        security.ArtifactFindings + " is missing",
+	}
+	if err := secStore.CreateScanRun(ctx, run); err != nil {
+		t.Fatalf("CreateScanRun() error = %v", err)
+	}
+
+	if err := r.ingestOwnedTasks(ctx, scan); err != nil {
+		t.Fatalf("ingestOwnedTasks() error = %v", err)
+	}
+
+	updated, err := secStore.GetScanRun(ctx, scan.Namespace, scanID)
+	if err != nil {
+		t.Fatalf("GetScanRun() error = %v", err)
+	}
+	if updated.Phase != scanRunPhaseSucceeded {
+		t.Fatalf("run.Phase = %q, want %q", updated.Phase, scanRunPhaseSucceeded)
+	}
+	if updated.ErrorMessage != "" {
+		t.Fatalf("run.ErrorMessage = %q, want empty after successful re-ingest", updated.ErrorMessage)
+	}
+	if _, err := secStore.GetLatestThreatModel(ctx, scan.Namespace, scan.Name); err != nil {
+		t.Fatalf("GetLatestThreatModel() error = %v", err)
+	}
+	if _, err := secStore.GetFinding(ctx, scan.Namespace, security.FindingID(lateFingerprint)); err != nil {
+		t.Fatalf("GetFinding(late artifact) error = %v", err)
 	}
 }
 
@@ -1185,7 +1399,7 @@ func TestRefreshScanRunStatusWaitsForAllDiscoveryScopes(t *testing.T) {
 	if err := secStore.SaveArtifact(ctx, threatTask.Namespace, threatTask.Name, security.ArtifactThreatModel, "text/markdown", []byte("# Threat Model")); err != nil {
 		t.Fatalf("SaveArtifact(threat model) error = %v", err)
 	}
-	saveTestFindingsArtifact(t, ctx, secStore, discoveryTask.Namespace, discoveryTask.Name, "initial", "head-0")
+	saveTestFindingsArtifact(t, ctx, secStore, discoveryTask.Namespace, discoveryTask.Name, "head-0")
 
 	run := &storepkg.ScanRun{ID: "scan_split_pending", Namespace: "default", RepositoryScan: "split-pending", TaskName: threatTask.Name, Mode: "initial", Phase: scanRunPhaseRunning, StartedAt: completed.Time}
 	if err := secStore.CreateScanRun(ctx, run); err != nil {
@@ -1251,7 +1465,7 @@ func TestIngestOwnedTasksFailsSucceededDiscoveryWithoutFindingsArtifact(t *testi
 		}
 		objects = append(objects, task)
 		if scope.Name != missingScope {
-			saveTestFindingsArtifact(t, ctx, secStore, task.Namespace, task.Name, "initial", fmt.Sprintf("head-%d", index))
+			saveTestFindingsArtifact(t, ctx, secStore, task.Namespace, task.Name, fmt.Sprintf("head-%d", index))
 		}
 	}
 	cl := fake.NewClientBuilder().

--- a/internal/controller/repositoryscan_controller_test.go
+++ b/internal/controller/repositoryscan_controller_test.go
@@ -419,6 +419,91 @@ func TestIngestOwnedTasksReingestsTerminalRunWhenArtifactsArrive(t *testing.T) {
 	}
 }
 
+func TestIngestOwnedTasksPreservesLatestCombinedScanSummary(t *testing.T) {
+	ctx := context.Background()
+	secStore := setupControllerSQLiteStore(t)
+	scheme := runtime.NewScheme()
+	if err := corev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	scanName := "combined-latest-summary"
+	scanID := "scan_combined_latest_summary"
+	scan := &corev1alpha1.RepositoryScan{
+		TypeMeta:   metav1.TypeMeta{APIVersion: corev1alpha1.GroupVersion.String(), Kind: "RepositoryScan"},
+		ObjectMeta: metav1.ObjectMeta{Name: scanName, Namespace: "default"},
+		Spec:       corev1alpha1.RepositoryScanSpec{RepoURL: "https://github.com/example/repo", AnalysisAgentRef: corev1alpha1.AgentReference{Name: "a"}},
+	}
+	completed := metav1.NewTime(mustParseTime(t, "2026-05-10T12:00:00Z"))
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "combined-latest-summary-task",
+			Namespace: "default",
+			Labels: map[string]string{
+				labels.LabelSecurityTarget: scanName,
+				labels.LabelSecurityScanID: scanID,
+				labels.LabelSecurityMode:   "initial",
+			},
+		},
+		Status: corev1alpha1.TaskStatus{
+			Phase:          corev1alpha1.TaskPhaseSucceeded,
+			CompletionTime: &completed,
+		},
+	}
+	findings := security.FindingsArtifact{
+		Version: 1,
+		Repository: security.FindingsArtifactRepo{
+			RepoURL: "https://github.com/example/repo",
+			Branch:  "main",
+			HeadSHA: "head-combined",
+			BaseSHA: "base-combined",
+		},
+		Scan: security.FindingsArtifactScan{
+			Mode:        "initial",
+			CommitCount: 7,
+			Summary:     "Rich combined scan summary from findings artifact",
+		},
+		Findings: []security.FindingsArtifactFinding{},
+	}
+	findingsJSON, err := json.Marshal(findings)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if err := secStore.SaveArtifact(ctx, task.Namespace, task.Name, security.ArtifactFindings, "application/json", findingsJSON); err != nil {
+		t.Fatalf("SaveArtifact(findings) error = %v", err)
+	}
+	if err := secStore.SaveArtifact(ctx, task.Namespace, task.Name, security.ArtifactThreatModel, "text/markdown", []byte("# Threat Model")); err != nil {
+		t.Fatalf("SaveArtifact(threat model) error = %v", err)
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&corev1alpha1.RepositoryScan{}).
+		WithObjects(scan, task).
+		Build()
+	r := &RepositoryScanReconciler{Client: cl, Scheme: scheme, SecurityStore: secStore, ArtifactStore: secStore}
+
+	if err := r.ingestOwnedTasks(ctx, scan); err != nil {
+		t.Fatalf("ingestOwnedTasks() error = %v", err)
+	}
+
+	run, err := secStore.GetScanRun(ctx, scan.Namespace, scanID)
+	if err != nil {
+		t.Fatalf("GetScanRun() error = %v", err)
+	}
+	if run.Summary != findings.Scan.Summary {
+		t.Fatalf("run.Summary = %q, want %q", run.Summary, findings.Scan.Summary)
+	}
+	current := &corev1alpha1.RepositoryScan{}
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(scan), current); err != nil {
+		t.Fatalf("cl.Get() error = %v", err)
+	}
+	condition := meta.FindStatusCondition(current.Status.Conditions, "Ready")
+	if condition == nil || condition.Message != findings.Scan.Summary {
+		t.Fatalf("Ready condition = %#v, want message %q", condition, findings.Scan.Summary)
+	}
+}
+
 func TestIngestScanTaskFailsSucceededTaskWithoutRequiredArtifacts(t *testing.T) {
 	ctx := context.Background()
 	store := setupControllerSQLiteStore(t)

--- a/internal/controller/repositoryscan_controller_test.go
+++ b/internal/controller/repositoryscan_controller_test.go
@@ -10,11 +10,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 	"unicode/utf8"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -167,6 +169,40 @@ func mustParseTime(t *testing.T, value string) time.Time {
 		t.Fatalf("time.Parse(%q): %v", value, err)
 	}
 	return parsed
+}
+
+func saveTestFindingsArtifact(
+	t *testing.T,
+	ctx context.Context,
+	store storepkg.ArtifactStore,
+	namespace string,
+	taskName string,
+	mode string,
+	headSHA string,
+) {
+	t.Helper()
+
+	findings := security.FindingsArtifact{
+		Version: 1,
+		Repository: security.FindingsArtifactRepo{
+			RepoURL: "https://github.com/example/repo",
+			Branch:  "main",
+			HeadSHA: headSHA,
+			BaseSHA: "base-" + headSHA,
+		},
+		Scan: security.FindingsArtifactScan{
+			Mode:    mode,
+			Summary: "No findings",
+		},
+		Findings: []security.FindingsArtifactFinding{},
+	}
+	data, err := json.Marshal(findings)
+	if err != nil {
+		t.Fatalf("json.Marshal(findings) error = %v", err)
+	}
+	if err := store.SaveArtifact(ctx, namespace, taskName, security.ArtifactFindings, "application/json", data); err != nil {
+		t.Fatalf("SaveArtifact(%s) error = %v", taskName, err)
+	}
 }
 
 func TestIngestScanTaskFailsSucceededTaskWithoutRequiredArtifacts(t *testing.T) {
@@ -1097,6 +1133,158 @@ func TestRefreshScanRunStatusSetsBothTimestampsOnSuccess(t *testing.T) {
 	}
 	if current.Status.LastSuccessfulScanAt == nil || !current.Status.LastSuccessfulScanAt.Time.Equal(completed) {
 		t.Fatalf("LastSuccessfulScanAt = %v, want %v", current.Status.LastSuccessfulScanAt, completed)
+	}
+}
+
+func TestRefreshScanRunStatusWaitsForAllDiscoveryScopes(t *testing.T) {
+	ctx := context.Background()
+	secStore := setupControllerSQLiteStore(t)
+	scheme := runtime.NewScheme()
+	if err := corev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	scan := &corev1alpha1.RepositoryScan{
+		TypeMeta:   metav1.TypeMeta{APIVersion: corev1alpha1.GroupVersion.String(), Kind: "RepositoryScan"},
+		ObjectMeta: metav1.ObjectMeta{Name: "split-pending", Namespace: "default"},
+		Spec:       corev1alpha1.RepositoryScanSpec{RepoURL: "https://github.com/example/repo", AnalysisAgentRef: corev1alpha1.AgentReference{Name: "a"}},
+	}
+	completed := metav1.NewTime(mustParseTime(t, "2026-05-09T10:00:00Z"))
+	threatTask := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "split-pending-threat",
+			Namespace: "default",
+			Labels: map[string]string{
+				labels.LabelSecurityTarget: "split-pending",
+				labels.LabelSecurityScanID: "scan_split_pending",
+				labels.LabelSecurityStage:  security.StageThreatModel,
+			},
+		},
+		Status: corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseSucceeded, CompletionTime: &completed},
+	}
+	discoveryTask := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "split-pending-discovery-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				labels.LabelSecurityTarget: "split-pending",
+				labels.LabelSecurityScanID: "scan_split_pending",
+				labels.LabelSecurityStage:  security.StageDiscovery,
+				labels.LabelSecurityScope:  security.DiscoveryScopes()[0].Name,
+			},
+		},
+		Status: corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseSucceeded, CompletionTime: &completed},
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&corev1alpha1.RepositoryScan{}).
+		WithObjects(scan, threatTask, discoveryTask).
+		Build()
+	r := &RepositoryScanReconciler{Client: cl, Scheme: scheme, SecurityStore: secStore, ArtifactStore: secStore}
+
+	if err := secStore.SaveArtifact(ctx, threatTask.Namespace, threatTask.Name, security.ArtifactThreatModel, "text/markdown", []byte("# Threat Model")); err != nil {
+		t.Fatalf("SaveArtifact(threat model) error = %v", err)
+	}
+	saveTestFindingsArtifact(t, ctx, secStore, discoveryTask.Namespace, discoveryTask.Name, "initial", "head-0")
+
+	run := &storepkg.ScanRun{ID: "scan_split_pending", Namespace: "default", RepositoryScan: "split-pending", TaskName: threatTask.Name, Mode: "initial", Phase: scanRunPhaseRunning, StartedAt: completed.Time}
+	if err := secStore.CreateScanRun(ctx, run); err != nil {
+		t.Fatalf("CreateScanRun() error = %v", err)
+	}
+	if err := r.refreshScanRunStatus(ctx, scan, run, run.ID, true); err != nil {
+		t.Fatalf("refreshScanRunStatus() error = %v", err)
+	}
+
+	current := &corev1alpha1.RepositoryScan{}
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(scan), current); err != nil {
+		t.Fatalf("cl.Get() error = %v", err)
+	}
+	if current.Status.Phase != repositoryScanPhaseScanning {
+		t.Fatalf("scan.Status.Phase = %q, want %q", current.Status.Phase, repositoryScanPhaseScanning)
+	}
+	if current.Status.LastSuccessfulScanAt != nil {
+		t.Fatalf("LastSuccessfulScanAt = %v, want nil while discovery scopes are pending", current.Status.LastSuccessfulScanAt)
+	}
+}
+
+func TestIngestOwnedTasksFailsSucceededDiscoveryWithoutFindingsArtifact(t *testing.T) {
+	ctx := context.Background()
+	secStore := setupControllerSQLiteStore(t)
+	scheme := runtime.NewScheme()
+	if err := corev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	scan := &corev1alpha1.RepositoryScan{
+		TypeMeta:   metav1.TypeMeta{APIVersion: corev1alpha1.GroupVersion.String(), Kind: "RepositoryScan"},
+		ObjectMeta: metav1.ObjectMeta{Name: "split-missing", Namespace: "default"},
+		Spec:       corev1alpha1.RepositoryScanSpec{RepoURL: "https://github.com/example/repo", AnalysisAgentRef: corev1alpha1.AgentReference{Name: "a"}},
+	}
+	completed := metav1.NewTime(mustParseTime(t, "2026-05-09T11:00:00Z"))
+	threatTask := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "split-missing-threat",
+			Namespace: "default",
+			Labels: map[string]string{
+				labels.LabelSecurityTarget: "split-missing",
+				labels.LabelSecurityScanID: "scan_split_missing",
+				labels.LabelSecurityStage:  security.StageThreatModel,
+			},
+		},
+		Status: corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseSucceeded, CompletionTime: &completed},
+	}
+	objects := []client.Object{scan, threatTask}
+	missingScope := security.DiscoveryScopes()[len(security.DiscoveryScopes())-1].Name
+	for index, scope := range security.DiscoveryScopes() {
+		task := &corev1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("split-missing-discovery-%d", index),
+				Namespace: "default",
+				Labels: map[string]string{
+					labels.LabelSecurityTarget: "split-missing",
+					labels.LabelSecurityScanID: "scan_split_missing",
+					labels.LabelSecurityStage:  security.StageDiscovery,
+					labels.LabelSecurityScope:  scope.Name,
+				},
+			},
+			Status: corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseSucceeded, CompletionTime: &completed},
+		}
+		objects = append(objects, task)
+		if scope.Name != missingScope {
+			saveTestFindingsArtifact(t, ctx, secStore, task.Namespace, task.Name, "initial", fmt.Sprintf("head-%d", index))
+		}
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&corev1alpha1.RepositoryScan{}).
+		WithObjects(objects...).
+		Build()
+	r := &RepositoryScanReconciler{Client: cl, Scheme: scheme, SecurityStore: secStore, ArtifactStore: secStore}
+
+	if err := secStore.SaveArtifact(ctx, threatTask.Namespace, threatTask.Name, security.ArtifactThreatModel, "text/markdown", []byte("# Threat Model")); err != nil {
+		t.Fatalf("SaveArtifact(threat model) error = %v", err)
+	}
+
+	if err := r.ingestOwnedTasks(ctx, scan); err != nil {
+		t.Fatalf("ingestOwnedTasks() error = %v", err)
+	}
+
+	current := &corev1alpha1.RepositoryScan{}
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(scan), current); err != nil {
+		t.Fatalf("cl.Get() error = %v", err)
+	}
+	if current.Status.Phase != repositoryScanPhaseError {
+		t.Fatalf("scan.Status.Phase = %q, want %q", current.Status.Phase, repositoryScanPhaseError)
+	}
+	condition := meta.FindStatusCondition(current.Status.Conditions, "Ready")
+	if condition == nil {
+		t.Fatal("Ready condition = nil, want failed condition")
+	}
+	if !strings.Contains(condition.Message, missingScope) || !strings.Contains(condition.Message, security.ArtifactFindings) {
+		t.Fatalf("condition.Message = %q, want missing scope and artifact", condition.Message)
+	}
+	if current.Status.LastSuccessfulScanAt != nil {
+		t.Fatalf("LastSuccessfulScanAt = %v, want nil for failed artifact validation", current.Status.LastSuccessfulScanAt)
 	}
 }
 

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -924,12 +924,50 @@ func (r *TaskReconciler) handleRunning(ctx context.Context, task *corev1alpha1.T
 						return r.completeTask(ctx, task, corev1alpha1.TaskPhaseFailed, msg)
 					}
 				}
+				if msg, ok, err := r.failedMountEventMessage(ctx, pod); err != nil {
+					return ctrl.Result{}, err
+				} else if ok {
+					msg = fmt.Sprintf("pod stuck initializing for over 2 minutes: %s", msg)
+					log.Info("failing task due to failed pod mount", "message", msg)
+					return r.completeTask(ctx, task, corev1alpha1.TaskPhaseFailed, msg)
+				}
 			}
 		}
 	}
 
 	// Job still running, requeue
 	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+}
+
+func (r *TaskReconciler) failedMountEventMessage(ctx context.Context, pod *corev1.Pod) (string, bool, error) {
+	if pod == nil {
+		return "", false, nil
+	}
+
+	var events corev1.EventList
+	if err := r.List(ctx, &events, client.InNamespace(pod.Namespace)); err != nil {
+		return "", false, err
+	}
+
+	for i := range events.Items {
+		event := &events.Items[i]
+		if event.Reason != "FailedMount" {
+			continue
+		}
+		ref := event.InvolvedObject
+		if ref.Kind != "Pod" || ref.Name != pod.Name {
+			continue
+		}
+		if ref.UID != "" && pod.UID != "" && ref.UID != pod.UID {
+			continue
+		}
+		message := strings.TrimSpace(event.Message)
+		if message == "" {
+			message = "pod volume mount failed"
+		}
+		return message, true, nil
+	}
+	return "", false, nil
 }
 
 func jobFailedDueToActiveDeadline(job *batchv1.Job) bool {

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -967,6 +967,9 @@ func eventObservedAt(event *corev1.Event) time.Time {
 	if event == nil {
 		return time.Time{}
 	}
+	if event.Series != nil && !event.Series.LastObservedTime.IsZero() {
+		return event.Series.LastObservedTime.Time
+	}
 	if !event.EventTime.IsZero() {
 		return event.EventTime.Time
 	}

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -46,8 +46,13 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-const taskTransactionTokenPendingTimeout = 2 * time.Minute
-const failedMountEventStaleAfter = 2 * time.Minute
+const (
+	taskTransactionTokenPendingTimeout = 2 * time.Minute
+	failedMountEventStaleAfter         = 2 * time.Minute
+
+	eventInvolvedObjectNameField = "involvedObject.name"
+	eventReasonField             = "reason"
+)
 
 const (
 	// ConditionTypeComplete indicates the task has completed
@@ -977,13 +982,35 @@ func eventObservedAt(event *corev1.Event) time.Time {
 	return time.Time{}
 }
 
+func eventInvolvedObjectNameIndex(obj client.Object) []string {
+	event, ok := obj.(*corev1.Event)
+	if !ok || event.InvolvedObject.Name == "" {
+		return nil
+	}
+	return []string{event.InvolvedObject.Name}
+}
+
+func eventReasonIndex(obj client.Object) []string {
+	event, ok := obj.(*corev1.Event)
+	if !ok || event.Reason == "" {
+		return nil
+	}
+	return []string{event.Reason}
+}
+
 func (r *TaskReconciler) failedMountEventMessage(ctx context.Context, pod *corev1.Pod, since time.Time) (string, bool, error) {
 	if pod == nil || !podWaitingForMountInitialization(pod) {
 		return "", false, nil
 	}
 
 	var events corev1.EventList
-	if err := r.List(ctx, &events, client.InNamespace(pod.Namespace)); err != nil {
+	if err := r.List(ctx, &events,
+		client.InNamespace(pod.Namespace),
+		client.MatchingFields{
+			eventInvolvedObjectNameField: pod.Name,
+			eventReasonField:             "FailedMount",
+		},
+	); err != nil {
 		return "", false, err
 	}
 
@@ -1700,6 +1727,12 @@ func (r *TaskReconciler) enforceHistoryLimits(ctx context.Context, task *corev1a
 // SetupWithManager sets up the controller with the Manager.
 func (r *TaskReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Recorder = mgr.GetEventRecorderFor("task-controller") //nolint:staticcheck
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Event{}, eventInvolvedObjectNameField, eventInvolvedObjectNameIndex); err != nil {
+		return err
+	}
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Event{}, eventReasonField, eventReasonIndex); err != nil {
+		return err
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1alpha1.Task{}).
 		Owns(&batchv1.Job{}).

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -47,6 +47,7 @@ import (
 )
 
 const taskTransactionTokenPendingTimeout = 2 * time.Minute
+const failedMountEventStaleAfter = 2 * time.Minute
 
 const (
 	// ConditionTypeComplete indicates the task has completed
@@ -924,7 +925,7 @@ func (r *TaskReconciler) handleRunning(ctx context.Context, task *corev1alpha1.T
 						return r.completeTask(ctx, task, corev1alpha1.TaskPhaseFailed, msg)
 					}
 				}
-				if msg, ok, err := r.failedMountEventMessage(ctx, pod); err != nil {
+				if msg, ok, err := r.failedMountEventMessage(ctx, pod, task.Status.StartTime.Time); err != nil {
 					return ctrl.Result{}, err
 				} else if ok {
 					msg = fmt.Sprintf("pod stuck initializing for over 2 minutes: %s", msg)
@@ -939,8 +940,45 @@ func (r *TaskReconciler) handleRunning(ctx context.Context, task *corev1alpha1.T
 	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 }
 
-func (r *TaskReconciler) failedMountEventMessage(ctx context.Context, pod *corev1.Pod) (string, bool, error) {
+func podWaitingForMountInitialization(pod *corev1.Pod) bool {
 	if pod == nil {
+		return false
+	}
+	for _, statuses := range [][]corev1.ContainerStatus{pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses} {
+		for _, cs := range statuses {
+			if cs.State.Waiting == nil {
+				continue
+			}
+			switch cs.State.Waiting.Reason {
+			case "ContainerCreating", "PodInitializing":
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func eventObservedAt(event *corev1.Event) time.Time {
+	if event == nil {
+		return time.Time{}
+	}
+	if !event.EventTime.IsZero() {
+		return event.EventTime.Time
+	}
+	if !event.LastTimestamp.IsZero() {
+		return event.LastTimestamp.Time
+	}
+	if !event.FirstTimestamp.IsZero() {
+		return event.FirstTimestamp.Time
+	}
+	if !event.CreationTimestamp.IsZero() {
+		return event.CreationTimestamp.Time
+	}
+	return time.Time{}
+}
+
+func (r *TaskReconciler) failedMountEventMessage(ctx context.Context, pod *corev1.Pod, since time.Time) (string, bool, error) {
+	if pod == nil || !podWaitingForMountInitialization(pod) {
 		return "", false, nil
 	}
 
@@ -949,6 +987,7 @@ func (r *TaskReconciler) failedMountEventMessage(ctx context.Context, pod *corev
 		return "", false, err
 	}
 
+	now := time.Now()
 	for i := range events.Items {
 		event := &events.Items[i]
 		if event.Reason != "FailedMount" {
@@ -959,6 +998,13 @@ func (r *TaskReconciler) failedMountEventMessage(ctx context.Context, pod *corev
 			continue
 		}
 		if ref.UID != "" && pod.UID != "" && ref.UID != pod.UID {
+			continue
+		}
+		observedAt := eventObservedAt(event)
+		if observedAt.IsZero() || (!since.IsZero() && observedAt.Before(since)) {
+			continue
+		}
+		if now.Sub(observedAt) > failedMountEventStaleAfter {
 			continue
 		}
 		message := strings.TrimSpace(event.Message)

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -963,6 +963,11 @@ func (r *TaskReconciler) isWithinJobCreationVisibilityGracePeriod(task *corev1al
 func (r *TaskReconciler) handleCompleted(ctx context.Context, task *corev1alpha1.Task) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
+	if err := r.cleanupTerminalTaskJob(ctx, task); err != nil {
+		log.Error(err, "failed to clean up terminal task Job")
+		return ctrl.Result{}, err
+	}
+
 	// Send webhook if configured and not already sent
 	if task.Spec.WebhookURL != "" && !task.Status.WebhookDelivered {
 		if err := r.WebhookNotifier.Notify(ctx, task); err != nil {
@@ -982,6 +987,33 @@ func (r *TaskReconciler) handleCompleted(ctx context.Context, task *corev1alpha1
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *TaskReconciler) cleanupTerminalTaskJob(ctx context.Context, task *corev1alpha1.Task) error {
+	if task.Status.JobName == "" {
+		return nil
+	}
+
+	job := &batchv1.Job{}
+	if err := r.Get(ctx, types.NamespacedName{Name: task.Status.JobName, Namespace: task.Namespace}, job); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("getting terminal task Job %q: %w", task.Status.JobName, err)
+	}
+
+	deleteJob := task.Status.Phase == corev1alpha1.TaskPhaseCancelled ||
+		(task.Status.Phase == corev1alpha1.TaskPhaseFailed && job.Status.Active > 0)
+	if !deleteJob {
+		return nil
+	}
+
+	propagationPolicy := metav1.DeletePropagationBackground
+	if err := r.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("deleting terminal task Job %q: %w", task.Status.JobName, err)
+	}
+
+	return nil
 }
 
 func (r *TaskReconciler) enforceParentScheduledTaskHistory(ctx context.Context, task *corev1alpha1.Task) error {

--- a/internal/controller/task_controller_unit_test.go
+++ b/internal/controller/task_controller_unit_test.go
@@ -2371,6 +2371,125 @@ func TestHandleRunning_JobFailed_WithRetry(t *testing.T) {
 	}
 }
 
+func TestHandleRunning_PodFailedMountFailsTask(t *testing.T) {
+	scheme := newTestScheme()
+	startTime := metav1.NewTime(time.Now().Add(-3 * time.Minute))
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "run-failed-mount", Namespace: "default"},
+		Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeContainer},
+		Status: corev1alpha1.TaskStatus{
+			Phase:     corev1alpha1.TaskPhaseRunning,
+			StartTime: &startTime,
+			JobName:   "run-failed-mount-job",
+		},
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "run-failed-mount-job", Namespace: "default"},
+		Status:     batchv1.JobStatus{Active: 1},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "run-failed-mount-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Labels: map[string]string{
+				labels.LabelTask: labels.SelectorValue(task.Name),
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name: "prepare-workspace",
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+					Reason: "PodInitializing",
+				}},
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "worker",
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+					Reason: "PodInitializing",
+				}},
+			}},
+		},
+	}
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "failed-mount", Namespace: "default"},
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Pod",
+			Name: pod.Name,
+			UID:  pod.UID,
+		},
+		Reason:  "FailedMount",
+		Message: `MountVolume.SetUp failed for volume "git-credentials": secret "missing" not found`,
+	}
+	r := newUnitReconciler(scheme, task, job, pod, event)
+
+	_, err := r.handleRunning(context.Background(), task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if task.Status.Phase != corev1alpha1.TaskPhaseFailed {
+		t.Fatalf("phase = %s, want Failed", task.Status.Phase)
+	}
+	if !strings.Contains(task.Status.Message, "secret") {
+		t.Fatalf("message = %q, want failed mount detail", task.Status.Message)
+	}
+}
+
+func TestHandleRunning_PodInitializingWithoutFailedMountRequeues(t *testing.T) {
+	scheme := newTestScheme()
+	startTime := metav1.NewTime(time.Now().Add(-3 * time.Minute))
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "run-pod-initializing", Namespace: "default"},
+		Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeContainer},
+		Status: corev1alpha1.TaskStatus{
+			Phase:     corev1alpha1.TaskPhaseRunning,
+			StartTime: &startTime,
+			JobName:   "run-pod-initializing-job",
+		},
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "run-pod-initializing-job", Namespace: "default"},
+		Status:     batchv1.JobStatus{Active: 1},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "run-pod-initializing-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				labels.LabelTask: labels.SelectorValue(task.Name),
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name: "prepare-workspace",
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+					Reason: "PodInitializing",
+				}},
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "worker",
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+					Reason: "PodInitializing",
+				}},
+			}},
+		},
+	}
+	r := newUnitReconciler(scheme, task, job, pod)
+
+	result, err := r.handleRunning(context.Background(), task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if task.Status.Phase != corev1alpha1.TaskPhaseRunning {
+		t.Fatalf("phase = %s, want Running", task.Status.Phase)
+	}
+	if result.RequeueAfter <= 0 {
+		t.Fatalf("RequeueAfter = %s, want positive duration", result.RequeueAfter)
+	}
+}
+
 func TestHandleRunning_JobStillRunning(t *testing.T) {
 	scheme := newTestScheme()
 	job := &batchv1.Job{

--- a/internal/controller/task_controller_unit_test.go
+++ b/internal/controller/task_controller_unit_test.go
@@ -57,7 +57,11 @@ func newTestScheme() *runtime.Scheme {
 
 // newUnitReconciler builds a TaskReconciler backed by a fake client.
 func newUnitReconciler(scheme *runtime.Scheme, objs ...client.Object) *TaskReconciler {
-	fb := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&corev1alpha1.Task{})
+	fb := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&corev1alpha1.Task{}).
+		WithIndex(&corev1.Event{}, eventInvolvedObjectNameField, eventInvolvedObjectNameIndex).
+		WithIndex(&corev1.Event{}, eventReasonField, eventReasonIndex)
 	if len(objs) > 0 {
 		fb = fb.WithObjects(objs...)
 	}

--- a/internal/controller/task_controller_unit_test.go
+++ b/internal/controller/task_controller_unit_test.go
@@ -2503,6 +2503,72 @@ func TestHandleRunning_StalePodFailedMountEventRequeues(t *testing.T) {
 	}
 }
 
+func TestHandleRunning_PodFailedMountSeriesFailsTask(t *testing.T) {
+	scheme := newTestScheme()
+	now := time.Now()
+	startTime := metav1.NewTime(now.Add(-4 * time.Minute))
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "run-series-failed-mount", Namespace: "default"},
+		Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeContainer},
+		Status: corev1alpha1.TaskStatus{
+			Phase:     corev1alpha1.TaskPhaseRunning,
+			StartTime: &startTime,
+			JobName:   "run-series-failed-mount-job",
+		},
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "run-series-failed-mount-job", Namespace: "default"},
+		Status:     batchv1.JobStatus{Active: 1},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "run-series-failed-mount-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Labels: map[string]string{
+				labels.LabelTask: labels.SelectorValue(task.Name),
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "worker",
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+					Reason: "PodInitializing",
+				}},
+			}},
+		},
+	}
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "series-failed-mount", Namespace: "default"},
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Pod",
+			Name: pod.Name,
+			UID:  pod.UID,
+		},
+		Reason:         "FailedMount",
+		Message:        `MountVolume.SetUp failed for volume "git-credentials": secret "missing" not found`,
+		LastTimestamp:  metav1.NewTime(now.Add(-3 * time.Minute)),
+		FirstTimestamp: metav1.NewTime(now.Add(-4 * time.Minute)),
+		Series: &corev1.EventSeries{
+			Count:            3,
+			LastObservedTime: metav1.MicroTime{Time: now.Add(-30 * time.Second)},
+		},
+	}
+	r := newUnitReconciler(scheme, task, job, pod, event)
+
+	_, err := r.handleRunning(context.Background(), task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if task.Status.Phase != corev1alpha1.TaskPhaseFailed {
+		t.Fatalf("phase = %s, want Failed", task.Status.Phase)
+	}
+	if !strings.Contains(task.Status.Message, "secret") {
+		t.Fatalf("message = %q, want failed mount detail", task.Status.Message)
+	}
+}
+
 func TestHandleRunning_PodInitializingWithoutFailedMountRequeues(t *testing.T) {
 	scheme := newTestScheme()
 	startTime := metav1.NewTime(time.Now().Add(-3 * time.Minute))

--- a/internal/controller/task_controller_unit_test.go
+++ b/internal/controller/task_controller_unit_test.go
@@ -2085,6 +2085,84 @@ func TestHandleCompleted_WebhookAlreadyDelivered(t *testing.T) {
 	}
 }
 
+func TestHandleCompleted_CancelledDeletesJob(t *testing.T) {
+	scheme := newTestScheme()
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "cancel-job", Namespace: "default"},
+		Status:     batchv1.JobStatus{Active: 1},
+	}
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "cancel-task", Namespace: "default"},
+		Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeContainer},
+		Status: corev1alpha1.TaskStatus{
+			Phase:   corev1alpha1.TaskPhaseCancelled,
+			JobName: "cancel-job",
+		},
+	}
+	r := newUnitReconciler(scheme, task, job)
+
+	_, err := r.handleCompleted(context.Background(), task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "cancel-job", Namespace: "default"}, &batchv1.Job{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected cancelled task Job to be deleted, got %v", err)
+	}
+}
+
+func TestHandleCompleted_FailedActiveJobDeletesJob(t *testing.T) {
+	scheme := newTestScheme()
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "failed-active-job", Namespace: "default"},
+		Status:     batchv1.JobStatus{Active: 1},
+	}
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "failed-active-task", Namespace: "default"},
+		Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeContainer},
+		Status: corev1alpha1.TaskStatus{
+			Phase:   corev1alpha1.TaskPhaseFailed,
+			JobName: "failed-active-job",
+		},
+	}
+	r := newUnitReconciler(scheme, task, job)
+
+	_, err := r.handleCompleted(context.Background(), task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "failed-active-job", Namespace: "default"}, &batchv1.Job{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected active failed task Job to be deleted, got %v", err)
+	}
+}
+
+func TestHandleCompleted_FailedInactiveJobRetainsJob(t *testing.T) {
+	scheme := newTestScheme()
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "failed-inactive-job", Namespace: "default"},
+		Status:     batchv1.JobStatus{Failed: 1},
+	}
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "failed-inactive-task", Namespace: "default"},
+		Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeContainer},
+		Status: corev1alpha1.TaskStatus{
+			Phase:   corev1alpha1.TaskPhaseFailed,
+			JobName: "failed-inactive-job",
+		},
+	}
+	r := newUnitReconciler(scheme, task, job)
+
+	_, err := r.handleCompleted(context.Background(), task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "failed-inactive-job", Namespace: "default"}, &batchv1.Job{}); err != nil {
+		t.Fatalf("expected inactive failed task Job to be retained, got %v", err)
+	}
+}
+
 func TestHandleCompleted_EnforcesScheduledTaskHistoryLimit(t *testing.T) {
 	scheme := newTestScheme()
 	parent := &corev1alpha1.Task{

--- a/internal/controller/task_controller_unit_test.go
+++ b/internal/controller/task_controller_unit_test.go
@@ -2373,7 +2373,8 @@ func TestHandleRunning_JobFailed_WithRetry(t *testing.T) {
 
 func TestHandleRunning_PodFailedMountFailsTask(t *testing.T) {
 	scheme := newTestScheme()
-	startTime := metav1.NewTime(time.Now().Add(-3 * time.Minute))
+	now := time.Now()
+	startTime := metav1.NewTime(now.Add(-3 * time.Minute))
 	task := &corev1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{Name: "run-failed-mount", Namespace: "default"},
 		Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeContainer},
@@ -2419,8 +2420,9 @@ func TestHandleRunning_PodFailedMountFailsTask(t *testing.T) {
 			Name: pod.Name,
 			UID:  pod.UID,
 		},
-		Reason:  "FailedMount",
-		Message: `MountVolume.SetUp failed for volume "git-credentials": secret "missing" not found`,
+		Reason:        "FailedMount",
+		Message:       `MountVolume.SetUp failed for volume "git-credentials": secret "missing" not found`,
+		LastTimestamp: metav1.NewTime(now.Add(-30 * time.Second)),
 	}
 	r := newUnitReconciler(scheme, task, job, pod, event)
 
@@ -2433,6 +2435,67 @@ func TestHandleRunning_PodFailedMountFailsTask(t *testing.T) {
 	}
 	if !strings.Contains(task.Status.Message, "secret") {
 		t.Fatalf("message = %q, want failed mount detail", task.Status.Message)
+	}
+}
+
+func TestHandleRunning_StalePodFailedMountEventRequeues(t *testing.T) {
+	scheme := newTestScheme()
+	now := time.Now()
+	startTime := metav1.NewTime(now.Add(-4 * time.Minute))
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "run-stale-failed-mount", Namespace: "default"},
+		Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeContainer},
+		Status: corev1alpha1.TaskStatus{
+			Phase:     corev1alpha1.TaskPhaseRunning,
+			StartTime: &startTime,
+			JobName:   "run-stale-failed-mount-job",
+		},
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "run-stale-failed-mount-job", Namespace: "default"},
+		Status:     batchv1.JobStatus{Active: 1},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "run-stale-failed-mount-pod",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Labels: map[string]string{
+				labels.LabelTask: labels.SelectorValue(task.Name),
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "worker",
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+					Reason: "PodInitializing",
+				}},
+			}},
+		},
+	}
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "stale-failed-mount", Namespace: "default"},
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Pod",
+			Name: pod.Name,
+			UID:  pod.UID,
+		},
+		Reason:        "FailedMount",
+		Message:       `MountVolume.SetUp failed for volume "git-credentials": secret "missing" not found`,
+		LastTimestamp: metav1.NewTime(now.Add(-3 * time.Minute)),
+	}
+	r := newUnitReconciler(scheme, task, job, pod, event)
+
+	result, err := r.handleRunning(context.Background(), task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if task.Status.Phase != corev1alpha1.TaskPhaseRunning {
+		t.Fatalf("phase = %s, want Running", task.Status.Phase)
+	}
+	if result.RequeueAfter <= 0 {
+		t.Fatalf("RequeueAfter = %s, want positive duration", result.RequeueAfter)
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve terminal RepositoryScan status and ingest terminal scan results reliably
- clean up active Jobs when Tasks become terminal through cancellation or failure
- fail Tasks stuck in PodInitializing because of FailedMount events, then clean up their Jobs
- include focused controller/API regression coverage and small build hygiene fixes

## Validation
- make lint-fix && make test
- deployed `docker.io/sozercan/orka:bugbash-failedmount-cleanup-20260519124528-amd64` to AKS and verified controller readiness
- live checks covered REST/security APIs, RepositoryScan workflows, Kontxt token replacement, provider fallback, strict namespace isolation, metrics auth, webhook delivery, controller restart recovery, failed mount cleanup, and a 75-task load burst
- full real-vulnerability RepositoryScan against OWASP/NodeGoat completed Ready with threat model, discovery, findings, and validation tasks

## Notes
- UI workflows and GitHub Actions OIDC were intentionally not covered in this bugbash pass
