### PR TITLE
docs: add autoreview pre-commit guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ Orka is a Kubernetes-native task execution platform that manages Jobs and Pods f
 - **No secrets** — never commit, log, or print API keys, tokens, or credentials. Use Kubernetes Secrets or env vars.
 - **No binaries in repo** — build artifacts go in `bin/` (gitignored) or CI release pipelines.
 - **Scope discipline** — implement exactly what's asked, nothing more.
+- **Pre-land/pre-commit code changes**: use `$autoreview` until no accepted/actionable findings remain, unless equivalent manual review already done, trivial/docs-only, or user opts out.
 - **Git push discipline** — after making a change, push to the current branch when it is not `main`; never push directly to `main`.
 
 ## Build & Test


### PR DESCRIPTION
## Summary
- Add AGENTS.md guidance requiring `$autoreview` for pre-land/pre-commit code changes until no accepted/actionable findings remain.
- Document exceptions for equivalent manual review, trivial/docs-only changes, or explicit opt-out.

## Verification
- `git diff --check`
- `$autoreview` not run: trivial docs-only change covered by the documented exception.