### PR TITLE
Publish website at GitHub Pages root

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -137,12 +137,15 @@ jobs:
           fi
 
           # Replace the website at the Pages root while preserving Pages
-          # metadata and the Helm chart repository.
+          # metadata and Helm chart repository artifacts.
           find . -mindepth 1 -maxdepth 1 \
             ! -name '.git' \
             ! -name '.nojekyll' \
             ! -name 'CNAME' \
             ! -name 'charts' \
+            ! -name 'index.yaml' \
+            ! -name '*.tgz' \
+            ! -name '*.prov' \
             -exec rm -rf {} +
 
           rsync -a ../website/build/ ./

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -136,21 +136,16 @@ jobs:
             git rm -rf . || true
           fi
 
-          # Remove files left by the previous root-level website deployment,
-          # while preserving Pages metadata and Helm chart artifacts.
+          # Replace the website at the Pages root while preserving Pages
+          # metadata and the Helm chart repository.
           find . -mindepth 1 -maxdepth 1 \
             ! -name '.git' \
             ! -name '.nojekyll' \
             ! -name 'CNAME' \
-            ! -name 'website' \
             ! -name 'charts' \
-            ! -name 'index.yaml' \
-            ! -name '*.tgz' \
-            ! -name '*.prov' \
             -exec rm -rf {} +
 
-          mkdir -p website
-          rsync -a --delete ../website/build/ website/
+          rsync -a ../website/build/ ./
           touch .nojekyll
 
           git add -A

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -8,7 +8,7 @@ const config = {
   title: 'Orka',
   tagline: 'Kubernetes-native AI task orchestration',
   url: 'https://sozercan.github.io',
-  baseUrl: '/orka/website/',
+  baseUrl: '/orka/',
   organizationName: 'sozercan',
   projectName: 'orka',
   trailingSlash: false,


### PR DESCRIPTION
## Summary
- publish the Docusaurus site at the GitHub Pages project root (`/orka/`) instead of `/orka/website/`
- update Docusaurus `baseUrl` to `/orka/`
- keep preserving `gh-pages/charts/` for the Helm chart repository while replacing root website files

## Verification
- `cd website && yarn build`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/website.yml`
- `typos website .github/workflows/website.yml` with crate-ci/typos v1.46.2
- `python3 /Users/sozercan/.codex/skills/autoreview/scripts/autoreview --mode local --parallel-tests ...` clean with the same focused checks in parallel