### PR TITLE
docs: document repository scan ref and e2e

### DIFF
--- a/api/v1alpha1/repositoryscan_types.go
+++ b/api/v1alpha1/repositoryscan_types.go
@@ -31,7 +31,7 @@ type RepositoryScanSpec struct {
 	// +optional
 	Repository string `json:"repository,omitempty"`
 
-	// Branch is the base branch to scan. Defaults to the repository default branch when omitted.
+	// Branch is the base branch to scan. Defaults to the literal main branch when omitted.
 	// +optional
 	Branch string `json:"branch,omitempty"`
 

--- a/config/crd/bases/core.orka.ai_repositoryscans.yaml
+++ b/config/crd/bases/core.orka.ai_repositoryscans.yaml
@@ -70,8 +70,8 @@ spec:
                 - name
                 type: object
               branch:
-                description: Branch is the base branch to scan. Defaults to the repository
-                  default branch when omitted.
+                description: Branch is the base branch to scan. Defaults to the literal
+                  main branch when omitted.
                 type: string
               forkRepo:
                 description: ForkRepo is the writable fork repository URL used for

--- a/website/docs/concepts/configuration.md
+++ b/website/docs/concepts/configuration.md
@@ -121,6 +121,7 @@ spec:
   owner: example
   repository: app
   branch: main
+  ref: "v1.2.3"                 # optional tag, branch, or commit SHA checkout override
   subPath: "services/api"       # optional monorepo scope
   gitSecretRef:                  # optional for private repositories
     name: github-credentials
@@ -147,6 +148,7 @@ spec:
 | `owner` | string | No | Repository owner or organization. Inferred from `repoURL` when omitted. |
 | `repository` | string | No | Repository name. Inferred from `repoURL` when omitted. |
 | `branch` | string | No | Base branch to scan. Defaults to the literal `main` when omitted (not resolved from the repository's actual default branch). Set this explicitly for repositories whose default branch is not `main`. |
+| `ref` | string | No | Specific git ref, tag, or commit SHA to check out for scan tasks. When `ref` is set and `branch` is omitted, scan workspaces check out the ref directly instead of forcing `main`; PR remediation still uses `prBaseBranch` or `main` unless `branch` is set. |
 | `subPath` | string | No | Optional subdirectory to scan in a monorepo. |
 | `gitSecretRef` | LocalObjectReference | No | Secret containing credentials for private repository access. |
 | `forkRepo` | string | No | Writable fork repository URL for patch proposal branches and remediation PRs. |

--- a/website/docs/development/security-scanning-design.md
+++ b/website/docs/development/security-scanning-design.md
@@ -91,6 +91,7 @@ type RepositoryScanSpec struct {
     Owner              string                         `json:"owner,omitempty"`      // derived or explicit
     Repository         string                         `json:"repository,omitempty"` // derived or explicit
     Branch             string                         `json:"branch,omitempty"`
+    Ref                string                         `json:"ref,omitempty"`
     SubPath            string                         `json:"subPath,omitempty"`
     GitSecretRef       *corev1.LocalObjectReference   `json:"gitSecretRef,omitempty"`
     ForkRepo           string                         `json:"forkRepo,omitempty"`
@@ -122,6 +123,7 @@ Notes:
 
 - `provider` defaults to `github`.
 - `branch` currently defaults to the literal `main` when omitted (`security.EffectiveBranch`); it is **not** resolved from the repository's actual default branch. Set `spec.branch` explicitly for repositories whose default branch is not `main` (e.g. `master`, `trunk`).
+- `ref` optionally pins scan tasks to a tag, branch, or commit SHA. Ref-only scans leave the worker workspace branch empty so the checkout can resolve the ref directly; trusted finding metadata reports the branch as `ref:<ref>`.
 - `schedule` uses the same cron format as `Task.spec.schedule`.
 - `historyDays` is intentionally simpler than a custom `30d` duration parser.
 - `forkRepo` and `prBaseBranch` map directly to existing workspace/PR concepts.

--- a/website/docs/development/testing.md
+++ b/website/docs/development/testing.md
@@ -83,6 +83,7 @@ End-to-end tests run against a dedicated Kind cluster:
 | `test/e2e/live_anthropic_compat_test.go` | Live Anthropic-compatible `/anthropic/v1/models` and `/anthropic/v1/messages` coverage with default tools-enabled behavior |
 | `test/e2e/live_agent_runtime_matrix_test.go` | Live Orka runtime matrix: Codex+GPT, Claude Code+Claude, Copilot+Gemini |
 | `.github/workflows/live-agent-sandbox-e2e.yml` / `scripts/live-agent-sandbox-e2e.sh` | Live upstream `agent-sandbox` Kind validation for Orka agent workspace claim, sandbox execution, delete cleanup, retained-session reuse, and token scrubbing using a fake model-free Claude runtime |
+| `.github/workflows/security-scan-e2e.yml` / `scripts/security-scan-e2e.sh` | Secret-free repository security scan Kind validation against pinned `sozercan/nodejs-goof` using the real mapper, deterministic fake Codex analyzer, v2 finding ingestion/drop diagnostics, threat-model rejection, idempotent rescan, and HITL no-auto-patch gating |
 | `test/e2e/tools_test.go` | Built-in tools (including `web_fetch`, `file_write`) and custom Tool CRD |
 | `test/e2e/scheduled_task_test.go` | Cron scheduling, suspend, `concurrencyPolicy: Forbid`, history-limit cleanup |
 | `test/e2e/task_lifecycle_test.go` | Timeout/retry/cancel plus session serialization and lock release |
@@ -103,6 +104,7 @@ missing or mismatched artifacts staying not ready.
 - `E2E_LIVE_COPILOT_PROXY_BASE_URL` (or `E2E_COPILOT_PROXY_BASE_URL` / `COPILOT_PROXY_BASE_URL`): enables the focused live copilot-proxy spec against a running proxy
 - `E2E_LIVE_COPILOT_PROXY_SERVICE_NAMESPACE`, `E2E_LIVE_COPILOT_PROXY_SERVICE_NAME`, `E2E_LIVE_COPILOT_PROXY_SERVICE_PORT`: optional overrides for how the live spec reaches the in-cluster proxy service for `/readyz` and `/v1/models` checks
 - Structural e2e tests (job/env/volume assertions) run without external model keys
+- Security Scan E2E is secret-free and model-free, but requires Docker plus local toolchain dependencies: Go, `kind`, `kubectl`, `curl`, and `jq`
 - Agent Substrate E2E is secret-free, but requires Docker plus local toolchain dependencies: Go, git, curl, `kind`, `kubectl`, `ko`, and `jq`
 
 The live copilot-proxy E2E path runs in a separate workflow and executes the focused live suites for:

--- a/website/docs/guides/repository-security-scanning.md
+++ b/website/docs/guides/repository-security-scanning.md
@@ -62,6 +62,7 @@ spec:
   provider: github
   repoURL: "https://github.com/example/app"
   branch: main
+  ref: "v1.2.3"                 # optional tag, branch, or commit SHA checkout override
   subPath: "services/api"        # optional monorepo scope
   gitSecretRef:                   # optional for private repositories
     name: github-credentials

--- a/website/docs/reference/api-reference.md
+++ b/website/docs/reference/api-reference.md
@@ -199,6 +199,7 @@ Common query parameters:
     "provider": "github",
     "repoURL": "https://github.com/example/app",
     "branch": "main",
+    "ref": "v1.2.3",
     "schedule": "0 2 * * *",
     "validationMode": "light",
     "analysisAgentRef": {"name": "security-reviewer"}
@@ -208,7 +209,7 @@ Common query parameters:
 
 **Response (201):** The created `RepositoryScan` resource.
 
-Required fields are `name`, `spec.repoURL`, and `spec.analysisAgentRef.name`. The API defaults or infers provider, owner, repository, branch, and validation mode where possible.
+Required fields are `name`, `spec.repoURL`, and `spec.analysisAgentRef.name`. The API defaults or infers provider, owner, repository, branch, and validation mode where possible. Set `spec.ref` to pin scan tasks to a specific tag, branch, or commit SHA; when `ref` is set without `branch`, scan workspaces check out that ref directly instead of forcing the default `main` branch.
 
 ### Security Findings Workflow
 


### PR DESCRIPTION
## Summary
- document RepositoryScan `spec.ref` in configuration, guide, API reference, and internal design docs
- fix the generated CRD/source wording for the branch default
- add the new secret-free security scan E2E workflow to the testing docs

Follow-up to #157, which was merged before this docs cleanup landed.

## Validation
- make manifests generate
- make lint-fix
- make test
- git diff --check