### PR TITLE
Stream OpenAI tool-loop progress

### DIFF
--- a/internal/api/anthropic_compat.go
+++ b/internal/api/anthropic_compat.go
@@ -386,6 +386,7 @@ func (h *AnthropicCompatHandler) HandleMessages(c fiber.Ctx) error {
 			anthropicLog.Error(err, "tool loop failed")
 			return anthropicError(c, 500, "api_error", "completion failed: "+err.Error())
 		}
+		resp = stripGoalStateSentinelFromResponse(resp)
 	} else {
 		// Transparent proxy: single LLM call, return response directly
 		resp, err = provider.Complete(ctx, compReq)

--- a/internal/api/anthropic_compat_test.go
+++ b/internal/api/anthropic_compat_test.go
@@ -1122,6 +1122,47 @@ func TestHandleStreamingMessages_StripsSentinelAndStreamsSafeToolProgress(t *tes
 	}
 }
 
+func TestHandleStreamingMessages_DoesNotStreamPrematureCoordinatorText(t *testing.T) {
+	mock := &mockAnthropicProvider{
+		responses: []*llm.CompletionResponse{
+			{Content: "premature anthropic secret progress", StopReason: oaiStopReasonEndTurn},
+			{Content: goalStateSentinel + "\nPR ready: https://example.test/pr/6", StopReason: oaiStopReasonEndTurn},
+		},
+	}
+
+	handler, app := setupTestAnthropicHandler()
+	handler.config.MaxPrematureEndRetries = 1
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingMessages(
+			c, mock,
+			&llm.CompletionRequest{
+				Model:    "claude-sonnet-4-20250514",
+				Messages: []llm.Message{{Role: testRoleUser, Content: "ship"}},
+			},
+			"claude-sonnet-4-20250514", 0, nil,
+		)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if strings.Contains(bodyStr, "premature anthropic secret progress") {
+		t.Fatalf("stream body leaked premature coordinator text: %s", bodyStr)
+	}
+	for _, want := range []string{"[Continuing workflow...]", "PR ready: https://example.test/pr/6", "message_stop"} {
+		if !strings.Contains(bodyStr, want) {
+			t.Fatalf("expected stream body to contain %q, got: %s", want, bodyStr)
+		}
+	}
+	if mock.callIdx != 2 {
+		t.Fatalf("expected 2 LLM calls, got %d", mock.callIdx)
+	}
+}
+
 // --- Tests: injectOrkaTools ---
 
 func TestInjectOrkaTools_BuiltinTools(t *testing.T) {

--- a/internal/api/anthropic_compat_test.go
+++ b/internal/api/anthropic_compat_test.go
@@ -10,8 +10,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -590,6 +592,41 @@ func TestConvertToAnthropicResponse(t *testing.T) {
 	}
 }
 
+func TestConvertToAnthropicResponse_PreservesGoalStateSentinelForTransparentProxy(t *testing.T) {
+	result := convertToAnthropicResponse(&llm.CompletionResponse{
+		Content:    goalStateSentinel + "\nPR ready: https://example.test/pr/3",
+		StopReason: oaiStopReasonEndTurn,
+	}, "claude-sonnet-4-20250514")
+
+	if len(result.Content) != 1 {
+		t.Fatalf("expected one text block, got %d", len(result.Content))
+	}
+	if result.Content[0].Text != goalStateSentinel+"\nPR ready: https://example.test/pr/3" {
+		t.Fatalf("text = %q", result.Content[0].Text)
+	}
+	if !strings.Contains(result.Content[0].Text, goalStateSentinel) {
+		t.Fatalf("transparent converter should preserve sentinel-like text: %q", result.Content[0].Text)
+	}
+}
+
+func TestAnthropicToolLoopFormatting_StripsGoalStateSentinel(t *testing.T) {
+	resp := stripGoalStateSentinelFromResponse(&llm.CompletionResponse{
+		Content:    goalStateSentinel + "\nPR ready: https://example.test/pr/3",
+		StopReason: oaiStopReasonEndTurn,
+	})
+	result := convertToAnthropicResponse(resp, "claude-sonnet-4-20250514")
+
+	if len(result.Content) != 1 {
+		t.Fatalf("expected one text block, got %d", len(result.Content))
+	}
+	if result.Content[0].Text != "PR ready: https://example.test/pr/3" {
+		t.Fatalf("text = %q", result.Content[0].Text)
+	}
+	if strings.Contains(result.Content[0].Text, goalStateSentinel) {
+		t.Fatalf("tool-loop formatted response leaked sentinel: %q", result.Content[0].Text)
+	}
+}
+
 // --- Tests: mapAnthropicStopReason ---
 
 func TestMapAnthropicStopReason(t *testing.T) {
@@ -1009,6 +1046,80 @@ func (m *mockAnthropicProvider) Stream(_ context.Context, _ *llm.CompletionReque
 
 func (m *mockAnthropicProvider) Name() string {
 	return "mock-anthropic"
+}
+
+func TestHandleStreamingMessages_StripsSentinelAndStreamsSafeToolProgress(t *testing.T) {
+	filePath := fmt.Sprintf("/tmp/orka-anthropic-stream-%d.txt", time.Now().UnixNano())
+	if err := os.WriteFile(filePath, []byte("anthropic streaming secret content"), 0o600); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(filePath) })
+
+	mock := &mockAnthropicProvider{
+		responses: []*llm.CompletionResponse{
+			{
+				Content:    "Reading file before final answer.\n",
+				StopReason: oaiStopReasonToolUse,
+				ToolCalls: []llm.ToolCall{{
+					ID:        "call_file_read",
+					Name:      "file_read",
+					Arguments: json.RawMessage(fmt.Sprintf(`{"path":%q}`, filePath)),
+				}},
+			},
+			{
+				Content:    goalStateSentinel + "\nPR ready: https://example.test/pr/4",
+				StopReason: oaiStopReasonEndTurn,
+			},
+		},
+	}
+
+	handler, app := setupTestAnthropicHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingMessages(
+			c, mock,
+			&llm.CompletionRequest{
+				Model:    "claude-sonnet-4-20250514",
+				Messages: []llm.Message{{Role: testRoleUser, Content: "read then report"}},
+				Tools:    []llm.Tool{{Name: "file_read"}},
+			},
+			"claude-sonnet-4-20250514", 0, nil,
+		)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	for _, want := range []string{
+		"Reading file before final answer.",
+		"[Tool file_read completed]",
+		"PR ready: https://example.test/pr/4",
+		"message_stop",
+	} {
+		if !strings.Contains(bodyStr, want) {
+			t.Fatalf("expected stream body to contain %q, got: %s", want, bodyStr)
+		}
+	}
+	for _, forbidden := range []string{
+		goalStateSentinel,
+		"anthropic streaming secret content",
+		"premature end",
+		"call_file_read",
+	} {
+		if strings.Contains(bodyStr, forbidden) {
+			t.Fatalf("stream body leaked internal content %q: %s", forbidden, bodyStr)
+		}
+	}
+	if mock.callIdx != 2 {
+		t.Fatalf("expected 2 LLM calls, got %d", mock.callIdx)
+	}
 }
 
 // --- Tests: injectOrkaTools ---

--- a/internal/api/anthropic_streaming.go
+++ b/internal/api/anthropic_streaming.go
@@ -110,22 +110,19 @@ func (h *AnthropicCompatHandler) handleStreamingMessages( //nolint:gocyclo
 
 				totalOutputTokens += resp.OutputTokens
 
-				// Emit text content
+				// Capture text content. It is emitted after tool-call/final-state
+				// classification so control markers can be stripped first.
 				if resp.Content != "" {
 					textContent = resp.Content
-					if err := writeContentBlockStart(w, blockIndex, AnthropicContentBlock{Type: "text", Text: ""}); err == nil {
-						_ = writeContentBlockDelta(w, blockIndex, AnthropicDelta{Type: "text_delta", Text: resp.Content})
-						_ = writeContentBlockStop(w, blockIndex)
-						blockIndex++
-					}
 				}
 
 				// Capture tool calls for server-side execution (don't emit tool_use blocks
 				// to the client — the client must not see them or it will try to execute locally)
 				toolCalls = resp.ToolCalls
 			} else {
-				// Consume stream chunks
-				inTextBlock := false
+				// Consume stream chunks. Text is buffered until this iteration's
+				// tool-call/final-state classification is known, so internal
+				// sentinels are never leaked to the client.
 				streamError := false
 				for chunk := range streamCh {
 					if chunk.Error != nil {
@@ -136,49 +133,19 @@ func (h *AnthropicCompatHandler) handleStreamingMessages( //nolint:gocyclo
 
 					// Handle text content
 					if chunk.Content != "" {
-						if !inTextBlock {
-							if err := writeContentBlockStart(w, blockIndex, AnthropicContentBlock{
-								Type: "text", Text: "",
-							}); err != nil {
-								break
-							}
-							inTextBlock = true
-						}
-						if err := writeContentBlockDelta(w, blockIndex, AnthropicDelta{
-							Type: "text_delta", Text: chunk.Content,
-						}); err != nil {
-							break
-						}
 						textContent += chunk.Content
 					}
 
 					// Handle tool calls — capture for server-side execution but don't
 					// emit tool_use blocks to the client stream
 					if chunk.ToolCall != nil {
-						if inTextBlock {
-							_ = writeContentBlockStop(w, blockIndex)
-							blockIndex++
-							inTextBlock = false
-						}
-
 						toolCalls = append(toolCalls, *chunk.ToolCall)
 					}
 
 					if chunk.Done {
-						if inTextBlock {
-							_ = writeContentBlockStop(w, blockIndex)
-							blockIndex++
-							inTextBlock = false
-						}
 						totalOutputTokens += estimateTokens(textContent)
 						break
 					}
-				}
-
-				// Close text block if stream ended without Done
-				if inTextBlock {
-					_ = writeContentBlockStop(w, blockIndex)
-					blockIndex++
 				}
 
 				// If stream errored with no content, fall back to Complete
@@ -193,11 +160,6 @@ func (h *AnthropicCompatHandler) handleStreamingMessages( //nolint:gocyclo
 					totalOutputTokens += resp.OutputTokens
 					if resp.Content != "" {
 						textContent = resp.Content
-						if err := writeContentBlockStart(w, blockIndex, AnthropicContentBlock{Type: "text", Text: ""}); err == nil {
-							_ = writeContentBlockDelta(w, blockIndex, AnthropicDelta{Type: "text_delta", Text: resp.Content})
-							_ = writeContentBlockStop(w, blockIndex)
-							blockIndex++
-						}
 					}
 					toolCalls = resp.ToolCalls
 				}
@@ -211,6 +173,7 @@ func (h *AnthropicCompatHandler) handleStreamingMessages( //nolint:gocyclo
 			// workflow continues instead of validation/review/PR being skipped.
 			if len(toolCalls) == 0 {
 				if hasGoalStateSentinelPrefix(textContent) {
+					writeAnthropicTextProgress(w, &blockIndex, stripGoalStateSentinel(textContent))
 					stopReason := oaiStopReasonEndTurn
 					_ = writeMessageDelta(w, stopReason, totalOutputTokens)
 					_ = writeMessageStop(w)
@@ -221,6 +184,7 @@ func (h *AnthropicCompatHandler) handleStreamingMessages( //nolint:gocyclo
 						"iteration", iteration,
 						"retries", prematureEndRetries,
 					)
+					writeAnthropicTextProgress(w, &blockIndex, stripGoalStateSentinel(textContent))
 					stopReason := oaiStopReasonEndTurn
 					_ = writeMessageDelta(w, stopReason, totalOutputTokens)
 					_ = writeMessageStop(w)
@@ -236,11 +200,8 @@ func (h *AnthropicCompatHandler) handleStreamingMessages( //nolint:gocyclo
 					"[System: You emitted text but did not include the literal %q sentinel that marks GOAL STATE A or GOAL STATE B. The workflow is not done. Per the TURN-ENDING INVARIANT, your next response MUST contain a tool_use (not text). Look at the POSTCONDITION TABLE and call the correct next tool. Do NOT emit any text until you are ready to write your final report that begins with %q on its own line.]",
 					goalStateSentinel, goalStateSentinel,
 				)
-				if err := writeContentBlockStart(w, blockIndex, AnthropicContentBlock{Type: "text", Text: ""}); err == nil {
-					_ = writeContentBlockDelta(w, blockIndex, AnthropicDelta{Type: "text_delta", Text: "[⚠️  premature end — re-prompting coordinator]"})
-					_ = writeContentBlockStop(w, blockIndex)
-					blockIndex++
-				}
+				writeAnthropicTextProgress(w, &blockIndex, stripGoalStateSentinel(textContent))
+				writeAnthropicTextProgress(w, &blockIndex, "[Continuing workflow...]\n\n")
 				messages = append(messages, llm.Message{
 					Role:    "assistant",
 					Content: textContent,
@@ -261,6 +222,7 @@ func (h *AnthropicCompatHandler) handleStreamingMessages( //nolint:gocyclo
 				"tool_calls", len(toolCalls),
 				"tools", toolNames,
 			)
+			writeAnthropicTextProgress(w, &blockIndex, stripGoalStateSentinel(textContent))
 
 			// Append assistant message with tool calls
 			messages = append(messages, llm.Message{
@@ -282,21 +244,9 @@ func (h *AnthropicCompatHandler) handleStreamingMessages( //nolint:gocyclo
 
 				result := executeExposedToolCall(streamCtx, tc, h.config.ToolTimeout, toolCtx, exposedToolNames)
 
-				// Emit tool result as a text content block so the user sees what happened
-				resultPreview := result
-				if len(resultPreview) > 2000 {
-					resultPreview = resultPreview[:2000] + "..."
-				}
-				if err := writeContentBlockStart(w, blockIndex, AnthropicContentBlock{
-					Type: "text", Text: "",
-				}); err == nil {
-					_ = writeContentBlockDelta(w, blockIndex, AnthropicDelta{
-						Type: "text_delta",
-						Text: fmt.Sprintf("[Tool %s result]: %s", tc.Name, resultPreview),
-					})
-					_ = writeContentBlockStop(w, blockIndex)
-					blockIndex++
-				}
+				// Emit safe tool progress metadata only. Raw tool results can
+				// contain file contents, task logs, transcripts, or credentials.
+				writeAnthropicTextProgress(w, &blockIndex, formatToolProgress(tc, result))
 
 				messages = append(messages, llm.Message{
 					Role:       "tool",
@@ -570,6 +520,19 @@ func writeAnthropicSSE(w *bufio.Writer, eventType string, data any) error {
 	}
 	_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, jsonData)
 	return w.Flush()
+}
+
+func writeAnthropicTextProgress(w *bufio.Writer, blockIndex *int, text string) {
+	if text == "" {
+		return
+	}
+	if err := writeContentBlockStart(w, *blockIndex, AnthropicContentBlock{Type: "text", Text: ""}); err != nil {
+		anthropicLog.Error(err, "failed to write progress content_block_start")
+		return
+	}
+	_ = writeContentBlockDelta(w, *blockIndex, AnthropicDelta{Type: "text_delta", Text: text})
+	_ = writeContentBlockStop(w, *blockIndex)
+	(*blockIndex)++
 }
 
 // writeMessageStart emits the message_start event.

--- a/internal/api/anthropic_streaming.go
+++ b/internal/api/anthropic_streaming.go
@@ -200,7 +200,6 @@ func (h *AnthropicCompatHandler) handleStreamingMessages( //nolint:gocyclo
 					"[System: You emitted text but did not include the literal %q sentinel that marks GOAL STATE A or GOAL STATE B. The workflow is not done. Per the TURN-ENDING INVARIANT, your next response MUST contain a tool_use (not text). Look at the POSTCONDITION TABLE and call the correct next tool. Do NOT emit any text until you are ready to write your final report that begins with %q on its own line.]",
 					goalStateSentinel, goalStateSentinel,
 				)
-				writeAnthropicTextProgress(w, &blockIndex, stripGoalStateSentinel(textContent))
 				writeAnthropicTextProgress(w, &blockIndex, "[Continuing workflow...]\n\n")
 				messages = append(messages, llm.Message{
 					Role:    "assistant",

--- a/internal/api/anthropic_tool_loop.go
+++ b/internal/api/anthropic_tool_loop.go
@@ -721,7 +721,6 @@ func runToolLoopWithObserver(
 				"retries", prematureEndRetries,
 				"content_prefix", truncateForLog(resp.Content, 120),
 			)
-			observer.assistantContent(resp.Content)
 			observer.prematureEndRetry()
 			messages = append(messages, llm.Message{
 				Role:    "assistant",

--- a/internal/api/anthropic_tool_loop.go
+++ b/internal/api/anthropic_tool_loop.go
@@ -139,6 +139,24 @@ func (o *toolLoopObserver) autoPoll() {
 	}
 }
 
+func formatToolProgress(tc llm.ToolCall, result string) string {
+	status := "completed"
+	var parsed struct {
+		Success *bool `json:"success"`
+		Data    struct {
+			Phase string `json:"phase"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(result), &parsed); err == nil {
+		if parsed.Success != nil && !*parsed.Success {
+			status = "failed"
+		} else if parsed.Data.Phase != "" {
+			status = "phase=" + parsed.Data.Phase
+		}
+	}
+	return fmt.Sprintf("[Tool %s %s]\n\n", tc.Name, status)
+}
+
 // coordinatorSystemPrompt returns the system prompt supplement for the proxy's coordinator mode.
 func coordinatorSystemPrompt(namespace string) string {
 	return fmt.Sprintf(`<orka_coordinator>
@@ -703,6 +721,7 @@ func runToolLoopWithObserver(
 				"retries", prematureEndRetries,
 				"content_prefix", truncateForLog(resp.Content, 120),
 			)
+			observer.assistantContent(resp.Content)
 			observer.prematureEndRetry()
 			messages = append(messages, llm.Message{
 				Role:    "assistant",

--- a/internal/api/openai_compat.go
+++ b/internal/api/openai_compat.go
@@ -522,15 +522,17 @@ func (h *OpenAICompatHandler) handleStreamingToolLoop(
 			}
 		}
 		observer := &toolLoopObserver{
-			OnAssistantContent: writeContent,
+			OnAssistantContent: func(content string) {
+				writeContent(stripGoalStateSentinel(content))
+			},
 			OnFinalContent: func(content string) {
 				writeContent(stripGoalStateSentinel(content))
 			},
 			OnToolResult: func(tc llm.ToolCall, result string) {
-				writeContent(formatOpenAIToolProgress(tc, result))
+				writeContent(formatToolProgress(tc, result))
 			},
 			OnPrematureEndRetry: func() {
-				writeContent("[⚠️  premature end — re-prompting coordinator]\n\n")
+				writeContent("[Continuing workflow...]\n\n")
 			},
 			OnAutoPoll: func() {
 				writeContent("[⏳ Auto-polling tasks...]\n")
@@ -606,24 +608,6 @@ func stripGoalStateSentinelFromResponse(resp *llm.CompletionResponse) *llm.Compl
 	respCopy := *resp
 	respCopy.Content = strippedContent
 	return &respCopy
-}
-
-func formatOpenAIToolProgress(tc llm.ToolCall, result string) string {
-	status := "completed"
-	var parsed struct {
-		Success *bool `json:"success"`
-		Data    struct {
-			Phase string `json:"phase"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal([]byte(result), &parsed); err == nil {
-		if parsed.Success != nil && !*parsed.Success {
-			status = "failed"
-		} else if parsed.Data.Phase != "" {
-			status = "phase=" + parsed.Data.Phase
-		}
-	}
-	return fmt.Sprintf("[Tool %s %s]\n\n", tc.Name, status)
 }
 
 // formatOAIResponse formats a CompletionResponse into OpenAI API format.

--- a/internal/api/openai_compat_test.go
+++ b/internal/api/openai_compat_test.go
@@ -856,7 +856,7 @@ func TestHandleStreamingToolLoop_StreamsProgressAndHidesServerSideToolCalls(t *t
 	mock := &oaiMockProvider{
 		responses: []*llm.CompletionResponse{
 			{
-				Content:    "Reading file before final answer.\n",
+				Content:    "Reading file before final answer.\n" + goalStateSentinel + "\n",
 				StopReason: oaiStopReasonToolUse,
 				ToolCalls: []llm.ToolCall{{
 					ID:        "call_file_read",

--- a/internal/api/openai_compat_test.go
+++ b/internal/api/openai_compat_test.go
@@ -955,6 +955,44 @@ func TestHandleNonStreamingToolLoop_StripsGoalStateSentinel(t *testing.T) {
 	}
 }
 
+func TestHandleStreamingToolLoop_DoesNotStreamPrematureCoordinatorText(t *testing.T) {
+	mock := &oaiMockProvider{
+		responses: []*llm.CompletionResponse{
+			{Content: "premature secret progress summary", StopReason: oaiStopReasonEndTurn},
+			{Content: goalStateSentinel + "\nPR ready: https://example.test/pr/5", StopReason: oaiStopReasonEndTurn},
+		},
+	}
+
+	handler, app := setupTestOpenAIHandler()
+	handler.config.MaxPrematureEndRetries = 1
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingToolLoop(
+			c, context.Background(), mock,
+			&llm.CompletionRequest{Model: "gpt-4", Messages: []llm.Message{{Role: "user", Content: "ship"}}},
+			"chatcmpl-premature", "gpt-4", 1234567890, nil, nil,
+		)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if strings.Contains(bodyStr, "premature secret progress summary") {
+		t.Fatalf("stream body leaked premature coordinator text: %s", bodyStr)
+	}
+	for _, want := range []string{"[Continuing workflow...]", "PR ready: https://example.test/pr/5", "[DONE]"} {
+		if !strings.Contains(bodyStr, want) {
+			t.Fatalf("expected stream body to contain %q, got: %s", want, bodyStr)
+		}
+	}
+	if mock.callIdx != 2 {
+		t.Fatalf("expected 2 LLM calls, got %d", mock.callIdx)
+	}
+}
+
 // --- Tests: extractContent edge cases ---
 
 func TestExtractContent_NonStringNonArray(t *testing.T) {

--- a/test/e2e/live_anthropic_compat_test.go
+++ b/test/e2e/live_anthropic_compat_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/sozercan/orka/test/utils"
 )
 
+const liveAnthropicGoalStateSentinel = "<ORKA_GOAL_STATE_REACHED>"
+
 var _ = Describe("Live Anthropic Compat API", Ordered, func() {
 	const (
 		liveAnthropicProviderName = "e2e-live-anthropic-compat-provider"
@@ -225,9 +227,9 @@ func postLiveAnthropicJSON(apiBaseURL, token, providerName, model, expectedText 
 		"max_tokens": 32,
 		"messages": [{
 			"role": "user",
-			"content": "Reply with exactly %s and nothing else. Do not use any tools."
+			"content": "Reply with exactly %s\n%s and nothing else. Do not use any tools."
 		}]
-	}`, providerName, model, expectedText)
+	}`, providerName, model, liveAnthropicGoalStateSentinel, expectedText)
 
 	req, err := http.NewRequest(http.MethodPost, strings.TrimRight(apiBaseURL, "/")+"/anthropic/v1/messages", strings.NewReader(body))
 	Expect(err).NotTo(HaveOccurred())
@@ -258,9 +260,9 @@ func postLiveAnthropicSSE(apiBaseURL, token, providerName, model, expectedText s
 		"stream": true,
 		"messages": [{
 			"role": "user",
-			"content": "Reply with exactly %s and nothing else. Do not use any tools."
+			"content": "Reply with exactly %s\n%s and nothing else. Do not use any tools."
 		}]
-	}`, providerName, model, expectedText)
+	}`, providerName, model, liveAnthropicGoalStateSentinel, expectedText)
 
 	req, err := http.NewRequest(http.MethodPost, strings.TrimRight(apiBaseURL, "/")+"/anthropic/v1/messages", strings.NewReader(body))
 	Expect(err).NotTo(HaveOccurred())

--- a/workers/common/agent_runtime_test.go
+++ b/workers/common/agent_runtime_test.go
@@ -991,6 +991,8 @@ func TestRunAgent_ManagedExecutionWorkspaceReusesExistingGitCheckout(t *testing.
 		t.Fatalf("initial CloneRepo failed: %v", err)
 	}
 	runGit(t, workspaceDir, "checkout", "-B", "stale-retained")
+	runGit(t, workspaceDir, "config", "user.email", "test@test.com")
+	runGit(t, workspaceDir, "config", "user.name", "Test")
 	if err := os.WriteFile(filepath.Join(workspaceDir, "stale.txt"), []byte("stale\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

- stream OpenAI-compatible server-side tool-loop progress inside the SSE response instead of buffering the full coordinator loop first
- keep Orka tool calls server-side while emitting safe assistant progress chunks
- strip the internal `<ORKA_GOAL_STATE_REACHED>` sentinel from tool-loop client output
- align Anthropic/OpenAI streaming output hygiene: neutral continuation text and safe tool progress metadata only, no raw tool results

## Validation

- `go test ./internal/api -run 'TestHandleStreamingToolLoop_|TestHandleNonStreamingToolLoop_|TestRunNonStreamingToolLoop_' -count=1 -v`
- `go test ./internal/api -run 'TestHandleStreamingMessages_StripsSentinelAndStreamsSafeToolProgress|TestConvertToAnthropicResponse_PreservesGoalStateSentinelForTransparentProxy|TestAnthropicToolLoopFormatting_StripsGoalStateSentinel|TestHandleStreamingToolLoop_|TestHandleNonStreamingToolLoop_' -count=1 -v`
- `make lint-fix && make test`
- `$autoreview` clean: no accepted/actionable findings reported
