### PR TITLE
feat(ui): add repository monitor creation

### DIFF
--- a/ui/src/components/monitors/repository-monitor-create-form.test.tsx
+++ b/ui/src/components/monitors/repository-monitor-create-form.test.tsx
@@ -39,6 +39,30 @@ vi.mock('@/hooks/use-secrets', () => ({
   useSecretNames: () => mockUseSecretNames(),
 }))
 
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as any
+}
+
+if (typeof HTMLElement !== 'undefined') {
+  if (!HTMLElement.prototype.hasPointerCapture) {
+    HTMLElement.prototype.hasPointerCapture = () => false
+  }
+  if (!HTMLElement.prototype.setPointerCapture) {
+    HTMLElement.prototype.setPointerCapture = () => {}
+  }
+  if (!HTMLElement.prototype.releasePointerCapture) {
+    HTMLElement.prototype.releasePointerCapture = () => {}
+  }
+  if (!HTMLElement.prototype.scrollIntoView) {
+    HTMLElement.prototype.scrollIntoView = () => {}
+  }
+}
+
 import userEvent from '@testing-library/user-event'
 import { render, screen, waitFor } from '@/test/test-utils'
 import { useUIStore } from '@/stores/ui'
@@ -84,7 +108,8 @@ describe('RepositoryMonitorCreateForm', () => {
     await user.type(screen.getByLabelText(/Max PRs per run/i), '10')
     await user.click(screen.getByRole('checkbox', { name: /Include draft pull requests/i }))
     await user.click(screen.getByRole('checkbox', { name: /Enable exact event runs/i }))
-    await user.selectOptions(screen.getByLabelText(/Review event/i), 'REQUEST_CHANGES')
+    await user.click(screen.getByRole('combobox', { name: /Review event/i }))
+    await user.click(await screen.findByRole('option', { name: 'REQUEST_CHANGES' }))
     await user.type(screen.getByLabelText(/Stale review TTL/i), '24h')
     await user.type(screen.getByLabelText(/Protected labels/i), 'security-sensitive, customer-data, security-sensitive')
     await user.type(screen.getByLabelText(/Pause labels/i), 'orka:pause')

--- a/ui/src/components/monitors/repository-monitor-create-form.test.tsx
+++ b/ui/src/components/monitors/repository-monitor-create-form.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('zustand/middleware', () => ({
+  persist: (fn: unknown) => fn,
+}))
+
+const mockNavigate = vi.fn()
+const mockMutateAsync = vi.fn()
+const mockUseCreateRepositoryMonitor = vi.fn()
+const mockUseAgentList = vi.fn()
+const mockUseSecretNames = vi.fn()
+const mockToastSuccess = vi.fn()
+const mockToastError = vi.fn()
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual = await vi.importActual('@tanstack/react-router')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}))
+
+vi.mock('@/hooks/use-monitors', () => ({
+  useCreateRepositoryMonitor: () => mockUseCreateRepositoryMonitor(),
+}))
+
+vi.mock('@/hooks/use-agents', () => ({
+  useAgentList: () => mockUseAgentList(),
+}))
+
+vi.mock('@/hooks/use-secrets', () => ({
+  useSecretNames: () => mockUseSecretNames(),
+}))
+
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@/test/test-utils'
+import { useUIStore } from '@/stores/ui'
+import { RepositoryMonitorCreateForm } from './repository-monitor-create-form'
+
+describe('RepositoryMonitorCreateForm', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset()
+    mockMutateAsync.mockReset()
+    mockToastSuccess.mockReset()
+    mockToastError.mockReset()
+    mockUseCreateRepositoryMonitor.mockReturnValue({ mutateAsync: mockMutateAsync, isPending: false })
+    mockUseAgentList.mockReturnValue({
+      data: {
+        items: [
+          { metadata: { name: 'repo-reviewer' }, spec: { runtime: { type: 'claude' } } },
+          { metadata: { name: 'codex-agent' }, spec: { runtime: { type: 'codex' } } },
+        ],
+      },
+      isLoading: false,
+    })
+    mockUseSecretNames.mockReturnValue({ data: { items: [{ name: 'repo-monitor-github' }] } })
+    mockMutateAsync.mockResolvedValue({
+      metadata: { name: 'example-app', namespace: 'default' },
+      spec: { repoURL: 'https://github.com/example/app' },
+    })
+    useUIStore.setState({ namespace: 'default', sidebarCollapsed: false, theme: 'light' })
+  })
+
+  it('submits the repository monitor create body and navigates to the created monitor', async () => {
+    const user = userEvent.setup()
+    render(<RepositoryMonitorCreateForm />)
+
+    await user.type(screen.getByLabelText(/Monitor name/i), 'example-app')
+    await user.type(screen.getByLabelText(/GitHub repository URL/i), 'https://github.com/example/app')
+    await user.clear(screen.getByLabelText(/Branch/i))
+    await user.type(screen.getByLabelText(/Branch/i), 'develop')
+    await user.type(screen.getByLabelText(/Reviewer Agent name/i), 'repo-reviewer')
+    await user.type(screen.getByLabelText(/Git Secret name/i), 'repo-monitor-github')
+    await user.clear(screen.getByLabelText(/Schedule/i))
+    await user.type(screen.getByLabelText(/Schedule/i), '*/15 * * * *')
+    await user.clear(screen.getByLabelText(/Max PRs per run/i))
+    await user.type(screen.getByLabelText(/Max PRs per run/i), '10')
+    await user.click(screen.getByRole('checkbox', { name: /Include draft pull requests/i }))
+    await user.click(screen.getByRole('checkbox', { name: /Enable exact event runs/i }))
+    await user.selectOptions(screen.getByLabelText(/Review event/i), 'REQUEST_CHANGES')
+    await user.type(screen.getByLabelText(/Stale review TTL/i), '24h')
+    await user.type(screen.getByLabelText(/Protected labels/i), 'security-sensitive, customer-data, security-sensitive')
+    await user.type(screen.getByLabelText(/Pause labels/i), 'orka:pause')
+
+    await user.click(screen.getByRole('button', { name: /Create Monitor/i }))
+
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1))
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      name: 'example-app',
+      namespace: 'default',
+      spec: {
+        provider: 'github',
+        repoURL: 'https://github.com/example/app',
+        branch: 'develop',
+        schedule: '*/15 * * * *',
+        gitSecretRef: { name: 'repo-monitor-github' },
+        targets: {
+          pullRequests: {
+            enabled: true,
+            includeDrafts: true,
+            maxPerRun: 10,
+          },
+        },
+        agents: {
+          reviewer: { name: 'repo-reviewer' },
+        },
+        review: {
+          event: 'REQUEST_CHANGES',
+          staleReviewTTL: '24h',
+          exactEventEnabled: true,
+        },
+        policy: {
+          protectedLabels: ['security-sensitive', 'customer-data'],
+          pauseLabels: ['orka:pause'],
+        },
+      },
+    })
+    expect(mockToastSuccess).toHaveBeenCalledWith('Repository monitor created')
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/monitors/$monitorId', params: { monitorId: 'example-app' } })
+  })
+
+  it('rejects non-root GitHub pull request URLs before submitting', async () => {
+    const user = userEvent.setup()
+    render(<RepositoryMonitorCreateForm />)
+
+    await user.type(screen.getByLabelText(/Monitor name/i), 'example-app')
+    await user.type(screen.getByLabelText(/GitHub repository URL/i), 'https://github.com/example/app/pull/1')
+    await user.type(screen.getByLabelText(/Reviewer Agent name/i), 'repo-reviewer')
+
+    await user.click(screen.getByRole('button', { name: /Create Monitor/i }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Repository URL must be a credential-free GitHub repository root')
+    expect(mockToastError).toHaveBeenCalledWith(expect.stringContaining('Repository URL must be a credential-free GitHub repository root'))
+    expect(mockMutateAsync).not.toHaveBeenCalled()
+  })
+
+  it('requires a reviewer Agent name', async () => {
+    const user = userEvent.setup()
+    render(<RepositoryMonitorCreateForm />)
+
+    await user.type(screen.getByLabelText(/Monitor name/i), 'example-app')
+    await user.type(screen.getByLabelText(/GitHub repository URL/i), 'https://github.com/example/app')
+
+    await user.click(screen.getByRole('button', { name: /Create Monitor/i }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Reviewer Agent name is required')
+    expect(mockMutateAsync).not.toHaveBeenCalled()
+  })
+})

--- a/ui/src/components/monitors/repository-monitor-create-form.tsx
+++ b/ui/src/components/monitors/repository-monitor-create-form.tsx
@@ -1,0 +1,353 @@
+import { useMemo, useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { useAgentList } from '@/hooks/use-agents'
+import { useCreateRepositoryMonitor } from '@/hooks/use-monitors'
+import { useSecretNames } from '@/hooks/use-secrets'
+import { useUIStore } from '@/stores/ui'
+
+const REVIEW_EVENTS = ['COMMENT', 'APPROVE', 'REQUEST_CHANGES'] as const
+
+type ReviewEvent = (typeof REVIEW_EVENTS)[number]
+
+function splitCommaList(value: string) {
+  const seen = new Set<string>()
+  const labels: string[] = []
+
+  for (const raw of value.split(',')) {
+    const label = raw.trim()
+    if (label && !seen.has(label)) {
+      seen.add(label)
+      labels.push(label)
+    }
+  }
+
+  return labels
+}
+
+function isCredentialFreeGitHubRepositoryURL(value: string) {
+  const repoURL = value.trim()
+  if (!repoURL) return false
+
+  if (/^git@github\.com:[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+(?:\.git)?$/.test(repoURL)) {
+    return true
+  }
+
+  if (!repoURL.startsWith('https://')) {
+    return false
+  }
+
+  try {
+    const parsed = new URL(repoURL)
+    if (parsed.protocol !== 'https:' || parsed.hostname !== 'github.com') return false
+    if (parsed.username || parsed.password || parsed.search || parsed.hash) return false
+
+    const pathParts = parsed.pathname.split('/').filter(Boolean)
+    if (pathParts.length !== 2) return false
+
+    return pathParts.every((part) => /^[A-Za-z0-9._-]+(?:\.git)?$/.test(part))
+  } catch {
+    return false
+  }
+}
+
+function maybeObject<T extends Record<string, unknown>>(value: T) {
+  const hasValue = Object.values(value).some((field) => {
+    if (Array.isArray(field)) return field.length > 0
+    return field !== undefined && field !== ''
+  })
+
+  return hasValue ? value : undefined
+}
+
+export function RepositoryMonitorCreateForm() {
+  const navigate = useNavigate()
+  const namespace = useUIStore((s) => s.namespace)
+  const createMonitor = useCreateRepositoryMonitor()
+  const { data: agents, isLoading: agentsLoading } = useAgentList()
+  const { data: secrets } = useSecretNames()
+
+  const [name, setName] = useState('')
+  const [repoURL, setRepoURL] = useState('')
+  const [branch, setBranch] = useState('main')
+  const [schedule, setSchedule] = useState('*/30 * * * *')
+  const [reviewerAgentName, setReviewerAgentName] = useState('')
+  const [gitSecretName, setGitSecretName] = useState('')
+  const [includeDrafts, setIncludeDrafts] = useState(false)
+  const [maxPRsPerRun, setMaxPRsPerRun] = useState('20')
+  const [reviewEvent, setReviewEvent] = useState<ReviewEvent>('COMMENT')
+  const [staleReviewTTL, setStaleReviewTTL] = useState('')
+  const [exactEventEnabled, setExactEventEnabled] = useState(false)
+  const [protectedLabels, setProtectedLabels] = useState('')
+  const [pauseLabels, setPauseLabels] = useState('')
+  const [formError, setFormError] = useState('')
+
+  const claudeAgents = useMemo(
+    () => (agents?.items ?? []).filter((agent) => agent.spec.runtime?.type === 'claude'),
+    [agents?.items],
+  )
+
+  const validate = () => {
+    const trimmedName = name.trim()
+    const trimmedRepoURL = repoURL.trim()
+    const trimmedReviewerAgentName = reviewerAgentName.trim()
+
+    if (!trimmedName) {
+      return 'Monitor name is required.'
+    }
+    if (!/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(trimmedName)) {
+      return 'Monitor name must be a Kubernetes DNS label using lowercase letters, numbers, and hyphens.'
+    }
+    if (!trimmedRepoURL) {
+      return 'GitHub repository URL is required.'
+    }
+    if (!isCredentialFreeGitHubRepositoryURL(trimmedRepoURL)) {
+      return 'Repository URL must be a credential-free GitHub repository root, such as https://github.com/org/repo.'
+    }
+    if (!trimmedReviewerAgentName) {
+      return 'Reviewer Agent name is required.'
+    }
+    if (!/^\d+$/.test(maxPRsPerRun)) {
+      return 'Max PRs per run must be a whole number from 1 to 100.'
+    }
+
+    const maxPerRun = Number(maxPRsPerRun)
+    if (maxPerRun < 1 || maxPerRun > 100) {
+      return 'Max PRs per run must be between 1 and 100.'
+    }
+
+    return ''
+  }
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+
+    const validationError = validate()
+    if (validationError) {
+      setFormError(validationError)
+      toast.error(validationError)
+      return
+    }
+
+    const policy = maybeObject({
+      protectedLabels: splitCommaList(protectedLabels),
+      pauseLabels: splitCommaList(pauseLabels),
+    })
+
+    const body = {
+      name: name.trim(),
+      namespace,
+      spec: {
+        provider: 'github',
+        repoURL: repoURL.trim(),
+        branch: branch.trim() || 'main',
+        schedule: schedule.trim() || undefined,
+        gitSecretRef: gitSecretName.trim() ? { name: gitSecretName.trim() } : undefined,
+        targets: {
+          pullRequests: {
+            enabled: true,
+            includeDrafts,
+            maxPerRun: Number(maxPRsPerRun),
+          },
+        },
+        agents: {
+          reviewer: { name: reviewerAgentName.trim() },
+        },
+        review: {
+          event: reviewEvent,
+          staleReviewTTL: staleReviewTTL.trim() || undefined,
+          exactEventEnabled,
+        },
+        policy,
+      },
+    }
+
+    try {
+      const monitor = await createMonitor.mutateAsync(body)
+      const monitorName = monitor.metadata.name || body.name
+      setFormError('')
+      toast.success('Repository monitor created')
+      navigate({ to: '/monitors/$monitorId', params: { monitorId: monitorName } })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      setFormError(message)
+      toast.error(`Failed to create repository monitor: ${message}`)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">New Repository Monitor</h1>
+          <p className="text-muted-foreground">
+            Create GitHub pull request review automation in the <span className="font-medium text-foreground">{namespace}</span> namespace.
+          </p>
+        </div>
+        <Button type="button" variant="outline" onClick={() => navigate({ to: '/monitors' })}>
+          Cancel
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Monitor setup</CardTitle>
+          <CardDescription>
+            Orka stores Secret names only. Add GitHub tokens or Claude keys as Kubernetes Secrets before creating the monitor.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-6" onSubmit={handleSubmit} noValidate>
+            {formError ? (
+              <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive" role="alert">
+                {formError}
+              </div>
+            ) : null}
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <label htmlFor="monitor-name" className="text-sm font-medium">Monitor name</label>
+                <Input
+                  id="monitor-name"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  placeholder="example-app"
+                  aria-invalid={formError.includes('Monitor name')}
+                />
+                <p className="text-xs text-muted-foreground">Lowercase Kubernetes resource name.</p>
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="monitor-branch" className="text-sm font-medium">Branch</label>
+                <Input id="monitor-branch" value={branch} onChange={(event) => setBranch(event.target.value)} placeholder="main" />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="monitor-repo-url" className="text-sm font-medium">GitHub repository URL</label>
+              <Input
+                id="monitor-repo-url"
+                value={repoURL}
+                onChange={(event) => setRepoURL(event.target.value)}
+                placeholder="https://github.com/org/repo"
+                aria-invalid={formError.includes('Repository URL') || formError.includes('GitHub repository URL')}
+              />
+              <p className="text-xs text-muted-foreground">
+                Use a repository root URL only. Pull request, issue, branch, file, query, fragment, HTTP, and token-bearing URLs are rejected.
+              </p>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <label htmlFor="monitor-reviewer-agent" className="text-sm font-medium">Reviewer Agent name</label>
+                <Input
+                  id="monitor-reviewer-agent"
+                  list="monitor-reviewer-agent-options"
+                  value={reviewerAgentName}
+                  onChange={(event) => setReviewerAgentName(event.target.value)}
+                  placeholder={agentsLoading ? 'Loading agents...' : 'repo-reviewer'}
+                  aria-invalid={formError.includes('Reviewer Agent')}
+                />
+                <datalist id="monitor-reviewer-agent-options">
+                  {claudeAgents.map((agent) => (
+                    <option key={agent.metadata.name} value={agent.metadata.name} />
+                  ))}
+                </datalist>
+                <p className="text-xs text-muted-foreground">
+                  Must be a Claude runtime Agent with an Anthropic credential Secret in this namespace.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="monitor-git-secret" className="text-sm font-medium">Git Secret name</label>
+                <Input
+                  id="monitor-git-secret"
+                  list="monitor-git-secret-options"
+                  value={gitSecretName}
+                  onChange={(event) => setGitSecretName(event.target.value)}
+                  placeholder="Optional, for private repos or rate limits"
+                />
+                <datalist id="monitor-git-secret-options">
+                  {(secrets?.items ?? []).map((secret) => (
+                    <option key={secret.name} value={secret.name} />
+                  ))}
+                </datalist>
+                <p className="text-xs text-muted-foreground">Secret must contain token, password, or GITHUB_TOKEN.</p>
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <label htmlFor="monitor-schedule" className="text-sm font-medium">Schedule</label>
+                <Input id="monitor-schedule" value={schedule} onChange={(event) => setSchedule(event.target.value)} placeholder="*/30 * * * *" />
+                <p className="text-xs text-muted-foreground">Leave empty for manual runs only.</p>
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="monitor-max-prs" className="text-sm font-medium">Max PRs per run</label>
+                <Input id="monitor-max-prs" type="number" min="1" max="100" value={maxPRsPerRun} onChange={(event) => setMaxPRsPerRun(event.target.value)} />
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <label className="flex items-center gap-3 rounded-md border p-3 text-sm">
+                <input type="checkbox" checked={includeDrafts} onChange={(event) => setIncludeDrafts(event.target.checked)} />
+                <span>
+                  <span className="font-medium">Include draft pull requests</span>
+                  <span className="block text-xs text-muted-foreground">Allow draft PRs to be selected for review.</span>
+                </span>
+              </label>
+              <label className="flex items-center gap-3 rounded-md border p-3 text-sm">
+                <input type="checkbox" checked={exactEventEnabled} onChange={(event) => setExactEventEnabled(event.target.checked)} />
+                <span>
+                  <span className="font-medium">Enable exact event runs</span>
+                  <span className="block text-xs text-muted-foreground">Queue exact-head reviews from GitHub pull request webhook events.</span>
+                </span>
+              </label>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <label htmlFor="monitor-review-event" className="text-sm font-medium">Review event</label>
+                <select
+                  id="monitor-review-event"
+                  className="border-input bg-background h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+                  value={reviewEvent}
+                  onChange={(event) => setReviewEvent(event.target.value as ReviewEvent)}
+                >
+                  {REVIEW_EVENTS.map((event) => (
+                    <option key={event} value={event}>{event}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="monitor-stale-ttl" className="text-sm font-medium">Stale review TTL</label>
+                <Input id="monitor-stale-ttl" value={staleReviewTTL} onChange={(event) => setStaleReviewTTL(event.target.value)} placeholder="Optional, e.g. 24h" />
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <label htmlFor="monitor-protected-labels" className="text-sm font-medium">Protected labels</label>
+                <Input id="monitor-protected-labels" value={protectedLabels} onChange={(event) => setProtectedLabels(event.target.value)} placeholder="security-sensitive, customer-data" />
+                <p className="text-xs text-muted-foreground">Comma-separated labels that block automation according to policy.</p>
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="monitor-pause-labels" className="text-sm font-medium">Pause labels</label>
+                <Input id="monitor-pause-labels" value={pauseLabels} onChange={(event) => setPauseLabels(event.target.value)} placeholder="orka:pause" />
+                <p className="text-xs text-muted-foreground">Comma-separated labels that pause further automation while present.</p>
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="outline" onClick={() => navigate({ to: '/monitors' })}>Cancel</Button>
+              <Button type="submit" disabled={createMonitor.isPending}>
+                {createMonitor.isPending ? 'Creating...' : 'Create Monitor'}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/ui/src/components/monitors/repository-monitor-create-form.tsx
+++ b/ui/src/components/monitors/repository-monitor-create-form.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { useAgentList } from '@/hooks/use-agents'
 import { useCreateRepositoryMonitor } from '@/hooks/use-monitors'
 import { useSecretNames } from '@/hooks/use-secrets'
@@ -308,17 +309,17 @@ export function RepositoryMonitorCreateForm() {
 
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
-                <label htmlFor="monitor-review-event" className="text-sm font-medium">Review event</label>
-                <select
-                  id="monitor-review-event"
-                  className="border-input bg-background h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
-                  value={reviewEvent}
-                  onChange={(event) => setReviewEvent(event.target.value as ReviewEvent)}
-                >
-                  {REVIEW_EVENTS.map((event) => (
-                    <option key={event} value={event}>{event}</option>
-                  ))}
-                </select>
+                <label id="monitor-review-event-label" className="text-sm font-medium">Review event</label>
+                <Select value={reviewEvent} onValueChange={(value) => setReviewEvent(value as ReviewEvent)}>
+                  <SelectTrigger aria-labelledby="monitor-review-event-label">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {REVIEW_EVENTS.map((event) => (
+                      <SelectItem key={event} value={event}>{event}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
               <div className="space-y-2">
                 <label htmlFor="monitor-stale-ttl" className="text-sm font-medium">Stale review TTL</label>

--- a/ui/src/components/monitors/repository-monitor-list.test.tsx
+++ b/ui/src/components/monitors/repository-monitor-list.test.tsx
@@ -59,6 +59,20 @@ describe('RepositoryMonitorList', () => {
     vi.useRealTimers()
   })
 
+
+  it('links to the create form from the empty state', () => {
+    mockUseRepositoryMonitors.mockReturnValue({
+      isLoading: false,
+      data: { items: [] },
+    })
+
+    render(<RepositoryMonitorList />)
+
+    expect(screen.getByText('No repository monitors configured.')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /New Monitor/i })).toHaveAttribute('href', '/monitors/create/new')
+    expect(screen.getByRole('link', { name: /Create repository monitor/i })).toHaveAttribute('href', '/monitors/create/new')
+  })
+
   it('renders repository monitor status and last run time', () => {
     mockUseRepositoryMonitors.mockReturnValue({
       isLoading: false,

--- a/ui/src/components/monitors/repository-monitor-list.tsx
+++ b/ui/src/components/monitors/repository-monitor-list.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router'
-import { Activity, GitPullRequest, Play, Wrench } from 'lucide-react'
+import { Activity, GitPullRequest, Play, Plus, Wrench } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -22,9 +22,17 @@ export function RepositoryMonitorList() {
 
   return (
     <div className="space-y-4">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Repository Monitors</h1>
-        <p className="text-muted-foreground">Maintainer automation state for pull requests, repairs, and audit trails</p>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Repository Monitors</h1>
+          <p className="text-muted-foreground">Maintainer automation state for pull requests, repairs, and audit trails</p>
+        </div>
+        <Link to="/monitors/create/new">
+          <Button>
+            <Plus className="mr-2 h-4 w-4" />
+            New Monitor
+          </Button>
+        </Link>
       </div>
 
       {isLoading ? (
@@ -41,8 +49,17 @@ export function RepositoryMonitorList() {
         </div>
       ) : (data?.items ?? []).length === 0 ? (
         <Card>
-          <CardContent className="py-12 text-center text-muted-foreground">
-            No repository monitors configured.
+          <CardContent className="space-y-4 py-12 text-center">
+            <div className="space-y-1">
+              <p className="font-medium">No repository monitors configured.</p>
+              <p className="text-sm text-muted-foreground">Create a monitor to review GitHub pull requests from the dashboard.</p>
+            </div>
+            <Link to="/monitors/create/new">
+              <Button>
+                <Plus className="mr-2 h-4 w-4" />
+                Create repository monitor
+              </Button>
+            </Link>
           </CardContent>
         </Card>
       ) : (

--- a/ui/src/hooks/use-monitors.test.tsx
+++ b/ui/src/hooks/use-monitors.test.tsx
@@ -1,0 +1,68 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import type { ReactNode } from 'react'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { server } from '@/test/mocks/server'
+
+vi.mock('zustand/middleware', () => ({
+  persist: (fn: unknown) => fn,
+}))
+
+import { useUIStore } from '@/stores/ui'
+import { useCreateRepositoryMonitor } from './use-monitors'
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  })
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  useUIStore.setState({ namespace: 'default', sidebarCollapsed: false, theme: 'light' })
+})
+
+describe('useCreateRepositoryMonitor', () => {
+  it('posts the create request and invalidates monitor list/detail queries', async () => {
+    const queryClient = createTestQueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    let receivedBody: unknown
+
+    server.use(
+      http.post('/api/v1/monitors/repositories', async ({ request }) => {
+        receivedBody = await request.json()
+        return HttpResponse.json({
+          metadata: { name: 'example-app', namespace: 'default' },
+          spec: { repoURL: 'https://github.com/example/app' },
+        }, { status: 201 })
+      }),
+    )
+
+    const body = {
+      name: 'example-app',
+      namespace: 'default',
+      spec: {
+        repoURL: 'https://github.com/example/app',
+        agents: { reviewer: { name: 'repo-reviewer' } },
+      },
+    }
+
+    const { result } = renderHook(() => useCreateRepositoryMonitor(), { wrapper: createWrapper(queryClient) })
+
+    await act(async () => {
+      await result.current.mutateAsync(body)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(receivedBody).toEqual(body)
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['monitors', 'repositories'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['monitors', 'repositories', 'default'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['monitors', 'repository', 'default', 'example-app'] })
+  })
+})

--- a/ui/src/hooks/use-monitors.ts
+++ b/ui/src/hooks/use-monitors.ts
@@ -8,6 +8,13 @@ interface ListResponse<T> {
   metadata?: { continue?: string }
 }
 
+export interface CreateRepositoryMonitorBody {
+  name: string
+  namespace?: string
+  metadata?: { name?: string; namespace?: string }
+  spec: RepositoryMonitor['spec']
+}
+
 export function useRepositoryMonitors() {
   const namespace = useUIStore((s) => s.namespace)
   return useQuery({
@@ -44,6 +51,24 @@ export function useRepositoryMonitorItems(name: string, kind = 'pull_request') {
     queryFn: () => api.get<ListResponse<MonitorItem>>(`/monitors/repositories/${name}/items`, { namespace, kind }),
     enabled: !!name,
     refetchInterval: 10000,
+  })
+}
+
+export function useCreateRepositoryMonitor() {
+  const queryClient = useQueryClient()
+  const namespace = useUIStore((s) => s.namespace)
+  return useMutation({
+    mutationFn: (body: CreateRepositoryMonitorBody) => api.post<RepositoryMonitor>('/monitors/repositories', body),
+    onSuccess: (monitor, variables) => {
+      const createdNamespace = monitor.metadata.namespace ?? variables.namespace ?? variables.metadata?.namespace ?? namespace
+      const createdName = monitor.metadata.name ?? variables.name ?? variables.metadata?.name
+
+      queryClient.invalidateQueries({ queryKey: ['monitors', 'repositories'] })
+      queryClient.invalidateQueries({ queryKey: ['monitors', 'repositories', createdNamespace] })
+      if (createdName) {
+        queryClient.invalidateQueries({ queryKey: ['monitors', 'repository', createdNamespace, createdName] })
+      }
+    },
   })
 }
 

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -30,6 +30,7 @@ import { Route as MonitorsMonitorIdRouteImport } from './routes/monitors/$monito
 import { Route as AgentsNewRouteImport } from './routes/agents/new'
 import { Route as AgentsAgentIdRouteImport } from './routes/agents/$agentId'
 import { Route as SecurityFindingsFindingIdRouteImport } from './routes/security/findings/$findingId'
+import { Route as MonitorsCreateNewRouteImport } from './routes/monitors/create/new'
 
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
@@ -137,6 +138,11 @@ const SecurityFindingsFindingIdRoute =
     path: '/security/findings/$findingId',
     getParentRoute: () => rootRouteImport,
   } as any)
+const MonitorsCreateNewRoute = MonitorsCreateNewRouteImport.update({
+  id: '/monitors/create/new',
+  path: '/monitors/create/new',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -159,6 +165,7 @@ export interface FileRoutesByFullPath {
   '/sessions/': typeof SessionsIndexRoute
   '/tasks/': typeof TasksIndexRoute
   '/tools/': typeof ToolsIndexRoute
+  '/monitors/create/new': typeof MonitorsCreateNewRoute
   '/security/findings/$findingId': typeof SecurityFindingsFindingIdRoute
 }
 export interface FileRoutesByTo {
@@ -182,6 +189,7 @@ export interface FileRoutesByTo {
   '/sessions': typeof SessionsIndexRoute
   '/tasks': typeof TasksIndexRoute
   '/tools': typeof ToolsIndexRoute
+  '/monitors/create/new': typeof MonitorsCreateNewRoute
   '/security/findings/$findingId': typeof SecurityFindingsFindingIdRoute
 }
 export interface FileRoutesById {
@@ -206,6 +214,7 @@ export interface FileRoutesById {
   '/sessions/': typeof SessionsIndexRoute
   '/tasks/': typeof TasksIndexRoute
   '/tools/': typeof ToolsIndexRoute
+  '/monitors/create/new': typeof MonitorsCreateNewRoute
   '/security/findings/$findingId': typeof SecurityFindingsFindingIdRoute
 }
 export interface FileRouteTypes {
@@ -231,6 +240,7 @@ export interface FileRouteTypes {
     | '/sessions/'
     | '/tasks/'
     | '/tools/'
+    | '/monitors/create/new'
     | '/security/findings/$findingId'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -254,6 +264,7 @@ export interface FileRouteTypes {
     | '/sessions'
     | '/tasks'
     | '/tools'
+    | '/monitors/create/new'
     | '/security/findings/$findingId'
   id:
     | '__root__'
@@ -277,6 +288,7 @@ export interface FileRouteTypes {
     | '/sessions/'
     | '/tasks/'
     | '/tools/'
+    | '/monitors/create/new'
     | '/security/findings/$findingId'
   fileRoutesById: FileRoutesById
 }
@@ -301,6 +313,7 @@ export interface RootRouteChildren {
   SessionsIndexRoute: typeof SessionsIndexRoute
   TasksIndexRoute: typeof TasksIndexRoute
   ToolsIndexRoute: typeof ToolsIndexRoute
+  MonitorsCreateNewRoute: typeof MonitorsCreateNewRoute
   SecurityFindingsFindingIdRoute: typeof SecurityFindingsFindingIdRoute
 }
 
@@ -453,6 +466,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SecurityFindingsFindingIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/monitors/create/new': {
+      id: '/monitors/create/new'
+      path: '/monitors/create/new'
+      fullPath: '/monitors/create/new'
+      preLoaderRoute: typeof MonitorsCreateNewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -477,6 +497,7 @@ const rootRouteChildren: RootRouteChildren = {
   SessionsIndexRoute: SessionsIndexRoute,
   TasksIndexRoute: TasksIndexRoute,
   ToolsIndexRoute: ToolsIndexRoute,
+  MonitorsCreateNewRoute: MonitorsCreateNewRoute,
   SecurityFindingsFindingIdRoute: SecurityFindingsFindingIdRoute,
 }
 export const routeTree = rootRouteImport

--- a/ui/src/routes/monitors/create/new.tsx
+++ b/ui/src/routes/monitors/create/new.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { RepositoryMonitorCreateForm } from '@/components/monitors/repository-monitor-create-form'
+
+export const Route = createFileRoute('/monitors/create/new')({
+  component: RepositoryMonitorCreateForm,
+})

--- a/ui/src/schemas/monitor.ts
+++ b/ui/src/schemas/monitor.ts
@@ -30,6 +30,7 @@ export const repositoryMonitorSpecSchema = z.object({
   review: z.object({
     event: z.string().optional(),
     requireGreenCI: z.boolean().optional(),
+    staleReviewTTL: z.string().optional(),
     exactEventEnabled: z.boolean().optional(),
   }).optional(),
   repair: z.object({
@@ -41,6 +42,18 @@ export const repositoryMonitorSpecSchema = z.object({
     requireMaintainerOptIn: z.boolean().optional(),
     requireGlobalMergeGate: z.boolean().optional(),
     allowedMergeMethods: z.array(z.string()).optional(),
+  }).optional(),
+  policy: z.object({
+    protectedLabels: z.array(z.string()).optional(),
+    pauseLabels: z.array(z.string()).optional(),
+    optInLabels: z.object({
+      autofix: z.string().optional(),
+      automerge: z.string().optional(),
+    }).optional(),
+    advisoryLabels: z.object({
+      enabled: z.boolean().optional(),
+    }).optional(),
+    allowedRepositoryPermissions: z.array(z.string()).optional(),
   }).optional(),
   validation: z.object({
     mode: z.string().optional(),


### PR DESCRIPTION
## Summary

Adds UI support for creating RepositoryMonitor resources from the Monitors page.

- Adds a create route at `/monitors/create/new`
- Adds New Monitor/Create buttons in the monitor list and empty state
- Adds a RepositoryMonitor create form for the current GitHub PR-monitor slice
- Adds `useCreateRepositoryMonitor()` with monitor list/detail invalidation
- Extends monitor schemas for create payload fields
- Adds focused tests for create links, submit payload, validation, and hook invalidation

## Validation

- `cd ui && bun run lint` — passed with existing Fast Refresh warnings in shared UI components
- `cd ui && bun run test` — passed, 67 files / 507 tests
- `cd ui && bun run build` — passed
- Browser fallback verification against built UI + mock API — passed
- `$autoreview` — clean, no accepted/actionable findings

## Notes

The create route uses `/monitors/create/new` instead of `/monitors/new` so a valid monitor named `new` remains addressable as `/monitors/new` in the existing detail route.