### PR TITLE
ci: free disk before E2E image builds

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -26,6 +26,27 @@ jobs:
       - name: Clone the code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - name: Free disk space for Docker-heavy E2E
+        run: |
+          set -euxo pipefail
+          echo "Disk usage before cleanup"
+          df -h
+          docker system df || true
+
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/swift
+
+          docker system prune -af || true
+          docker builder prune -af || true
+
+          echo "Disk usage after cleanup"
+          df -h
+          docker system df || true
+
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:


### PR DESCRIPTION
## Summary

Adds an early disk cleanup step to the Docker-heavy E2E workflow before Go/kind setup and image builds.

The E2E job recently flaked in `BeforeSuite` while `kind load docker-image` tried to `docker save` a worker image and failed with:

```text
no space left on device
```

This cleanup removes unused preinstalled runner toolchains and prunes Docker residue before the workflow builds and loads the Orka images.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/test-e2e.yml`
- `$autoreview` with the same actionlint command as parallel validation: clean, no accepted/actionable findings