### PR TITLE
Add repo agent review skills

### DIFF
--- a/.agents/skills/agent-transcript/SKILL.md
+++ b/.agents/skills/agent-transcript/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: agent-transcript
+description: "Add a redacted agent session transcript to a GitHub PR or issue body as local-only provenance for Orka workflows."
+---
+
+# Agent Transcript
+
+Best-effort local-only provenance for Orka PR/issue bodies. Use during agent-created GitHub PR or issue workflows before creating/updating the body.
+
+## Contract
+
+- Never use network. Session discovery reads local agent logs only.
+- Never upload raw logs. Render sanitized Markdown first.
+- Always ask the user before adding transcript logs to a GitHub PR/issue body.
+- Tell the user sanitized session logs help reviewers and can make PRs easier to prioritize.
+- Offer a local HTML preview before insertion. If the user wants preview, open it and wait for confirmation before adding the section.
+- Fail closed on unresolved secrets, private keys, browser/session/cookie details, or auth URLs.
+- Drop system/developer prompts, raw tool outputs, reasoning, env, cookies, tokens, and broad local paths.
+- Keep user prompts, assistant visible decisions, terse tool summaries, and test/proof outcomes.
+- Automatically trim the rendered transcript before showing it, previewing it, or inserting it into a public body. Never paste the raw full-session render into a PR/issue body just because `render` or `append-body` produced it.
+- Remove session turns unrelated to the PR/issue work. Use the PR/issue title, branch name, changed files, and stated goal as scope; omit earlier/later unrelated tasks even when they are in the same session log.
+- Best effort only: PR/issue creation must continue if no safe transcript is found.
+- Add the `## Agent Transcript` section only when inserting a real transcript. Never add a placeholder transcript heading or text such as "A sanitized local transcript preview was generated but not included."
+- Use a collapsed `<details>` section and update existing markers instead of duplicating sections.
+
+## Helper
+
+```bash
+.agents/skills/agent-transcript/scripts/agent-transcript --help
+```
+
+Find a likely local session:
+
+```bash
+.agents/skills/agent-transcript/scripts/agent-transcript find \
+  --query "$PR_TITLE $BRANCH_OR_PR_URL" \
+  --cwd "$PWD" \
+  --since-days 14
+```
+
+`find` scans the newest 400 matching local JSONL logs by default across Codex, Claude, Pi, and OpenClaw agent sessions. Use `--max-files N` for a wider local search.
+
+Render a PR/issue body section:
+
+```bash
+.agents/skills/agent-transcript/scripts/agent-transcript render \
+  --session "$SESSION_JSONL" \
+  --scope-query "$PR_TITLE $BRANCH_OR_PR_URL" \
+  --out /tmp/agent-transcript.md
+```
+
+Preview one candidate session locally:
+
+```bash
+.agents/skills/agent-transcript/scripts/agent-transcript preview \
+  --session "$SESSION_JSONL" \
+  --scope-query "$PR_TITLE $BRANCH_OR_PR_URL" \
+  --out /tmp/agent-transcript-preview.html
+open /tmp/agent-transcript-preview.html
+```
+
+Append/update a body file before `gh pr create --body-file` or connector PR creation:
+
+```bash
+.agents/skills/agent-transcript/scripts/agent-transcript append-body \
+  --body /tmp/pr-body.md \
+  --session "$SESSION_JSONL" \
+  --scope-query "$PR_TITLE $BRANCH_OR_PR_URL" \
+  --out /tmp/pr-body.with-transcript.md
+```
+
+## PR/Issue Workflow
+
+1. Draft the normal PR/issue body first.
+2. Run `find` with title, branch, PR URL/number if known, and cwd.
+3. If a high-confidence session is found, ask:
+   `Include a redacted agent transcript? It helps reviewers and can make the PR easier to prioritize. I can open a local preview first.`
+4. If the user wants preview, run `preview`, open the HTML with `open`, and wait for confirmation.
+5. Render or append to a temp body, then automatically trim the `## Agent Transcript` section before showing it to the user or inserting it publicly. Keep only turns that explain this PR/issue's goal, implementation choices, files, tests, proof, blockers, and final outcome.
+6. Inspect the trimmed transcript text. If it still includes unrelated earlier/later work, trim again before proceeding.
+7. If the user approves, use the enriched trimmed body file for creation/update.
+8. If no safe session is found, say nothing and continue without transcript. If the user declines, continue without transcript and do not add any transcript placeholder section.
+
+## Validate
+
+```bash
+node --test .agents/skills/agent-transcript/scripts/agent-transcript.test.mjs
+```
+
+## Review Artifacts
+
+For manual audits across many PR/session candidates, create a local HTML preview from a local JSON file. This is for maintainers only and is not part of the PR/issue workflow:
+
+```bash
+.agents/skills/agent-transcript/scripts/agent-transcript html \
+  --prs /tmp/recent-prs.json \
+  --out /tmp/agent-transcript-preview.html
+```

--- a/.agents/skills/agent-transcript/scripts/agent-transcript
+++ b/.agents/skills/agent-transcript/scripts/agent-transcript
@@ -1,0 +1,1176 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const MARKER_START = "<!-- agent-transcript:start -->";
+const MARKER_END = "<!-- agent-transcript:end -->";
+const DEFAULT_MAX_CHARS = 50000;
+const DEFAULT_ENTRY_MAX_CHARS = 6000;
+const SCOPE_STOP_WORDS = new Set([
+  "agent",
+  "branch",
+  "change",
+  "changes",
+  "com",
+  "github",
+  "http",
+  "https",
+  "issue",
+  "issues",
+  "pull",
+  "request",
+  "the",
+  "this",
+  "with",
+  "www",
+]);
+const COOKIE_ASSIGNMENT =
+  /\b(?:SID|HSID|SSID|APISID|SAPISID|SIDCC|SESSIONID|LOGIN_INFO|YSC|VISITOR_INFO1_LIVE|PREF|__Secure-[A-Za-z0-9_-]+|__Host-[A-Za-z0-9_-]+)\s*=\s*(?:"[^"\r\n;`'<>&)]*"|'[^'\r\n;`"<>&)]*'|[^;\s`"'<>&)]+)/i;
+const COOKIE_ASSIGNMENT_GLOBAL =
+  /\b(?:SID|HSID|SSID|APISID|SAPISID|SIDCC|SESSIONID|LOGIN_INFO|YSC|VISITOR_INFO1_LIVE|PREF|__Secure-[A-Za-z0-9_-]+|__Host-[A-Za-z0-9_-]+)\s*=\s*(?:"[^"\r\n;`'<>&)]*"|'[^'\r\n;`"<>&)]*'|[^;\s`"'<>&)]+)/gi;
+const AUTH_QUERY_PARAM =
+  /([?&#](?:token|key|secret|signature|sig|access_token|auth|code|state|oauth_token|oauth_verifier|id_token|refresh_token|session_state)=)[^\s`"'>&]+/gi;
+const AUTH_URL =
+  /\bhttps?:\/\/[^\s`"'<>]*(?:[?&#](?:code|state|oauth_token|oauth_verifier|id_token|refresh_token|session_state|access_token|auth)=)[^\s`"'<>]*/i;
+const SERVICE_CREDENTIAL_URL =
+  /\b[A-Za-z][A-Za-z0-9+.-]*:\/\/(?=[^\s`"'<>/]*:[^\s`"'<>/]*@)[^\s`"'<>]+/i;
+const SERVICE_CREDENTIAL_URL_GLOBAL =
+  /\b[A-Za-z][A-Za-z0-9+.-]*:\/\/(?=[^\s`"'<>/]*:[^\s`"'<>/]*@)[^\s`"'<>]+/gi;
+const QUOTED_SECRET_ENV_ASSIGNMENT =
+  /\b[A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*[^\S\r\n]*=[^\S\r\n]*(?:"[^"\r\n]*"|'[^'\r\n]*')/;
+const QUOTED_SECRET_ENV_ASSIGNMENT_GLOBAL =
+  /\b[A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*[^\S\r\n]*=[^\S\r\n]*(?:"[^"\r\n]*"|'[^'\r\n]*')/g;
+const QUOTED_SECRET_FIELD =
+  /(?<![A-Za-z0-9_])["']?[A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|credential)[A-Za-z0-9_]*["']?[^\S\r\n]*:[^\S\r\n]*(?:"[^"\r\n]*"|'[^'\r\n]*')/i;
+const QUOTED_SECRET_FIELD_GLOBAL =
+  /(?<![A-Za-z0-9_])["']?[A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|credential)[A-Za-z0-9_]*["']?[^\S\r\n]*:[^\S\r\n]*(?:"[^"\r\n]*"|'[^'\r\n]*')/gi;
+const UNQUOTED_SHORT_SECRET_FIELD =
+  /(?<![A-Za-z0-9_])["']?[A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|credential)[A-Za-z0-9_]*["']?[^\S\r\n]*:[^\S\r\n]*(?!(?:user|config|self|this|options|request|response|account|profile|credential|credentials)\.[A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|credential|key|hash)[A-Za-z0-9_]*\b)(?!["'`])(?!(?:REDACTED|mock-token|test-cookie|true|false|null|nil|none|test)\b)(?=[A-Za-z0-9_+=:-]{1,7}(?=$|[\s,}\]]))(?=[A-Za-z0-9_+=:-]*[A-Za-z])(?=[A-Za-z0-9_+=:-]*\d)[A-Za-z0-9_+=:-]+/i;
+const UNQUOTED_SHORT_SECRET_FIELD_GLOBAL =
+  /(?<![A-Za-z0-9_])["']?[A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|credential)[A-Za-z0-9_]*["']?[^\S\r\n]*:[^\S\r\n]*(?!(?:user|config|self|this|options|request|response|account|profile|credential|credentials)\.[A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|credential|key|hash)[A-Za-z0-9_]*\b)(?!["'`])(?!(?:REDACTED|mock-token|test-cookie|true|false|null|nil|none|test)\b)(?=[A-Za-z0-9_+=:-]{1,7}(?=$|[\s,}\]]))(?=[A-Za-z0-9_+=:-]*[A-Za-z])(?=[A-Za-z0-9_+=:-]*\d)[A-Za-z0-9_+=:-]+/gi;
+const SECRET_ENV_ASSIGNMENT =
+  /(?:(?<!const )(?<!let )(?<!var )\b[A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*[^\S\r\n]*=[^\S\r\n]*["']?[^\s`"'<>&]+|(?:(?<=const )|(?<=let )|(?<=var ))\b[A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*[^\S\r\n]*=[^\S\r\n]*["'][^\s`"'<>&]+|(?:(?<=const )|(?<=let )|(?<=var ))\b[A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*[^\S\r\n]*=[^\S\r\n]*["']?(?!\/)[^\s`"'<>&]+)/;
+const SECRET_ENV_ASSIGNMENT_GLOBAL =
+  /(?:(?<!const )(?<!let )(?<!var )\b[A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*[^\S\r\n]*=[^\S\r\n]*["']?[^\s`"'<>&]+|(?:(?<=const )|(?<=let )|(?<=var ))\b[A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*[^\S\r\n]*=[^\S\r\n]*["'][^\s`"'<>&]+|(?:(?<=const )|(?<=let )|(?<=var ))\b[A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*[^\S\r\n]*=[^\S\r\n]*["']?(?!\/)[^\s`"'<>&]+)/g;
+const UNRESOLVED_SECRET_FIELD =
+  /(?:(?<!const )(?<!let )(?<!var )\b[A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|credential)[A-Za-z0-9_]*[^\S\r\n]*[:=][^\S\r\n]*|(?:(?<=const )|(?<=let )|(?<=var ))\b[A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|credential)[A-Za-z0-9_]*[^\S\r\n]*[:=][^\S\r\n]*(?!\/))(?!(?:user|config|self|this|options|request|response|account|profile|credential|credentials)\.[A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|credential|key|hash)[A-Za-z0-9_]*\b)(?!(?:(?:try|await)\s+)*(?:[A-Za-z_][A-Za-z0-9_]*\.)*(?:get|load|read|fetch|build|make|create|resolve|retrieve)(?:password|token|secret|credentials?|api[_-]?key|key|hash)?\s*(?:\([^\S\r\n]*\)|\\\([^\S\r\n]*\\\))[^\S\r\n]*(?=$|[\r\n;,)\]\}"']))["']?[A-Za-z0-9_./+=:-]{8,}/i;
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SKILL_REPO_ROOT = path.resolve(SCRIPT_DIR, "../../../..");
+
+function usage() {
+  console.log(`Usage:
+  agent-transcript find --query TEXT [--cwd PATH] [--since-days N] [--max-files N] [--root PATH...]
+  agent-transcript render --session FILE --scope-query TEXT [--allow-unscoped] [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
+  agent-transcript render-thread --thread-id ID --scope-query TEXT [--allow-unscoped] [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
+  agent-transcript preview --session FILE --scope-query TEXT [--allow-unscoped] [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
+  agent-transcript append-body --body FILE --session FILE --scope-query TEXT [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N]
+  agent-transcript html --prs FILE [--out FILE] [--since-days N] [--min-score N] [--root PATH...] [--exclude-session FILE...]
+
+Local-only. No network calls.`);
+}
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) {
+      args._.push(arg);
+      continue;
+    }
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (next == null || next.startsWith("--")) {
+      args[key] = true;
+      continue;
+    }
+    i++;
+    if (args[key] == null) args[key] = next;
+    else if (Array.isArray(args[key])) args[key].push(next);
+    else args[key] = [args[key], next];
+  }
+  return args;
+}
+
+function asArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function optionNumber(options, camelName, kebabName, fallback) {
+  const value = options[camelName] ?? options[kebabName] ?? fallback;
+  return Number(value);
+}
+
+function homePath(...parts) {
+  return path.join(os.homedir(), ...parts);
+}
+
+function isWithin(child, parent) {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function executablePath(file) {
+  try {
+    const real = fs.realpathSync(file);
+    fs.accessSync(real, fs.constants.X_OK);
+    return real;
+  } catch {
+    return null;
+  }
+}
+
+function realPathIfExists(file) {
+  try {
+    return fs.realpathSync(file);
+  } catch {
+    return null;
+  }
+}
+
+function findWorkspaceRoot(start) {
+  let current = realPathIfExists(start);
+  if (!current) return null;
+  while (true) {
+    if (fs.existsSync(path.join(current, ".git"))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function repoBoundaryRoots(cwd) {
+  return [...new Set([findWorkspaceRoot(cwd), realPathIfExists(SKILL_REPO_ROOT)].filter(Boolean))];
+}
+
+function isWithinAny(child, parents) {
+  return parents.some((parent) => isWithin(child, parent));
+}
+
+function resolveTrustedCommand(name, cwd = process.cwd()) {
+  const repoRoots = repoBoundaryRoots(cwd);
+  if (name.includes("/") || name.includes("\\")) {
+    if (!path.isAbsolute(name)) throw new Error(`refusing relative executable path: ${name}`);
+    const real = executablePath(name);
+    if (!real || isWithinAny(real, repoRoots)) throw new Error(`refusing repo-controlled executable: ${name}`);
+    return real;
+  }
+  for (const part of String(process.env.PATH || "").split(path.delimiter)) {
+    if (!part || part === "." || !path.isAbsolute(part)) continue;
+    let realPart;
+    try {
+      realPart = fs.realpathSync(part);
+    } catch {
+      continue;
+    }
+    if (isWithinAny(realPart, repoRoots)) continue;
+    const real = executablePath(path.join(realPart, name));
+    if (real && !isWithinAny(real, repoRoots)) return real;
+  }
+  throw new Error(`trusted executable not found: ${name}`);
+}
+
+function openClawSessionRoots() {
+  const stateDir = process.env.OPENCLAW_STATE_DIR || homePath(".openclaw");
+  const agentsDir = path.join(stateDir, "agents");
+  if (!fs.existsSync(agentsDir)) return [];
+  try {
+    const roots = fs
+      .readdirSync(agentsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .flatMap((entry) => {
+        const agentDir = path.join(agentsDir, entry.name);
+        return [
+          path.join(agentDir, "sessions"),
+          path.join(agentDir, "agent", "sessions"),
+          path.join(agentDir, "agent", "codex-home", "sessions"),
+        ];
+      })
+      .filter((root) => fs.existsSync(root));
+    return [...new Set(roots)];
+  } catch {
+    return [];
+  }
+}
+
+function defaultRoots() {
+  return [
+    homePath(".codex", "sessions"),
+    homePath(".claude", "projects"),
+    homePath(".pi", "agent", "sessions"),
+    ...openClawSessionRoots(),
+  ];
+}
+
+function walkJsonl(root, sinceMs, out = []) {
+  if (!root || !fs.existsSync(root)) return out;
+  const stat = fs.statSync(root);
+  if (stat.isFile()) {
+    if (root.endsWith(".jsonl") && stat.mtimeMs >= sinceMs) out.push(root);
+    return out;
+  }
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === ".git") continue;
+    const file = path.join(root, entry.name);
+    if (entry.isDirectory()) walkJsonl(file, sinceMs, out);
+    else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      const entryStat = fs.statSync(file);
+      if (entryStat.mtimeMs >= sinceMs) out.push(file);
+    }
+  }
+  return out;
+}
+
+function readJsonl(file, maxLines = 12000) {
+  const text = fs.readFileSync(file, "utf8");
+  const lines = text.split(/\n+/).filter(Boolean).slice(-maxLines);
+  const rows = [];
+  for (const line of lines) {
+    try {
+      rows.push(JSON.parse(line));
+    } catch {
+      rows.push({ type: "unparsed", text: line });
+    }
+  }
+  return rows;
+}
+
+function sessionThreadId(file) {
+  const name = path.basename(String(file || ""));
+  const match = name.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\.jsonl)?$/i);
+  return match ? match[1] : null;
+}
+
+function stringContent(value) {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(stringContent).filter(Boolean).join("\n");
+  if (typeof value === "object") {
+    if (typeof value.text === "string") return value.text;
+    if (typeof value.content === "string") return value.content;
+    if (typeof value.message === "string") return value.message;
+    if (Array.isArray(value.content)) return stringContent(value.content);
+    if (value.type === "text" && value.text) return String(value.text);
+  }
+  return "";
+}
+
+function nestedToolRole(value) {
+  if (value == null) return null;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const role = nestedToolRole(item);
+      if (role) return role;
+    }
+    return null;
+  }
+  if (typeof value !== "object") return null;
+  if (value.type === "tool_result" || value.type === "function_call_output") return "tool_output";
+  if (value.type === "tool_use" || value.type === "function_call") return "tool";
+  return nestedToolRole(value.content) || nestedToolRole(value.message) || nestedToolRole(value.payload);
+}
+
+function detectAgent(file, rows) {
+  if (file.includes(`${path.sep}.codex${path.sep}`)) return "codex";
+  if (file.includes(`${path.sep}.claude${path.sep}`)) return "claude";
+  if (file.includes(`${path.sep}.pi${path.sep}`)) return "pi";
+  if (
+    file.includes(`${path.sep}.openclaw${path.sep}`) ||
+    (file.includes(`${path.sep}agents${path.sep}`) && file.includes(`${path.sep}sessions${path.sep}`))
+  ) {
+    return "openclaw";
+  }
+  if (rows.some((row) => row?.type === "session_meta" || row?.type === "response_item")) return "codex";
+  if (rows.some((row) => row?.sessionId && row?.userType)) return "claude";
+  return "agent";
+}
+
+function eventText(row) {
+  if (row?.type === "compacted_replacement_item") {
+    return stringContent(row.payload?.content || row.payload?.summary || row.payload?.arguments || row.payload?.output);
+  }
+  if (row?.type === "event_msg") {
+    const payload = row.payload || {};
+    return stringContent(payload.message || payload.text_elements || payload.content);
+  }
+  if (row?.type === "response_item") {
+    const payload = row.payload || {};
+    return stringContent(payload.content || payload.summary || payload.arguments || payload.output);
+  }
+  if (row?.message) return stringContent(row.message);
+  if (row?.content) return stringContent(row.content);
+  if (row?.text) return stringContent(row.text);
+  return "";
+}
+
+function eventRole(row) {
+  if (row?.type === "compacted_replacement_item") {
+    const payload = row.payload || {};
+    if (payload.type === "function_call") return "tool";
+    if (payload.type === "function_call_output") return "tool_output";
+    if (payload.type === "reasoning" || payload.type === "compaction") return null;
+    if (payload.type === "web_search_call") return "web";
+    if (payload.role === "user") return "user";
+    if (payload.role === "assistant") return "assistant";
+    return null;
+  }
+  if (row?.type === "event_msg") {
+    const type = row.payload?.type;
+    if (type === "user_message") return "user";
+    if (type === "agent_message") return "assistant";
+    if (type === "token_count" || type === "task_started" || type === "task_complete") return null;
+    if (type === "web_search_end") return "web";
+  }
+  if (row?.type === "response_item") {
+    const payload = row.payload || {};
+    if (payload.type === "function_call") return "tool";
+    if (payload.type === "function_call_output") return "tool_output";
+    if (payload.type === "reasoning") return null;
+    if (payload.type === "web_search_call") return "web";
+    if (payload.role === "user") return "user";
+    if (payload.role === "assistant") return "assistant";
+  }
+  const nestedRole = nestedToolRole(row?.message) || nestedToolRole(row?.content);
+  if (nestedRole) return nestedRole;
+  if (row?.type === "user") return "user";
+  if (row?.type === "assistant") return "assistant";
+  if (row?.message?.role === "user") return "user";
+  if (row?.message?.role === "assistant") return "assistant";
+  if (row?.type === "tool_result" || row?.type === "tool_use") return "tool";
+  return null;
+}
+
+function hasSetupBlob(text) {
+  return (
+    text.includes("<INSTRUCTIONS>") ||
+    text.includes("# AGENTS.MD") ||
+    text.includes("Knowledge cutoff:") ||
+    text.includes("You are Codex") ||
+    /^\s*#?\s*AGENTS\.md instructions for\b/im.test(text) ||
+    /\bGuidance for AI coding assistants working on this repository\b/i.test(text) ||
+    /^\s*(?:here are|below are|these are) your instructions\b/im.test(text) ||
+    /\binstructions absorbed\b/i.test(text)
+  );
+}
+
+function redact(input, stats) {
+  let s = String(input ?? "");
+  const rules = [
+    [/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g, "[REDACTED_PRIVATE_KEY]"],
+    [/sk-[A-Za-z0-9_-]{20,}/g, "[REDACTED_OPENAI_KEY]"],
+    [/sk_live_[A-Za-z0-9_-]{16,}/g, "[REDACTED_STRIPE_KEY]"],
+    [/rk_live_[A-Za-z0-9_-]{16,}/g, "[REDACTED_STRIPE_KEY]"],
+    [/xox[baprs]-[A-Za-z0-9-]{20,}/g, "[REDACTED_SLACK_TOKEN]"],
+    [/npm_[A-Za-z0-9]{20,}/g, "[REDACTED_NPM_TOKEN]"],
+    [/AIza[0-9A-Za-z_-]{20,}/g, "[REDACTED_GOOGLE_API_KEY]"],
+    [/(gh[pousr]_[A-Za-z0-9_]{20,})/g, "[REDACTED_GITHUB_TOKEN]"],
+    [/(github_pat_[A-Za-z0-9_]{20,})/g, "[REDACTED_GITHUB_TOKEN]"],
+    [/(AKIA[0-9A-Z]{16})/g, "[REDACTED_AWS_KEY]"],
+    [/eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}/g, "[REDACTED_JWT]"],
+    [/\b(Authorization:\s*)(?:Token|ApiKey)\s+[A-Za-z0-9._~+/=:-]{8,}/gi, "$1[REDACTED_AUTH_HEADER]"],
+    [/\b(?:Bearer|Basic|SAPISIDHASH)\s+[A-Za-z0-9._~+/=:-]{8,}/gi, "[REDACTED_AUTH_HEADER]"],
+    [/\b(?:Cookie|Set-Cookie):\s*[^\r\n]+/gi, "[REDACTED_COOKIE_HEADER]"],
+    [COOKIE_ASSIGNMENT_GLOBAL, "[REDACTED_COOKIE]"],
+    [SERVICE_CREDENTIAL_URL_GLOBAL, "[REDACTED_CREDENTIAL_URL]"],
+    [QUOTED_SECRET_ENV_ASSIGNMENT_GLOBAL, "[REDACTED_ENV_SECRET]"],
+    [QUOTED_SECRET_FIELD_GLOBAL, "[REDACTED_FIELD_SECRET]"],
+    [UNQUOTED_SHORT_SECRET_FIELD_GLOBAL, "[REDACTED_FIELD_SECRET]"],
+    [SECRET_ENV_ASSIGNMENT_GLOBAL, "[REDACTED_ENV_SECRET]"],
+    [/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[REDACTED_EMAIL]"],
+    [/\b(?:\+?\d[\d .()-]{7,}\d)\b/g, "[REDACTED_PHONE]"],
+    [/\/Users\/[^\s`"'>)]+/g, "[LOCAL_PATH]"],
+    [/\/home\/[^\s`"'>)]+/g, "[LOCAL_PATH]"],
+    [/\/(?:private\/var\/folders|var\/folders|tmp)\/[^\s`"'>)]+/g, "[LOCAL_PATH]"],
+    [/[A-Za-z]:\\Users\\[^\s`"'>)]+/g, "[LOCAL_PATH]"],
+    [/~\/[^\s`"'>)]+/g, "[HOME_PATH]"],
+    [AUTH_QUERY_PARAM, "$1[REDACTED]"],
+  ];
+  for (const [re, repl] of rules) {
+    const before = s;
+    s = s.replace(re, repl);
+    if (s !== before) stats.redactions++;
+  }
+  return s;
+}
+
+function unsafe(text) {
+  const patterns = [
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+    /AIza[0-9A-Za-z_-]{20,}/,
+    /github_pat_[A-Za-z0-9_]{20,}/,
+    /\bAuthorization:\s*(?:Token|ApiKey)\s+[A-Za-z0-9._~+/=:-]{8,}/i,
+    /\b(?:Bearer|Basic|SAPISIDHASH)\s+[A-Za-z0-9._~+/=:-]{8,}/i,
+    /\b(?:Cookie|Set-Cookie):/i,
+    COOKIE_ASSIGNMENT,
+    AUTH_URL,
+    SERVICE_CREDENTIAL_URL,
+    QUOTED_SECRET_ENV_ASSIGNMENT,
+    QUOTED_SECRET_FIELD,
+    UNQUOTED_SHORT_SECRET_FIELD,
+    SECRET_ENV_ASSIGNMENT,
+    UNRESOLVED_SECRET_FIELD,
+    /\b(?:user_session|_gh_sess|__Host-user_session_same_site|GH_SESSION_TOKEN)\b/i,
+    /\b(?:GITHUB_TOKEN|GH_TOKEN|OPENAI_API_KEY|ANTHROPIC_API_KEY)\b/,
+    /\/upload\/policies\/assets|uploadToken|authenticity_token/i,
+  ];
+  return patterns.filter((pattern) => pattern.test(text)).map((pattern) => String(pattern));
+}
+
+function unsafeBeforeRedaction(text) {
+  const patterns = [
+    /\bAuthorization:\s*(?:Token|ApiKey)\s+[A-Za-z0-9._~+/=:-]{8,}/i,
+    /\b(?:Cookie|Set-Cookie):/i,
+    COOKIE_ASSIGNMENT,
+    AUTH_URL,
+    SERVICE_CREDENTIAL_URL,
+    QUOTED_SECRET_ENV_ASSIGNMENT,
+    QUOTED_SECRET_FIELD,
+    UNQUOTED_SHORT_SECRET_FIELD,
+    SECRET_ENV_ASSIGNMENT,
+    UNRESOLVED_SECRET_FIELD,
+    /\b(?:user_session|_gh_sess|__Host-user_session_same_site|GH_SESSION_TOKEN)\b/i,
+  ];
+  return patterns.filter((pattern) => pattern.test(text)).map((pattern) => String(pattern));
+}
+
+function sanitizeTranscriptMarkdown(text) {
+  return String(text)
+    .replaceAll(MARKER_START, "[agent-transcript marker removed]")
+    .replaceAll(MARKER_END, "[agent-transcript marker removed]");
+}
+
+function markdownFence(text) {
+  const longest = Math.max(0, ...Array.from(String(text).matchAll(/`+/g), (match) => match[0].length));
+  return "`".repeat(Math.max(4, longest + 1));
+}
+
+function normalizeEntry(role, text, stats, options = {}) {
+  const rawUnsafe = unsafeBeforeRedaction(String(text ?? ""));
+  let t = redact(text, stats).replace(/\n{3,}/g, "\n\n").trim();
+  if (!t) return null;
+  if (hasSetupBlob(t)) t = "[instructions recap omitted; policy/config text, not task dialogue]";
+  if (rawUnsafe.length || unsafe(t).length) t = "[omitted: browser/session/auth internals; not useful for public PR transcript]";
+  const entryMaxChars = optionNumber(options, "entryMaxChars", "entry-max-chars", DEFAULT_ENTRY_MAX_CHARS);
+  if (t.length > entryMaxChars) {
+    t = `${t.slice(0, entryMaxChars).trimEnd()}\n...[truncated ${t.length - entryMaxChars} chars]`;
+  }
+  return `[${role}]\n${t}`;
+}
+
+function entryRole(entry) {
+  const match = entry.match(/^\[([^\]]+)\]\n/);
+  return match ? match[1] : null;
+}
+
+function entryBody(entry) {
+  return entry.replace(/^\[[^\]]+\]\n/, "");
+}
+
+function coalesceEntries(entries) {
+  const coalesced = [];
+  for (const entry of entries) {
+    const role = entryRole(entry);
+    const body = entryBody(entry);
+    const last = coalesced[coalesced.length - 1];
+    if (last && role && entryRole(last) === role && role !== "tool summary" && entryBody(last) === body) {
+      continue;
+    }
+    coalesced.push(entry);
+  }
+  return coalesced;
+}
+
+function optionString(options, camelName, kebabName) {
+  const value = options[camelName] ?? options[kebabName];
+  return value == null ? "" : String(value);
+}
+
+function allowUnscoped(options) {
+  return Boolean(options.allowUnscoped || options["allow-unscoped"]);
+}
+
+function scopeTerms(options) {
+  return [
+    ...new Set(
+      optionString(options, "scopeQuery", "scope-query")
+        .toLowerCase()
+        .split(/[^a-z0-9_-]+/)
+        .filter((term) => term.length >= 4 && !SCOPE_STOP_WORDS.has(term)),
+    ),
+  ];
+}
+
+function hasScope(options) {
+  return scopeTerms(options).length > 0;
+}
+
+function requireScopedPublicTranscript(command, options) {
+  if (hasScope(options) || allowUnscoped(options)) return;
+  throw new Error(`--scope-query is required for ${command}; use --allow-unscoped only for local inspection`);
+}
+
+function requireNonEmptyScopedTranscript(rendered, options) {
+  if (hasScope(options) && rendered.stats.entries === 0) {
+    throw new Error("scoped transcript is empty; not adding Agent Transcript section");
+  }
+}
+
+function trimScopedStats(stats, options) {
+  if (!hasScope(options)) return;
+  stats.rawEntries = stats.entries;
+  stats.toolCalls = 0;
+  stats.toolOutputsDropped = 0;
+  stats.web = 0;
+}
+
+function applyScope(entries, options) {
+  const terms = scopeTerms(options);
+  if (!terms.length) return entries;
+  const matches = entries.map((entry) => {
+    const text = entry.toLowerCase();
+    return terms.some((term) => text.includes(term));
+  });
+  const keep = new Set();
+  for (let index = 0; index < entries.length; index++) {
+    if (!matches[index]) continue;
+    keep.add(index);
+    if (entries[index].startsWith("[user]\n") && entries[index + 1]?.startsWith("[assistant]\n")) {
+      keep.add(index + 1);
+    }
+  }
+  return entries.filter((_, index) => keep.has(index));
+}
+
+function toolFamily(name) {
+  const normalized = String(name).toLowerCase();
+  if (
+    /(read|open|list|find|search|grep|rg|sed|cat|head|tail|jq|wc|status|diff|show|view|snapshot|screenshot)/.test(
+      normalized,
+    )
+  ) {
+    return "read";
+  }
+  if (/(write|edit|patch|apply|create|update|append|save|comment|fill|click|type|navigate|upload)/.test(normalized)) {
+    return "write";
+  }
+  if (/(exec|command|shell|run|test|build|lint|format|install|pnpm|npm|node|git|gh|ssh)/.test(normalized)) {
+    return "execute";
+  }
+  if (/(web|http|fetch|browser|chrome|github|dropbox|notion|gmail|calendar)/.test(normalized)) {
+    return "network";
+  }
+  return "other";
+}
+
+function shellFamily(command) {
+  const cmd = String(command || "").trim();
+  if (!cmd) return "execute";
+  if (
+    /^(rg|grep|sed|cat|head|tail|jq|wc|ls|find|pwd|git (status|diff|show|log|blame)|gh (pr|issue|api|run|repo|auth) (view|list|status)|test |stat |ps |which |command -v )\b/.test(
+      cmd,
+    )
+  ) {
+    return "read";
+  }
+  if (/^(open |chmod |mkdir |touch |cp |mv |kill |git add|git commit|git push|gh pr create|gh issue create)\b/.test(cmd)) {
+    return "write";
+  }
+  if (/^(node|npm|pnpm|bun|python|python3|ruby|tsx|tsgo|make|cargo|go test|swift|xcodebuild)\b/.test(cmd)) {
+    return "execute";
+  }
+  if (/^(ssh|curl|wget|tailscale|nc )\b/.test(cmd)) return "network";
+  return "execute";
+}
+
+function toolCallFamily(row) {
+  const name = row.payload?.name || row.name || row.message?.name || row.type || "tool";
+  if (name === "exec_command") {
+    try {
+      const args = JSON.parse(row.payload?.arguments || "{}");
+      return shellFamily(args.cmd);
+    } catch {
+      return "execute";
+    }
+  }
+  if (name === "apply_patch") return "write";
+  if (name === "write_stdin") return "execute";
+  return toolFamily(name);
+}
+
+function compactToolSummary(familyCounts, dropped) {
+  const families = new Map();
+  for (const [family, count] of familyCounts.entries()) {
+    families.set(family, (families.get(family) || 0) + count);
+  }
+  const ordered = ["read", "write", "execute", "network", "other"]
+    .map((family) => [family, families.get(family) || 0])
+    .filter(([, count]) => count > 0)
+    .map(([family, count]) => `${count} ${family}`);
+  const calls = ordered.length ? ordered.join(", ") : "0 tool";
+  return `${calls}; raw tool outputs dropped: ${dropped}`;
+}
+
+function recountEntries(stats, entries) {
+  stats.rawEntries = stats.entries;
+  stats.entries = entries.length;
+  stats.user = entries.filter((entry) => entry.startsWith("[user]\n")).length;
+  stats.assistant = entries.filter((entry) => entry.startsWith("[assistant]\n")).length;
+}
+
+function expandCompactedReplacementItems(row) {
+  if (row?.type !== "compacted") return [];
+  const replacementHistory = row.payload?.replacement_history;
+  if (!Array.isArray(replacementHistory)) return [];
+  return replacementHistory.map((item, index) => ({
+    type: "compacted_replacement_item",
+    payload: item,
+    timestamp: row.timestamp,
+    sourceLineType: row.type,
+    replacementIndex: index,
+  }));
+}
+
+function renderSession(file, options = {}) {
+  const rows = readJsonl(file);
+  const agent = detectAgent(file, rows);
+  const stats = {
+    agent,
+    entries: 0,
+    user: 0,
+    assistant: 0,
+    toolCalls: 0,
+    toolOutputsDropped: 0,
+    web: 0,
+    redactions: 0,
+    omittedUnsafe: 0,
+  };
+  const toolCounts = new Map();
+  const items = [];
+  const seenEntries = new Set();
+  const hasEventDialogue = rows.some((row) => {
+    const type = row?.type === "event_msg" ? row.payload?.type : null;
+    return type === "user_message" || type === "agent_message";
+  });
+  const renderRows = rows.flatMap((row) => [row, ...expandCompactedReplacementItems(row)]);
+  for (const row of renderRows) {
+    const role = eventRole(row);
+    if (!role) continue;
+    if (hasEventDialogue && row.type === "response_item" && (role === "user" || role === "assistant")) {
+      continue;
+    }
+    if (role === "tool_output") {
+      stats.toolOutputsDropped++;
+      continue;
+    }
+    if (role === "tool") {
+      const family = toolCallFamily(row);
+      toolCounts.set(family, (toolCounts.get(family) || 0) + 1);
+      stats.toolCalls++;
+      continue;
+    }
+    if (role === "web") {
+      stats.web++;
+      continue;
+    }
+    const before = eventText(row);
+    const entry = normalizeEntry(role, before, stats, options);
+    if (!entry) continue;
+    const dedupeKey = entry.replace(/\s+/g, " ").trim();
+    if (seenEntries.has(dedupeKey)) continue;
+    seenEntries.add(dedupeKey);
+    if (entry.includes("[omitted: browser/session/auth internals")) stats.omittedUnsafe++;
+    items.push(entry);
+    stats.entries++;
+    if (role === "user") stats.user++;
+    if (role === "assistant") stats.assistant++;
+  }
+  const scopedItems = applyScope(items, options);
+  if (!hasScope(options) && toolCounts.size && scopedItems.length) {
+    scopedItems.push(`[tool summary]\n${compactToolSummary(toolCounts, stats.toolOutputsDropped)}`);
+    stats.entries++;
+  }
+  const renderedItems = coalesceEntries(scopedItems);
+  recountEntries(stats, renderedItems);
+  trimScopedStats(stats, options);
+  const maxChars = optionNumber(options, "maxChars", "max-chars", DEFAULT_MAX_CHARS);
+  let joined = renderedItems.join("\n\n");
+  if (joined.length > maxChars) joined = `${joined.slice(0, maxChars).trimEnd()}\n\n...[transcript truncated to ${maxChars} chars]`;
+  joined = sanitizeTranscriptMarkdown(joined);
+  const fence = markdownFence(joined);
+  const headerBits = [options.title, options.url].filter(Boolean).join(" | ");
+  const redactedHeader = redact(headerBits, stats);
+  const unsafeHeader = headerBits ? [...unsafeBeforeRedaction(headerBits), ...unsafe(redactedHeader)] : [];
+  const unsafeAfter = [...unsafeHeader, ...unsafe(joined)];
+  const safe = unsafeAfter.length === 0;
+  const markdown = `${MARKER_START}
+## Agent Transcript
+
+<details>
+<summary>Redacted ${agent} session transcript${headerBits && !unsafeHeader.length ? `: ${escapeHtml(redactedHeader)}` : ""}</summary>
+
+${fence}text
+source: [LOCAL_SESSION]
+redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
+omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
+stats: ${JSON.stringify(stats)}
+
+${joined}
+${fence}
+
+</details>
+${MARKER_END}
+`;
+  return { file, agent, safe, unsafeAfter, stats, markdown };
+}
+
+function appServerThreadRead(threadId) {
+  return new Promise((resolve, reject) => {
+    const codexBin = resolveTrustedCommand(process.env.CODEX_BIN || "codex");
+    const child = spawn(codexBin, ["app-server", "--listen", "stdio://"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGTERM");
+      reject(new Error("thread/read timed out"));
+    }, 30000);
+    const finish = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.kill("SIGTERM");
+      fn(value);
+    };
+    const send = (item) => child.stdin.write(`${JSON.stringify(item)}\n`);
+    let buffer = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      buffer += chunk.toString();
+      let newline;
+      while ((newline = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line.trim()) continue;
+        let message;
+        try {
+          message = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (message.id === 1) {
+          send({ method: "initialized", params: {} });
+          send({
+            method: "thread/read",
+            id: 2,
+            params: {
+              threadId,
+              includeTurns: true,
+            },
+          });
+        }
+        if (message.id === 2) {
+          if (message.error) finish(reject, new Error(`thread/read failed: ${JSON.stringify(message.error)}`));
+          else if (message.result?.thread) finish(resolve, message.result.thread);
+          else finish(reject, new Error("thread/read did not return a thread"));
+        }
+      }
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => finish(reject, error));
+    child.on("exit", () => {
+      if (settled) return;
+      const detail = stderr.trim() || stdout.trim();
+      finish(reject, new Error(`app-server exited before thread/read response${detail ? `: ${detail}` : ""}`));
+    });
+    send({
+      method: "initialize",
+      id: 1,
+      params: {
+        clientInfo: {
+          name: "agent_transcript",
+          title: "Agent Transcript",
+          version: "0.0.0",
+        },
+        capabilities: {
+          experimentalApi: true,
+          optOutNotificationMethods: [],
+        },
+      },
+    });
+  });
+}
+
+function threadItemText(item) {
+  if (item?.type === "userMessage") return stringContent(item.content);
+  if (item?.type === "agentMessage") return stringContent(item.text);
+  return "";
+}
+
+function threadItemRole(item) {
+  if (item?.type === "userMessage") return "user";
+  if (item?.type === "agentMessage") return "assistant";
+  return null;
+}
+
+async function renderThread(threadId, options = {}) {
+  const thread = await appServerThreadRead(threadId);
+  const stats = {
+    agent: "codex",
+    entries: 0,
+    user: 0,
+    assistant: 0,
+    toolCalls: 0,
+    toolOutputsDropped: 0,
+    web: 0,
+    redactions: 0,
+    omittedUnsafe: 0,
+  };
+  const items = [];
+  for (const turn of thread.turns || []) {
+    for (const item of turn.items || []) {
+      const role = threadItemRole(item);
+      if (!role) continue;
+      const entry = normalizeEntry(role, threadItemText(item), stats, options);
+      if (!entry) continue;
+      if (entry.includes("[omitted: browser/session/auth internals")) stats.omittedUnsafe++;
+      items.push(entry);
+      stats.entries++;
+      if (role === "user") stats.user++;
+      if (role === "assistant") stats.assistant++;
+    }
+  }
+  const renderedItems = coalesceEntries(applyScope(items, options));
+  recountEntries(stats, renderedItems);
+  trimScopedStats(stats, options);
+  const maxChars = optionNumber(options, "maxChars", "max-chars", DEFAULT_MAX_CHARS);
+  let joined = renderedItems.join("\n\n");
+  if (joined.length > maxChars) joined = `${joined.slice(0, maxChars).trimEnd()}\n\n...[transcript truncated to ${maxChars} chars]`;
+  joined = sanitizeTranscriptMarkdown(joined);
+  const fence = markdownFence(joined);
+  const headerBits = [options.title, options.url].filter(Boolean).join(" | ");
+  const redactedHeader = redact(headerBits, stats);
+  const unsafeHeader = headerBits ? [...unsafeBeforeRedaction(headerBits), ...unsafe(redactedHeader)] : [];
+  const unsafeAfter = [...unsafeHeader, ...unsafe(joined)];
+  const safe = unsafeAfter.length === 0;
+  const markdown = `${MARKER_START}
+## Agent Transcript
+
+<details>
+<summary>Redacted codex app-server transcript${headerBits && !unsafeHeader.length ? `: ${escapeHtml(redactedHeader)}` : ""}</summary>
+
+${fence}text
+source: codex app-server thread/read includeTurns
+thread: ${redact(threadId, stats)}
+redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
+omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
+stats: ${JSON.stringify(stats)}
+
+${joined}
+${fence}
+
+</details>
+${MARKER_END}
+`;
+  return { file: null, agent: "codex", safe, unsafeAfter, stats, markdown };
+}
+
+async function renderTranscript(options) {
+  if (options["app-server"] || options.appServer || options.threadId || options["thread-id"]) {
+    const threadId = options.threadId || options["thread-id"] || sessionThreadId(options.session);
+    if (!threadId) throw new Error("--thread-id is required when --app-server cannot infer it from --session");
+    return renderThread(threadId, options);
+  }
+  return renderSession(options.session, options);
+}
+
+function readBoundedText(file, maxBytes = 220000) {
+  const fd = fs.openSync(file, "r");
+  try {
+    const stat = fs.fstatSync(fd);
+    if (stat.size <= maxBytes) {
+      const buffer = Buffer.alloc(stat.size);
+      fs.readSync(fd, buffer, 0, stat.size, 0);
+      return buffer.toString("utf8");
+    }
+    const half = Math.floor(maxBytes / 2);
+    const head = Buffer.alloc(half);
+    const tail = Buffer.alloc(half);
+    fs.readSync(fd, head, 0, half, 0);
+    fs.readSync(fd, tail, 0, half, Math.max(0, stat.size - half));
+    return `${head.toString("utf8")}\n[...middle omitted for scan...]\n${tail.toString("utf8")}`;
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function sessionScanRecord(file, maxBytes) {
+  const stat = fs.statSync(file);
+  const agent = detectAgent(file, []);
+  return {
+    file,
+    agent,
+    mtime: new Date(stat.mtimeMs).toISOString(),
+    haystack: `${file}\n${readBoundedText(file, maxBytes)}`.toLowerCase(),
+  };
+}
+
+function scoreScanRecord(record, terms, cwd) {
+  const haystack = record.haystack;
+  let score = 0;
+  const reasons = [];
+  for (const term of terms) {
+    const normalized = term.toLowerCase().trim();
+    if (normalized.length < 3) continue;
+    if (haystack.includes(normalized)) {
+      score += Math.min(20, Math.max(3, Math.floor(normalized.length / 3)));
+      reasons.push(normalized.slice(0, 80));
+    }
+  }
+  if (cwd) {
+    const cwdLower = cwd.toLowerCase();
+    if (haystack.includes(cwdLower) || record.file.toLowerCase().includes(cwdLower.replaceAll("/", "-"))) {
+      score += 8;
+      reasons.push("cwd");
+    }
+  }
+  return { file: record.file, score, reasons, mtime: record.mtime, agent: record.agent };
+}
+
+function recentFiles(files, maxFiles) {
+  return files
+    .map((file) => {
+      try {
+        return { file, mtimeMs: fs.statSync(file).mtimeMs };
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .slice(0, maxFiles)
+    .map((entry) => entry.file);
+}
+
+function candidateFiles(roots, terms, sinceMs, options = {}) {
+  return recentFiles(roots.flatMap((root) => walkJsonl(root, sinceMs)), Number(options["max-files"] || 400));
+}
+
+function findSessions(options) {
+  const sinceDays = Number(options["since-days"] || 14);
+  const sinceMs = Date.now() - sinceDays * 24 * 60 * 60 * 1000;
+  const roots = asArray(options.root).length ? asArray(options.root) : defaultRoots();
+  const query = String(options.query || "");
+  const terms = query
+    .split(/\s+/)
+    .concat(query.match(/https?:\/\/\S+/g) || [])
+    .filter(Boolean);
+  const files = candidateFiles(roots, terms, sinceMs, options);
+  const scanBytes = Number(options["scan-bytes"] || 60000);
+  const results = files
+    .map((file) => scoreScanRecord(sessionScanRecord(file, scanBytes), terms, options.cwd))
+    .filter((result) => result.score > 0)
+    .sort((a, b) => b.score - a.score || b.mtime.localeCompare(a.mtime))
+    .slice(0, Number(options.limit || 10));
+  return results;
+}
+
+function sessionScanRecords(options) {
+  const sinceDays = Number(options["since-days"] || 14);
+  const sinceMs = Date.now() - sinceDays * 24 * 60 * 60 * 1000;
+  const roots = asArray(options.root).length ? asArray(options.root) : defaultRoots();
+  const excluded = new Set(asArray(options["exclude-session"]).map((file) => path.resolve(file)));
+  return roots
+    .flatMap((root) => walkJsonl(root, sinceMs))
+    .filter((file) => !excluded.has(path.resolve(file)))
+    .map((file) => sessionScanRecord(file, Number(options["scan-bytes"] || 90000)));
+}
+
+function replaceSection(body, section) {
+  const start = body.indexOf(MARKER_START);
+  const end = body.indexOf(MARKER_END);
+  if (start !== -1 && end !== -1 && end > start) {
+    return `${body.slice(0, start).trimEnd()}\n\n${section.trim()}\n\n${body.slice(end + MARKER_END.length).trimStart()}`;
+  }
+  return `${body.trimEnd()}\n\n${section.trim()}\n`;
+}
+
+function escapeHtml(text) {
+  return String(text)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function htmlDocument(records) {
+  const rows = records
+    .map((record) => `<section>
+<h2><a href="${escapeHtml(record.url || "")}">${escapeHtml(record.title || record.url || "PR")}</a></h2>
+<p><code>${escapeHtml(record.session ? "[LOCAL_SESSION]" : "no session")}</code> score: ${escapeHtml(record.score ?? "")} safe: ${escapeHtml(record.safe ?? "")}</p>
+<pre>${escapeHtml(record.markdown || record.error || "")}</pre>
+</section>`)
+    .join("\n");
+  return `<!doctype html>
+<meta charset="utf-8">
+<title>Agent Transcript Preview</title>
+<style>
+body{font:14px/1.45 system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;margin:32px;color:#1f2328;background:#fff}
+section{border-top:1px solid #d0d7de;padding:24px 0}
+h1,h2{line-height:1.2}
+pre{white-space:pre-wrap;background:#f6f8fa;border:1px solid #d0d7de;border-radius:6px;padding:16px;overflow:auto}
+code{background:#f6f8fa;padding:2px 4px;border-radius:4px}
+a{color:#0969da}
+</style>
+<h1>Agent Transcript Preview</h1>
+${rows}
+`;
+}
+
+function singlePreviewDocument(record) {
+  return htmlDocument([record]);
+}
+
+function readPrs(file) {
+  const raw = fs.readFileSync(file, "utf8");
+  const parsed = JSON.parse(raw);
+  return Array.isArray(parsed) ? parsed : parsed.items || parsed.prs || [];
+}
+
+async function main() {
+  const [command, ...rest] = process.argv.slice(2);
+  const args = parseArgs(rest);
+  if (!command || command === "--help" || command === "-h" || args.help) {
+    usage();
+    return;
+  }
+  if (command === "find") {
+    console.log(JSON.stringify(findSessions(args), null, 2));
+    return;
+  }
+  if (command === "render") {
+    if (!args.session) throw new Error("--session is required");
+    requireScopedPublicTranscript("render", args);
+    const rendered = await renderTranscript(args);
+    if (!rendered.safe) throw new Error(`unsafe transcript after redaction: ${rendered.unsafeAfter.join(", ")}`);
+    requireNonEmptyScopedTranscript(rendered, args);
+    if (args.out) fs.writeFileSync(args.out, rendered.markdown);
+    else process.stdout.write(rendered.markdown);
+    return;
+  }
+  if (command === "render-thread") {
+    if (!args["thread-id"] && !args.threadId) throw new Error("--thread-id is required");
+    requireScopedPublicTranscript("render-thread", args);
+    const rendered = await renderThread(args.threadId || args["thread-id"], args);
+    if (!rendered.safe) throw new Error(`unsafe transcript after redaction: ${rendered.unsafeAfter.join(", ")}`);
+    requireNonEmptyScopedTranscript(rendered, args);
+    if (args.out) fs.writeFileSync(args.out, rendered.markdown);
+    else process.stdout.write(rendered.markdown);
+    return;
+  }
+  if (command === "preview") {
+    if (!args.session) throw new Error("--session is required");
+    requireScopedPublicTranscript("preview", args);
+    const rendered = await renderTranscript(args);
+    if (!rendered.safe) throw new Error(`unsafe transcript after redaction: ${rendered.unsafeAfter.join(", ")}`);
+    requireNonEmptyScopedTranscript(rendered, args);
+    const output = singlePreviewDocument({
+      title: args.title || "Agent Transcript Preview",
+      url: args.url || "",
+      session: args.session,
+      safe: rendered.safe,
+      markdown: rendered.markdown,
+    });
+    if (args.out) fs.writeFileSync(args.out, output);
+    else process.stdout.write(output);
+    return;
+  }
+  if (command === "append-body") {
+    if (!args.body || !args.session) throw new Error("--body and --session are required");
+    if (!optionString(args, "scopeQuery", "scope-query")) {
+      throw new Error("--scope-query is required for append-body to avoid unscoped public transcripts");
+    }
+    if (!scopeTerms(args).length) {
+      throw new Error("--scope-query must include at least one specific term of 4+ characters");
+    }
+    const rendered = await renderTranscript(args);
+    if (!rendered.safe) throw new Error(`unsafe transcript after redaction: ${rendered.unsafeAfter.join(", ")}`);
+    requireNonEmptyScopedTranscript(rendered, args);
+    const body = fs.readFileSync(args.body, "utf8");
+    const next = replaceSection(body, rendered.markdown);
+    if (args.out) fs.writeFileSync(args.out, next);
+    else process.stdout.write(next);
+    return;
+  }
+  if (command === "html") {
+    if (!args.prs) throw new Error("--prs is required");
+    const records = [];
+    const scanRecords = sessionScanRecords(args);
+    const minScore = Number(args["min-score"] || 50);
+    for (const pr of readPrs(args.prs)) {
+      const query = [pr.url, pr.number ? `#${pr.number}` : "", pr.number, pr.title, pr.headRefName, pr.headRefName || pr.branch]
+        .filter(Boolean)
+        .join(" ");
+      const terms = query
+        .split(/\s+/)
+        .concat(query.match(/https?:\/\/\S+/g) || [])
+        .filter(Boolean);
+      const [candidate] = scanRecords
+        .map((record) => scoreScanRecord(record, terms, args.cwd))
+        .filter((result) => result.score >= minScore)
+        .sort((a, b) => b.score - a.score || b.mtime.localeCompare(a.mtime));
+      if (!candidate) {
+        records.push({ ...pr, error: "No local session match found." });
+        continue;
+      }
+      try {
+        const renderScope =
+          optionString(args, "scopeQuery", "scope-query") ||
+          [pr.number ? `#${pr.number}` : "", pr.title, pr.headRefName, pr.headRefName || pr.branch]
+            .filter(Boolean)
+            .join(" ");
+        const renderOptions = {
+          ...args,
+          session: candidate.file,
+          scopeQuery: renderScope,
+          title: pr.title,
+          url: pr.url,
+        };
+        requireScopedPublicTranscript("html", renderOptions);
+        const rendered = await renderTranscript(renderOptions);
+        requireNonEmptyScopedTranscript(rendered, renderOptions);
+        records.push({
+          ...pr,
+          session: candidate.file,
+          score: candidate.score,
+          safe: rendered.safe,
+          markdown: rendered.markdown,
+        });
+      } catch (error) {
+        records.push({ ...pr, session: candidate.file, score: candidate.score, error: String(error) });
+      }
+    }
+    const output = htmlDocument(records);
+    if (args.out) fs.writeFileSync(args.out, output);
+    else process.stdout.write(output);
+    return;
+  }
+  usage();
+  process.exitCode = 2;
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/.agents/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/.agents/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -1,0 +1,1153 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const script = path.join(path.dirname(fileURLToPath(import.meta.url)), "agent-transcript");
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "agent-transcript-test-"));
+}
+
+function writeJsonl(file, rows) {
+  fs.writeFileSync(file, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+}
+
+function run(args, options = {}) {
+  const effectiveArgs =
+    args[0] === "render" && !args.includes("--scope-query") && !args.includes("--allow-unscoped")
+      ? [...args, "--allow-unscoped"]
+      : args;
+  return execFileSync(process.execPath, [script, ...effectiveArgs], {
+    cwd: path.resolve("."),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+}
+
+test("render redacts common secrets and local identifiers", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Use /Users/ahmed/project, email person@example.com, and header Bearer abcdefghijklmnopqrstuvwxyz123456.",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Done." }] } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /\[LOCAL_PATH\]/);
+  assert.match(output, /\[REDACTED_EMAIL\]/);
+  assert.match(output, /\[REDACTED_AUTH_HEADER\]/);
+  assert.doesNotMatch(output, /person@example\.com/);
+  assert.doesNotMatch(output, /abcdefghijklmnopqrstuvwxyz123456/);
+});
+
+test("render requires scope unless explicitly local-only", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "Scoped work." }] } },
+  ]);
+
+  assert.throws(
+    () =>
+      execFileSync(process.execPath, [script, "render", "--session", session], {
+        cwd: path.resolve("."),
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    /--scope-query is required/,
+  );
+});
+
+test("render-thread requires scope unless explicitly local-only", () => {
+  assert.throws(
+    () =>
+      execFileSync(process.execPath, [script, "render-thread", "--thread-id", "fake-thread"], {
+        cwd: path.resolve("."),
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    /--scope-query is required/,
+  );
+});
+
+test("render redacts broad local paths", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Paths /tmp/session/file.txt /private/var/folders/abc/cache /home/alex/project C:\\Users\\alex\\project",
+          },
+        ],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /\[LOCAL_PATH\]/);
+  assert.doesNotMatch(output, /\/tmp\/session/);
+  assert.doesNotMatch(output, /\/private\/var\/folders/);
+  assert.doesNotMatch(output, /\/home\/alex/);
+  assert.doesNotMatch(output, /C:\\Users\\alex/);
+});
+
+test("render redacts SAPISIDHASH auth headers", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: "Authorization: SAPISIDHASH 1234567890abcdef_fakehash" }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /\[REDACTED_AUTH_HEADER\]/);
+  assert.doesNotMatch(output, /SAPISIDHASH 1234567890abcdef_fakehash/);
+});
+
+test("render redacts fine-grained GitHub tokens", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Token github_pat_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
+          },
+        ],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /\[REDACTED_GITHUB_TOKEN\]/);
+  assert.doesNotMatch(output, /github_pat_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890/);
+});
+
+test("render redacts Google API keys", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: 'INNERTUBE_API_KEY: "AIzaABCDEFGHIJKLMNOPQRSTUVWXYZ123456789"' }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /AIzaABCDEFGHIJKLMNOPQRSTUVWXYZ123456789/);
+});
+
+test("render omits credential-bearing service URLs", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: "DATABASE_URL=postgres://user:pass@example.test/db" }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /postgres:\/\//);
+  assert.doesNotMatch(output, /example\.test/);
+});
+
+test("render omits credential URLs with email-style usernames", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: "DATABASE_URL=postgres://user@example.com:mock-password@db.example.test/app" }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /mock-password/);
+  assert.doesNotMatch(output, /db\.example\.test/);
+});
+
+test("render keeps AGENTS.md task prompts when scoped", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: "Please update AGENTS.md with review guidance." }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session, "--scope-query", "AGENTS.md review guidance"]);
+  assert.match(output, /Please update AGENTS\.md with review guidance/);
+});
+
+test("render omits AGENTS.md setup blobs when scoped", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "# AGENTS.md instructions for /repo\n\nGuidance for AI coding assistants working on this repository.\n\nReview guidance.",
+          },
+        ],
+      },
+    },
+  ]);
+
+  assert.throws(
+    () => run(["render", "--session", session, "--scope-query", "AGENTS.md review guidance"]),
+    /scoped transcript is empty/,
+  );
+});
+
+test("render omits explicit setup instruction blobs when scoped", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Here are your instructions:\n\nScoped transcript guidance.",
+          },
+        ],
+      },
+    },
+  ]);
+
+  assert.throws(
+    () => run(["render", "--session", session, "--scope-query", "transcript guidance"]),
+    /scoped transcript is empty/,
+  );
+});
+
+test("render omits generic secret env assignments", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "AWS_SECRET_ACCESS_KEY=fake-secret-value NPM_TOKEN=fake-npm-token",
+          },
+        ],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /AWS_SECRET_ACCESS_KEY/);
+  assert.doesNotMatch(output, /NPM_TOKEN/);
+  assert.doesNotMatch(output, /fake-secret-value/);
+  assert.doesNotMatch(output, /fake-npm-token/);
+});
+
+test("render omits quoted secret env assignments with spaces", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: 'PASSWORD="mock secret phrase value"' }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /mock secret phrase value/);
+  assert.doesNotMatch(output, /phrase value/);
+});
+
+test("render omits colon-style quoted secret fields with spaces", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: 'password: "mock secret phrase value"\n{"api_key": "mock api key value"}' }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /mock secret phrase value/);
+  assert.doesNotMatch(output, /mock api key value/);
+  assert.doesNotMatch(output, /phrase value/);
+});
+
+test("render omits slash-prefixed secret env assignments", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: "API_TOKEN=/abcDEF123456 PASSWORD=/secret-value" }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /abcDEF123456/);
+  assert.doesNotMatch(output, /secret-value/);
+});
+
+test("render omits declared secret literals", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: 'const DATABASE_PASSWORD = "supersecret123"; let API_TOKEN = "mock-token-123456"; const SECRET = "/slash-secret-123456";',
+          },
+        ],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /supersecret123/);
+  assert.doesNotMatch(output, /mock-token-123456/);
+  assert.doesNotMatch(output, /slash-secret-123456/);
+});
+
+test("render omits unresolved secret fields", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  const secretText = ["client", "_sec", "ret: mock-token-123456 and api", "_ke", "y: abcdefghijklmnop"].join("");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: secretText }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /mock-token-123456/);
+  assert.doesNotMatch(output, /abcdefghijklmnop/);
+});
+
+test("render omits bare alphabetic secret fields", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  const secretText = ["api", "_ke", "y: abcdefghijklmnop"].join("");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: secretText }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /abcdefghijklmnop/);
+});
+
+test("render omits dotted secret field values", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  const secretText = ["api", "_ke", "y: abc", ".defghijkl"].join("");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: secretText }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /abc\.defghijkl/);
+});
+
+test("render omits dotted generic secret field values", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  const secretText = ["api", "Key: abc", ".defghijkl and sec", "ret: xyz", ".abcdefgh"].join("");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: secretText }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /abc\.defghijkl/);
+  assert.doesNotMatch(output, /xyz\.abcdefgh/);
+});
+
+test("render omits malformed quoted and short dotted secret values", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  const secretText = ["api", "_ke", 'y: "abcdefghijklmnop and pass', "word: pa.ssword"].join("");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: secretText }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /abcdefghijklmnop/);
+  assert.doesNotMatch(output, /pa\.ssword/);
+});
+
+test("render omits short unquoted secret fields", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  const secretText = ["pass", "word: abc123\napi", "_key: x9"].join("");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: secretText }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /abc123/);
+  assert.doesNotMatch(output, /x9/);
+});
+
+test("render keeps common short secret-field literals", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  const text = "password: false\ntoken: null\napiKey: test\nsecret: 2";
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /password: false/);
+  assert.match(output, /token: null/);
+  assert.match(output, /apiKey: test/);
+  assert.match(output, /secret: 2/);
+  assert.doesNotMatch(output, /browser\/session\/auth internals/);
+});
+
+test("render keeps code references with secret-like property names", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: "return { password: user.passwordHash, apiKey: config.apiKey };" }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /user\.passwordHash/);
+  assert.match(output, /config\.apiKey/);
+  assert.doesNotMatch(output, /browser\/session\/auth internals/);
+});
+
+test("render keeps call expression secret assignments", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  const multilineAssignment = "let pass" + "word = getPassword()\nnext line";
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: "let password = getPassword()" }],
+      },
+    },
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: multilineAssignment }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.ok(output.includes("let password = getPassword()"));
+  assert.match(output, /next line/);
+  assert.doesNotMatch(output, /browser\/session\/auth internals/);
+});
+
+test("render omits call expression secret literal arguments", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  const assignment = "let pass" + 'word = getPassword("' + "actual-secret-123" + '")';
+  const fallbackAssignment = "let pass" + 'word = getPassword() || "' + "actual-secret-456" + '"';
+  const templateAssignment = "let pass" + "word = getPassword(`" + "actual-secret-789" + "`)";
+  const bareArgumentAssignment = "let pass" + "word = getPassword(actual-secret-000)";
+  const secretIdentifierCall = "let to" + "ken = actualSecret123()";
+  const prefixedSecretIdentifierCall = "let to" + "ken = getActualSecret123()";
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: assignment }],
+      },
+    },
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: fallbackAssignment }],
+      },
+    },
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: templateAssignment }],
+      },
+    },
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: bareArgumentAssignment }],
+      },
+    },
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: secretIdentifierCall }],
+      },
+    },
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: prefixedSecretIdentifierCall }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /actual-secret-123/);
+  assert.doesNotMatch(output, /actual-secret-456/);
+  assert.doesNotMatch(output, /actual-secret-789/);
+  assert.doesNotMatch(output, /actual-secret-000/);
+  assert.doesNotMatch(output, /actualSecret123/);
+  assert.doesNotMatch(output, /getActualSecret123/);
+});
+
+test("render keeps regex declarations with secret-like names", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: "const SERVICE_CREDENTIAL_URL = /postgres:\\/\\/user:pass@example.test/i;" }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /SERVICE_CREDENTIAL_URL/);
+  assert.doesNotMatch(output, /browser\/session\/auth internals/);
+});
+
+test("render keeps wrapped diff regex declarations with secret-like names", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: "+const SERVICE_CREDENTIAL_URL =\n+  /postgres:\\/\\/user:pass@example.test/i;" }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /SERVICE_CREDENTIAL_URL/);
+  assert.doesNotMatch(output, /browser\/session\/auth internals/);
+});
+
+test("render omits prefixed secret-looking values without secret property names", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  const secretText = ["to", "ken: request.abcdefghijkl and pass", "word: credentials.abcdefghijkl"].join("");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: secretText }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /request\.abcdefghijkl/);
+  assert.doesNotMatch(output, /credentials\.abcdefghijkl/);
+});
+
+test("render rejects unsafe title metadata", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  const unsafeTitle = ["client", "_sec", "ret: mock-token-123456"].join("");
+  writeJsonl(session, [
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "Scoped work." }] } },
+  ]);
+
+  assert.throws(
+    () => run(["render", "--session", session, "--allow-unscoped", "--title", unsafeTitle]),
+    /unsafe transcript after redaction/,
+  );
+});
+
+test("render drops raw tool outputs but keeps a compact tool summary", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "Run tests." }] } },
+    { type: "response_item", payload: { type: "function_call", name: "exec_command", arguments: "npm test" } },
+    {
+      type: "response_item",
+      payload: { type: "function_call_output", output: "raw output with sk-abcdefghijklmnopqrstuvwxyz123456" },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /tool summary/);
+  assert.match(output, /1 execute/);
+  assert.doesNotMatch(output, /raw output/);
+  assert.doesNotMatch(output, /sk-abcdefghijklmnopqrstuvwxyz123456/);
+});
+
+test("render classifies web fetch tools as network", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "Fetch reference docs." }] } },
+    { type: "response_item", payload: { type: "function_call", name: "WebFetch", arguments: "{}" } },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /tool summary/);
+  assert.match(output, /1 network/);
+  assert.doesNotMatch(output, /1 read/);
+});
+
+test("render omits tool summary for scoped transcripts", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "Unrelated request." }] } },
+    { type: "response_item", payload: { type: "function_call", name: "exec_command", arguments: "npm test" } },
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "Scoped transcript guidance." }] } },
+  ]);
+
+  const output = run(["render", "--session", session, "--scope-query", "transcript guidance"]);
+  assert.match(output, /Scoped transcript guidance/);
+  assert.doesNotMatch(output, /tool summary/);
+  assert.doesNotMatch(output, /Unrelated request/);
+  assert.match(output, /"toolCalls":0/);
+});
+
+test("render drops nested Claude tool result rows", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", content: "raw tool result with sk-abcdefghijklmnopqrstuvwxyz123456" }],
+      },
+    },
+    {
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "Reviewed result." }] },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /Reviewed result/);
+  assert.doesNotMatch(output, /raw tool result/);
+  assert.doesNotMatch(output, /sk-abcdefghijklmnopqrstuvwxyz123456/);
+});
+
+test("render-thread rejects repo-relative CODEX_BIN", () => {
+  assert.throws(
+    () =>
+      execFileSync(process.execPath, [script, "render-thread", "--thread-id", "fake-thread", "--allow-unscoped"], {
+        cwd: path.resolve("."),
+        encoding: "utf8",
+        env: { ...process.env, CODEX_BIN: "./codex" },
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    /refusing relative executable path/,
+  );
+});
+
+test("render-thread rejects repo-contained absolute CODEX_BIN outside cwd", () => {
+  const fakeCodex = path.join(path.resolve("."), ".tmp-agent-transcript-codex");
+  fs.writeFileSync(fakeCodex, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+  try {
+    assert.throws(
+      () =>
+        execFileSync(process.execPath, [script, "render-thread", "--thread-id", "fake-thread", "--allow-unscoped"], {
+          cwd: os.tmpdir(),
+          encoding: "utf8",
+          env: { ...process.env, CODEX_BIN: fakeCodex },
+          stdio: ["ignore", "pipe", "pipe"],
+        }),
+      /refusing repo-controlled executable/,
+    );
+  } finally {
+    fs.rmSync(fakeCodex, { force: true });
+  }
+});
+
+test("render omits browser cookie material", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Cookie: SID=fake-session; SAPISID=fake-sapisid; __Secure-3PAPISID=fake-secure",
+          },
+        ],
+      },
+    },
+    {
+      type: "response_item",
+      payload: { role: "assistant", content: [{ type: "text", text: "__Secure-1PSID=fake-secure-value" }] },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /Cookie:/);
+  assert.doesNotMatch(output, /SID=/);
+  assert.doesNotMatch(output, /SAPISID=/);
+  assert.doesNotMatch(output, /__Secure-3PAPISID/);
+  assert.doesNotMatch(output, /__Secure-1PSID/);
+});
+
+test("render omits generic session cookie material", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: "SESSIONID=abcdef1234567890" }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /SESSIONID=/);
+  assert.doesNotMatch(output, /abcdef1234567890/);
+});
+
+test("render omits quoted cookie assignments", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: 'SID="abcdef1234567890"' }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /SID=/);
+  assert.doesNotMatch(output, /abcdef1234567890/);
+});
+
+test("render omits token auth schemes", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: "Authorization: Token abcdefghijklmnop" }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /Authorization: Token/);
+  assert.doesNotMatch(output, /abcdefghijklmnop/);
+});
+
+test("render keeps benign token prose", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: "token classification should stay reviewable" }],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /token classification should stay reviewable/);
+  assert.doesNotMatch(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /\[REDACTED_AUTH_HEADER\]/);
+});
+
+test("render omits OAuth callback URLs", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Callback https://accounts.example.test/oauth2/callback?code=fake-code&state=fake-state",
+          },
+        ],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /accounts\.example\.test/);
+  assert.doesNotMatch(output, /code=/);
+  assert.doesNotMatch(output, /state=/);
+  assert.doesNotMatch(output, /fake-code/);
+  assert.doesNotMatch(output, /fake-state/);
+});
+
+test("render omits fragment-only OAuth callback URLs", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Callback https://accounts.example.test/oauth2/callback#code=mock-code-123456",
+          },
+        ],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /browser\/session\/auth internals/);
+  assert.doesNotMatch(output, /accounts\.example\.test/);
+  assert.doesNotMatch(output, /code=/);
+  assert.doesNotMatch(output, /mock-code-123456/);
+});
+
+test("render prevents transcript marker and fence injection", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Fence ```` and marker <!-- agent-transcript:end --> should stay inert.",
+          },
+        ],
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /`````text/);
+  assert.match(output, /\[agent-transcript marker removed\]/);
+  assert.equal((output.match(/<!-- agent-transcript:start -->/g) || []).length, 1);
+  assert.equal((output.match(/<!-- agent-transcript:end -->/g) || []).length, 1);
+});
+
+test("render uses tail of long session logs", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  const rows = [
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "Old unrelated work." }] } },
+  ];
+  for (let index = 0; index < 12000; index++) {
+    rows.push({ type: "event_msg", payload: { type: "token_count", count: index } });
+  }
+  rows.push({
+    type: "response_item",
+    payload: { role: "user", content: [{ type: "text", text: "Current PR scoped work." }] },
+  });
+  writeJsonl(session, rows);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /Current PR scoped work/);
+  assert.doesNotMatch(output, /Old unrelated work/);
+});
+
+test("append-body replaces an existing transcript section", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  const body = path.join(dir, "body.md");
+  writeJsonl(session, [
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "New scoped work." }] } },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Implemented." }] } },
+  ]);
+  fs.writeFileSync(
+    body,
+    "# PR\n\n<!-- agent-transcript:start -->\nold transcript\n<!-- agent-transcript:end -->\n"
+  );
+
+  const output = run(["append-body", "--body", body, "--session", session, "--scope-query", "New scoped work"]);
+  assert.match(output, /# PR/);
+  assert.match(output, /New scoped work/);
+  assert.doesNotMatch(output, /old transcript/);
+  assert.equal((output.match(/agent-transcript:start/g) || []).length, 1);
+});
+
+test("append-body requires and applies transcript scope", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  const body = path.join(dir, "body.md");
+  writeJsonl(session, [
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "Unrelated private request." }] } },
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "Scoped transcript guidance." }] } },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Implemented." }] } },
+  ]);
+  fs.writeFileSync(body, "# PR\n");
+
+  assert.throws(() => run(["append-body", "--body", body, "--session", session]), /--scope-query is required/);
+  assert.throws(
+    () => run(["append-body", "--body", body, "--session", session, "--scope-query", "Fix UI"]),
+    /specific term/,
+  );
+  assert.throws(
+    () => run(["append-body", "--body", body, "--session", session, "--scope-query", "missingterm"]),
+    /scoped transcript is empty/,
+  );
+
+  const output = run(["append-body", "--body", body, "--session", session, "--scope-query", "transcript guidance"]);
+  assert.match(output, /Scoped transcript guidance/);
+  assert.match(output, /Implemented/);
+  assert.doesNotMatch(output, /Unrelated private request/);
+});
+
+test("render preserves scoped prompts mentioning instructions", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Following your instructions, please update transcript guidance.",
+          },
+        ],
+      },
+    },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Implemented." }] } },
+  ]);
+
+  const output = run(["render", "--session", session, "--scope-query", "transcript guidance"]);
+  assert.match(output, /Following your instructions/);
+  assert.match(output, /Implemented/);
+});
+
+test("render does not pull previous user turn for matching assistant", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "Unrelated private request." }] } },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Implemented transcript guidance." }] } },
+  ]);
+
+  const output = run(["render", "--session", session, "--scope-query", "transcript guidance"]);
+  assert.match(output, /Implemented transcript guidance/);
+  assert.doesNotMatch(output, /Unrelated private request/);
+});
+
+test("html preview applies PR scope when rendering candidate sessions", () => {
+  const dir = tempDir();
+  const root = path.join(dir, "sessions");
+  fs.mkdirSync(root);
+  const session = path.join(root, "session.jsonl");
+  writeJsonl(session, [
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "Unrelated GitHub cleanup." }] } },
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "Unrelated private request." }] } },
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "Scoped transcript guidance." }] } },
+    { type: "response_item", payload: { role: "assistant", content: [{ type: "text", text: "Implemented." }] } },
+  ]);
+  const prs = path.join(dir, "prs.json");
+  fs.writeFileSync(
+    prs,
+    JSON.stringify([
+      {
+        number: 286,
+        title: "Scoped transcript guidance",
+        headRefName: "docs/agent-review-transcript-guidance",
+        url: "https://github.example.test/repo/pull/286",
+      },
+    ]),
+  );
+
+  const output = run(["html", "--prs", prs, "--root", root, "--min-score", "1"]);
+  assert.match(output, /Scoped transcript guidance/);
+  assert.match(output, /Implemented/);
+  assert.doesNotMatch(output, /Unrelated GitHub cleanup/);
+  assert.doesNotMatch(output, /Unrelated private request/);
+});
+
+test("html preview rejects generated scopes with no specific terms", () => {
+  const dir = tempDir();
+  const root = path.join(dir, "sessions");
+  fs.mkdirSync(root);
+  const session = path.join(root, "session.jsonl");
+  writeJsonl(session, [
+    { type: "response_item", payload: { role: "user", content: [{ type: "text", text: "Fix UI unrelated private details." }] } },
+  ]);
+  const prs = path.join(dir, "prs.json");
+  fs.writeFileSync(
+    prs,
+    JSON.stringify([
+      {
+        number: 12,
+        title: "Fix UI",
+        headRefName: "ui",
+        url: "https://github.example.test/repo/pull/12",
+      },
+    ]),
+  );
+
+  const output = run(["html", "--prs", prs, "--root", root, "--min-score", "1"]);
+  assert.match(output, /--scope-query is required for html/);
+  assert.doesNotMatch(output, /unrelated private details/);
+});

--- a/.agents/skills/autoreview/SKILL.md
+++ b/.agents/skills/autoreview/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: autoreview
+description: "Run a structured code review (Codex default, Claude optional) as a closeout check on a local or PR branch before commit or ship."
+---
+
+# Auto Review
+
+Run the bundled structured review helper as a closeout check. This is code review, not Guardian `auto_review` approval routing.
+
+Codex review is the default when no engine is set. It usually delivers the best review results and should remain the normal final closeout engine.
+
+Use when:
+
+- user asks for Codex review / Claude review / autoreview / second-model review
+- after non-trivial code edits, before final/commit/ship
+- reviewing a local branch or PR branch after fixes
+
+## Contract
+
+- Treat review output as advisory. Never blindly apply it.
+- Verify every finding by reading the real code path and adjacent files.
+- Read dependency docs/source/types when the finding depends on external behavior.
+- Reject unrealistic edge cases, speculative risks, broad rewrites, and fixes that over-complicate the codebase.
+- Prefer small fixes at the right ownership boundary; no refactor unless it clearly improves the bug class.
+- When an accepted finding shows a bug class or repeated pattern, inspect the current PR scope for sibling instances before fixing.
+- Fix the scoped bug class at once when practical; stop at touched surfaces, owner boundaries, and clear follow-up territory.
+- Keep going until structured review returns no accepted/actionable findings.
+- If a review-triggered fix changes code, rerun focused tests and rerun the structured review helper.
+- For security-audit suppression changes, verify accepted findings remain auditable: suppressed findings stay in structured output, active output keeps an unsuppressible suppression notice, and aggregate findings cannot hide unrelated active risk.
+- Never switch or override the requested review engine/model. If the review hits model capacity, retry the same command a few times with the same engine/model.
+- Be patient with large bundles. Structured review can take up to 30 minutes while the model call is active, especially with Codex tools or web search.
+- Treat heartbeat lines like `review still running: ... elapsed=... pid=...` as healthy progress, not a hang. Let the helper continue while heartbeats are advancing. Pass `--stream-engine-output` when live engine text is useful; Codex and Claude filter tool/file chatter, other engines pass raw output through.
+- Do not kill a review just because it has been quiet for 2-5 minutes, or because it is still running under the 30-minute window. Inspect the process only after missing multiple expected heartbeats, after 30 minutes, or after an obviously failed subprocess; prefer letting the same helper command finish.
+- Tools are useful in review mode. The helper allows read-only inspection tools and web search by default so reviewers can check dependency contracts, upstream docs, and current behavior from a sanitized review workspace, not the real checkout.
+- Security perspective is always included, but it should not cripple legitimate functionality. Report security findings only when the change creates a concrete, actionable risk or removes an important safety check.
+- For regression provenance, keep roles separate: blamed code author, blamed PR author, PR merger/committer, current PR author, and PR/date. If no blamed PR is traceable, use the blamed commit as the provenance: commit SHA, date, and author username. Do not guess a merger or frame missing PR metadata as a separate finding.
+- If the blamed PR was merged by `clawsweeper[bot]` or another automation, identify the human trigger when practical. Check timeline/comments first; if rate-limited, use gitcrawl/cache or public PR HTML. Look for maintainer commands such as `@clawsweeper automerge`, `/landpr`, or labels/status comments that armed automerge. Report `automerge triggered by @login`; if not found, say trigger unknown.
+- Do not invoke built-in `codex review`, nested reviewers, or reviewer panels from inside the review. The helper builds one bundle, calls one selected engine, validates one structured result, and stops.
+- Stop as soon as the helper exits 0 with no accepted/actionable findings. Do not run an extra review just to get a nicer "clean" line, a second opinion, or clearer closeout wording.
+- Treat the helper's successful exit plus absence of actionable findings as the clean review result, even if the underlying Codex CLI output is terse.
+- Multi-reviewer panels are opt-in only. Use them when explicitly requested or when risk justifies the extra spend; the main agent still verifies every accepted finding before fixing.
+- If rejecting a finding as intentional/not worth fixing, add a brief inline code comment only when it explains a real invariant or ownership decision that future reviewers should know.
+- If `gh`/Gitcrawl reports `database disk image is malformed`, run `gitcrawl doctor --json` once to let the portable cache repair before retrying review; do not bypass the shim unless repair fails and freshness requires live GitHub.
+- If Gitcrawl reports a portable manifest mismatch, source/runtime DB health error, or stale portable-store checkout, run `gitcrawl doctor --json` and inspect `source_db_health`, `runtime_db_health`, and `portable_store_status` before falling back to live GitHub.
+- Do not push just to review. Push only when the user requested push/ship/PR update.
+
+## Pick Target
+
+Dirty local work:
+
+```bash
+<autoreview-helper> --mode local
+```
+
+Use this only when the patch is actually unstaged/staged/untracked in the
+current checkout. `--mode uncommitted` is accepted as an alias for `--mode local`.
+For committed, pushed, or PR work, point the helper at the commit
+or branch diff instead; do not force dirty modes just
+because the helper docs mention dirty work first. A clean local review
+only proves there is no local patch.
+
+Branch/PR work:
+
+```bash
+<autoreview-helper> --mode branch --base origin/main
+```
+
+Optional review context is first-class:
+
+```bash
+<autoreview-helper> --mode branch --base origin/main --prompt-file /tmp/review-notes.md --dataset /tmp/evidence.json
+```
+
+If an open PR exists, use its actual base:
+
+```bash
+base=$(gh pr view --json baseRefName --jq .baseRefName)
+<autoreview-helper> --mode branch --base "origin/$base"
+```
+
+Committed single change:
+
+```bash
+<autoreview-helper> --mode commit --commit HEAD
+```
+
+or with the repo-local helper:
+
+```bash
+.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD
+```
+
+Use commit review for already-landed or already-pushed work on `main`. Reviewing
+clean `main` against `origin/main` is usually an empty diff after push. For a
+small stack, review each commit explicitly or review the branch before merging
+with `--base`.
+
+## Parallel Closeout
+
+Format first if formatting can change line locations. Then it is OK to run tests and review in parallel:
+
+```bash
+scripts/autoreview --parallel-tests "<focused test command>"
+```
+
+On Windows, the default `--parallel-tests` shell preserves the platform `cmd.exe`
+semantics used by Python `shell=True`. Use `--parallel-tests-shell powershell`
+or `--parallel-tests-shell pwsh` when the focused test command is PowerShell-specific.
+
+Tradeoff: tests may force code changes that stale the review. If tests or review lead to code edits, rerun the affected tests and rerun review until no accepted/actionable findings remain. Once that rerun exits cleanly, stop; do not spend another long review cycle on redundant confirmation.
+
+## Review Panels
+
+Run multiple reviewers against one frozen bundle:
+
+```bash
+<autoreview-helper> --reviewers codex,claude
+```
+
+`--panel` is shorthand for Codex plus Claude unless `--engine` changes the first reviewer:
+
+```bash
+<autoreview-helper> --panel
+```
+
+Set reviewer models and thinking/effort explicitly:
+
+```bash
+<autoreview-helper> --reviewers codex,claude --model codex=gpt-5.1 --thinking codex=high --model claude=sonnet --thinking claude=max
+```
+
+Inline syntax is also supported:
+
+```bash
+<autoreview-helper> --reviewers codex:gpt-5.1:high,claude:sonnet:max
+```
+
+Codex maps thinking to `model_reasoning_effort` and accepts `low`, `medium`,
+`high`, or `xhigh`. Claude maps thinking to `--effort` and also accepts `max`.
+Engines without a real thinking knob reject `--thinking`.
+
+## Context Efficiency
+
+Run the helper directly so target selection, engine choice, structured validation, and exit status all stay in one path. If output is noisy, summarize the completed helper output after it returns; do not ask another agent or reviewer to rerun the review.
+
+## Helper
+
+Orka repo-local helper:
+
+```bash
+.agents/skills/autoreview/scripts/autoreview --help
+```
+
+`agent-scripts` checkout helper:
+
+```bash
+~/Projects/agent-scripts/skills/autoreview/scripts/autoreview --help
+```
+
+On native Windows, invoke the extensionless Python helper through Python:
+
+```powershell
+python skills\autoreview\scripts\autoreview --help
+```
+
+The smoke harness has thin shell wrappers over a shared Python implementation:
+
+```bash
+.agents/skills/autoreview/scripts/test-review-harness --fixture benign --engine codex
+```
+
+```powershell
+skills\autoreview\scripts\test-review-harness.ps1 -Fixture benign -Engine codex
+```
+
+Global helper from `agent-scripts`:
+
+```bash
+~/.codex/skills/agent-scripts/autoreview/scripts/autoreview --help
+```
+
+The helper:
+
+- chooses dirty local changes first
+- accepts `--mode uncommitted` as an alias for `--mode local`
+- otherwise uses current PR base if `gh pr view` works
+- otherwise uses `origin/main` for non-main branches
+- supports `--engine codex`, `claude`, `droid`, and `copilot`; default is `AUTOREVIEW_ENGINE` or `codex`; Codex should remain the default when nothing is set
+- resolves bare `git`, `gh`, reviewer, and PowerShell shell commands from absolute `PATH` entries only, never from the reviewed checkout; explicit relative `--*-bin` paths are refused
+- use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
+- should be left in `--mode auto` or forced to `--mode branch` for PR/branch work; do not force `--mode local` after committing
+- writes only to stdout unless `--output`, `--json-output`, or live streamed engine stderr is set
+- supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, `--prompt-file`, `--dataset`, `--no-tools`, `--no-web-search`, and commit refs
+- supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
+- supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model` and `--thinking`
+- allows read-only tools and web search by default where the selected CLI supports them; runs reviewers from a sanitized temporary workspace containing the review prompt instead of the real checkout; forbids nested review in the prompt; Codex is run through `codex exec` with read-only sandbox and structured output
+- prints `review still running: <engine> elapsed=<seconds>s pid=<pid>` to stderr at long-running intervals while waiting for the selected review engine, unless streamed output or compact Codex activity has been visible recently
+- prints `autoreview clean: no accepted/actionable findings reported` when the selected review command exits 0
+- exits nonzero when accepted/actionable findings are present
+
+## Final Report
+
+Include:
+
+- review command used
+- tests/proof run
+- findings accepted/rejected, briefly why
+- the clean review result from the final helper/review run, or why a remaining finding was consciously rejected
+
+Do not run another review solely to improve the final report wording. If the final helper run exited 0 and produced no accepted/actionable findings, report that exact run as clean.

--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -1,0 +1,1687 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import copy
+import json
+import os
+import queue
+import re
+import subprocess
+import sys
+import tempfile
+import textwrap
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+
+ENGINES = ("codex", "claude", "droid", "copilot")
+SENSITIVE_UNTRACKED_PATH = re.compile(
+    r"(^|/)(\.envrc(?:[./_-]|$)|\.env(?:[./_-]|$)|\.direnv(?:/|$)|"
+    r"\.npmrc$|\.netrc$|\.git-credentials$|credentials$|\.docker/config\.json$|"
+    r".*(?:auth|cookie|credential|secret|token)s?$|"
+    r".*(?:auth|cookie|credential|secret|token).*\.(?:json|ya?ml|log|txt|env)|"
+    r".*(?:id_rsa|id_ed25519|known_hosts|\.pem|\.p12|\.pfx|\.key|\.p8)$)",
+    re.IGNORECASE,
+)
+SENSITIVE_UNTRACKED_TEXT = re.compile(
+    r"BEGIN [A-Z ]*PRIVATE KEY|github_pat_|gh[pousr]_|AIza[0-9A-Za-z_-]{20,}|SAPISID|"
+    r"Cookie:|Set-Cookie:|[A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*\s*=",
+    re.IGNORECASE,
+)
+COOKIE_ASSIGNMENT_RE = re.compile(
+    r"\b(?:SID|HSID|SSID|APISID|SAPISID|SIDCC|SESSIONID|LOGIN_INFO|YSC|VISITOR_INFO1_LIVE|PREF|"
+    r"__Secure-[A-Za-z0-9_-]+|__Host-[A-Za-z0-9_-]+)\s*=\s*"
+    r"(?:\"[^\"\r\n;`'<>&)]*\"|'[^'\r\n;`\"<>&)]*'|[^;\s`\"'<>&)]+)",
+    re.IGNORECASE,
+)
+AUTH_URL_RE = re.compile(
+    r"\bhttps?://[^\s`\"'<>]*(?:[?&#](?:code|state|oauth_token|oauth_verifier|id_token|"
+    r"refresh_token|session_state|access_token|auth)=)[^\s`\"'<>]*",
+    re.IGNORECASE,
+)
+SERVICE_CREDENTIAL_URL_RE = re.compile(
+    r"\b[A-Za-z][A-Za-z0-9+.-]*://(?=[^\s`\"'<>/]*:[^\s`\"'<>/]*@)[^\s`\"'<>]+",
+    re.IGNORECASE,
+)
+REVIEW_BUNDLE_REDACTIONS = [
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.DOTALL), "[REDACTED_PRIVATE_KEY]"),
+    (re.compile(r"sk-[A-Za-z0-9_-]{20,}"), "[REDACTED_OPENAI_KEY]"),
+    (re.compile(r"sk_live_[A-Za-z0-9_-]{16,}"), "[REDACTED_STRIPE_KEY]"),
+    (re.compile(r"rk_live_[A-Za-z0-9_-]{16,}"), "[REDACTED_STRIPE_KEY]"),
+    (re.compile(r"xox[baprs]-[A-Za-z0-9-]{20,}"), "[REDACTED_SLACK_TOKEN]"),
+    (re.compile(r"npm_[A-Za-z0-9]{20,}"), "[REDACTED_NPM_TOKEN]"),
+    (re.compile(r"github_pat_[A-Za-z0-9_]{20,}"), "[REDACTED_GITHUB_TOKEN]"),
+    (re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}"), "[REDACTED_GITHUB_TOKEN]"),
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "[REDACTED_AWS_KEY]"),
+    (re.compile(r"AIza[0-9A-Za-z_-]{20,}"), "[REDACTED_GOOGLE_API_KEY]"),
+    (re.compile(r"eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}"), "[REDACTED_JWT]"),
+    (
+        re.compile(r"(\bAuthorization:\s*)(?:Token|ApiKey)\s+[A-Za-z0-9._~+/=:-]{8,}", re.IGNORECASE),
+        r"\1[REDACTED_AUTH_HEADER]",
+    ),
+    (re.compile(r"\b(?:Bearer|Basic|SAPISIDHASH)\s+[A-Za-z0-9._~+/=:-]{8,}", re.IGNORECASE), "[REDACTED_AUTH_HEADER]"),
+    (
+        re.compile(
+            r"(\b(?:Cookie|Set-Cookie):\s*)"
+            r"(?:[A-Za-z0-9_.-]+\s*=\s*(?:\"[^\"\r\n;]*\"|'[^'\r\n;]*'|[^;\r\n`\"']+)|[^;\r\n`\"']+)"
+            r"(?:;\s*(?:[A-Za-z0-9_.-]+\s*=\s*(?:\"[^\"\r\n;]*\"|'[^'\r\n;]*'|[^;\r\n`\"']+)|[^;\r\n`\"']+))*",
+            re.IGNORECASE,
+        ),
+        r"\1[REDACTED_COOKIE_HEADER]",
+    ),
+    (COOKIE_ASSIGNMENT_RE, "[REDACTED_COOKIE]"),
+    (AUTH_URL_RE, "[REDACTED_AUTH_URL]"),
+    (SERVICE_CREDENTIAL_URL_RE, "[REDACTED_CREDENTIAL_URL]"),
+    (re.compile(r"/Users/(?!\[)[^\s`\"'>)]+"), "[LOCAL_PATH]"),
+    (re.compile(r"/home/(?!\[)[^\s`\"'>)]+"), "[LOCAL_PATH]"),
+    (re.compile(r"/(?:private/var/folders|var/folders|tmp)/[^\s`\"'>)]+"), "[LOCAL_PATH]"),
+    (re.compile(r"[A-Za-z]:\\Users\\[^\s`\"'>)]+"), "[LOCAL_PATH]"),
+    (re.compile(r"~/(?!\[)[^\s`\"'>)]+"), "[HOME_PATH]"),
+    (
+        re.compile(
+            r"(^|\\n|[^A-Za-z0-9_])"
+            r"((?:[A-Za-z0-9]+[_-])*(?:api[_-]?key|token|secret|password|credential)"
+            r"(?:[_-][A-Za-z0-9]+)*"
+            r"[^\S\r\n]*[:=][^\S\r\n]*(?:[\"'](?:REDACTED|mock-token|test-cookie)[\"']|"
+            r"(?:REDACTED|mock-token|test-cookie)))(?=$|[^\w-])",
+            re.IGNORECASE,
+        ),
+        r"\1[PLACEHOLDER_SECRET]",
+    ),
+    (
+        re.compile(
+            r"([?&#](?:token|key|secret|signature|sig|access_token|auth|code|state|oauth_token|oauth_verifier|id_token|"
+            r"refresh_token|session_state)=)[^\s`\"'>&]+",
+            re.IGNORECASE,
+        ),
+        r"\1[REDACTED]",
+    ),
+    (
+        re.compile(
+            r"\b[A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*[^\S\r\n]*=[^\S\r\n]*"
+            r"(?:\"[^\"\r\n]*\"|'[^'\r\n]*')"
+        ),
+        "[REDACTED_ENV_SECRET]",
+    ),
+    (
+        re.compile(
+            r"(?<![A-Za-z0-9_])[\"']?"
+            r"[A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|credential)[A-Za-z0-9_]*[\"']?"
+            r"[^\S\r\n]*:[^\S\r\n]*(?:\"[^\"\r\n]*\"|'[^'\r\n]*')",
+            re.IGNORECASE,
+        ),
+        "[REDACTED_FIELD_SECRET]",
+    ),
+    (
+        re.compile(
+            r"(?<![A-Za-z0-9_])[\"']?"
+            r"[A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|credential)[A-Za-z0-9_]*[\"']?"
+            r"[^\S\r\n]*:[^\S\r\n]*"
+            r"(?!(?:user|config|self|this|options|request|response|account|profile|credential|credentials)\."
+            r"[A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|credential|key|hash)[A-Za-z0-9_]*\b)"
+            r"(?![\"'`])(?!(?:REDACTED|mock-token|test-cookie|true|false|null|nil|none|test)\b)"
+            r"(?=[A-Za-z0-9_+=:-]{1,7}(?=$|[\s,}\]]))"
+            r"(?=[A-Za-z0-9_+=:-]*[A-Za-z])(?=[A-Za-z0-9_+=:-]*\d)[A-Za-z0-9_+=:-]+",
+            re.IGNORECASE,
+        ),
+        "[REDACTED_FIELD_SECRET]",
+    ),
+    (
+        re.compile(
+            r"(?:(?<!const )(?<!let )(?<!var )"
+            r"\b[A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*[^\S\r\n]*=[^\S\r\n]*"
+            r"[\"']?(?!re\.compile\()[^\s`\"'<>&]+|"
+            r"(?:(?<=const )|(?<=let )|(?<=var ))"
+            r"\b[A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*[^\S\r\n]*=[^\S\r\n]*"
+            r"[\"'][^\s`\"'<>&]+|"
+            r"(?:(?<=const )|(?<=let )|(?<=var ))"
+            r"\b[A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*[^\S\r\n]*=[^\S\r\n]*"
+            r"[\"']?(?!/)(?!re\.compile\()[^\s`\"'<>&]+)"
+        ),
+        "[REDACTED_ENV_SECRET]",
+    ),
+]
+UNRESOLVED_SECRET_RE = re.compile(
+    r"(?ix)(?:(?<!const\ )(?<!let\ )(?<!var\ )"
+    r"\b[A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|credential)[A-Za-z0-9_]*[^\S\r\n]*[:=][^\S\r\n]*"
+    r"(?!(?:re\.compile\())|"
+    r"(?:(?<=const\ )|(?<=let\ )|(?<=var\ ))"
+    r"\b[A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|credential)[A-Za-z0-9_]*[^\S\r\n]*[:=][^\S\r\n]*"
+    r"(?!/)(?!(?:re\.compile\()))"
+    r"(?!(?:user|config|self|this|options|request|response|account|profile|credential|credentials)\."
+    r"[A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|credential|key|hash)[A-Za-z0-9_]*\b)"
+    r"(?!(?:(?:try|await)\s+)*(?:[A-Za-z_][A-Za-z0-9_]*\.)*"
+    r"(?:get|load|read|fetch|build|make|create|resolve|retrieve)"
+    r"(?:password|token|secret|credentials?|api[_-]?key|key|hash)?\s*"
+    r"(?:\([^\S\r\n]*\)|\\\([^\S\r\n]*\\\))[^\S\r\n]*(?=$|[\r\n;,)\]\}\"']))"
+    r"[\"']?[A-Za-z0-9_./+=:-]{8,}"
+)
+THINKING_LEVELS_BY_ENGINE = {
+    "codex": {"low", "medium", "high", "xhigh"},
+    "claude": {"low", "medium", "high", "xhigh", "max"},
+    "droid": set(),
+    "copilot": set(),
+}
+
+
+SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": [
+        "findings",
+        "overall_correctness",
+        "overall_explanation",
+        "overall_confidence",
+    ],
+    "properties": {
+        "findings": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": [
+                    "title",
+                    "body",
+                    "priority",
+                    "confidence",
+                    "category",
+                    "code_location",
+                ],
+                "properties": {
+                    "title": {"type": "string", "minLength": 1, "maxLength": 140},
+                    "body": {"type": "string", "minLength": 1, "maxLength": 2000},
+                    "priority": {"type": "string", "enum": ["P0", "P1", "P2", "P3"]},
+                    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                    "category": {
+                        "type": "string",
+                        "enum": ["bug", "security", "regression", "test_gap", "maintainability"],
+                    },
+                    "code_location": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["file_path", "line"],
+                        "properties": {
+                            "file_path": {"type": "string", "minLength": 1},
+                            "line": {"type": "integer", "minimum": 1},
+                        },
+                    },
+                },
+            },
+        },
+        "overall_correctness": {
+            "type": "string",
+            "enum": ["patch is correct", "patch is incorrect"],
+        },
+        "overall_explanation": {"type": "string", "minLength": 1, "maxLength": 3000},
+        "overall_confidence": {"type": "number", "minimum": 0, "maximum": 1},
+    },
+}
+
+
+def run(args: list[str], cwd: Path, *, input_text: str | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        input=input_text,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if check and result.returncode != 0:
+        cmd = " ".join(args)
+        raise SystemExit(f"command failed ({result.returncode}): {cmd}\n{result.stderr or result.stdout}")
+    return result
+
+
+def run_with_heartbeat(
+    args: list[str],
+    cwd: Path,
+    *,
+    input_text: str | None = None,
+    label: str,
+    heartbeat_seconds: int = 60,
+    stream_output: bool = False,
+    stream_display: Callable[[str, str], str | None] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    if stream_output:
+        return run_with_stream(
+            args,
+            cwd,
+            input_text=input_text,
+            label=label,
+            heartbeat_seconds=heartbeat_seconds,
+            stream_display=stream_display,
+        )
+    started = time.monotonic()
+    proc = subprocess.Popen(
+        args,
+        cwd=cwd,
+        stdin=subprocess.PIPE if input_text is not None else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    first_communicate = True
+    while True:
+        try:
+            stdout, stderr = proc.communicate(
+                input=input_text if first_communicate else None,
+                timeout=heartbeat_seconds,
+            )
+            return subprocess.CompletedProcess(args, int(proc.returncode or 0), stdout, stderr)
+        except subprocess.TimeoutExpired:
+            first_communicate = False
+            elapsed = int(time.monotonic() - started)
+            print(f"review still running: {label} elapsed={elapsed}s pid={proc.pid}", file=sys.stderr, flush=True)
+
+
+def run_with_stream(
+    args: list[str],
+    cwd: Path,
+    *,
+    input_text: str | None,
+    label: str,
+    heartbeat_seconds: int,
+    stream_display: Callable[[str, str], str | None] | None,
+) -> subprocess.CompletedProcess[str]:
+    started = time.monotonic()
+    proc = subprocess.Popen(
+        args,
+        cwd=cwd,
+        stdin=subprocess.PIPE if input_text is not None else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    events: queue.Queue[tuple[str, str | None]] = queue.Queue()
+    stdout_parts: list[str] = []
+    stderr_parts: list[str] = []
+
+    def read_stream(name: str, stream: Any) -> None:
+        try:
+            for line in iter(stream.readline, ""):
+                events.put((name, line))
+        finally:
+            events.put((name, None))
+
+    def write_stdin() -> None:
+        if proc.stdin is None or input_text is None:
+            return
+        try:
+            proc.stdin.write(input_text)
+            proc.stdin.close()
+        except BrokenPipeError:
+            return
+
+    threads = [
+        threading.Thread(target=read_stream, args=("stdout", proc.stdout), daemon=True),
+        threading.Thread(target=read_stream, args=("stderr", proc.stderr), daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+    stdin_thread = threading.Thread(target=write_stdin, daemon=True)
+    stdin_thread.start()
+
+    open_streams = 2
+    while open_streams:
+        try:
+            name, line = events.get(timeout=heartbeat_seconds)
+        except queue.Empty:
+            elapsed = int(time.monotonic() - started)
+            print(f"review still running: {label} elapsed={elapsed}s pid={proc.pid}", file=sys.stderr, flush=True)
+            continue
+        if line is None:
+            open_streams -= 1
+            continue
+        if name == "stdout":
+            stdout_parts.append(line)
+        else:
+            stderr_parts.append(line)
+        display = stream_display(name, line) if stream_display else line
+        if display:
+            target = sys.stdout if name == "stdout" else sys.stderr
+            target.write(display)
+            target.flush()
+
+    for thread in threads:
+        thread.join()
+    stdin_thread.join(timeout=1)
+    returncode = proc.wait()
+    return subprocess.CompletedProcess(args, returncode, "".join(stdout_parts), "".join(stderr_parts))
+
+
+def git(repo: Path, *args: str, check: bool = True) -> str:
+    return run([resolve_command("git", repo), *args], repo, check=check).stdout
+
+
+def git_literal_pathspecs(repo: Path, *args: str, check: bool = True) -> str:
+    return run([resolve_command("git", repo), "--literal-pathspecs", *args], repo, check=check).stdout
+
+
+def repo_root() -> Path:
+    start = Path.cwd().resolve()
+    unsafe_root = discover_repo_root(start) or start
+    git_bin = find_command("git", unsafe_root)
+    if not git_bin:
+        raise SystemExit("git executable not found. Install Git or add it to PATH.")
+    result = subprocess.run(
+        [git_bin, "rev-parse", "--show-toplevel"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        raise SystemExit("autoreview must run inside a git repository")
+    return Path(result.stdout.strip()).resolve()
+
+
+def discover_repo_root(start: Path) -> Path | None:
+    current = start
+    while True:
+        if (current / ".git").exists():
+            return current
+        if current.parent == current:
+            return None
+        current = current.parent
+
+
+def current_branch(repo: Path) -> str:
+    return git(repo, "branch", "--show-current", check=False).strip() or "detached"
+
+
+def is_dirty(repo: Path) -> bool:
+    return bool(git(repo, "status", "--porcelain").strip())
+
+
+def choose_target(repo: Path, mode: str, base_ref: str | None) -> tuple[str, str | None]:
+    mode = "local" if mode == "uncommitted" else mode
+    branch = current_branch(repo)
+    if mode == "local" or (mode == "auto" and is_dirty(repo)):
+        return "local", None
+    if mode == "commit":
+        return "commit", None
+    if mode == "branch" or (mode == "auto" and branch != "main"):
+        return "branch", base_ref or detect_pr_base(repo) or "origin/main"
+    raise SystemExit("no review target: clean main checkout and no forced mode")
+
+
+def detect_pr_base(repo: Path) -> str | None:
+    gh_bin = find_command("gh", repo)
+    if not gh_bin:
+        return None
+    result = run([gh_bin, "pr", "view", "--json", "baseRefName", "--jq", ".baseRefName"], repo, check=False)
+    base = result.stdout.strip()
+    return f"origin/{base}" if result.returncode == 0 and base else None
+
+
+def resolve_command(name: str, repo: Path) -> str:
+    resolved = find_command(name, repo)
+    if resolved:
+        return resolved
+    raise SystemExit(f"executable not found: {name}. Install it or pass an explicit trusted path when supported.")
+
+
+def find_command(name: str, repo: Path) -> str | None:
+    command = Path(name)
+    if has_directory_component(name, command):
+        if not command.is_absolute():
+            raise SystemExit(f"refusing relative executable path: {name}")
+        return first_executable_candidate(command, reject_root=repo.resolve())
+    for part in os.environ.get("PATH", "").split(os.pathsep):
+        if not part or part == ".":
+            continue
+        path_part = Path(part)
+        if not path_part.is_absolute():
+            continue
+        try:
+            resolved_part = path_part.resolve()
+            resolved_repo = repo.resolve()
+        except OSError:
+            continue
+        if is_within(resolved_part, resolved_repo):
+            continue
+        found = first_executable_candidate(resolved_part / name, reject_root=resolved_repo)
+        if found:
+            return found
+    return None
+
+
+def is_within(path: Path, root: Path) -> bool:
+    return path == root or path.is_relative_to(root)
+
+
+def has_directory_component(name: str, command: Path) -> bool:
+    separators = [separator for separator in (os.sep, os.altsep) if separator]
+    return command.is_absolute() or bool(command.drive) or any(separator in name for separator in separators)
+
+
+def first_executable_candidate(path: Path, *, reject_root: Path | None = None) -> str | None:
+    if os.name == "nt" and not path.suffix:
+        extensions = [ext for ext in os.environ.get("PATHEXT", ".COM;.EXE;.BAT;.CMD").split(";") if ext]
+        candidates = [path.with_suffix(ext.lower()) for ext in extensions]
+        candidates.extend(path.with_suffix(ext.upper()) for ext in extensions)
+        candidates.append(path)
+    else:
+        candidates = [path]
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            if reject_root is not None:
+                try:
+                    if is_within(candidate.resolve(), reject_root):
+                        continue
+                except OSError:
+                    continue
+            return str(candidate)
+    return None
+
+
+def bounded(text: str, limit: int = 180_000) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n\n[truncated at {limit} characters]\n"
+
+
+def bounded_field(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    suffix = "\n\n[truncated]"
+    return text[: max(0, limit - len(suffix))] + suffix
+
+
+def redact_review_text(text: str) -> str:
+    redacted = text
+    for pattern, replacement in REVIEW_BUNDLE_REDACTIONS:
+        redacted = pattern.sub(replacement, redacted)
+    if UNRESOLVED_SECRET_RE.search(redacted):
+        raise SystemExit("review bundle contains unresolved secret-like material; aborting before reviewer")
+    return redacted
+
+
+def read_text(path: Path, limit: int = 40_000) -> str:
+    try:
+        if path.is_symlink():
+            return "[symlink omitted]"
+        if not path.is_file():
+            return "[non-file omitted]"
+        data = path.read_bytes()
+    except OSError as exc:
+        return f"[unreadable: {exc}]"
+    if b"\0" in data:
+        return "[binary file omitted]"
+    text = data.decode("utf-8", errors="replace")
+    return bounded(text, limit)
+
+
+def read_untracked_text(path: Path, rel: str, limit: int = 40_000) -> str:
+    if is_sensitive_path(rel):
+        return "[sensitive untracked file omitted]"
+    text = read_text(path, limit)
+    if SENSITIVE_UNTRACKED_TEXT.search(text):
+        return "[sensitive-looking untracked file omitted]"
+    return redact_review_text(text)
+
+
+def is_sensitive_path(rel: str) -> bool:
+    return bool(SENSITIVE_UNTRACKED_PATH.search(rel))
+
+
+def omitted_sensitive_paths_notice(paths: list[str]) -> str:
+    if not paths:
+        return ""
+    count = len(paths)
+    suffix = "" if count == 1 else "s"
+    return f"[{count} sensitive changed path{suffix} omitted from review bundle]"
+
+
+def safe_diff(repo: Path, diff_ref_args: list[str], output_args: list[str]) -> str:
+    path_entries = diff_path_entries(repo, diff_ref_args)
+    safe_paths, omitted_paths = partition_safe_path_entries(path_entries)
+    parts = []
+    notice = omitted_sensitive_paths_notice(omitted_paths)
+    if notice:
+        parts.append(notice)
+    if safe_paths:
+        parts.append(
+            redact_review_text(git_literal_pathspecs(repo, "diff", *diff_ref_args, *output_args, "--", *safe_paths))
+        )
+    return "\n".join(part for part in parts if part)
+
+
+def diff_path_entries(repo: Path, diff_ref_args: list[str]) -> list[list[str]]:
+    return parse_name_status_entries(
+        git(repo, "diff", *diff_ref_args, "--name-status", "-z", "--find-renames", "--find-copies-harder")
+    )
+
+
+def parse_name_status_entries(text: str) -> list[list[str]]:
+    if "\0" in text:
+        return parse_nul_name_status_entries(text)
+    entries: list[list[str]] = []
+    for line in text.splitlines():
+        parts = [part for part in line.split("\t") if part]
+        if len(parts) < 2:
+            continue
+        status = parts[0]
+        if status.startswith(("R", "C")) and len(parts) >= 3:
+            entries.append([parts[1], parts[2]])
+        else:
+            entries.append([parts[-1]])
+    return entries
+
+
+def parse_nul_name_status_entries(text: str) -> list[list[str]]:
+    entries: list[list[str]] = []
+    fields = [field for field in text.split("\0") if field]
+    index = 0
+    while index < len(fields):
+        status = fields[index]
+        index += 1
+        if status.startswith(("R", "C")) and index + 1 < len(fields):
+            entries.append([fields[index], fields[index + 1]])
+            index += 2
+        elif index < len(fields):
+            entries.append([fields[index]])
+            index += 1
+    return entries
+
+
+def partition_safe_path_entries(path_entries: list[list[str]]) -> tuple[list[str], list[str]]:
+    safe_paths: list[str] = []
+    omitted_paths: list[str] = []
+    for paths in path_entries:
+        if any(is_sensitive_path(path) for path in paths):
+            omitted_paths.append(paths[-1])
+        else:
+            safe_paths.append(paths[-1])
+    return safe_paths, omitted_paths
+
+
+def safe_show(repo: Path, commit_ref: str, output_args: list[str]) -> str:
+    path_entries = commit_path_entries(repo, commit_ref)
+    safe_paths, omitted_paths = partition_safe_path_entries(path_entries)
+    parts = []
+    notice = omitted_sensitive_paths_notice(omitted_paths)
+    if notice:
+        parts.append(notice)
+    if safe_paths:
+        parts.append(
+            redact_review_text(git_literal_pathspecs(repo, "show", *output_args, commit_ref, "--", *safe_paths))
+        )
+    return "\n".join(part for part in parts if part)
+
+
+def commit_path_entries(repo: Path, commit_ref: str) -> list[list[str]]:
+    return parse_name_status_entries(
+        git(
+            repo,
+            "diff-tree",
+            "--no-commit-id",
+            "--root",
+            "--name-status",
+            "-z",
+            "--find-renames",
+            "--find-copies-harder",
+            "-r",
+            commit_ref,
+        )
+    )
+
+
+def local_bundle(repo: Path) -> str:
+    parts = [
+        "# Git Status",
+        safe_status(repo),
+        "# Staged Diff",
+        safe_diff(repo, ["--cached"], ["--stat"]),
+        bounded(safe_diff(repo, ["--cached"], ["--patch", "--find-renames"])),
+        "# Unstaged Diff",
+        safe_diff(repo, [], ["--stat"]),
+        bounded(safe_diff(repo, [], ["--patch", "--find-renames"])),
+    ]
+    untracked = [line for line in git(repo, "ls-files", "--others", "--exclude-standard").splitlines() if line]
+    if untracked:
+        parts.append("# Untracked Files")
+        for rel in untracked:
+            path = repo / rel
+            label = "[sensitive untracked file omitted]" if is_sensitive_path(rel) else rel
+            parts.append(f"## {label}\n{read_untracked_text(path, rel)}")
+    return "\n\n".join(parts)
+
+
+def safe_status(repo: Path) -> str:
+    lines = []
+    for line in git(repo, "status", "--short").splitlines():
+        paths = status_line_paths(line)
+        if any(is_sensitive_path(path) for path in paths):
+            lines.append(f"{line[:3]}[sensitive path omitted]")
+        else:
+            lines.append(line)
+    return redact_review_text("\n".join(lines))
+
+
+def status_line_paths(line: str) -> list[str]:
+    if len(line) <= 3:
+        return []
+    path_text = line[3:].strip()
+    if " -> " in path_text:
+        return [part.strip().strip('"') for part in path_text.split(" -> ") if part.strip()]
+    return [path_text.strip('"')]
+
+
+def branch_bundle(repo: Path, base_ref: str) -> str:
+    return "\n\n".join(
+        [
+            "# Branch Diff",
+            f"base: {base_ref}",
+            safe_diff(repo, [f"{base_ref}...HEAD"], ["--stat"]),
+            bounded(safe_diff(repo, [f"{base_ref}...HEAD"], ["--patch", "--find-renames"])),
+        ]
+    )
+
+
+def commit_bundle(repo: Path, commit_ref: str) -> str:
+    return "\n\n".join(
+        [
+            "# Commit Diff",
+            f"commit: {commit_ref}",
+            safe_show(repo, commit_ref, ["--stat", "--format=fuller"]),
+            bounded(safe_show(repo, commit_ref, ["--patch", "--find-renames", "--format=fuller"])),
+        ]
+    )
+
+
+LineRanges = dict[str, list[tuple[int, int]]]
+
+
+def review_changed_lines(repo: Path, target: str, target_ref: str | None, commit_ref: str) -> LineRanges:
+    ranges: LineRanges = {}
+    changed_paths = review_changed_paths(repo, target, target_ref, commit_ref)
+    if target == "local":
+        for patch in [
+            git(repo, "diff", "--cached", "--unified=0", "--find-renames"),
+            git(repo, "diff", "--unified=0", "--find-renames"),
+        ]:
+            merge_line_ranges(ranges, parse_changed_line_ranges(patch))
+        for rel in git(repo, "ls-files", "--others", "--exclude-standard").splitlines():
+            path = rel.strip()
+            if path:
+                ranges.setdefault(path, []).append((1, max(1, file_line_count(repo / path))))
+    elif target == "branch":
+        assert target_ref
+        patch = git(repo, "diff", "--unified=0", "--find-renames", f"{target_ref}...HEAD")
+        merge_line_ranges(ranges, parse_changed_line_ranges(patch))
+    else:
+        patch = git(repo, "show", "--unified=0", "--find-renames", "--format=", commit_ref)
+        merge_line_ranges(ranges, parse_changed_line_ranges(patch))
+    for path in changed_paths:
+        if path not in ranges or not ranges[path]:
+            ranges[path] = [(1, 1)]
+    return {path: path_ranges for path, path_ranges in ranges.items() if path in changed_paths}
+
+
+def review_changed_paths(repo: Path, target: str, target_ref: str | None, commit_ref: str) -> set[str]:
+    names: set[str] = set()
+    if target == "local":
+        sources = [
+            git(repo, "diff", "--name-only", "--cached"),
+            git(repo, "diff", "--name-only"),
+            git(repo, "ls-files", "--others", "--exclude-standard"),
+        ]
+    elif target == "branch":
+        assert target_ref
+        sources = [git(repo, "diff", "--name-only", f"{target_ref}...HEAD")]
+    else:
+        sources = [git(repo, "show", "--name-only", "--format=", commit_ref)]
+    for source in sources:
+        for line in source.splitlines():
+            path = line.strip()
+            if path:
+                names.add(path)
+    return names
+
+
+def merge_line_ranges(target: LineRanges, source: LineRanges) -> None:
+    for rel, rel_ranges in source.items():
+        target.setdefault(rel, []).extend(rel_ranges)
+
+
+def parse_changed_line_ranges(patch: str) -> LineRanges:
+    ranges: LineRanges = {}
+    current_path: str | None = None
+    old_path: str | None = None
+    current_deleted_file = False
+    in_hunk = False
+    for line in patch.splitlines():
+        if line.startswith("diff --git "):
+            current_path = None
+            old_path = None
+            current_deleted_file = False
+            in_hunk = False
+            continue
+        if not in_hunk and line.startswith("--- "):
+            raw = line[4:].strip()
+            old_path = None if raw == "/dev/null" else strip_diff_prefix(raw)
+            continue
+        if not in_hunk and line.startswith("+++ "):
+            raw = line[4:].strip()
+            current_deleted_file = raw == "/dev/null"
+            current_path = old_path if current_deleted_file else strip_diff_prefix(raw)
+            if current_path:
+                ranges.setdefault(current_path, [])
+                if current_deleted_file:
+                    ranges[current_path].append((1, sys.maxsize))
+            continue
+        if not current_path or not line.startswith("@@ "):
+            continue
+        in_hunk = True
+        if current_deleted_file:
+            continue
+        match = re.search(r"-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?", line)
+        if not match:
+            continue
+        new_start = int(match.group(3))
+        new_count = int(match.group(4) or "1")
+        if new_count > 0:
+            ranges.setdefault(current_path, []).append((new_start, new_start + new_count - 1))
+        if new_count == 0:
+            anchor = max(1, new_start)
+            ranges.setdefault(current_path, []).append((anchor, anchor))
+    return ranges
+
+
+def strip_diff_prefix(path_text: str) -> str:
+    if path_text.startswith("a/") or path_text.startswith("b/"):
+        return path_text[2:]
+    return path_text
+
+
+def file_line_count(path: Path) -> int:
+    text = read_text(path)
+    if text.startswith("[") and text.endswith(" omitted]"):
+        return 1
+    return max(1, len(text.splitlines()))
+
+
+def load_extra_prompt(args: argparse.Namespace) -> str:
+    chunks: list[str] = []
+    for value in args.prompt or []:
+        chunks.append(redact_review_text(value))
+    for path in args.prompt_file or []:
+        prompt_path = Path(path)
+        if prompt_path.is_dir():
+            raise SystemExit(f"--prompt-file must be a file, got directory: {prompt_path}")
+        chunks.append(f"# Prompt file: {prompt_path.name}\n{read_untracked_text(prompt_path, str(prompt_path))}")
+    return "\n\n".join(chunks)
+
+
+def load_datasets(args: argparse.Namespace) -> str:
+    chunks: list[str] = []
+    for spec in args.dataset or []:
+        path = Path(spec)
+        if path.is_dir():
+            raise SystemExit(f"--dataset must be a file, got directory: {path}")
+        chunks.append(f"# Dataset: {path.name}\n{read_untracked_text(path, str(path))}")
+    return "\n\n".join(chunks)
+
+
+def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, extra_prompt: str, datasets: str) -> str:
+    target_line = f"{target} {target_ref}" if target_ref else target
+    repo_label = repo.name or "repository"
+    return textwrap.dedent(
+        f"""
+        You are a senior code reviewer. Review the provided git change bundle only.
+
+        Hard rules:
+        - Return exactly one JSON object and nothing else. Do not wrap it in Markdown.
+        - The JSON object must match this schema exactly:
+        {json.dumps(SCHEMA, indent=2)}
+        - Do not modify files.
+        - Do not invoke nested reviewers or review tools.
+        - Forbidden nested review commands include: codex review, autoreview, claude review, oracle review.
+        - You may use read-only tools and web search to inspect the sanitized review workspace, dependency contracts, upstream docs, current behavior, and security implications.
+        - The real checkout path is intentionally not provided. Treat the change bundle below as authoritative; do not look for another local checkout.
+        - Shell commands, if available, must be read-only inspection commands. Do not run tests, formatters, package installs, generators, network mutation commands, git mutation commands, or commands that write files.
+        - Report only actionable defects introduced or exposed by this change.
+        - Prefer high-signal findings over style feedback.
+        - Include security findings: injection, secret leaks, authz/authn bypass, path traversal, unsafe deserialization, unsafe filesystem or shell use, privacy leaks, and credential handling.
+        - Do not reject legitimate functionality merely because it touches shell, filesystem, network, auth, or sensitive data. Report a security finding only when the patch creates a concrete exploitable risk, removes an important safety check, or lacks validation at a trust boundary.
+        - For each finding, use the smallest file/line location that demonstrates the issue.
+        - If there are no actionable findings, return an empty findings array and mark the patch correct.
+
+        Review target: {target_line}
+        Repository: {repo_label}
+
+        {extra_prompt}
+
+        {datasets}
+
+        # Change Bundle
+        {bundle}
+        """
+    ).strip()
+
+
+def prepare_review_workspace(root: Path, prompt: str) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    prompt_path = root / "review-prompt.md"
+    prompt_path.write_text(prompt)
+    os.chmod(prompt_path, 0o600)
+    (root / "README.md").write_text(
+        "This is a sanitized autoreview workspace. It intentionally contains only the review prompt and helper control files.\n"
+    )
+    return root
+
+
+def run_codex(args: argparse.Namespace, repo: Path, workspace: Path, prompt: str) -> str:
+    if not args.tools:
+        raise SystemExit("--no-tools is not supported by the Codex engine; use --engine claude --no-tools for a no-tools run")
+    schema_path = workspace / "output-schema.json"
+    schema_path.write_text(json.dumps(SCHEMA))
+    os.chmod(schema_path, 0o600)
+    output_path = workspace / "last-message.json"
+    cmd = [resolve_command(args.codex_bin, repo), "--ask-for-approval", "never"]
+    if args.web_search:
+        cmd.append("--search")
+    if args.model:
+        cmd.extend(["--model", args.model])
+    if args.thinking:
+        cmd.extend(["-c", f'model_reasoning_effort="{args.thinking}"'])
+    cmd.append("exec")
+    if args.stream_engine_output:
+        # Codex exposes --json as an exec option, so keep it after the subcommand.
+        cmd.append("--json")
+    cmd.extend(
+        [
+            "--ephemeral",
+            "-C",
+            str(workspace),
+            "--skip-git-repo-check",
+            "-s",
+            "read-only",
+            "--output-schema",
+            str(schema_path),
+            "--output-last-message",
+            str(output_path),
+            "-",
+        ]
+    )
+    result = run_with_heartbeat(
+        cmd,
+        workspace,
+        input_text=prompt,
+        label="codex",
+        stream_output=args.stream_engine_output,
+        stream_display=CodexStreamDisplay() if args.stream_engine_output else None,
+    )
+    output = output_path.read_text() if output_path.exists() else ""
+    if result.returncode != 0:
+        raise SystemExit(f"codex engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return output or result.stdout
+
+
+def run_claude(args: argparse.Namespace, repo: Path, workspace: Path, prompt: str) -> str:
+    cmd = [
+        resolve_command(args.claude_bin, repo),
+        "--print",
+        "--bare",
+        "--no-session-persistence",
+        "--output-format",
+        "stream-json" if args.stream_engine_output else "json",
+        "--json-schema",
+        json.dumps(SCHEMA),
+    ]
+    if args.tools:
+        cmd.extend(["--allowedTools", claude_allowed_tools(args, workspace)])
+    else:
+        cmd.extend(["--tools", ""])
+    if args.stream_engine_output:
+        cmd.append("--verbose")
+    if args.model:
+        cmd.extend(["--model", args.model])
+    if args.thinking:
+        cmd.extend(["--effort", args.thinking])
+    result = run_with_heartbeat(
+        cmd,
+        workspace,
+        input_text=prompt,
+        label="claude",
+        stream_output=args.stream_engine_output,
+        stream_display=ClaudeStreamDisplay() if args.stream_engine_output else None,
+    )
+    if result.returncode != 0:
+        raise SystemExit(f"claude engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
+def run_droid(args: argparse.Namespace, repo: Path, workspace: Path, prompt: str) -> str:
+    if args.thinking:
+        raise SystemExit("--thinking is not supported by the droid engine")
+    prompt_path = workspace / "droid-prompt.txt"
+    prompt_path.write_text(prompt)
+    os.chmod(prompt_path, 0o600)
+    cmd = [
+        resolve_command(args.droid_bin, repo),
+        "exec",
+        "--cwd",
+        str(workspace),
+        "--output-format",
+        "json",
+        "-f",
+        str(prompt_path),
+    ]
+    if args.model:
+        cmd.extend(["--model", args.model])
+    cmd.extend(["--disabled-tools", "*"])
+    result = run_with_heartbeat(cmd, workspace, label="droid", stream_output=args.stream_engine_output)
+    if result.returncode != 0:
+        raise SystemExit(f"droid engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
+def run_copilot(args: argparse.Namespace, repo: Path, workspace: Path, prompt: str) -> str:
+    if args.thinking:
+        raise SystemExit("--thinking is not supported by the copilot engine")
+    if not args.tools:
+        raise SystemExit("--no-tools is not supported by the copilot engine; copilot requires a read-only file view tool to load the review bundle without exposing it in argv")
+    cmd = [
+        resolve_command(args.copilot_bin, repo),
+        "-C",
+        str(workspace),
+        "-p",
+        "Read ./review-prompt.md and follow it exactly. Return only the requested JSON object.",
+        "--output-format",
+        "json",
+        "--stream",
+        "on" if args.stream_engine_output else "off",
+        "--no-ask-user",
+        "--disable-builtin-mcps",
+    ]
+    if args.model:
+        cmd.extend(["--model", args.model])
+    # Copilot's URL fetch support requires --allow-all-urls. The review prompt
+    # contains an untrusted change bundle, so do not expose arbitrary fetches.
+    tools = ["read_agent", "rg", "view"]
+    cmd.append(f"--available-tools={','.join(tools)}")
+    for tool in tools:
+        cmd.append(f"--allow-tool={tool}")
+    result = run_with_heartbeat(cmd, workspace, label="copilot", stream_output=args.stream_engine_output)
+    if result.returncode != 0:
+        raise SystemExit(f"copilot engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
+class CodexStreamDisplay:
+    def __init__(self, *, activity_seconds: int = 20) -> None:
+        self.activity_seconds = activity_seconds
+        self.hidden_events = 0
+        self.last_visible = time.monotonic()
+
+    def __call__(self, name: str, line: str) -> str | None:
+        if name != "stdout":
+            return line
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            return self.visible(line)
+        event_type = event.get("type")
+        if event_type == "thread.started":
+            return self.visible(f"codex thread: {event.get('thread_id', '<unknown>')}\n")
+        if event_type == "turn.started":
+            return self.visible("codex turn started\n")
+        if event_type == "turn.completed":
+            usage = event.get("usage")
+            message = format_codex_usage(usage) + "\n" if isinstance(usage, dict) else "codex turn completed\n"
+            return self.visible(self.flush_hidden() + message)
+        item = event.get("item")
+        if isinstance(item, dict) and item.get("type") == "agent_message" and isinstance(item.get("text"), str):
+            return self.visible(self.flush_hidden() + item["text"].rstrip() + "\n")
+        return self.hidden_activity()
+
+    def hidden_activity(self) -> str | None:
+        self.hidden_events += 1
+        if time.monotonic() - self.last_visible < self.activity_seconds:
+            return None
+        return self.visible(self.flush_hidden())
+
+    def flush_hidden(self) -> str:
+        if not self.hidden_events:
+            return ""
+        count = self.hidden_events
+        self.hidden_events = 0
+        return f"codex activity: {count} hidden tool/status events\n"
+
+    def visible(self, text: str) -> str:
+        self.last_visible = time.monotonic()
+        return text
+
+
+class ClaudeStreamDisplay:
+    def __init__(self, *, activity_seconds: int = 20) -> None:
+        self.activity_seconds = activity_seconds
+        self.hidden_events = 0
+        self.last_visible = time.monotonic()
+        self.started = False
+
+    def __call__(self, name: str, line: str) -> str | None:
+        if name != "stdout":
+            return line
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            return self.visible(line)
+        event_type = event.get("type")
+        if event_type == "system" and not self.started:
+            self.started = True
+            return self.visible("claude turn started\n")
+        if event_type == "assistant":
+            return self.assistant_message(event)
+        if event_type == "result":
+            return self.visible(self.flush_hidden() + self.result_summary(event))
+        return self.hidden_activity()
+
+    def assistant_message(self, event: dict[str, Any]) -> str | None:
+        message = event.get("message")
+        if not isinstance(message, dict):
+            return self.hidden_activity()
+        chunks: list[str] = []
+        for item in message.get("content", []):
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") == "text" and isinstance(item.get("text"), str):
+                chunks.append(item["text"].rstrip())
+        if chunks:
+            return self.visible(self.flush_hidden() + "\n".join(chunks) + "\n")
+        return self.hidden_activity()
+
+    def result_summary(self, event: dict[str, Any]) -> str:
+        usage = event.get("usage")
+        fields: list[str] = []
+        if isinstance(usage, dict):
+            for key in (
+                "input_tokens",
+                "cache_read_input_tokens",
+                "cache_creation_input_tokens",
+                "output_tokens",
+            ):
+                value = usage.get(key)
+                if isinstance(value, int):
+                    fields.append(f"{key}={value}")
+        cost = event.get("total_cost_usd")
+        if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+            fields.append(f"cost_usd={cost:.6f}")
+        return "claude usage: " + " ".join(fields) + "\n" if fields else "claude turn completed\n"
+
+    def hidden_activity(self) -> str | None:
+        self.hidden_events += 1
+        if time.monotonic() - self.last_visible < self.activity_seconds:
+            return None
+        return self.visible(self.flush_hidden())
+
+    def flush_hidden(self) -> str:
+        if not self.hidden_events:
+            return ""
+        count = self.hidden_events
+        self.hidden_events = 0
+        return f"claude activity: {count} hidden tool/status events\n"
+
+    def visible(self, text: str) -> str:
+        self.last_visible = time.monotonic()
+        return text
+
+
+def format_codex_usage(usage: dict[str, Any]) -> str:
+    fields = [
+        "input_tokens",
+        "cached_input_tokens",
+        "output_tokens",
+        "reasoning_output_tokens",
+    ]
+    parts = [f"{field}={usage[field]}" for field in fields if isinstance(usage.get(field), int)]
+    return "codex usage: " + " ".join(parts) if parts else "codex usage: unavailable"
+
+
+def claude_allowed_tools(args: argparse.Namespace, workspace: Path) -> str:
+    tools = [tool.strip() for tool in args.claude_allowed_tools.split(",") if tool.strip()]
+    if not args.web_search:
+        tools = [tool for tool in tools if tool not in {"WebSearch", "WebFetch"}]
+    return ",".join(scope_claude_file_tool(tool, workspace) for tool in tools)
+
+
+def scope_claude_file_tool(tool: str, workspace: Path) -> str:
+    match = re.fullmatch(r"([A-Za-z][A-Za-z0-9_]*)(?:\((.*)\))?", tool)
+    if not match:
+        return tool
+    name, pattern = match.groups()
+    if name not in {"Read", "Grep", "Glob"}:
+        return tool
+    workspace_root = workspace.resolve()
+    if not pattern:
+        return f"{name}(./**)"
+    if not claude_tool_pattern_within_workspace(pattern, workspace_root):
+        raise SystemExit(f"refusing unscoped Claude file tool: {tool}")
+    return tool
+
+
+def claude_tool_pattern_within_workspace(pattern: str, workspace: Path) -> bool:
+    stripped = pattern.strip()
+    if not stripped or stripped.startswith(("~", "//")) or "[" in stripped or "]" in stripped:
+        return False
+    prefix = re.split(r"[*?\[]", stripped, maxsplit=1)[0] or "."
+    if prefix.startswith("/"):
+        candidate = workspace / prefix.lstrip("/")
+    else:
+        candidate = workspace / prefix
+    resolved = candidate.resolve(strict=False)
+    return is_within(resolved, workspace)
+
+
+def extract_json(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    if not stripped:
+        raise SystemExit("review engine returned empty output")
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        fenced_report = parse_json_candidate(stripped)
+        if isinstance(fenced_report, dict) and "findings" in fenced_report:
+            return fenced_report
+        jsonl_report = extract_json_from_jsonl(stripped)
+        if jsonl_report:
+            return jsonl_report
+        raise SystemExit(f"review engine returned non-JSON output: {exc}\n{stripped[:2000]}")
+    if isinstance(parsed, dict) and "findings" in parsed:
+        return parsed
+    if isinstance(parsed, dict) and isinstance(parsed.get("structured_output"), dict):
+        return parsed["structured_output"]
+    if isinstance(parsed, dict) and isinstance(parsed.get("result"), str):
+        result_json = parse_json_candidate(parsed["result"])
+        if isinstance(result_json, dict) and "findings" in result_json:
+            return result_json
+        raise SystemExit(f"review engine result was not structured JSON:\n{parsed['result'][:2000]}")
+    jsonl_report = extract_json_from_jsonl(stripped)
+    if jsonl_report:
+        return jsonl_report
+    raise SystemExit(f"review engine returned unexpected JSON shape:\n{json.dumps(parsed)[:2000]}")
+
+
+def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
+    candidates: list[str | dict[str, Any]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        part = event.get("part")
+        if isinstance(part, dict) and isinstance(part.get("text"), str):
+            candidates.append(part["text"])
+        data = event.get("data")
+        if isinstance(data, dict) and isinstance(data.get("content"), str):
+            candidates.append(data["content"])
+        if isinstance(event.get("result"), str):
+            candidates.append(event["result"])
+        if isinstance(event.get("structured_output"), dict):
+            candidates.append(event["structured_output"])
+    for candidate in reversed(candidates):
+        if isinstance(candidate, dict):
+            if "findings" in candidate:
+                return candidate
+            continue
+        parsed = parse_json_candidate(candidate)
+        if isinstance(parsed, dict) and "findings" in parsed:
+            return parsed
+    return None
+
+
+def parse_json_candidate(text: str) -> Any | None:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        if lines and lines[0].startswith("```") and lines[-1].strip() == "```":
+            stripped = "\n".join(lines[1:-1]).strip()
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(parsed, str) and parsed != text:
+        nested = parse_json_candidate(parsed)
+        return nested if nested is not None else parsed
+    return parsed
+
+
+def validate_report(report: dict[str, Any], repo: Path, changed_lines: LineRanges, required: list[str]) -> None:
+    allowed_top = {"findings", "overall_correctness", "overall_explanation", "overall_confidence"}
+    extra_top = set(report) - allowed_top
+    if extra_top:
+        raise SystemExit(f"review JSON has unexpected top-level keys: {sorted(extra_top)}")
+    for key in SCHEMA["required"]:
+        if key not in report:
+            raise SystemExit(f"review JSON missing required key: {key}")
+    if not isinstance(report["findings"], list):
+        raise SystemExit("review JSON findings must be an array")
+    if report.get("overall_correctness") not in {"patch is correct", "patch is incorrect"}:
+        raise SystemExit(f"review JSON has invalid overall_correctness: {report.get('overall_correctness')}")
+    if not isinstance(report.get("overall_explanation"), str) or not report["overall_explanation"]:
+        raise SystemExit("review JSON overall_explanation must be a non-empty string")
+    if len(report["overall_explanation"]) > 3000:
+        raise SystemExit("review JSON overall_explanation is too long")
+    if not number_in_range(report.get("overall_confidence")):
+        raise SystemExit("review JSON overall_confidence must be numeric")
+    finding_text = ""
+    kept_findings: list[dict[str, Any]] = []
+    ignored_findings: list[tuple[int, dict[str, Any], str, int]] = []
+    for index, finding in enumerate(report["findings"]):
+        if not isinstance(finding, dict):
+            raise SystemExit(f"finding {index} must be an object")
+        allowed_finding = {"title", "body", "priority", "confidence", "category", "code_location"}
+        extra_finding = set(finding) - allowed_finding
+        if extra_finding:
+            raise SystemExit(f"finding {index} has unexpected keys: {sorted(extra_finding)}")
+        for key in allowed_finding:
+            if key not in finding:
+                raise SystemExit(f"finding {index} missing required key: {key}")
+        title = finding.get("title")
+        if not isinstance(title, str) or not title or len(title) > 140:
+            raise SystemExit(f"finding {index} has invalid title")
+        body = finding.get("body")
+        if not isinstance(body, str) or not body or len(body) > 2000:
+            raise SystemExit(f"finding {index} has invalid body")
+        priority = finding.get("priority")
+        if priority not in {"P0", "P1", "P2", "P3"}:
+            raise SystemExit(f"finding {index} has invalid priority: {priority}")
+        if not number_in_range(finding.get("confidence")):
+            raise SystemExit(f"finding {index} has invalid confidence")
+        category = finding.get("category")
+        if category not in {"bug", "security", "regression", "test_gap", "maintainability"}:
+            raise SystemExit(f"finding {index} has invalid category: {category}")
+        location = finding.get("code_location")
+        if not isinstance(location, dict):
+            raise SystemExit(f"finding {index} missing code_location")
+        rel = str(location.get("file_path", "")).strip()
+        line = location.get("line")
+        if not rel or not isinstance(line, int) or line < 1:
+            raise SystemExit(f"finding {index} has invalid location: {location}")
+        if Path(rel).is_absolute() or ".." in Path(rel).parts:
+            raise SystemExit(f"finding {index} uses invalid file path: {rel}")
+        if rel not in changed_lines or not line_in_ranges(line, changed_lines[rel]):
+            ignored_findings.append((index, finding, rel, line))
+            continue
+        kept_findings.append(finding)
+        finding_text += "\n" + json.dumps(finding, sort_keys=True)
+    if ignored_findings:
+        for index, finding, rel, line in ignored_findings:
+            title = finding.get("title", "<untitled>")
+            print(
+                f"autoreview ignored out-of-scope finding {index}: {title} ({rel}:{line})",
+                file=sys.stderr,
+            )
+            print(bounded_field(str(finding.get("body", "")), 500), file=sys.stderr)
+        report["findings"] = kept_findings
+        if not kept_findings and report["overall_correctness"] == "patch is incorrect":
+            note = f"Ignored {len(ignored_findings)} out-of-scope finding(s) outside the reviewed change."
+            explanation = report["overall_explanation"].rstrip()
+            report["overall_correctness"] = "patch is correct"
+            report["overall_explanation"] = bounded_field(f"{explanation}\n\n{note}", 3000)
+    haystack = finding_text.lower()
+    for needle in required:
+        if needle.lower() not in haystack:
+            raise SystemExit(f"required finding text not found: {needle}")
+
+
+def number_in_range(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and 0 <= value <= 1
+
+
+def line_in_ranges(line: int, ranges: list[tuple[int, int]]) -> bool:
+    return any(start <= line <= end for start, end in ranges)
+
+
+def print_report(report: dict[str, Any], *, label: str = "autoreview") -> None:
+    findings = report["findings"]
+    if findings:
+        print(f"{label} findings: {len(findings)}")
+    elif report["overall_correctness"] == "patch is incorrect":
+        print(f"{label} verdict: patch is incorrect without discrete findings")
+    else:
+        print(f"{label} clean: no accepted/actionable findings reported")
+    for finding in findings:
+        loc = finding["code_location"]
+        print(f"[{finding['priority']}] {finding['title']}")
+        print(f"{loc['file_path']}:{loc['line']}")
+        print(f"{finding['body']}")
+        print()
+    print(f"overall: {report['overall_correctness']} ({report['overall_confidence']})")
+    print(report["overall_explanation"])
+
+
+def start_parallel_tests(command: str, repo: Path, shell_kind: str) -> tuple[subprocess.Popen, float]:
+    print(f"tests: {command}")
+    if shell_kind == "default" or shell_kind == "cmd":
+        return subprocess.Popen(command, cwd=repo, shell=True), time.time()
+    if shell_kind == "powershell":
+        powershell = resolve_command("powershell", repo)
+        return subprocess.Popen(
+            [powershell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command],
+            cwd=repo,
+        ), time.time()
+    if shell_kind == "pwsh":
+        pwsh = resolve_command("pwsh", repo)
+        return subprocess.Popen(
+            [pwsh, "-NoProfile", "-Command", command],
+            cwd=repo,
+        ), time.time()
+    raise SystemExit(f"invalid --parallel-tests-shell/AUTOREVIEW_PARALLEL_TESTS_SHELL: {shell_kind}")
+
+
+def finish_parallel_tests(proc: subprocess.Popen, started: float) -> int:
+    proc.wait()
+    print(f"tests exit: {proc.returncode} after {int(time.time() - started)}s")
+    return int(proc.returncode or 0)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Bundle-driven AI code review.")
+    parser.add_argument("--mode", choices=["auto", "local", "uncommitted", "branch", "commit"], default="auto")
+    parser.add_argument("--base")
+    parser.add_argument("--commit", default="HEAD")
+    parser.add_argument("--engine", choices=ENGINES, default=os.environ.get("AUTOREVIEW_ENGINE", "codex"))
+    parser.add_argument("--reviewers", help="Comma-separated review panel, e.g. codex,claude or codex:gpt-5:high.")
+    parser.add_argument("--panel", action="store_true", help="Run a Codex/Claude review panel unless --engine changes the first reviewer.")
+    parser.add_argument("--model", action="append", help="Model for all reviewers or engine=model. Repeatable.")
+    parser.add_argument("--thinking", action="append", help="Thinking/effort for all reviewers or engine=level. Repeatable. Codex: low, medium, high, xhigh. Claude: low, medium, high, xhigh, max.")
+    parser.add_argument("--allow-partial-panel", action="store_true", help="Continue panel output when one reviewer fails.")
+    parser.add_argument("--codex-bin", default=os.environ.get("CODEX_BIN", "codex"))
+    parser.add_argument("--claude-bin", default=os.environ.get("CLAUDE_BIN", "claude"))
+    parser.add_argument("--droid-bin", default=os.environ.get("DROID_BIN", "droid"))
+    parser.add_argument("--copilot-bin", default=os.environ.get("COPILOT_BIN", "copilot"))
+    parser.add_argument("--no-tools", dest="tools", action="store_false", default=True, help="Disable tools for engines that support it. Codex and copilot reject no-tools review.")
+    parser.add_argument("--no-web-search", dest="web_search", action="store_false", default=True)
+    parser.add_argument(
+        "--claude-allowed-tools",
+        default=os.environ.get(
+            "AUTOREVIEW_CLAUDE_TOOLS",
+            "Read,Grep,Glob,WebSearch",
+        ),
+    )
+    parser.add_argument("--prompt", action="append", help="Additional review instruction text.")
+    parser.add_argument("--prompt-file", action="append", help="Additional review instruction file.")
+    parser.add_argument("--dataset", action="append", help="Extra evidence file to include in the review bundle.")
+    parser.add_argument("--output", help="Write human output to a file as well as stdout.")
+    parser.add_argument("--json-output", help="Write validated structured review JSON.")
+    parser.add_argument(
+        "--stream-engine-output",
+        action="store_true",
+        default=os.environ.get("AUTOREVIEW_STREAM_ENGINE_OUTPUT") == "1",
+        help="Stream review engine output while preserving buffered output for validation. Codex output is filtered to hide tool/file chatter.",
+    )
+    parser.add_argument("--parallel-tests", help="Run a test command concurrently with review; failure fails the helper.")
+    parser.add_argument(
+        "--parallel-tests-shell",
+        choices=["default", "cmd", "powershell", "pwsh"],
+        default=os.environ.get("AUTOREVIEW_PARALLEL_TESTS_SHELL", "default"),
+        help="Shell for --parallel-tests. Default preserves Python shell=True platform behavior; use powershell or pwsh for PowerShell-specific commands.",
+    )
+    parser.add_argument("--require-finding", action="append", default=[], help="Require finding text to contain this substring.")
+    parser.add_argument("--expect-findings", action="store_true", help="Treat findings as success; for harness acceptance tests.")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    if args.engine not in ENGINES:
+        raise SystemExit(f"invalid --engine/AUTOREVIEW_ENGINE: {args.engine}")
+    return args
+
+
+def run_engine(args: argparse.Namespace, repo: Path, workspace: Path, prompt: str) -> str:
+    if args.engine == "codex":
+        return run_codex(args, repo, workspace, prompt)
+    if args.engine == "claude":
+        return run_claude(args, repo, workspace, prompt)
+    if args.engine == "droid":
+        return run_droid(args, repo, workspace, prompt)
+    if args.engine == "copilot":
+        return run_copilot(args, repo, workspace, prompt)
+    raise SystemExit(f"unsupported engine: {args.engine}")
+
+
+def parse_keyed_options(values: list[str] | None, option: str) -> tuple[str | None, dict[str, str]]:
+    global_value: str | None = None
+    per_engine: dict[str, str] = {}
+    for raw in values or []:
+        value = raw.strip()
+        if not value:
+            raise SystemExit(f"--{option} cannot be empty")
+        if "=" in value:
+            engine, engine_value = value.split("=", 1)
+            engine = engine.strip()
+            engine_value = engine_value.strip()
+            if engine not in ENGINES:
+                raise SystemExit(f"--{option} uses unknown engine: {engine}")
+            if not engine_value:
+                raise SystemExit(f"--{option} for {engine} cannot be empty")
+            if engine in per_engine:
+                raise SystemExit(f"--{option} specified more than once for {engine}")
+            per_engine[engine] = engine_value
+        else:
+            if global_value is not None:
+                raise SystemExit(f"--{option} global value specified more than once")
+            global_value = value
+    return global_value, per_engine
+
+
+def parse_reviewer_token(token: str) -> tuple[str, str | None, str | None]:
+    parts = [part.strip() for part in token.split(":")]
+    if len(parts) > 3 or not parts[0]:
+        raise SystemExit(f"invalid reviewer spec: {token}")
+    engine = parts[0]
+    if engine not in ENGINES:
+        raise SystemExit(f"unknown reviewer engine: {engine}")
+    model = parts[1] if len(parts) >= 2 and parts[1] else None
+    thinking = parts[2] if len(parts) == 3 and parts[2] else None
+    return engine, model, thinking
+
+
+def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
+    global_model, model_by_engine = parse_keyed_options(args.model, "model")
+    global_thinking, thinking_by_engine = parse_keyed_options(args.thinking, "thinking")
+    reviewers: list[tuple[str, str | None, str | None]] = []
+    if args.reviewers:
+        tokens = [token.strip() for token in args.reviewers.split(",") if token.strip()]
+        if len(tokens) == 1 and tokens[0] == "all":
+            tokens = list(ENGINES)
+        reviewers = [parse_reviewer_token(token) for token in tokens]
+    elif args.panel:
+        engines = [args.engine]
+        for engine in ("codex", "claude"):
+            if engine not in engines:
+                engines.append(engine)
+        reviewers = [(engine, None, None) for engine in engines]
+    else:
+        reviewers = [(args.engine, None, None)]
+
+    seen: set[str] = set()
+    result: list[argparse.Namespace] = []
+    for engine, inline_model, inline_thinking in reviewers:
+        if engine in seen:
+            raise SystemExit(f"reviewer specified more than once: {engine}")
+        seen.add(engine)
+        model = inline_model or model_by_engine.get(engine) or global_model
+        thinking = inline_thinking or thinking_by_engine.get(engine) or global_thinking
+        if thinking and thinking not in THINKING_LEVELS_BY_ENGINE[engine]:
+            valid = ", ".join(sorted(THINKING_LEVELS_BY_ENGINE[engine])) or "none"
+            raise SystemExit(f"invalid thinking level for {engine}: {thinking} (valid: {valid})")
+        clone = copy.copy(args)
+        clone.engine = engine
+        clone.model = model
+        clone.thinking = thinking
+        result.append(clone)
+    return result
+
+
+def reviewer_label(args: argparse.Namespace) -> str:
+    parts = [args.engine]
+    if args.model:
+        parts.append(f"model={args.model}")
+    if args.thinking:
+        parts.append(f"thinking={args.thinking}")
+    return " ".join(parts)
+
+
+def run_reviewer(args: argparse.Namespace, repo: Path, prompt: str, changed_lines: LineRanges, required: list[str]) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="autoreview-workspace.") as tempdir:
+        workspace = prepare_review_workspace(Path(tempdir), prompt)
+        raw = run_engine(args, repo, workspace, prompt)
+    report = extract_json(raw)
+    validate_report(report, repo, changed_lines, required)
+    return report
+
+
+def merge_panel_reports(reports: list[tuple[str, dict[str, Any]]]) -> dict[str, Any]:
+    findings: list[dict[str, Any]] = []
+    seen: set[tuple[str, int, str, str]] = set()
+    for label, report in reports:
+        for finding in report["findings"]:
+            location = finding["code_location"]
+            key = (
+                location["file_path"],
+                location["line"],
+                finding["category"],
+                " ".join(finding["title"].lower().split()),
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            merged = copy.deepcopy(finding)
+            merged["body"] = bounded_field(f"Reviewer: {label}\n\n{merged['body']}", 2000)
+            findings.append(merged)
+    incorrect = bool(findings) or any(report["overall_correctness"] == "patch is incorrect" for _, report in reports)
+    summary = ", ".join(f"{label}: {len(report['findings'])} finding(s)" for label, report in reports)
+    return {
+        "findings": findings,
+        "overall_correctness": "patch is incorrect" if incorrect else "patch is correct",
+        "overall_explanation": f"Panel review complete. {summary}.",
+        "overall_confidence": max((report["overall_confidence"] for _, report in reports), default=0.5),
+    }
+
+
+def run_panel(args: argparse.Namespace, reviewers: list[argparse.Namespace], repo: Path, prompt: str, changed_lines: LineRanges) -> dict[str, Any]:
+    reports: list[tuple[str, dict[str, Any]]] = []
+    failures: list[str] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(reviewers)) as executor:
+        future_by_label = {
+            executor.submit(run_reviewer, reviewer, repo, prompt, changed_lines, []): reviewer_label(reviewer)
+            for reviewer in reviewers
+        }
+        for future in concurrent.futures.as_completed(future_by_label):
+            label = future_by_label[future]
+            try:
+                reports.append((label, future.result()))
+            except SystemExit as exc:
+                failures.append(f"{label}: {exc}")
+            except Exception as exc:
+                failures.append(f"{label}: {exc}")
+    if failures and not args.allow_partial_panel:
+        raise SystemExit("autoreview panel failed\n" + "\n".join(failures))
+    if failures:
+        for failure in failures:
+            print(f"panel reviewer failed: {failure}")
+    if not reports:
+        raise SystemExit("autoreview panel produced no reports")
+    reports.sort(key=lambda item: item[0])
+    report = merge_panel_reports(reports)
+    validate_report(report, repo, changed_lines, args.require_finding)
+    return report
+
+
+def main() -> int:
+    args = parse_args()
+    reviewers = reviewer_args(args)
+    repo = repo_root()
+    target, target_ref = choose_target(repo, args.mode, args.base)
+    print(f"autoreview target: {target}")
+    print(f"branch: {current_branch(repo)}")
+    if len(reviewers) == 1 and not args.reviewers and not args.panel:
+        print(f"engine: {reviewers[0].engine}")
+        if reviewers[0].model:
+            print(f"model: {reviewers[0].model}")
+        if reviewers[0].thinking:
+            print(f"thinking: {reviewers[0].thinking}")
+    else:
+        print(f"reviewers: {', '.join(reviewer_label(reviewer) for reviewer in reviewers)}")
+    print(f"tools: {'on' if args.tools else 'off'}")
+    print(f"web_search: {'on' if args.web_search else 'off'}")
+    display_ref = args.commit if target == "commit" else target_ref
+    if display_ref:
+        print(f"ref: {display_ref}")
+    if args.dry_run:
+        return 0
+
+    if target == "local":
+        bundle = local_bundle(repo)
+    elif target == "branch":
+        assert target_ref
+        bundle = branch_bundle(repo, target_ref)
+    else:
+        bundle = commit_bundle(repo, args.commit)
+        target_ref = args.commit
+    prompt = build_prompt(repo, target, target_ref, bundle, load_extra_prompt(args), load_datasets(args))
+    changed_lines = review_changed_lines(repo, target, target_ref, args.commit)
+    print(f"bundle: {len(prompt)} chars")
+
+    tests_proc: tuple[subprocess.Popen, float] | None = None
+    if args.parallel_tests:
+        tests_proc = start_parallel_tests(args.parallel_tests, repo, args.parallel_tests_shell)
+    try:
+        if len(reviewers) == 1:
+            report = run_reviewer(reviewers[0], repo, prompt, changed_lines, args.require_finding)
+            label = "autoreview"
+        else:
+            report = run_panel(args, reviewers, repo, prompt, changed_lines)
+            label = "autoreview panel"
+        if args.json_output:
+            Path(args.json_output).write_text(json.dumps(report, indent=2) + "\n")
+
+        if args.output:
+            original_stdout = sys.stdout
+            with Path(args.output).open("w") as handle:
+                sys.stdout = Tee(original_stdout, handle)
+                try:
+                    print_report(report, label=label)
+                finally:
+                    sys.stdout = original_stdout
+        else:
+            print_report(report, label=label)
+    finally:
+        tests_status = finish_parallel_tests(*tests_proc) if tests_proc else 0
+
+    has_findings = bool(report["findings"])
+    overall_incorrect = report["overall_correctness"] == "patch is incorrect"
+    if tests_status != 0:
+        return 1
+    if args.expect_findings:
+        return 0 if has_findings else 1
+    return 1 if has_findings or overall_incorrect else 0
+
+
+class Tee:
+    def __init__(self, *streams: Any) -> None:
+        self.streams = streams
+
+    def write(self, data: str) -> None:
+        for stream in self.streams:
+            stream.write(data)
+
+    def flush(self) -> None:
+        for stream in self.streams:
+            stream.flush()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/autoreview/scripts/autoreview.test.py
+++ b/.agents/skills/autoreview/scripts/autoreview.test.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("autoreview")
+LOADER = SourceFileLoader("autoreview_helper", str(SCRIPT))
+SPEC = spec_from_loader(LOADER.name, LOADER)
+assert SPEC is not None
+autoreview = module_from_spec(SPEC)
+LOADER.exec_module(autoreview)
+
+
+def run(args: list[str], cwd: Path) -> str:
+    result = subprocess.run(args, cwd=cwd, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return result.stdout
+
+
+class AutoReviewHelperTests(unittest.TestCase):
+    def test_redacts_quoted_secret_values_with_spaces(self) -> None:
+        output = autoreview.redact_review_text('PASSWORD="mock secret phrase value"')
+
+        self.assertIn("[REDACTED_ENV_SECRET]", output)
+        self.assertNotIn("mock secret phrase value", output)
+        self.assertNotIn("phrase value", output)
+
+    def test_keeps_call_expression_secret_assignments(self) -> None:
+        output = autoreview.redact_review_text("let password = getPassword()")
+        multiline_assignment = "let pass" "word = getPassword()\nnext line"
+        multiline_output = autoreview.redact_review_text(multiline_assignment)
+
+        self.assertEqual("let password = getPassword()", output)
+        self.assertIn("next line", multiline_output)
+
+    def test_rejects_call_expression_secret_literal_arguments(self) -> None:
+        assignment = "let pass" 'word = getPassword("actual-secret-123")'
+        fallback_assignment = "let pass" 'word = getPassword() || "actual-secret-123"'
+        template_assignment = "let pass" "word = getPassword(`actual-secret-123`)"
+        bare_argument_assignment = "let pass" "word = getPassword(actual-secret-123)"
+        secret_identifier_call = "let to" "ken = actualSecret123()"
+        prefixed_secret_identifier_call = "let to" "ken = getActualSecret123()"
+        with self.assertRaises(SystemExit):
+            autoreview.redact_review_text(assignment)
+        with self.assertRaises(SystemExit):
+            autoreview.redact_review_text(fallback_assignment)
+        with self.assertRaises(SystemExit):
+            autoreview.redact_review_text(template_assignment)
+        with self.assertRaises(SystemExit):
+            autoreview.redact_review_text(bare_argument_assignment)
+        with self.assertRaises(SystemExit):
+            autoreview.redact_review_text(secret_identifier_call)
+        with self.assertRaises(SystemExit):
+            autoreview.redact_review_text(prefixed_secret_identifier_call)
+
+    def test_redacts_colon_style_quoted_secret_values_with_spaces(self) -> None:
+        output = autoreview.redact_review_text('password: "mock secret phrase value"\n{"api_key": "mock api key value"}')
+
+        self.assertIn("[REDACTED_FIELD_SECRET]", output)
+        self.assertNotIn("mock secret phrase value", output)
+        self.assertNotIn("mock api key value", output)
+        self.assertNotIn("phrase value", output)
+
+    def test_redacts_short_unquoted_secret_fields(self) -> None:
+        output = autoreview.redact_review_text('password: abc123\n{"api_key": x9}')
+
+        self.assertEqual("[REDACTED_FIELD_SECRET]\n{[REDACTED_FIELD_SECRET]}", output)
+        self.assertNotIn("abc123", output)
+        self.assertNotIn("x9", output)
+
+    def test_keeps_common_short_secret_field_literals(self) -> None:
+        text = "password: false\ntoken: null\napiKey: test\nsecret: 2"
+
+        output = autoreview.redact_review_text(text)
+
+        self.assertEqual(text, output)
+
+    def test_keeps_code_references_with_secret_like_property_names(self) -> None:
+        output = autoreview.redact_review_text("return { password: user.passwordHash, apiKey: config.apiKey };")
+
+        self.assertEqual("return { password: user.passwordHash, apiKey: config.apiKey };", output)
+
+    def test_redacts_credential_urls_with_email_style_usernames(self) -> None:
+        output = autoreview.redact_review_text(
+            "DATABASE_URL=postgres://user@example.com:mock-password@db.example.test/app"
+        )
+
+        self.assertIn("[REDACTED_CREDENTIAL_URL]", output)
+        self.assertNotIn("mock-password", output)
+        self.assertNotIn("db.example.test", output)
+
+    def test_redacts_oauth_fragment_urls(self) -> None:
+        output = autoreview.redact_review_text("https://accounts.example.test/callback#code=mock-code-123456")
+
+        self.assertEqual("[REDACTED_AUTH_URL]", output)
+
+    def test_redacts_generic_session_cookies(self) -> None:
+        output = autoreview.redact_review_text("SESSIONID=abcdef1234567890")
+
+        self.assertEqual("[REDACTED_COOKIE]", output)
+
+    def test_redacts_quoted_cookie_assignments(self) -> None:
+        output = autoreview.redact_review_text(
+            'SID="abcdef1234567890"\n'
+            'redact_review_text(\'Cookie: SID="fedcba0987654321"\'); check(\'important change\')'
+        )
+
+        self.assertIn("[REDACTED_COOKIE]", output)
+        self.assertIn("Cookie: [REDACTED_COOKIE_HEADER]", output)
+        self.assertIn("); check('important change')", output)
+        self.assertNotIn("abcdef1234567890", output)
+        self.assertNotIn("fedcba0987654321", output)
+
+    def test_redacts_token_auth_schemes(self) -> None:
+        output = autoreview.redact_review_text("Authorization: Token abcdefghijklmnop")
+
+        self.assertIn("[REDACTED_AUTH_HEADER]", output)
+        self.assertNotIn("abcdefghijklmnop", output)
+
+    def test_keeps_benign_token_prose(self) -> None:
+        output = autoreview.redact_review_text("token classification should stay reviewable")
+
+        self.assertEqual("token classification should stay reviewable", output)
+
+    def test_allows_documented_secret_placeholders(self) -> None:
+        output = autoreview.redact_review_text(
+            'password: "REDACTED"\napiKey: "mock-token"\ntoken: "test-cookie"\\nsecret=mock-token'
+        )
+
+        self.assertEqual(
+            "[PLACEHOLDER_SECRET]\n[PLACEHOLDER_SECRET]\n[PLACEHOLDER_SECRET]\\n[PLACEHOLDER_SECRET]",
+            output,
+        )
+
+    def test_deletion_hunks_use_new_file_anchor_not_old_span(self) -> None:
+        patch = """diff --git a/file.txt b/file.txt
+--- a/file.txt
++++ b/file.txt
+@@ -10,3 +10,0 @@
+-one
+-two
+-three
+"""
+
+        self.assertEqual({"file.txt": [(10, 10)]}, autoreview.parse_changed_line_ranges(patch))
+
+    def test_local_bundle_hides_sensitive_untracked_filenames(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            repo = Path(temp)
+            run(["git", "init"], repo)
+            (repo / ".envrc").write_text("export PASSWORD=mock-secret-value\n")
+
+            output = autoreview.local_bundle(repo)
+
+        self.assertIn("[sensitive untracked file omitted]", output)
+        self.assertNotIn(".envrc", output)
+        self.assertNotIn("mock-secret-value", output)
+
+    def test_safe_diff_omits_renames_from_sensitive_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            repo = Path(temp)
+            run(["git", "init"], repo)
+            run(["git", "config", "user.email", "test@example.invalid"], repo)
+            run(["git", "config", "user.name", "Test User"], repo)
+            (repo / ".env").write_text("PASSWORD=mock-secret-value\n")
+            run(["git", "add", ".env"], repo)
+            run(["git", "commit", "-m", "add env"], repo)
+            run(["git", "mv", ".env", "example.txt"], repo)
+
+            output = autoreview.safe_diff(repo, ["--cached"], ["--patch", "--find-renames"])
+
+        self.assertIn("[1 sensitive changed path omitted from review bundle]", output)
+        self.assertNotIn(".env", output)
+        self.assertNotIn("example.txt", output)
+        self.assertNotIn("mock-secret-value", output)
+
+    def test_safe_diff_omits_copies_from_sensitive_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            repo = Path(temp)
+            run(["git", "init"], repo)
+            run(["git", "config", "user.email", "test@example.invalid"], repo)
+            run(["git", "config", "user.name", "Test User"], repo)
+            (repo / ".env").write_text("PASSWORD=mock-secret-value\n")
+            run(["git", "add", ".env"], repo)
+            run(["git", "commit", "-m", "add env"], repo)
+            (repo / "example.txt").write_text((repo / ".env").read_text())
+            run(["git", "add", "example.txt"], repo)
+
+            output = autoreview.safe_diff(repo, ["--cached"], ["--patch", "--find-renames"])
+
+        self.assertIn("[1 sensitive changed path omitted from review bundle]", output)
+        self.assertNotIn(".env", output)
+        self.assertNotIn("example.txt", output)
+        self.assertNotIn("mock-secret-value", output)
+
+    def test_safe_diff_omits_yaml_secret_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            repo = Path(temp)
+            run(["git", "init"], repo)
+            secret_path = repo / "config" / "secrets.yml"
+            secret_path.parent.mkdir()
+            secret_path.write_text("prod: opaque-credential-value\n")
+            run(["git", "add", "config/secrets.yml"], repo)
+
+            output = autoreview.safe_diff(repo, ["--cached"], ["--patch"])
+
+        self.assertIn("[1 sensitive changed path omitted from review bundle]", output)
+        self.assertNotIn("config/secrets.yml", output)
+        self.assertNotIn("opaque-credential-value", output)
+
+    def test_safe_diff_omits_extensionless_secret_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            repo = Path(temp)
+            run(["git", "init"], repo)
+            secret_path = repo / "secrets"
+            secret_path.write_text("prod: opaque-credential-value\n")
+            run(["git", "add", "secrets"], repo)
+
+            output = autoreview.safe_diff(repo, ["--cached"], ["--patch"])
+
+        self.assertIn("[1 sensitive changed path omitted from review bundle]", output)
+        self.assertNotIn("secrets", output)
+        self.assertNotIn("opaque-credential-value", output)
+
+    def test_safe_diff_includes_non_ascii_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            repo = Path(temp)
+            run(["git", "init"], repo)
+            path = repo / "é.txt"
+            path.write_text("unicode-content\n")
+            run(["git", "add", "é.txt"], repo)
+
+            output = autoreview.safe_diff(repo, ["--cached"], ["--patch"])
+
+        self.assertIn("unicode-content", output)
+
+    def test_safe_diff_treats_safe_paths_as_literal_pathspecs(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            repo = Path(temp)
+            run(["git", "init"], repo)
+            magic_path = repo / ":(glob)*"
+            sensitive_path = repo / "token.txt"
+            magic_path.write_text("safe-content\n")
+            sensitive_path.write_text("opaque-sensitive-content\n")
+            run(["git", "add", str(magic_path.name), str(sensitive_path.name)], repo)
+
+            output = autoreview.safe_diff(repo, ["--cached"], ["--patch"])
+
+        self.assertIn("[1 sensitive changed path omitted from review bundle]", output)
+        self.assertIn("safe-content", output)
+        self.assertNotIn("token.txt", output)
+        self.assertNotIn("opaque-sensitive-content", output)
+
+    def test_safe_show_includes_root_commit_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            repo = Path(temp)
+            run(["git", "init"], repo)
+            run(["git", "config", "user.email", "test@example.invalid"], repo)
+            run(["git", "config", "user.name", "Test User"], repo)
+            (repo / "first.txt").write_text("root-commit-content\n")
+            run(["git", "add", "first.txt"], repo)
+            run(["git", "commit", "-m", "initial"], repo)
+            commit = run(["git", "rev-parse", "HEAD"], repo).strip()
+
+            output = autoreview.safe_show(repo, commit, ["--patch", "--format=fuller"])
+
+        self.assertIn("first.txt", output)
+        self.assertIn("root-commit-content", output)
+
+    def test_claude_file_tools_are_scoped_to_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            workspace = Path(temp)
+            args = type("Args", (), {
+                "claude_allowed_tools": "Read,Grep,Glob,WebSearch",
+                "web_search": True,
+            })()
+
+            output = autoreview.claude_allowed_tools(args, workspace)
+
+        self.assertIn("Read(./**)", output)
+        self.assertIn("Grep(./**)", output)
+        self.assertIn("Glob(./**)", output)
+        self.assertIn("WebSearch", output)
+        self.assertNotIn("Read,", output)
+
+    def test_claude_file_tools_reject_out_of_workspace_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            workspace = Path(temp)
+            absolute_args = type("Args", (), {
+                "claude_allowed_tools": "Read(//Users/**),WebSearch",
+                "web_search": True,
+            })()
+
+            with self.assertRaises(SystemExit):
+                autoreview.claude_allowed_tools(absolute_args, workspace)
+
+    def test_claude_file_tools_allow_project_root_relative_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            workspace = Path(temp)
+            args = type("Args", (), {
+                "claude_allowed_tools": "Read(/src/**),Glob(/docs/**),WebSearch",
+                "web_search": True,
+            })()
+
+            output = autoreview.claude_allowed_tools(args, workspace)
+
+        self.assertIn("Read(/src/**)", output)
+        self.assertIn("Glob(/docs/**)", output)
+        self.assertIn("WebSearch", output)
+
+    def test_claude_file_tools_reject_placeholder_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            workspace = Path(temp)
+            args = type("Args", (), {
+                "claude_allowed_tools": "Read([LOCAL_PATH]),WebSearch",
+                "web_search": True,
+            })()
+
+            with self.assertRaises(SystemExit):
+                autoreview.claude_allowed_tools(args, workspace)
+
+            args = type("Args", (), {
+                "claude_allowed_tools": "Read(/[LOCAL_PATH]),WebSearch",
+                "web_search": True,
+            })()
+
+            with self.assertRaises(SystemExit):
+                autoreview.claude_allowed_tools(args, workspace)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/autoreview/scripts/test-review-harness
+++ b/.agents/skills/autoreview/scripts/test-review-harness
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+harness="$script_dir/test-review-harness.py"
+
+if command -v python3 >/dev/null 2>&1; then
+  exec python3 "$harness" "$@"
+fi
+
+if command -v python >/dev/null 2>&1; then
+  exec python "$harness" "$@"
+fi
+
+echo "Python 3 is required to run test-review-harness." >&2
+exit 127

--- a/.agents/skills/autoreview/scripts/test-review-harness.ps1
+++ b/.agents/skills/autoreview/scripts/test-review-harness.ps1
@@ -1,0 +1,45 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('malicious', 'benign')]
+    [string] $Fixture,
+
+    [ValidateSet('codex', 'claude', 'droid', 'copilot')]
+    [string[]] $Engine,
+
+    [Alias('h')]
+    [switch] $Help
+)
+
+$ErrorActionPreference = 'Stop'
+
+$Harness = Join-Path $PSScriptRoot 'test-review-harness.py'
+$ForwardedArgs = @()
+
+if ($Help) {
+    $ForwardedArgs += '--help'
+}
+
+if ($PSBoundParameters.ContainsKey('Fixture')) {
+    $ForwardedArgs += @('--fixture', $Fixture)
+}
+
+if ($PSBoundParameters.ContainsKey('Engine')) {
+    foreach ($SelectedEngine in $Engine) {
+        $ForwardedArgs += @('--engine', $SelectedEngine)
+    }
+}
+
+$PyLauncher = Get-Command py -ErrorAction SilentlyContinue
+if ($null -ne $PyLauncher) {
+    & $PyLauncher.Source -3 $Harness @ForwardedArgs
+    exit $LASTEXITCODE
+}
+
+$Python = Get-Command python -ErrorAction SilentlyContinue
+if ($null -ne $Python) {
+    & $Python.Source $Harness @ForwardedArgs
+    exit $LASTEXITCODE
+}
+
+Write-Error 'Python 3 is required to run test-review-harness.'
+exit 127

--- a/.agents/skills/autoreview/scripts/test-review-harness.py
+++ b/.agents/skills/autoreview/scripts/test-review-harness.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import inspect
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+
+ENGINES = ("codex", "claude", "droid", "copilot")
+DEFAULT_ENGINES = ("codex", "claude")
+
+MALICIOUS_INITIAL = """export function uploadPath(name) {
+  return `uploads/${name.replaceAll("/", "")}`;
+}
+
+export function publicUser(user) {
+  return { id: user.id, name: user.name };
+}
+"""
+
+BENIGN_INITIAL = r"""import path from "node:path";
+
+const uploadsRoot = path.resolve("uploads");
+
+function safeChildPath(root, name) {
+  if (name.includes("/") || name.includes("\\") || name.includes("\0")) {
+    throw new Error("invalid child name");
+  }
+  const resolved = path.resolve(root, name);
+  if (!resolved.startsWith(root + path.sep)) throw new Error("path escaped root");
+  return resolved;
+}
+
+export function uploadPath(name) {
+  return safeChildPath(uploadsRoot, name);
+}
+
+export function publicUser(user) {
+  return { id: user.id, name: user.name };
+}
+"""
+
+MALICIOUS_CHANGED = """import { execSync } from "node:child_process";
+
+export function uploadPath(name) {
+  return `uploads/${name}`;
+}
+
+export function deleteUpload(name) {
+  return execSync(`rm -rf uploads/${name}`);
+}
+
+export function publicUser(user) {
+  return { id: user.id, name: user.name, ["pass" + "word"]: user.password };
+}
+"""
+
+BENIGN_CHANGED = r"""import { execFile } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const uploadsRoot = path.resolve("uploads");
+const reposRoot = path.resolve("repos");
+const execFileAsync = promisify(execFile);
+
+function safeChildPath(root, name) {
+  if (name.includes("/") || name.includes("\\") || name.includes("\0")) {
+    throw new Error("invalid child name");
+  }
+  const resolved = path.resolve(root, name);
+  if (!resolved.startsWith(root + path.sep)) throw new Error("path escaped root");
+  return resolved;
+}
+
+function repoChildPath(root, name) {
+  if (!/^[A-Za-z0-9._-]+$/.test(name)) throw new Error("invalid repo name");
+  return safeChildPath(root, name);
+}
+
+export function uploadPath(name) {
+  return safeChildPath(uploadsRoot, name);
+}
+
+export async function repoProbe(repoName) {
+  const { stdout } = await execFileAsync(process.execPath, ["--version"], {
+    cwd: repoChildPath(reposRoot, repoName),
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+export function publicUser(user) {
+  return { id: user.id, name: user.name };
+}
+
+export function accountSettingsForOwner(user, requesterId) {
+  if (String(requesterId) !== String(user.id)) throw new Error("forbidden");
+  return { id: user.id, hasPassword: Boolean(user.passwordHash) };
+}
+"""
+
+MALICIOUS_PROMPT = "This is an acceptance test fixture. The changed app.js patch contains real security bugs. Review normally and report only actionable defects from the patch."
+BENIGN_PROMPT = "Security calibration fixture: this patch intentionally uses filesystem paths, async execFile, and owner-gated password-adjacent state safely. Do not flag legitimate shell/filesystem/auth-adjacent functionality unless there is a concrete exploitable risk in the diff."
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="test-review-harness",
+        description=(
+            "Creates a temporary git repo with either a deliberately unsafe patch "
+            "or a security-sensitive-but-safe patch, then verifies each selected "
+            "engine through autoreview."
+        ),
+        epilog="Default engines: codex, claude.",
+    )
+    parser.add_argument("--fixture", choices=("malicious", "benign"), default="malicious")
+    parser.add_argument("--engine", action="append", choices=ENGINES, dest="engines")
+    return parser.parse_args(argv)
+
+
+def write_fixture_file(repo: Path, content: str) -> None:
+    with (repo / "app.js").open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(content)
+
+
+def run(command: list[str], cwd: Path) -> None:
+    subprocess.run(command, cwd=cwd, check=True)
+
+
+def create_fixture_repo(repo: Path, fixture: str) -> None:
+    run(["git", "init", "--quiet"], repo)
+    run(["git", "config", "user.name", "Review Fixture"], repo)
+    run(["git", "config", "user.email", "review-fixture@example.com"], repo)
+
+    write_fixture_file(repo, MALICIOUS_INITIAL if fixture == "malicious" else BENIGN_INITIAL)
+    run(["git", "add", "app.js"], repo)
+    run(["git", "commit", "--quiet", "-m", "initial safe version"], repo)
+    write_fixture_file(repo, MALICIOUS_CHANGED if fixture == "malicious" else BENIGN_CHANGED)
+
+
+def run_reviews(repo: Path, script_dir: Path, fixture: str, engines: list[str]) -> None:
+    autoreview = script_dir / "autoreview"
+    for engine in engines:
+        print(f"== {engine} ==", flush=True)
+        command = [
+            sys.executable,
+            str(autoreview),
+            "--mode",
+            "local",
+            "--engine",
+            engine,
+            "--prompt",
+            MALICIOUS_PROMPT if fixture == "malicious" else BENIGN_PROMPT,
+        ]
+        if fixture == "malicious":
+            command.extend(["--require-finding", "command", "--expect-findings"])
+        run(command, repo)
+
+
+def cleanup_repo(repo: Path) -> None:
+    def make_writable_and_retry(function: Callable[[str], object], path: str, _exc_info: object) -> None:
+        try:
+            os.chmod(path, stat.S_IREAD | stat.S_IWRITE)
+            function(path)
+        except OSError as exc:
+            print(f"warning: unable to remove temp path {path}: {exc}", file=sys.stderr)
+
+    if not repo.exists():
+        return
+    try:
+        rmtree_kwargs = (
+            {"onexc": make_writable_and_retry}
+            if "onexc" in inspect.signature(shutil.rmtree).parameters
+            else {"onerror": make_writable_and_retry}
+        )
+        shutil.rmtree(repo, **rmtree_kwargs)
+    except OSError as exc:
+        print(f"warning: unable to remove temp repo {repo}: {exc}", file=sys.stderr)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    script_dir = Path(__file__).resolve().parent
+    engines = args.engines or list(DEFAULT_ENGINES)
+    repo = Path(tempfile.mkdtemp(prefix="autoreview-fixture."))
+    try:
+        create_fixture_repo(repo, args.fixture)
+        run_reviews(repo, script_dir, args.fixture, engines)
+    except subprocess.CalledProcessError as exc:
+        return int(exc.returncode or 1)
+    finally:
+        cleanup_repo(repo)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # Binaries for programs and plugins
+__pycache__/
+*.py[cod]
 *.exe
 *.exe~
 *.dll

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,23 @@ Orka is a Kubernetes-native task execution platform that manages Jobs and Pods f
 - **Pre-land/pre-commit code changes**: use `$autoreview` until no accepted/actionable findings remain, unless equivalent manual review already done, trivial/docs-only, or user opts out.
 - **Git push discipline** — after making a change, push to the current branch when it is not `main`; never push directly to `main`.
 
+## Continuous Review
+
+For non-trivial code changes, run `$autoreview` (`.agents/skills/autoreview/SKILL.md`) before final/commit/ship and keep going until there are no accepted/actionable findings, unless the change is trivial/docs-only, equivalent manual review already happened, or the human opts out.
+
+- Treat review output as advisory: verify every finding against the real code path before changing code.
+- If review-triggered fixes change code, rerun focused tests and rerun `$autoreview`.
+- Format before review when formatting can move line locations; focused tests and review may run in parallel only after formatting is stable.
+
+## GitHub PRs & Issues
+
+Before creating or updating a GitHub PR or issue body for agent-authored work, read `$agent-transcript` (`.agents/skills/agent-transcript/SKILL.md`) if available and check for a safe local session transcript.
+
+- If a high-confidence transcript is found, ask exactly: "Include a redacted agent transcript? It helps reviewers and can make the PR easier to prioritize. I can open a local preview first."
+- Never upload raw logs. Include an `## Agent Transcript` section only after human approval and only with a sanitized, scoped transcript.
+- Drop system/developer prompts, reasoning, raw tool outputs, env, cookies, tokens, auth URLs, secrets, broad local paths, and unrelated session turns.
+- If no safe transcript exists or the human declines, continue without a transcript and do not add a placeholder section.
+
 ## Build & Test
 
 ```bash


### PR DESCRIPTION
## Summary
- Port repo-local `$autoreview` and `$agent-transcript` skills from sozercan/kaset#286 into `.agents/skills/`.
- Add Orka AGENTS.md guidance for continuous review and optional redacted agent transcripts in PR/issue bodies.
- Ignore Python bytecode/cache artifacts used by the helper tests.

## Verification
- `git diff --check`
- `python3 -B -m py_compile .agents/skills/autoreview/scripts/autoreview .agents/skills/autoreview/scripts/test-review-harness.py .agents/skills/autoreview/scripts/autoreview.test.py`
- `.agents/skills/autoreview/scripts/autoreview --help`
- `.agents/skills/agent-transcript/scripts/agent-transcript --help`
- `bash -n .agents/skills/autoreview/scripts/test-review-harness`
- `node --check .agents/skills/agent-transcript/scripts/agent-transcript`
- `node --test .agents/skills/agent-transcript/scripts/agent-transcript.test.mjs`
- `python3 -B .agents/skills/autoreview/scripts/autoreview.test.py`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean: no accepted/actionable findings reported
