### PR TITLE
test(cli): add binary e2e coverage

### DIFF
--- a/test/e2e/api_test.go
+++ b/test/e2e/api_test.go
@@ -14,7 +14,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -257,6 +259,19 @@ var _ = Describe("REST API Endpoints", Ordered, func() {
 		downloadBody, err := io.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(downloadBody)).To(Equal(artifactContent))
+
+		By("listing and downloading the artifact through the compiled CLI")
+		cliHome := newIsolatedCLIHome(apiBaseURL, token)
+		cliArtifacts := runOrka(cliHome, "task", "artifacts", taskName)
+		expectOrkaSuccess(cliArtifacts, token)
+		Expect(cliArtifacts.Stdout).To(ContainSubstring(artifactName))
+
+		cliDownloadPath := filepath.Join(GinkgoT().TempDir(), artifactName)
+		cliDownload := runOrka(cliHome, "task", "download", taskName, artifactName, "-o", cliDownloadPath)
+		expectOrkaSuccess(cliDownload, token)
+		downloaded, err := os.ReadFile(cliDownloadPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(downloaded)).To(Equal(artifactContent))
 	})
 
 	It("should stream task logs via GET /api/v1/tasks/{id}/logs", func() {

--- a/test/e2e/cli_helpers_test.go
+++ b/test/e2e/cli_helpers_test.go
@@ -1,0 +1,309 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
+
+	"github.com/sozercan/orka/test/utils"
+)
+
+var (
+	buildOrkaCLIOnce sync.Once
+	builtOrkaCLIPath string
+	buildOrkaCLIErr  error
+)
+
+type cliResult struct {
+	Args   []string
+	Stdout string
+	Stderr string
+	Err    error
+}
+
+func buildOrkaCLI() string {
+	GinkgoHelper()
+	buildOrkaCLIOnce.Do(func() {
+		projectDir, err := utils.GetProjectDir()
+		if err != nil {
+			buildOrkaCLIErr = err
+			return
+		}
+		cmd := exec.Command("make", "build-cli")
+		cmd.Dir = projectDir
+		cmd.Env = append(os.Environ(), "GO111MODULE=on")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			buildOrkaCLIErr = fmt.Errorf("make build-cli failed: %w\n%s", err, strings.TrimSpace(string(output)))
+			return
+		}
+		builtOrkaCLIPath = filepath.Join(projectDir, "bin", "orka")
+		if st, statErr := os.Stat(builtOrkaCLIPath); statErr != nil {
+			buildOrkaCLIErr = statErr
+		} else if st.IsDir() {
+			buildOrkaCLIErr = fmt.Errorf("%s is a directory", builtOrkaCLIPath)
+		}
+	})
+	Expect(buildOrkaCLIErr).NotTo(HaveOccurred())
+	Expect(builtOrkaCLIPath).NotTo(BeEmpty())
+	return builtOrkaCLIPath
+}
+
+func newIsolatedCLIHome(apiBaseURL, token string) string {
+	GinkgoHelper()
+	home, err := os.MkdirTemp("", "orka-cli-e2e-home-*")
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() {
+		_ = os.RemoveAll(home)
+	})
+	writeCLIConfig(home, apiBaseURL, namespace, token)
+	return home
+}
+
+func newIsolatedCLIHomeWithNamespace(apiBaseURL, configNamespace, token string) string {
+	GinkgoHelper()
+	home, err := os.MkdirTemp("", "orka-cli-e2e-home-*")
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() {
+		_ = os.RemoveAll(home)
+	})
+	writeCLIConfig(home, apiBaseURL, configNamespace, token)
+	return home
+}
+
+func writeCLIConfig(home, apiBaseURL, configNamespace, token string) {
+	GinkgoHelper()
+	configDir := filepath.Join(home, ".orka")
+	Expect(os.MkdirAll(configDir, 0o700)).To(Succeed())
+	body := fmt.Sprintf("server: %s\nnamespace: %s\ntoken: %s\n", apiBaseURL, configNamespace, token)
+	Expect(os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(body), 0o600)).To(Succeed())
+}
+
+func runOrka(home string, args ...string) cliResult {
+	return runOrkaWithTimeout(5*time.Minute, home, args...)
+}
+
+func runOrkaWithTimeout(timeout time.Duration, home string, args ...string) cliResult {
+	GinkgoHelper()
+	binary := buildOrkaCLI()
+	cmd := exec.Command(binary, args...)
+	cmd.Env = isolatedCLIEnv(home)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := runCommandWithTimeout(cmd, timeout)
+	return cliResult{
+		Args:   append([]string{}, args...),
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+		Err:    err,
+	}
+}
+
+func runCommandWithTimeout(cmd *exec.Cmd, timeout time.Duration) error {
+	GinkgoHelper()
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout):
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		select {
+		case err := <-done:
+			if err != nil {
+				return fmt.Errorf("command timed out after %s: %w", timeout, err)
+			}
+		case <-time.After(5 * time.Second):
+		}
+		return fmt.Errorf("command timed out after %s", timeout)
+	}
+}
+
+func isolatedCLIEnv(home string) []string {
+	env := make([]string, 0, len(os.Environ())+2)
+	for _, entry := range os.Environ() {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "HOME":
+			continue
+		}
+		env = append(env, entry)
+	}
+	env = append(env, "HOME="+home, "GO111MODULE=on")
+	return env
+}
+
+func expectOrkaSuccess(result cliResult, forbidden ...string) {
+	GinkgoHelper()
+	expectNoSensitiveOutput(result, forbidden...)
+	if result.Err != nil {
+		Fail(fmt.Sprintf("orka %s failed: %v\n%s", strings.Join(result.Args, " "), result.Err, redactedCLIOutput(result, forbidden...)), 1)
+	}
+}
+
+func expectOrkaFailure(result cliResult, forbidden ...string) {
+	GinkgoHelper()
+	expectNoSensitiveOutput(result, forbidden...)
+	if result.Err == nil {
+		Fail(fmt.Sprintf("orka %s succeeded unexpectedly\n%s", strings.Join(result.Args, " "), redactedCLIOutput(result, forbidden...)), 1)
+	}
+}
+
+func expectNoSensitiveOutput(result cliResult, forbidden ...string) {
+	GinkgoHelper()
+	combined := result.Stdout + result.Stderr
+	for _, secret := range forbidden {
+		if strings.TrimSpace(secret) == "" {
+			continue
+		}
+		if strings.Contains(combined, secret) {
+			Fail(fmt.Sprintf(
+				"orka output contained sensitive value digest=%s\n%s",
+				sensitiveDigest(secret),
+				redactedCLIOutput(result, forbidden...),
+			), 1)
+		}
+	}
+}
+
+func sensitiveDigest(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:8])
+}
+
+func redactedCLIOutput(result cliResult, forbidden ...string) string {
+	stdout := redactSensitive(result.Stdout, forbidden...)
+	stderr := redactSensitive(result.Stderr, forbidden...)
+	return fmt.Sprintf("stdout:\n%s\nstderr:\n%s", strings.TrimSpace(stdout), strings.TrimSpace(stderr))
+}
+
+func redactSensitive(value string, forbidden ...string) string {
+	redacted := value
+	for _, secret := range forbidden {
+		if strings.TrimSpace(secret) == "" {
+			continue
+		}
+		redacted = strings.ReplaceAll(redacted, secret, "<redacted:"+sensitiveDigest(secret)+">")
+	}
+	redacted = jwtLikeRegexp.ReplaceAllString(redacted, "<redacted-jwt>")
+	return redacted
+}
+
+var jwtLikeRegexp = regexp.MustCompile(`eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+`)
+
+func expectJSONOutput(output string) any {
+	GinkgoHelper()
+	var decoded any
+	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+		Fail(fmt.Sprintf("expected valid JSON output: %v\n%s", err, truncateForLog(output, 1024)), 1)
+	}
+	return decoded
+}
+
+func expectJSONObject(output string) map[string]any {
+	GinkgoHelper()
+	decoded := expectJSONOutput(output)
+	object, ok := decoded.(map[string]any)
+	Expect(ok).To(BeTrue(), "expected JSON object, got %T", decoded)
+	return object
+}
+
+func expectYAMLOutput(output string) map[string]any {
+	GinkgoHelper()
+	var decoded map[string]any
+	if err := yaml.Unmarshal([]byte(output), &decoded); err != nil {
+		Fail(fmt.Sprintf("expected valid YAML output: %v\n%s", err, truncateForLog(output, 1024)), 1)
+	}
+	return decoded
+}
+
+func expectListContainsName(decoded any, name string) {
+	GinkgoHelper()
+	for _, item := range extractListItems(decoded) {
+		if itemName(item) == name {
+			return
+		}
+	}
+	Fail(fmt.Sprintf("expected list output to contain resource %q", name), 1)
+}
+
+func extractListItems(decoded any) []any {
+	switch v := decoded.(type) {
+	case []any:
+		return v
+	case map[string]any:
+		for _, key := range []string{"items", "data"} {
+			if items, ok := v[key].([]any); ok {
+				return items
+			}
+		}
+	}
+	return nil
+}
+
+func itemName(item any) string {
+	m, ok := item.(map[string]any)
+	if !ok {
+		return ""
+	}
+	if name, _ := m["name"].(string); name != "" {
+		return name
+	}
+	if id, _ := m["id"].(string); id != "" {
+		return id
+	}
+	metadata, _ := m["metadata"].(map[string]any)
+	name, _ := metadata["name"].(string)
+	return name
+}
+
+func nestedStringFromMap(m map[string]any, path ...string) string {
+	var cur any = m
+	for _, key := range path {
+		obj, ok := cur.(map[string]any)
+		if !ok {
+			return ""
+		}
+		cur = obj[key]
+	}
+	value, _ := cur.(string)
+	return value
+}
+
+func writeTempManifest(dir, name, body string) string {
+	GinkgoHelper()
+	path := filepath.Join(dir, name)
+	Expect(os.WriteFile(path, []byte(strings.TrimSpace(body)+"\n"), 0o600)).To(Succeed())
+	return path
+}

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -1,0 +1,414 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/sozercan/orka/test/utils"
+)
+
+var _ = Describe("Orka CLI binary", Ordered, func() {
+	var (
+		apiBaseURL     string
+		portForwardCmd *exec.Cmd
+		cancelPF       context.CancelFunc
+		token          string
+		home           string
+		suffix         string
+	)
+
+	BeforeAll(func() {
+		By("building the orka CLI binary")
+		buildOrkaCLI()
+
+		By("setting up a controller API port-forward for CLI commands")
+		var err error
+		apiBaseURL, cancelPF, portForwardCmd, err = startControllerAPIPortForward(18110)
+		Expect(err).NotTo(HaveOccurred(), "Failed to start controller API port-forward")
+
+		By("creating an isolated CLI home with service-account credentials")
+		token, err = serviceAccountToken()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(token).NotTo(BeEmpty())
+		home = newIsolatedCLIHome(apiBaseURL, token)
+		suffix = fmt.Sprintf("%d", time.Now().UnixNano())
+	})
+
+	AfterAll(func() {
+		By("stopping CLI controller API port-forward")
+		stopPortForward(cancelPF, portForwardCmd)
+	})
+
+	It("authenticates from isolated config and lists model catalogs", func() {
+		By("validating the configured service-account token")
+		validate := runOrka(home, "auth", "validate")
+		expectOrkaSuccess(validate, token)
+		validateJSON := expectJSONObject(validate.Stdout)
+		Expect(validateJSON["authenticated"]).To(Equal(true))
+
+		By("showing a sanitized identity")
+		whoami := runOrka(home, "auth", "whoami", "-o", "json")
+		expectOrkaSuccess(whoami, token)
+		identity := expectJSONObject(whoami.Stdout)
+		Expect(identity["authenticated"]).To(Equal(true))
+		Expect(identity).NotTo(HaveKey("token"))
+		Expect(identity).NotTo(HaveKey("bearerToken"))
+
+		By("listing OpenAI-compatible models as JSON")
+		openAIModels := runOrka(home, "models", "list", "--compat", "openai", "-o", "json")
+		expectOrkaSuccess(openAIModels, token)
+		expectJSONObject(openAIModels.Stdout)
+
+		By("listing Anthropic-compatible models as JSON")
+		anthropicModels := runOrka(home, "models", "list", "--compat", "anthropic", "-o", "json")
+		expectOrkaSuccess(anthropicModels, token)
+		expectJSONObject(anthropicModels.Stdout)
+
+		By("rejecting an invalid configured token without printing it")
+		invalidToken := "invalid-cli-e2e-token-" + suffix
+		invalidHome := newIsolatedCLIHome(apiBaseURL, invalidToken)
+		invalid := runOrka(invalidHome, "auth", "validate")
+		expectOrkaFailure(invalid, invalidToken)
+	})
+
+	It("runs a container task workflow through the compiled CLI", func() {
+		taskName := "e2e-cli-task-" + suffix
+		failedTaskName := "e2e-cli-fail-" + suffix
+		mismatchTaskName := "e2e-cli-ns-mismatch-" + suffix
+		tmpDir := GinkgoT().TempDir()
+
+		DeferCleanup(deleteK8sResource, "task", taskName)
+		DeferCleanup(deleteK8sResource, "task", failedTaskName)
+		DeferCleanup(deleteK8sResource, "task", mismatchTaskName)
+
+		By("creating a container task from a manifest without metadata.namespace")
+		taskManifest := writeTempManifest(tmpDir, "task.yaml", fmt.Sprintf(`
+apiVersion: core.orka.ai/v1alpha1
+kind: Task
+metadata:
+  name: %s
+spec:
+  type: container
+  image: busybox:latest
+  command: ["sh", "-c"]
+  args: ["echo cli-e2e-result"]
+`, taskName))
+		created := runOrka(home, "task", "create", "-f", taskManifest)
+		expectOrkaSuccess(created, token)
+		Expect(created.Stdout).To(ContainSubstring(taskName))
+
+		By("listing tasks as JSON and table output")
+		listJSON := runOrka(home, "task", "list", "--limit", "200", "-o", "json")
+		expectOrkaSuccess(listJSON, token)
+		expectListContainsName(expectJSONOutput(listJSON.Stdout), taskName)
+
+		listTable := runOrka(home, "task", "list", "--limit", "200", "-o", "table")
+		expectOrkaSuccess(listTable, token)
+		Expect(listTable.Stdout).To(ContainSubstring("NAME"))
+		Expect(listTable.Stdout).To(ContainSubstring(taskName))
+
+		By("getting the task as YAML and verifying CLI namespace injection")
+		getYAML := runOrka(home, "task", "get", taskName, "-o", "yaml")
+		expectOrkaSuccess(getYAML, token)
+		taskYAML := expectYAMLOutput(getYAML.Stdout)
+		Expect(nestedStringFromMap(taskYAML, "metadata", "namespace")).To(Equal(namespace))
+
+		By("overriding a wrong configured namespace with --namespace")
+		wrongNamespaceHome := newIsolatedCLIHomeWithNamespace(apiBaseURL, "default", token)
+		withoutOverride := runOrka(wrongNamespaceHome, "task", "get", taskName, "-o", "json")
+		expectOrkaFailure(withoutOverride, token)
+		withOverride := runOrka(wrongNamespaceHome, "--namespace", namespace, "task", "get", taskName, "-o", "json")
+		expectOrkaSuccess(withOverride, token)
+		withOverrideJSON := expectJSONObject(withOverride.Stdout)
+		Expect(nestedStringFromMap(withOverrideJSON, "metadata", "namespace")).To(Equal(namespace))
+
+		By("rejecting a manifest namespace mismatch before creating a task")
+		mismatchManifest := writeTempManifest(tmpDir, "namespace-mismatch.yaml", fmt.Sprintf(`
+apiVersion: core.orka.ai/v1alpha1
+kind: Task
+metadata:
+  name: %s
+  namespace: default
+spec:
+  type: container
+  image: busybox:latest
+  command: ["echo"]
+  args: ["must-not-run"]
+`, mismatchTaskName))
+		mismatch := runOrka(home, "--namespace", namespace, "task", "create", "-f", mismatchManifest)
+		expectOrkaFailure(mismatch, token)
+		Expect(mismatch.Stderr + mismatch.Stdout).To(ContainSubstring("manifest namespace"))
+		Expect(k8sResourceExists("task", mismatchTaskName)).To(BeFalse())
+
+		By("waiting for the task to succeed through the CLI")
+		wait := runOrkaWithTimeout(4*time.Minute, home, "task", "wait", taskName, "--timeout", "3m")
+		expectOrkaSuccess(wait, token)
+		Expect(wait.Stdout).To(ContainSubstring("succeeded"))
+
+		By("reading task result text and JSON through the CLI")
+		var result cliResult
+		Eventually(func() error {
+			result = runOrka(home, "task", "result", taskName)
+			if result.Err != nil {
+				return fmt.Errorf("task result failed: %v\n%s", result.Err, redactedCLIOutput(result, token))
+			}
+			if !strings.Contains(result.Stdout, "cli-e2e-result") {
+				return fmt.Errorf("task result missing sentinel: %s", truncateForLog(result.Stdout, 512))
+			}
+			return nil
+		}, 45*time.Second, 2*time.Second).Should(Succeed())
+		expectNoSensitiveOutput(result, token)
+
+		resultJSON := runOrka(home, "task", "result", taskName, "-o", "json")
+		expectOrkaSuccess(resultJSON, token)
+		resultPayload := expectJSONObject(resultJSON.Stdout)
+		Expect(fmt.Sprint(resultPayload["result"])).To(ContainSubstring("cli-e2e-result"))
+
+		By("checking child-task and plan endpoints through the CLI")
+		children := runOrka(home, "task", "children", taskName, "-o", "json")
+		expectOrkaSuccess(children, token)
+		expectJSONOutput(children.Stdout)
+
+		plan := runOrka(home, "task", "plan", taskName, "-o", "json")
+		expectOrkaFailure(plan, token)
+
+		workspace := runOrka(home, "workspace", "status", taskName, "-o", "json")
+		expectOrkaSuccess(workspace, token)
+		workspacePayload := expectJSONObject(workspace.Stdout)
+		Expect(workspacePayload["task"]).To(Equal(taskName))
+		Expect(workspacePayload["namespace"]).To(Equal(namespace))
+
+		By("returning nonzero when waiting for a failed task")
+		failedManifest := writeTempManifest(tmpDir, "failed-task.yaml", fmt.Sprintf(`
+apiVersion: core.orka.ai/v1alpha1
+kind: Task
+metadata:
+  name: %s
+spec:
+  type: container
+  image: busybox:latest
+  command: ["false"]
+`, failedTaskName))
+		failedCreated := runOrka(home, "task", "create", "-f", failedManifest)
+		expectOrkaSuccess(failedCreated, token)
+		failedWait := runOrkaWithTimeout(3*time.Minute, home, "task", "wait", failedTaskName, "--timeout", "2m")
+		expectOrkaFailure(failedWait, token)
+		Expect(failedWait.Stderr + failedWait.Stdout).To(ContainSubstring("Failed"))
+
+		By("deleting tasks through the CLI")
+		deleted := runOrka(home, "task", "delete", taskName)
+		expectOrkaSuccess(deleted, token)
+		failedDeleted := runOrka(home, "task", "delete", failedTaskName)
+		expectOrkaSuccess(failedDeleted, token)
+	})
+
+	It("performs provider, agent, tool, skill, and secret workflows through the CLI", func() {
+		tmpDir := GinkgoT().TempDir()
+		providerName := "e2e-cli-provider-" + suffix
+		providerSecretName := "e2e-cli-provider-secret-" + suffix
+		agentName := "e2e-cli-agent-" + suffix
+		toolName := "e2e-cli-tool-" + suffix
+		skillName := "e2e-cli-skill-" + suffix
+		secretSentinel := "cli-e2e-secret-sentinel-" + suffix
+
+		DeferCleanup(deleteK8sResource, "provider", providerName)
+		DeferCleanup(deleteK8sResource, "secret", providerSecretName)
+		DeferCleanup(deleteK8sResource, "agent", agentName)
+		DeferCleanup(deleteK8sResource, "tool", toolName)
+		DeferCleanup(deleteK8sResource, "skill", skillName)
+
+		By("creating a test secret without logging its value")
+		Expect(createK8sSecret(providerSecretName, namespace, map[string]string{"api-key": secretSentinel})).To(Succeed())
+
+		By("creating, reading, listing, updating, and deleting a provider")
+		providerManifest := writeTempManifest(tmpDir, "provider.yaml", fmt.Sprintf(`
+apiVersion: core.orka.ai/v1alpha1
+kind: Provider
+metadata:
+  name: %s
+spec:
+  type: openai
+  secretRef:
+    name: %s
+    key: api-key
+  defaultModel: gpt-cli-e2e
+`, providerName, providerSecretName))
+		providerUpdatedManifest := writeTempManifest(tmpDir, "provider-updated.yaml", fmt.Sprintf(`
+apiVersion: core.orka.ai/v1alpha1
+kind: Provider
+metadata:
+  name: %s
+spec:
+  type: openai
+  secretRef:
+    name: %s
+    key: api-key
+  defaultModel: gpt-cli-e2e-updated
+`, providerName, providerSecretName))
+		expectOrkaSuccess(runOrka(home, "provider", "create", "-f", providerManifest), token, secretSentinel)
+		providerGet := runOrka(home, "provider", "get", providerName, "-o", "json")
+		expectOrkaSuccess(providerGet, token, secretSentinel)
+		Expect(nestedStringFromMap(expectJSONObject(providerGet.Stdout), "metadata", "name")).To(Equal(providerName))
+		providerList := runOrka(home, "provider", "list", "-o", "yaml")
+		expectOrkaSuccess(providerList, token, secretSentinel)
+		expectListContainsName(expectYAMLOutput(providerList.Stdout), providerName)
+		expectOrkaSuccess(runOrka(home, "provider", "update", providerName, "-f", providerUpdatedManifest), token, secretSentinel)
+		providerUpdated := expectJSONObject(runSuccessfulOrka(home, []string{token, secretSentinel}, "provider", "get", providerName, "-o", "json").Stdout)
+		Expect(nestedStringFromMap(providerUpdated, "spec", "defaultModel")).To(Equal("gpt-cli-e2e-updated"))
+
+		By("ensuring secret list output is metadata-only and redacted")
+		secretList := runOrka(home, "secret", "list", "-o", "json")
+		expectOrkaSuccess(secretList, token, secretSentinel)
+		expectListContainsName(expectJSONObject(secretList.Stdout), providerSecretName)
+		Expect(secretList.Stdout).NotTo(ContainSubstring("stringData"))
+		Expect(secretList.Stdout).NotTo(ContainSubstring("\"data\""))
+
+		By("creating, reading, listing, updating, and deleting an agent")
+		agentManifest := writeTempManifest(tmpDir, "agent.yaml", fmt.Sprintf(`
+apiVersion: core.orka.ai/v1alpha1
+kind: Agent
+metadata:
+  name: %s
+spec:
+  runtime:
+    type: claude
+    defaultMaxTurns: 5
+    defaultAllowBash: false
+`, agentName))
+		agentUpdatedManifest := writeTempManifest(tmpDir, "agent-updated.yaml", fmt.Sprintf(`
+apiVersion: core.orka.ai/v1alpha1
+kind: Agent
+metadata:
+  name: %s
+spec:
+  runtime:
+    type: claude
+    defaultMaxTurns: 7
+    defaultAllowBash: false
+`, agentName))
+		expectOrkaSuccess(runOrka(home, "agent", "create", "-f", agentManifest), token)
+		agentGet := runOrka(home, "agent", "get", agentName, "-o", "json")
+		expectOrkaSuccess(agentGet, token)
+		Expect(nestedStringFromMap(expectJSONObject(agentGet.Stdout), "metadata", "name")).To(Equal(agentName))
+		agentList := runOrka(home, "agent", "list", "-o", "json")
+		expectOrkaSuccess(agentList, token)
+		expectListContainsName(expectJSONOutput(agentList.Stdout), agentName)
+		expectOrkaSuccess(runOrka(home, "agent", "update", agentName, "-f", agentUpdatedManifest), token)
+		agentUpdated := expectJSONObject(runSuccessfulOrka(home, []string{token}, "agent", "get", agentName, "-o", "json").Stdout)
+		agentSpec, ok := agentUpdated["spec"].(map[string]any)
+		Expect(ok).To(BeTrue(), "agent spec should be a JSON object")
+		agentRuntime, ok := agentSpec["runtime"].(map[string]any)
+		Expect(ok).To(BeTrue(), "agent runtime should be a JSON object")
+		Expect(agentRuntime["defaultMaxTurns"]).To(BeNumerically("==", 7))
+
+		By("creating, reading, listing, updating, and deleting a tool")
+		toolManifest := writeTempManifest(tmpDir, "tool.yaml", fmt.Sprintf(`
+apiVersion: core.orka.ai/v1alpha1
+kind: Tool
+metadata:
+  name: %s
+spec:
+  description: CLI e2e HTTP tool
+  http:
+    url: https://example.invalid/orka-cli-e2e
+    method: POST
+`, toolName))
+		toolUpdatedManifest := writeTempManifest(tmpDir, "tool-updated.yaml", fmt.Sprintf(`
+apiVersion: core.orka.ai/v1alpha1
+kind: Tool
+metadata:
+  name: %s
+spec:
+  description: CLI e2e HTTP tool updated
+  http:
+    url: https://example.invalid/orka-cli-e2e-updated
+    method: POST
+`, toolName))
+		expectOrkaSuccess(runOrka(home, "tool", "create", "-f", toolManifest), token)
+		toolGet := runOrka(home, "tool", "get", toolName, "-o", "json")
+		expectOrkaSuccess(toolGet, token)
+		Expect(nestedStringFromMap(expectJSONObject(toolGet.Stdout), "metadata", "name")).To(Equal(toolName))
+		toolList := runOrka(home, "tool", "list", "-o", "json")
+		expectOrkaSuccess(toolList, token)
+		expectListContainsName(expectJSONObject(toolList.Stdout), toolName)
+		expectOrkaSuccess(runOrka(home, "tool", "update", toolName, "-f", toolUpdatedManifest), token)
+		toolUpdated := expectJSONObject(runSuccessfulOrka(home, []string{token}, "tool", "get", toolName, "-o", "json").Stdout)
+		Expect(nestedStringFromMap(toolUpdated, "spec", "description")).To(Equal("CLI e2e HTTP tool updated"))
+
+		By("initializing, validating, importing, reading, updating, and deleting a skill")
+		skillDir := filepath.Join(tmpDir, "skill")
+		expectOrkaSuccess(runOrka(home, "skill", "init", skillDir, "--name", skillName, "--description", "CLI e2e skill"), token)
+		skillFile := filepath.Join(skillDir, "SKILL.md")
+		expectOrkaSuccess(runOrka(home, "skill", "validate", skillFile), token)
+		expectOrkaSuccess(runOrka(home, "skill", "import", skillFile, "--name", skillName), token)
+		skillList := runOrka(home, "skill", "list", "-o", "json")
+		expectOrkaSuccess(skillList, token)
+		expectListContainsName(expectJSONOutput(skillList.Stdout), skillName)
+		skillGet := runOrka(home, "skill", "get", skillName, "-o", "json")
+		expectOrkaSuccess(skillGet, token)
+		Expect(nestedStringFromMap(expectJSONObject(skillGet.Stdout), "metadata", "name")).To(Equal(skillName))
+		skillContent := runOrka(home, "skill", "content", skillName)
+		expectOrkaSuccess(skillContent, token)
+		Expect(skillContent.Stdout).To(ContainSubstring("CLI e2e skill"))
+		skillUpdateManifest := writeTempManifest(tmpDir, "skill-updated.yaml", fmt.Sprintf(`
+apiVersion: core.orka.ai/v1alpha1
+kind: Skill
+metadata:
+  name: %s
+spec:
+  description: CLI e2e skill updated
+  content:
+    inline: |
+      # %s
+
+      Updated CLI e2e skill content.
+`, skillName, skillName))
+		expectOrkaSuccess(runOrka(home, "skill", "update", skillName, "-f", skillUpdateManifest), token)
+		skillUpdatedContent := runOrka(home, "skill", "content", skillName)
+		expectOrkaSuccess(skillUpdatedContent, token)
+		Expect(skillUpdatedContent.Stdout).To(ContainSubstring("Updated CLI e2e skill content"))
+
+		By("deleting created resources through the CLI")
+		expectOrkaSuccess(runOrka(home, "skill", "delete", skillName), token)
+		expectOrkaSuccess(runOrka(home, "tool", "delete", toolName), token)
+		expectOrkaSuccess(runOrka(home, "agent", "delete", agentName), token)
+		expectOrkaSuccess(runOrka(home, "provider", "delete", providerName), token, secretSentinel)
+	})
+})
+
+func runSuccessfulOrka(home string, forbidden []string, args ...string) cliResult {
+	GinkgoHelper()
+	result := runOrka(home, args...)
+	expectOrkaSuccess(result, forbidden...)
+	return result
+}
+
+func deleteK8sResource(kind, name string) {
+	if strings.TrimSpace(name) == "" {
+		return
+	}
+	cmd := exec.Command("kubectl", "delete", kind, name, "-n", namespace, "--ignore-not-found")
+	_, _ = utils.Run(cmd)
+}
+
+func k8sResourceExists(kind, name string) bool {
+	cmd := exec.Command("kubectl", "get", kind, name, "-n", namespace, "--ignore-not-found")
+	output, err := utils.Run(cmd)
+	return err == nil && strings.TrimSpace(output) != ""
+}


### PR DESCRIPTION
## Summary

- add binary-level e2e helpers that build and run `bin/orka` against the deployed Orka API with an isolated temp `HOME`
- cover CLI auth/config, model catalogs, container task workflows, namespace behavior, provider/agent/tool/skill CRUD, and secret-list redaction
- extend the existing artifact API e2e scenario with `orka task artifacts` and `orka task download` checks

Follow-up to #166 after the full CLI resource coverage landed.

## Verification

- `go test -tags=e2e ./test/e2e -run '^$'`
- `go test ./cmd/cli ./internal/cli/client ./internal/api ./internal/tools`
  - initial post-rebase run hit a transient `internal/api` `i/o timeout`; `go test ./internal/api` passed on rerun
- `make lint-fix`
- `make test`
- `$autoreview`: clean, no accepted/actionable findings reported

## Not run locally

- `make test-e2e-run-only` could not run to completion because Docker is unavailable in this environment: `Cannot connect to the Docker daemon at unix:///Users/sozercan/.docker/run/docker.sock`.
