### PR TITLE
[codex] Fix Dependabot automerge concurrency

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -30,7 +30,10 @@ permissions:
   statuses: read
 
 concurrency:
-  group: dependabot-automerge-${{ github.event.workflow_run.head_branch || inputs.pr || github.run_id }}
+  # workflow_run events can arrive in large bursts. Use the upstream run id so
+  # unrelated PR completions do not evict pending automerge attempts from the
+  # same broad `main` concurrency group.
+  group: dependabot-automerge-${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || format('manual-{0}', inputs.pr || github.run_id) }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- Make Dependabot Automerge workflow concurrency unique per upstream `workflow_run` event.
- Keep a stable manual-dispatch concurrency group for explicit PR merges.
- Prevent bursts of unrelated completed checks from evicting queued automerge attempts from a broad `main` group.

## Why
Under heavy CI activity, many `workflow_run` events arrive close together. The workflow's previous concurrency key collapsed those runs into the same broad group, so queued automerge attempts could cancel one another before reaching the merge logic.

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/dependabot-automerge.yml`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
