### PR TITLE
feat(cli): add safe login and generated docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,15 @@ ui-test-coverage: ## Run UI unit tests with coverage.
 build: manifests generate fmt vet ui-build ## Build manager binary.
 	go build -o bin/manager cmd/main.go
 
+
+.PHONY: docs-cli
+docs-cli: build-cli ## Generate CLI command reference docs.
+	scripts/generate-cli-docs.sh
+
+.PHONY: docs-cli-check
+docs-cli-check: build-cli ## Check generated CLI command reference docs are up to date.
+	scripts/generate-cli-docs.sh --check
+
 .PHONY: build-cli
 build-cli: ## Build orka CLI binary.
 	go build -ldflags "-X main.version=$(shell git describe --tags --always --dirty 2>/dev/null || echo dev)" -o bin/orka ./cmd/cli/

--- a/cmd/cli/config.go
+++ b/cmd/cli/config.go
@@ -4,6 +4,9 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -15,6 +18,7 @@ func newConfigCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newConfigSetServerCmd())
 	cmd.AddCommand(newConfigSetTokenCmd())
+	cmd.AddCommand(newConfigSetNamespaceCmd())
 	cmd.AddCommand(newConfigViewCmd())
 	return cmd
 }
@@ -37,17 +41,69 @@ func newConfigSetServerCmd() *cobra.Command {
 }
 
 func newConfigSetTokenCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "set-token <token>",
+	var tokenFile string
+	cmd := &cobra.Command{
+		Use:   "set-token [token]",
 		Short: "Set the default authentication token",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if tokenFile != "" && len(args) > 0 {
+				return fmt.Errorf("provide token as an argument or --file, not both")
+			}
+
+			value := ""
+			if tokenFile != "" {
+				data, err := readTokenInput(cmd, tokenFile)
+				if err != nil {
+					return err
+				}
+				value = strings.TrimSpace(string(data))
+			} else if len(args) == 1 {
+				value = strings.TrimSpace(args[0])
+			}
+			if value == "" {
+				return fmt.Errorf("token argument or --file is required")
+			}
+
 			cfg := loadConfig()
-			cfg.Token = args[0]
+			cfg.Token = value
 			if err := saveConfig(cfg); err != nil {
 				return fmt.Errorf("save config: %w", err)
 			}
 			fmt.Println("Token saved.")
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&tokenFile, "file", "f", "", "Read token from file (use - for stdin)")
+	return cmd
+}
+
+func readTokenInput(cmd *cobra.Command, path string) ([]byte, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("token file path is required")
+	}
+	if path == "-" {
+		return io.ReadAll(cmd.InOrStdin())
+	}
+	return os.ReadFile(path)
+}
+
+func newConfigSetNamespaceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set-namespace <namespace>",
+		Short: "Set the default Kubernetes namespace",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			ns := strings.TrimSpace(args[0])
+			if ns == "" {
+				return fmt.Errorf("namespace is required")
+			}
+			cfg := loadConfig()
+			cfg.Namespace = ns
+			if err := saveConfig(cfg); err != nil {
+				return fmt.Errorf("save config: %w", err)
+			}
+			fmt.Printf("Namespace set to %s\n", ns)
 			return nil
 		},
 	}

--- a/cmd/cli/config_test.go
+++ b/cmd/cli/config_test.go
@@ -3,8 +3,12 @@
 package main
 
 import (
+	"os"
+	"strings"
 	"testing"
 )
+
+const configTestNamespace = "orka-system"
 
 func TestNewConfigCmd(t *testing.T) {
 	cmd := newConfigCmd()
@@ -17,7 +21,7 @@ func TestNewConfigCmd(t *testing.T) {
 	for _, sub := range cmd.Commands() {
 		subNames[sub.Use] = true
 	}
-	for _, want := range []string{"set-server <url>", "set-token <token>", "view"} {
+	for _, want := range []string{"set-server <url>", "set-token [token]", "set-namespace <namespace>", "view"} {
 		if !subNames[want] {
 			t.Errorf("missing subcommand %q", want)
 		}
@@ -54,15 +58,15 @@ func TestConfigSetTokenCmd(t *testing.T) {
 	t.Setenv("HOME", tmp)
 
 	cmd := newConfigSetTokenCmd()
-	cmd.SetArgs([]string{"my-secret-token"})
+	cmd.SetArgs([]string{"opaque-value-123"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error: %v", err)
 	}
 
 	cfg := loadConfig()
-	if cfg.Token != "my-secret-token" {
-		t.Errorf("Token = %q, want %q", cfg.Token, "my-secret-token")
+	if cfg.Token != "opaque-value-123" {
+		t.Errorf("Token = %q, want %q", cfg.Token, "opaque-value-123")
 	}
 }
 
@@ -71,6 +75,71 @@ func TestConfigSetTokenCmdNoArgs(t *testing.T) {
 	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err == nil {
 		t.Error("expected error with no args")
+	}
+}
+
+func TestConfigSetTokenCmdFromFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	tokenPath := tmp + "/token.txt"
+	if err := os.WriteFile(tokenPath, []byte("file-value-123\n"), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	cmd := newConfigSetTokenCmd()
+	cmd.SetArgs([]string{"--file", tokenPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	cfg := loadConfig()
+	if cfg.Token != "file-value-123" {
+		t.Errorf("Token = %q, want %q", cfg.Token, "file-value-123")
+	}
+}
+
+func TestConfigSetTokenCmdFromStdin(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	cmd := newConfigSetTokenCmd()
+	cmd.SetIn(strings.NewReader("stdin-value-123\n"))
+	cmd.SetArgs([]string{"--file", "-"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	cfg := loadConfig()
+	if cfg.Token != "stdin-value-123" {
+		t.Errorf("Token = %q, want %q", cfg.Token, "stdin-value-123")
+	}
+}
+
+func TestConfigSetTokenCmdRejectsArgWithFile(t *testing.T) {
+	cmd := newConfigSetTokenCmd()
+	cmd.SetArgs([]string{"arg-value-123", "--file", "token.txt"})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error when token arg and --file are both provided")
+	}
+}
+
+func TestConfigSetNamespaceCmd(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	cmd := newConfigSetNamespaceCmd()
+	cmd.SetArgs([]string{configTestNamespace})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	cfg := loadConfig()
+	if cfg.Namespace != configTestNamespace {
+		t.Errorf("Namespace = %q, want %q", cfg.Namespace, configTestNamespace)
 	}
 }
 
@@ -111,7 +180,7 @@ func TestConfigSetServerPreservesToken(t *testing.T) {
 
 	// Set token first
 	tokenCmd := newConfigSetTokenCmd()
-	tokenCmd.SetArgs([]string{"my-token"})
+	tokenCmd.SetArgs([]string{"opaque-value-456"})
 	if err := tokenCmd.Execute(); err != nil {
 		t.Fatalf("set-token error: %v", err)
 	}
@@ -125,8 +194,8 @@ func TestConfigSetServerPreservesToken(t *testing.T) {
 
 	// Verify both are preserved
 	cfg := loadConfig()
-	if cfg.Token != "my-token" {
-		t.Errorf("Token = %q, want %q (should be preserved)", cfg.Token, "my-token")
+	if cfg.Token != "opaque-value-456" {
+		t.Errorf("Token = %q, want %q (should be preserved)", cfg.Token, "opaque-value-456")
 	}
 	if cfg.Server != "http://srv:8080" {
 		t.Errorf("Server = %q, want %q", cfg.Server, "http://srv:8080")

--- a/cmd/cli/helpers_test.go
+++ b/cmd/cli/helpers_test.go
@@ -623,3 +623,19 @@ func TestRootCmdIncludesCoverageCommands(t *testing.T) {
 		}
 	}
 }
+
+func TestArticleFor(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "agent", want: "an"},
+		{name: "provider", want: "a"},
+		{name: "", want: "a"},
+	}
+	for _, tt := range tests {
+		if got := articleFor(tt.name); got != tt.want {
+			t.Errorf("articleFor(%q) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}

--- a/cmd/cli/login.go
+++ b/cmd/cli/login.go
@@ -11,6 +11,7 @@ import (
 
 func newLoginCmd() *cobra.Command {
 	var serviceAccount string
+	var noOpen, redactToken bool
 
 	cmd := &cobra.Command{
 		Use:   "login",
@@ -29,12 +30,15 @@ func newLoginCmd() *cobra.Command {
 				server = defaultServer
 			}
 			if ns == "" {
+				ns = cfg.Namespace
+			}
+			if ns == "" {
 				ns = "default"
 			}
 
 			if token == "" {
 				var err error
-				token, err = createServiceAccountToken(serviceAccount, ns)
+				token, err = serviceAccountLoginFunc(serviceAccount, ns)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Error creating token: %v\n", err)
 					fmt.Fprintf(os.Stderr, "You can provide a token directly with --token\n")
@@ -43,11 +47,35 @@ func newLoginCmd() *cobra.Command {
 			}
 
 			loginURL := fmt.Sprintf("%s/login#token=%s", server, token)
-			fmt.Printf("Login URL: %s\n", loginURL)
+			displayURL := loginURL
+			if redactToken {
+				displayURL = fmt.Sprintf("%s/login#token=<redacted>", server)
+			}
+			fmt.Printf("Login URL: %s\n", displayURL)
+
+			if noOpen {
+				if redactToken {
+					fmt.Println(
+						"Browser opening skipped. The printed login URL is redacted and cannot be opened manually. " +
+							"Rerun without --redact-token in a trusted terminal if you need to copy the URL.",
+					)
+				} else {
+					fmt.Println("Browser opening skipped. Open the login URL above in your browser manually.")
+				}
+				return nil
+			}
 
 			if err := openBrowser(loginURL); err != nil {
 				fmt.Fprintf(os.Stderr, "Could not open browser: %v\n", err)
-				fmt.Fprintln(os.Stderr, "Open the URL above in your browser manually.")
+				if redactToken {
+					fmt.Fprintln(
+						os.Stderr,
+						"The printed login URL is redacted and cannot be opened manually. "+
+							"Rerun without --redact-token in a trusted terminal if you need to copy the URL.",
+					)
+				} else {
+					fmt.Fprintln(os.Stderr, "Open the URL above in your browser manually.")
+				}
 				return nil
 			}
 			fmt.Println("Browser opened successfully. You can now log in to the Orka dashboard.")
@@ -56,6 +84,13 @@ func newLoginCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&serviceAccount, "service-account", "default", "ServiceAccount name")
+	cmd.Flags().BoolVar(&noOpen, "no-open", false, "Print the login URL without opening a browser")
+	cmd.Flags().BoolVar(
+		&redactToken,
+		"redact-token",
+		false,
+		"Redact the token in printed output while preserving browser login",
+	)
 
 	return cmd
 }

--- a/cmd/cli/login_test.go
+++ b/cmd/cli/login_test.go
@@ -3,6 +3,10 @@
 package main
 
 import (
+	"errors"
+	"io"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -48,7 +52,7 @@ func TestNewLoginCmd_WithTokenFlag(t *testing.T) {
 	root.AddCommand(cmd)
 
 	// With --token provided, it should try to construct URL and open browser.
-	root.SetArgs([]string{"login", "--server", "http://test-server:8080", "--token", "test-token-123"})
+	root.SetArgs([]string{"login", "--server", "http://test-server:8080", "--token", "opaque-login-value-123"})
 
 	err := root.Execute()
 	if err != nil {
@@ -94,9 +98,175 @@ func TestNewLoginCmd_DefaultServerFromConfig(t *testing.T) {
 	root := newRootCmd()
 	root.AddCommand(cmd)
 
-	root.SetArgs([]string{"login", "--token", "my-token"})
+	root.SetArgs([]string{"login", "--token", "opaque-value-456"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("Execute() error: %v", err)
 	}
+}
+
+func TestNewLoginCmd_UsesConfiguredNamespaceForCreatedToken(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	cfg := orkaConfig{Server: "http://configured-server:9090", Namespace: "orka-system"}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("saveConfig error: %v", err)
+	}
+
+	var gotServiceAccount, gotNamespace string
+	origCreate := serviceAccountLoginFunc
+	serviceAccountLoginFunc = func(serviceAccount, namespace string) (string, error) {
+		gotServiceAccount = serviceAccount
+		gotNamespace = namespace
+		return "opaque-login-value-789", nil
+	}
+	t.Cleanup(func() { serviceAccountLoginFunc = origCreate })
+
+	origBrowser := openBrowserFunc
+	openBrowserFunc = func(string) error { return nil }
+	t.Cleanup(func() { openBrowserFunc = origBrowser })
+
+	root := newRootCmd()
+	root.SetArgs([]string{"login", "--service-account", "orka-client"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if gotServiceAccount != "orka-client" {
+		t.Fatalf("serviceAccount = %q, want orka-client", gotServiceAccount)
+	}
+	if gotNamespace != "orka-system" {
+		t.Fatalf("namespace = %q, want configured namespace", gotNamespace)
+	}
+}
+
+func TestNewLoginCmd_NoOpenRedactsTokenInOutput(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	opened := false
+	orig := openBrowserFunc
+	openBrowserFunc = func(string) error {
+		opened = true
+		return nil
+	}
+	t.Cleanup(func() { openBrowserFunc = orig })
+
+	root := newRootCmd()
+	root.SetArgs([]string{
+		"login",
+		"--server", "http://test-server:8080",
+		"--token", "opaque-login-value-123",
+		"--no-open",
+		"--redact-token",
+	})
+
+	stdout, err := captureOutput(t, root.Execute)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if opened {
+		t.Fatal("browser opener was called despite --no-open")
+	}
+	if strings.Contains(stdout, "opaque-login-value-123") {
+		t.Fatalf("stdout leaked token: %q", stdout)
+	}
+	if !strings.Contains(stdout, "Login URL: http://test-server:8080/login#token=<redacted>") {
+		t.Fatalf("stdout = %q, want redacted login URL", stdout)
+	}
+	if !strings.Contains(stdout, "printed login URL is redacted") {
+		t.Fatalf("stdout = %q, want redacted no-open guidance", stdout)
+	}
+	if strings.Contains(stdout, "Use the login URL above") {
+		t.Fatalf("stdout = %q, should not suggest using the redacted URL", stdout)
+	}
+}
+
+func TestNewLoginCmd_RedactsOutputButOpensFullURL(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	var openedURL string
+	orig := openBrowserFunc
+	openBrowserFunc = func(url string) error {
+		openedURL = url
+		return nil
+	}
+	t.Cleanup(func() { openBrowserFunc = orig })
+
+	root := newRootCmd()
+	root.SetArgs([]string{
+		"login",
+		"--server", "http://test-server:8080",
+		"--token", "opaque-login-value-123",
+		"--redact-token",
+	})
+
+	stdout, err := captureOutput(t, root.Execute)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if openedURL != "http://test-server:8080/login#token=opaque-login-value-123" {
+		t.Fatalf("openedURL = %q, want full token URL", openedURL)
+	}
+	if strings.Contains(stdout, "opaque-login-value-123") {
+		t.Fatalf("stdout leaked token: %q", stdout)
+	}
+	if !strings.Contains(stdout, "Login URL: http://test-server:8080/login#token=<redacted>") {
+		t.Fatalf("stdout = %q, want redacted login URL", stdout)
+	}
+}
+
+func TestNewLoginCmd_RedactedBrowserFailureExplainsURLIsNotUsable(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	orig := openBrowserFunc
+	openBrowserFunc = func(string) error { return errors.New("browser unavailable") }
+	t.Cleanup(func() { openBrowserFunc = orig })
+
+	root := newRootCmd()
+	root.SetArgs([]string{
+		"login",
+		"--server", "http://test-server:8080",
+		"--token", "opaque-login-value-123",
+		"--redact-token",
+	})
+
+	stderr, err := captureStderr(t, root.Execute)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if !strings.Contains(stderr, "printed login URL is redacted") {
+		t.Fatalf("stderr = %q, want redacted URL guidance", stderr)
+	}
+	if strings.Contains(stderr, "Open the URL above") {
+		t.Fatalf("stderr = %q, should not suggest opening the redacted URL", stderr)
+	}
+}
+
+func captureStderr(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+
+	oldStderr := os.Stderr
+	stderrReader, stderrWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stderr pipe: %v", err)
+	}
+
+	os.Stderr = stderrWriter
+	defer func() {
+		os.Stderr = oldStderr
+		stderrReader.Close() //nolint:errcheck
+	}()
+
+	runErr := fn()
+	stderrWriter.Close() //nolint:errcheck
+
+	stderr, err := io.ReadAll(stderrReader)
+	if err != nil {
+		t.Fatalf("failed to read captured stderr: %v", err)
+	}
+	return string(stderr), runErr
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -79,6 +79,10 @@ func newRootCmd() *cobra.Command {
 	return cmd
 }
 
+// serviceAccountLoginFunc is used by login to request ServiceAccount login credentials.
+// Tests can replace this to avoid calling kubectl.
+var serviceAccountLoginFunc = createServiceAccountToken
+
 // createServiceAccountToken generates a token for the given ServiceAccount using kubectl.
 func createServiceAccountToken(serviceAccount, namespace string) (string, error) {
 	kubectlPath, err := exec.LookPath("kubectl")

--- a/cmd/cli/memory.go
+++ b/cmd/cli/memory.go
@@ -227,7 +227,7 @@ func newMemoryDeleteCmd() *cobra.Command {
 func newMemoryEnableDisableCmd(action string) *cobra.Command {
 	return &cobra.Command{
 		Use:   action + " <id>",
-		Short: action + " a memory",
+		Short: titleName(action) + " a memory",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := newClientFromCmd(cmd)

--- a/cmd/cli/memory_test.go
+++ b/cmd/cli/memory_test.go
@@ -48,3 +48,12 @@ func TestMemoryUpdateFileUsesManifestNamespace(t *testing.T) {
 		t.Fatalf("body namespace = %#v, want %s", gotBody["namespace"], manifestNamespace)
 	}
 }
+
+func TestMemoryEnableDisableShortDescriptionsUseSentenceCase(t *testing.T) {
+	if got := newMemoryEnableDisableCmd("enable").Short; got != "Enable a memory" {
+		t.Fatalf("enable short = %q, want %q", got, "Enable a memory")
+	}
+	if got := newMemoryEnableDisableCmd("disable").Short; got != "Disable a memory" {
+		t.Fatalf("disable short = %q, want %q", got, "Disable a memory")
+	}
+}

--- a/cmd/cli/resource_commands.go
+++ b/cmd/cli/resource_commands.go
@@ -85,7 +85,7 @@ func newCRUDListCmd(spec crudResourceSpec) *cobra.Command {
 func newCRUDGetCmd(spec crudResourceSpec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get <name>",
-		Short: "Get a " + spec.Name + " resource",
+		Short: "Get " + articleFor(spec.Name) + " " + spec.Name + " resource",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := newClientFromCmd(cmd)
@@ -104,7 +104,7 @@ func newCRUDCreateCmd(spec crudResourceSpec) *cobra.Command {
 	var file string
 	cmd := &cobra.Command{
 		Use:   "create -f <file>",
-		Short: "Create a " + spec.Name + " resource from a manifest",
+		Short: "Create " + articleFor(spec.Name) + " " + spec.Name + " resource from a manifest",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if file == "" {
 				return fmt.Errorf("--file (-f) is required")
@@ -130,7 +130,7 @@ func newCRUDUpdateCmd(spec crudResourceSpec) *cobra.Command {
 	var file string
 	cmd := &cobra.Command{
 		Use:   "update <name> -f <file>",
-		Short: "Update a " + spec.Name + " resource from a manifest",
+		Short: "Update " + articleFor(spec.Name) + " " + spec.Name + " resource from a manifest",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if file == "" {
@@ -160,7 +160,7 @@ func newCRUDUpdateCmd(spec crudResourceSpec) *cobra.Command {
 func newCRUDDeleteCmd(spec crudResourceSpec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete <name>",
-		Short: "Delete a " + spec.Name + " resource",
+		Short: "Delete " + articleFor(spec.Name) + " " + spec.Name + " resource",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := newClientFromCmd(cmd)
@@ -170,6 +170,18 @@ func newCRUDDeleteCmd(spec crudResourceSpec) *cobra.Command {
 			fmt.Fprintf(cmd.OutOrStdout(), "%s deleted: %s\n", titleName(spec.Name), args[0]) //nolint:errcheck
 			return nil
 		},
+	}
+}
+
+func articleFor(s string) string {
+	if s == "" {
+		return "a"
+	}
+	switch strings.ToLower(s[:1]) {
+	case "a", "e", "i", "o", "u":
+		return "an"
+	default:
+		return "a"
 	}
 }
 

--- a/scripts/generate-cli-docs.sh
+++ b/scripts/generate-cli-docs.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/generate-cli-docs.sh [--check] [output-file]
+
+Generate the Docusaurus CLI command reference from the compiled orka binary.
+Set ORKA_CLI_BIN to use a specific binary. Defaults to bin/orka and builds it
+with make build-cli when it is missing.
+USAGE
+}
+
+check=false
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+if [[ "${1:-}" == "--check" ]]; then
+  check=true
+  shift
+fi
+
+out="${1:-website/docs/reference/cli-commands.md}"
+cli_bin="${ORKA_CLI_BIN:-bin/orka}"
+
+if [[ ! -x "$cli_bin" ]]; then
+  make build-cli >/dev/null
+fi
+
+commands=(
+  ""
+  "login"
+  "run"
+  "config" "config set-server" "config set-token" "config set-namespace" "config view"
+  "auth" "auth validate" "auth whoami"
+  "models" "models list"
+  "status"
+  "audit" "audit trace"
+  "task" "task create" "task list" "task get" "task logs" "task result" "task plan" "task children" "task wait" "task delete" "task artifacts" "task download"
+  "workspace" "workspace status"
+  "provider" "provider list" "provider get" "provider create" "provider update" "provider delete"
+  "agent" "agent list" "agent get" "agent create" "agent update" "agent delete"
+  "tool" "tool list" "tool get" "tool create" "tool update" "tool delete"
+  "skill" "skill list" "skill get" "skill content" "skill create" "skill init" "skill validate" "skill import" "skill update" "skill delete"
+  "secret" "secret list"
+  "session" "session list" "session get" "session delete"
+  "memory" "memory list" "memory get" "memory create" "memory update" "memory delete" "memory enable" "memory disable" "memory proposal" "memory proposal list" "memory proposal get" "memory proposal review" "memory proposal apply" "memory proposal archive"
+  "security" "security repo" "security repo list" "security repo get" "security repo create" "security repo update" "security repo delete" "security scan" "security scan run" "security scan list" "security threat-model" "security threat-model get" "security threat-model update" "security finding" "security finding list" "security finding get" "security finding dismiss" "security finding reopen" "security finding validate" "security finding patch" "security finding patches" "security finding pr" "security slice" "security slice list" "security slice get" "security dropped-findings" "security dropped-findings list"
+  "monitor" "monitor list" "monitor get" "monitor create" "monitor update" "monitor delete" "monitor run" "monitor runs" "monitor items" "monitor events"
+  "substrate" "substrate pool" "substrate pool list" "substrate pool get" "substrate pool create" "substrate pool update" "substrate pool delete"
+  "completion"
+)
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+{
+  cat <<'HEADER'
+---
+slug: /cli-commands
+---
+
+# CLI Command Reference
+
+This page is generated from `orka --help` output. Do not edit it by hand; run:
+
+```bash
+make docs-cli
+```
+
+For workflow-oriented examples and coverage notes, see [CLI Reference](./cli.md).
+
+HEADER
+
+  for command in "${commands[@]}"; do
+    if [[ -z "$command" ]]; then
+      title="orka"
+      args=(--help)
+    else
+      title="orka $command"
+      # shellcheck disable=SC2206
+      parts=($command)
+      args=("${parts[@]}" --help)
+    fi
+
+    printf '## `%s`\n\n' "$title"
+    printf '```text\n'
+    "$cli_bin" "${args[@]}"
+    printf '```\n\n'
+  done
+} > "$tmp"
+
+if [[ "$check" == true ]]; then
+  if ! cmp -s "$tmp" "$out"; then
+    echo "$out is out of date; run make docs-cli" >&2
+    diff -u "$out" "$tmp" >&2 || true
+    exit 1
+  fi
+  echo "$out is up to date"
+else
+  mkdir -p "$(dirname "$out")"
+  mv "$tmp" "$out"
+  trap - EXIT
+fi

--- a/test/e2e/cli_local_test.go
+++ b/test/e2e/cli_local_test.go
@@ -61,12 +61,16 @@ var _ = Describe("Orka CLI local binary paths", Ordered, func() {
 
 		writeCLIConfig(localHome, "", namespace, "")
 		configPath := filepath.Join(localHome, ".orka", "config.yaml")
-		fakeToken := "fake-config-token-sentinel-" + suffix
+		fakeToken := "fake-config-value-sentinel-" + suffix
 
-		By("setting server and a fake token through the compiled binary")
+		By("setting server, namespace, and a fake token through the compiled binary")
+		tokenPath := filepath.Join(localHome, "fake-token.txt")
+		Expect(os.WriteFile(tokenPath, []byte(fakeToken+"\n"), 0o600)).To(Succeed())
 		setServer := runOrka(localHome, "config", "set-server", apiBaseURL)
 		expectOrkaSuccess(setServer, fakeToken)
-		setToken := runOrka(localHome, "config", "set-token", fakeToken)
+		setNamespace := runOrka(localHome, "config", "set-namespace", namespace)
+		expectOrkaSuccess(setNamespace, fakeToken)
+		setToken := runOrka(localHome, "config", "set-token", "--file", tokenPath)
 		expectOrkaSuccess(setToken, fakeToken)
 
 		By("verifying config view uses the isolated config and masks the fake token")
@@ -97,6 +101,40 @@ var _ = Describe("Orka CLI local binary paths", Ordered, func() {
 		Expect(status.Stdout).To(ContainSubstring("Ready:"))
 		Expect(status.Stdout).To(ContainSubstring("Tasks:"))
 		Expect(status.Stdout).To(ContainSubstring("Agents:"))
+	})
+
+	It("generates completion scripts and safe redacted login output", func() {
+		localHome, err := os.MkdirTemp("", "orka-cli-local-e2e-home-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = os.RemoveAll(localHome) })
+
+		By("generating shell completions through the compiled binary")
+		for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+			completion := runOrka(localHome, "completion", shell)
+			expectOrkaSuccess(completion)
+			Expect(completion.Stdout).To(ContainSubstring("orka"), "completion output for %s should mention the orka command", shell)
+		}
+
+		By("printing a redacted login URL without opening a browser")
+		fakeToken := "fake-login-value-sentinel-" + suffix
+		login := runOrka(localHome,
+			"login",
+			"--server", apiBaseURL,
+			"--token", fakeToken,
+			"--no-open",
+			"--redact-token",
+		)
+		expectOrkaSuccess(login, fakeToken)
+		Expect(login.Stdout).To(ContainSubstring("Login URL: " + apiBaseURL + "/login#token=<redacted>"))
+		Expect(login.Stdout).To(ContainSubstring("Browser opening skipped"))
+	})
+
+	It("returns a clean run error when the API is unreachable", func() {
+		fakeToken := "fake-run-value-sentinel-" + suffix
+		unreachableHome := newIsolatedCLIHome("http://127.0.0.1:1", fakeToken)
+		run := runOrkaWithTimeout(15*time.Second, unreachableHome, "run", "--session", "e2e-cli-run-negative-"+suffix, "hello")
+		expectOrkaFailure(run, fakeToken)
+		Expect(run.Stderr + run.Stdout).To(ContainSubstring("cannot reach server"))
 	})
 
 	It("creates a container task from flags, reads logs, filters tasks, and traces an empty audit", func() {

--- a/test/e2e/cli_security_monitor_test.go
+++ b/test/e2e/cli_security_monitor_test.go
@@ -12,6 +12,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"time"
 
@@ -121,6 +122,12 @@ spec:
 			expectJSONObject(result.Stdout)
 		}
 
+		if os.Getenv("ORKA_CLI_E2E_LIVE_ACTIONS") == "1" {
+			By("triggering an explicitly enabled manual security scan run")
+			scanRun := runOrka(home, "security", "scan", "run", repositoryScanName)
+			expectOrkaSuccess(scanRun, token, fakeAnthropicKey)
+		}
+
 		By("creating and reading a RepositoryMonitor with required repoURL and reviewer agent fields")
 		monitorManifest := writeTempManifest(tmpDir, "repository-monitor.yaml", repositoryMonitorManifest(monitorName, repoURL, agentName))
 		expectOrkaSuccess(runOrka(home, "monitor", "create", "-f", monitorManifest), token, fakeAnthropicKey)
@@ -147,6 +154,12 @@ spec:
 			result := runOrka(home, args...)
 			expectOrkaSuccess(result, token, fakeAnthropicKey)
 			expectJSONObject(result.Stdout)
+		}
+
+		if os.Getenv("ORKA_CLI_E2E_LIVE_ACTIONS") == "1" {
+			By("triggering an explicitly enabled repository monitor run")
+			monitorRun := runOrka(home, "monitor", "run", monitorName, "--target-kind", "pull_request", "--target-number", "1")
+			expectOrkaSuccess(monitorRun, token, fakeAnthropicKey)
 		}
 
 		By("deleting the monitor and repository scan through the CLI")

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1,0 +1,2908 @@
+---
+slug: /cli-commands
+---
+
+# CLI Command Reference
+
+This page is generated from `orka --help` output. Do not edit it by hand; run:
+
+```bash
+make docs-cli
+```
+
+For workflow-oriented examples and coverage notes, see [CLI Reference](./cli.md).
+
+## `orka`
+
+```text
+Orka CLI — Kubernetes-native task execution platform
+
+Usage:
+  orka [command]
+
+Available Commands:
+  agent       Manage agents
+  audit       Inspect audit and transaction traces
+  auth        Inspect authentication
+  completion  Generate the autocompletion script for the specified shell
+  config      Manage CLI configuration
+  help        Help about any command
+  login       Authenticate with the Orka dashboard
+  memory      Manage durable memory
+  models      List compatible model IDs
+  monitor     Manage repository monitors
+  provider    Manage providers
+  run         Chat with the Orka AI assistant
+  secret      Inspect secret metadata
+  security    Manage repository security scans
+  session     Manage sessions
+  skill       Manage skills
+  status      Show system overview (health, tasks, agents)
+  substrate   Inspect and manage substrate resources
+  task        Manage tasks
+  tool        Manage tools
+  workspace   Inspect task workspace status
+
+Flags:
+  -h, --help                    help for orka
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+  -v, --version                 version for orka
+
+Use "orka [command] --help" for more information about a command.
+```
+
+## `orka login`
+
+```text
+Generate a ServiceAccount token and open the Orka dashboard in your browser.
+
+Usage:
+  orka login [flags]
+
+Flags:
+  -h, --help                     help for login
+      --no-open                  Print the login URL without opening a browser
+      --redact-token             Redact the token in printed output while preserving browser login
+      --service-account string   ServiceAccount name (default "default")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka run`
+
+```text
+Ollama-style chat interface.
+
+  One-shot:    orka run "explain kubernetes pods"
+  Interactive: orka run
+  Piped:       echo "fix bugs" | orka run
+
+Usage:
+  orka run [prompt] [flags]
+
+Flags:
+      --agent string      Agent to use for the task
+  -h, --help              help for run
+      --model string      Model to use
+      --provider string   Provider to use
+      --session string    Resume a specific session
+  -v, --verbose count     Verbosity level (-v, -vv)
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka config`
+
+```text
+Manage CLI configuration
+
+Usage:
+  orka config [command]
+
+Available Commands:
+  set-namespace Set the default Kubernetes namespace
+  set-server    Set the default Orka server URL
+  set-token     Set the default authentication token
+  view          Show current configuration
+
+Flags:
+  -h, --help   help for config
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka config [command] --help" for more information about a command.
+```
+
+## `orka config set-server`
+
+```text
+Set the default Orka server URL
+
+Usage:
+  orka config set-server <url> [flags]
+
+Flags:
+  -h, --help   help for set-server
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka config set-token`
+
+```text
+Set the default authentication token
+
+Usage:
+  orka config set-token [token] [flags]
+
+Flags:
+  -f, --file string   Read token from file (use - for stdin)
+  -h, --help          help for set-token
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka config set-namespace`
+
+```text
+Set the default Kubernetes namespace
+
+Usage:
+  orka config set-namespace <namespace> [flags]
+
+Flags:
+  -h, --help   help for set-namespace
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka config view`
+
+```text
+Show current configuration
+
+Usage:
+  orka config view [flags]
+
+Flags:
+  -h, --help   help for view
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka auth`
+
+```text
+Inspect authentication
+
+Usage:
+  orka auth [command]
+
+Available Commands:
+  validate    Validate current credentials
+  whoami      Show sanitized authenticated identity
+
+Flags:
+  -h, --help   help for auth
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka auth [command] --help" for more information about a command.
+```
+
+## `orka auth validate`
+
+```text
+Validate current credentials
+
+Usage:
+  orka auth validate [flags]
+
+Flags:
+  -h, --help            help for validate
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka auth whoami`
+
+```text
+Show sanitized authenticated identity
+
+Usage:
+  orka auth whoami [flags]
+
+Flags:
+  -h, --help            help for whoami
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka models`
+
+```text
+List compatible model IDs
+
+Usage:
+  orka models [command]
+
+Available Commands:
+  list        List model IDs
+
+Flags:
+  -h, --help   help for models
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka models [command] --help" for more information about a command.
+```
+
+## `orka models list`
+
+```text
+List model IDs
+
+Usage:
+  orka models list [flags]
+
+Flags:
+      --compat string   Compatibility surface: openai or anthropic (default "openai")
+  -h, --help            help for list
+  -o, --output string   Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka status`
+
+```text
+Show system overview (health, tasks, agents)
+
+Usage:
+  orka status [flags]
+
+Flags:
+  -h, --help   help for status
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka audit`
+
+```text
+Inspect audit and transaction traces
+
+Usage:
+  orka audit [command]
+
+Available Commands:
+  trace       Show tasks correlated by kontxt transaction ID
+
+Flags:
+  -h, --help   help for audit
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka audit [command] --help" for more information about a command.
+```
+
+## `orka audit trace`
+
+```text
+Show tasks correlated by kontxt transaction ID
+
+Usage:
+  orka audit trace <transaction-id> [flags]
+
+Flags:
+  -h, --help        help for trace
+      --limit int   Maximum number of matching tasks to show (default 100)
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task`
+
+```text
+Manage tasks
+
+Usage:
+  orka task [command]
+
+Available Commands:
+  artifacts   List artifacts for a task
+  children    List child tasks
+  create      Create a new task
+  delete      Delete a task
+  download    Download task artifacts
+  get         Get task details
+  list        List tasks
+  logs        Get task logs
+  plan        Get task autonomous plan state
+  result      Get task result
+  wait        Wait for a task to complete
+
+Flags:
+  -h, --help   help for task
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka task [command] --help" for more information about a command.
+```
+
+## `orka task create`
+
+```text
+Create a new task
+
+Usage:
+  orka task create <prompt> [flags]
+
+Flags:
+      --agent string          Agent reference name
+      --arg stringArray       Command argument (repeat for multiple arguments)
+      --command stringArray   Command entry to run (repeat for multiple entries)
+      --env stringArray       Environment variable KEY=VALUE (repeatable)
+  -f, --file string           Path to task YAML/JSON manifest
+  -h, --help                  help for create
+      --image string          Container image
+      --model string          Model name for AI tasks
+      --name string           Task name (default: generated)
+      --priority int32        Task priority (0-1000)
+      --provider string       Provider reference name (default "default")
+      --schedule string       Cron schedule for recurring tasks
+      --suspend               Suspend scheduled task runs
+      --timeout string        Task timeout (e.g., "5m", "1h")
+      --timezone string       IANA time zone for scheduled tasks
+      --type string           Task type: ai, container, agent (default "ai")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task list`
+
+```text
+List tasks
+
+Usage:
+  orka task list [flags]
+
+Aliases:
+  list, ls
+
+Flags:
+      --continue string      Continue token for the next page
+      --cursor string        Cursor token for the next page
+  -h, --help                 help for list
+      --limit int            Maximum number of results (default 20)
+  -o, --output string        Output format: table, json, yaml (default "table")
+      --status string        Filter by status (client-side scan; may page through many tasks)
+      --transaction string   Filter by kontxt transaction ID (client-side scan)
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task get`
+
+```text
+Get task details
+
+Usage:
+  orka task get <name> [flags]
+
+Flags:
+  -h, --help               help for get
+  -o, --output string      Output format: table, json, yaml (default "json")
+      --show-transaction   Show only transaction metadata
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task logs`
+
+```text
+Get task logs
+
+Usage:
+  orka task logs <name> [flags]
+
+Flags:
+  -f, --follow   Stream logs in real time
+  -h, --help     help for logs
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task result`
+
+```text
+Get task result
+
+Usage:
+  orka task result <name> [flags]
+
+Flags:
+  -h, --help            help for result
+  -o, --output string   Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task plan`
+
+```text
+Get task autonomous plan state
+
+Usage:
+  orka task plan <name> [flags]
+
+Flags:
+  -h, --help            help for plan
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task children`
+
+```text
+List child tasks
+
+Usage:
+  orka task children <name> [flags]
+
+Flags:
+  -h, --help            help for children
+  -o, --output string   Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task wait`
+
+```text
+Wait for a task to complete
+
+Usage:
+  orka task wait <name> [flags]
+
+Flags:
+  -h, --help             help for wait
+      --timeout string   Maximum time to wait (e.g. 5m)
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task delete`
+
+```text
+Delete a task
+
+Usage:
+  orka task delete <name> [flags]
+
+Aliases:
+  delete, rm
+
+Flags:
+  -h, --help   help for delete
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task artifacts`
+
+```text
+List artifacts for a task
+
+Usage:
+  orka task artifacts <task-name> [flags]
+
+Flags:
+  -h, --help   help for artifacts
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task download`
+
+```text
+Download task artifacts
+
+Usage:
+  orka task download <task-name> [filename] [flags]
+
+Flags:
+  -h, --help            help for download
+  -o, --output string   output file path
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka workspace`
+
+```text
+Inspect task workspace status
+
+Usage:
+  orka workspace [command]
+
+Available Commands:
+  status      Show safe workspace status fields
+
+Flags:
+  -h, --help   help for workspace
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka workspace [command] --help" for more information about a command.
+```
+
+## `orka workspace status`
+
+```text
+Show safe workspace status fields
+
+Usage:
+  orka workspace status <task> [flags]
+
+Flags:
+  -h, --help            help for status
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka provider`
+
+```text
+Manage providers
+
+Usage:
+  orka provider [command]
+
+Available Commands:
+  create      Create a provider resource from a manifest
+  delete      Delete a provider resource
+  get         Get a provider resource
+  list        List provider resources
+  update      Update a provider resource from a manifest
+
+Flags:
+  -h, --help   help for provider
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka provider [command] --help" for more information about a command.
+```
+
+## `orka provider list`
+
+```text
+List provider resources
+
+Usage:
+  orka provider list [flags]
+
+Flags:
+      --continue string   Continue/cursor token for the next page
+      --cursor string     Cursor token for the next page
+  -h, --help              help for list
+      --limit int         Maximum number of results (default 100)
+  -o, --output string     Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka provider get`
+
+```text
+Get a provider resource
+
+Usage:
+  orka provider get <name> [flags]
+
+Flags:
+  -h, --help            help for get
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka provider create`
+
+```text
+Create a provider resource from a manifest
+
+Usage:
+  orka provider create -f <file> [flags]
+
+Flags:
+  -f, --file string   Path to YAML/JSON manifest (use - for stdin)
+  -h, --help          help for create
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka provider update`
+
+```text
+Update a provider resource from a manifest
+
+Usage:
+  orka provider update <name> -f <file> [flags]
+
+Flags:
+  -f, --file string   Path to YAML/JSON manifest (use - for stdin)
+  -h, --help          help for update
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka provider delete`
+
+```text
+Delete a provider resource
+
+Usage:
+  orka provider delete <name> [flags]
+
+Flags:
+  -h, --help   help for delete
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka agent`
+
+```text
+Manage agents
+
+Usage:
+  orka agent [command]
+
+Available Commands:
+  create      Create an agent from a manifest
+  delete      Delete an agent
+  get         Get agent details
+  list        List agents
+  update      Update an agent resource from a manifest
+
+Flags:
+  -h, --help   help for agent
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka agent [command] --help" for more information about a command.
+```
+
+## `orka agent list`
+
+```text
+List agents
+
+Usage:
+  orka agent list [flags]
+
+Flags:
+  -h, --help            help for list
+  -o, --output string   Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka agent get`
+
+```text
+Get agent details
+
+Usage:
+  orka agent get <name> [flags]
+
+Flags:
+  -h, --help            help for get
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka agent create`
+
+```text
+Create an agent from a manifest
+
+Usage:
+  orka agent create -f <file> [flags]
+
+Flags:
+  -f, --file string   Path to agent YAML/JSON manifest
+  -h, --help          help for create
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka agent update`
+
+```text
+Update an agent resource from a manifest
+
+Usage:
+  orka agent update <name> -f <file> [flags]
+
+Flags:
+  -f, --file string   Path to YAML/JSON manifest (use - for stdin)
+  -h, --help          help for update
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka agent delete`
+
+```text
+Delete an agent
+
+Usage:
+  orka agent delete <name> [flags]
+
+Flags:
+  -h, --help   help for delete
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka tool`
+
+```text
+Manage tools
+
+Usage:
+  orka tool [command]
+
+Available Commands:
+  create      Create a tool resource from a manifest
+  delete      Delete a tool resource
+  get         Get a tool resource
+  list        List tool resources
+  update      Update a tool resource from a manifest
+
+Flags:
+  -h, --help   help for tool
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka tool [command] --help" for more information about a command.
+```
+
+## `orka tool list`
+
+```text
+List tool resources
+
+Usage:
+  orka tool list [flags]
+
+Flags:
+      --continue string   Continue/cursor token for the next page
+      --cursor string     Cursor token for the next page
+  -h, --help              help for list
+      --limit int         Maximum number of results (default 100)
+  -o, --output string     Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka tool get`
+
+```text
+Get a tool resource
+
+Usage:
+  orka tool get <name> [flags]
+
+Flags:
+  -h, --help            help for get
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka tool create`
+
+```text
+Create a tool resource from a manifest
+
+Usage:
+  orka tool create -f <file> [flags]
+
+Flags:
+  -f, --file string   Path to YAML/JSON manifest (use - for stdin)
+  -h, --help          help for create
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka tool update`
+
+```text
+Update a tool resource from a manifest
+
+Usage:
+  orka tool update <name> -f <file> [flags]
+
+Flags:
+  -f, --file string   Path to YAML/JSON manifest (use - for stdin)
+  -h, --help          help for update
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka tool delete`
+
+```text
+Delete a tool resource
+
+Usage:
+  orka tool delete <name> [flags]
+
+Flags:
+  -h, --help   help for delete
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka skill`
+
+```text
+Manage skills
+
+Usage:
+  orka skill [command]
+
+Available Commands:
+  content     Print raw skill content
+  create      Create a skill from a YAML manifest
+  delete      Delete a skill
+  get         Get skill details
+  import      Create a skill from a local SKILL.md file
+  init        Initialize a local SKILL.md template
+  list        List skills
+  update      Update a skill resource from a manifest
+  validate    Validate a local skill manifest or SKILL.md file
+
+Flags:
+  -h, --help   help for skill
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka skill [command] --help" for more information about a command.
+```
+
+## `orka skill list`
+
+```text
+List skills
+
+Usage:
+  orka skill list [flags]
+
+Flags:
+  -h, --help            help for list
+  -o, --output string   Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka skill get`
+
+```text
+Get skill details
+
+Usage:
+  orka skill get <name> [flags]
+
+Flags:
+  -h, --help            help for get
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka skill content`
+
+```text
+Print raw skill content
+
+Usage:
+  orka skill content <name> [flags]
+
+Flags:
+  -h, --help   help for content
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka skill create`
+
+```text
+Create a skill from a YAML manifest
+
+Usage:
+  orka skill create -f <file> [flags]
+
+Flags:
+  -f, --file string   Path to skill YAML manifest
+  -h, --help          help for create
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka skill init`
+
+```text
+Initialize a local SKILL.md template
+
+Usage:
+  orka skill init [dir] [flags]
+
+Flags:
+      --description string   Skill description for the template
+      --force                Overwrite an existing SKILL.md
+  -h, --help                 help for init
+      --name string          Skill name for the template
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka skill validate`
+
+```text
+Validate a local skill manifest or SKILL.md file
+
+Usage:
+  orka skill validate [-f manifest.yaml] [SKILL.md] [flags]
+
+Flags:
+  -f, --file string   Path to skill YAML/JSON manifest
+  -h, --help          help for validate
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka skill import`
+
+```text
+Create a skill from a local SKILL.md file
+
+Usage:
+  orka skill import <path/to/SKILL.md> [flags]
+
+Flags:
+  -h, --help          help for import
+      --name string   Override skill name (default: derived from filename)
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka skill update`
+
+```text
+Update a skill resource from a manifest
+
+Usage:
+  orka skill update <name> -f <file> [flags]
+
+Flags:
+  -f, --file string   Path to YAML/JSON manifest (use - for stdin)
+  -h, --help          help for update
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka skill delete`
+
+```text
+Delete a skill
+
+Usage:
+  orka skill delete <name> [flags]
+
+Flags:
+  -h, --help   help for delete
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka secret`
+
+```text
+Inspect secret metadata
+
+Usage:
+  orka secret [command]
+
+Available Commands:
+  list        List secret resources
+
+Flags:
+  -h, --help   help for secret
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka secret [command] --help" for more information about a command.
+```
+
+## `orka secret list`
+
+```text
+List secret resources
+
+Usage:
+  orka secret list [flags]
+
+Flags:
+      --continue string   Continue/cursor token for the next page
+      --cursor string     Cursor token for the next page
+  -h, --help              help for list
+      --limit int         Maximum number of results (default 100)
+  -o, --output string     Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka session`
+
+```text
+Manage sessions
+
+Usage:
+  orka session [command]
+
+Available Commands:
+  delete      Delete a session resource
+  get         Get a session resource
+  list        List session resources
+
+Flags:
+  -h, --help   help for session
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka session [command] --help" for more information about a command.
+```
+
+## `orka session list`
+
+```text
+List session resources
+
+Usage:
+  orka session list [flags]
+
+Flags:
+      --continue string   Continue/cursor token for the next page
+      --cursor string     Cursor token for the next page
+  -h, --help              help for list
+      --limit int         Maximum number of results (default 100)
+  -o, --output string     Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka session get`
+
+```text
+Get a session resource
+
+Usage:
+  orka session get <name> [flags]
+
+Flags:
+  -h, --help            help for get
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka session delete`
+
+```text
+Delete a session resource
+
+Usage:
+  orka session delete <name> [flags]
+
+Flags:
+  -h, --help   help for delete
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka memory`
+
+```text
+Manage durable memory
+
+Usage:
+  orka memory [command]
+
+Available Commands:
+  create      Create a memory
+  delete      Delete a memory
+  disable     Disable a memory
+  enable      Enable a memory
+  get         Get a memory
+  list        List memories
+  proposal    Manage memory proposals
+  update      Update a memory
+
+Flags:
+  -h, --help   help for memory
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka memory [command] --help" for more information about a command.
+```
+
+## `orka memory list`
+
+```text
+List memories
+
+Usage:
+  orka memory list [flags]
+
+Flags:
+      --agentName string     Filter by agentName
+  -h, --help                 help for list
+      --ids string           Filter by ids
+      --include-deleted      Include deleted memories
+      --include-disabled     Include disabled memories
+      --limit int            Maximum number of results (default 100)
+  -o, --output string        Output format: table, json, yaml (default "table")
+      --parentTask string    Filter by parentTask
+      --query string         Filter by query
+      --sessionName string   Filter by sessionName
+      --source string        Filter by source
+      --tags string          Filter by tags
+      --taskName string      Filter by taskName
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka memory get`
+
+```text
+Get a memory
+
+Usage:
+  orka memory get <id> [flags]
+
+Flags:
+  -h, --help            help for get
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka memory create`
+
+```text
+Create a memory
+
+Usage:
+  orka memory create [flags]
+
+Flags:
+      --content string   Memory content
+  -f, --file string      Path to memory JSON/YAML body
+  -h, --help             help for create
+      --source string    Memory source (default "cli")
+      --tags string      Comma-separated tags
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka memory update`
+
+```text
+Update a memory
+
+Usage:
+  orka memory update <id> [flags]
+
+Flags:
+      --content string   Memory content
+  -f, --file string      Path to memory JSON/YAML body
+  -h, --help             help for update
+      --source string    Memory source
+      --tags string      Comma-separated tags
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka memory delete`
+
+```text
+Delete a memory
+
+Usage:
+  orka memory delete <id> [flags]
+
+Flags:
+  -h, --help   help for delete
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka memory enable`
+
+```text
+Enable a memory
+
+Usage:
+  orka memory enable <id> [flags]
+
+Flags:
+  -h, --help   help for enable
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka memory disable`
+
+```text
+Disable a memory
+
+Usage:
+  orka memory disable <id> [flags]
+
+Flags:
+  -h, --help   help for disable
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka memory proposal`
+
+```text
+Manage memory proposals
+
+Usage:
+  orka memory proposal [command]
+
+Available Commands:
+  apply       Apply an accepted memory proposal
+  archive     Archive a memory proposal
+  get         Get a memory proposal
+  list        List memory proposals
+  review      Review a memory proposal
+
+Flags:
+  -h, --help   help for proposal
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka memory proposal [command] --help" for more information about a command.
+```
+
+## `orka memory proposal list`
+
+```text
+List memory proposals
+
+Usage:
+  orka memory proposal list [flags]
+
+Flags:
+      --agent-name string   Filter by agent name
+  -h, --help                help for list
+      --limit int           Maximum number of results (default 100)
+  -o, --output string       Output format: table, json, yaml (default "table")
+      --query string        Search query
+      --status string       Filter by proposal status
+      --task-name string    Filter by task name
+      --type string         Filter by proposal type
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka memory proposal get`
+
+```text
+Get a memory proposal
+
+Usage:
+  orka memory proposal get <id> [flags]
+
+Flags:
+  -h, --help            help for get
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka memory proposal review`
+
+```text
+Review a memory proposal
+
+Usage:
+  orka memory proposal review <id> [flags]
+
+Flags:
+  -h, --help              help for review
+      --note string       Review note
+      --reviewer string   Reviewer name
+      --status string     Review status (accepted or rejected)
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka memory proposal apply`
+
+```text
+Apply an accepted memory proposal
+
+Usage:
+  orka memory proposal apply <id> [flags]
+
+Flags:
+      --applied-by string   Reviewer applying the proposal
+  -h, --help                help for apply
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka memory proposal archive`
+
+```text
+Archive a memory proposal
+
+Usage:
+  orka memory proposal archive <id> [flags]
+
+Flags:
+  -h, --help   help for archive
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security`
+
+```text
+Manage repository security scans
+
+Usage:
+  orka security [command]
+
+Available Commands:
+  dropped-findings Inspect dropped findings
+  finding          Manage security findings
+  repo             Manage security repository scan configs
+  scan             Run and list security scan runs
+  slice            Inspect security review slices
+  threat-model     Manage security threat models
+
+Flags:
+  -h, --help   help for security
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka security [command] --help" for more information about a command.
+```
+
+## `orka security repo`
+
+```text
+Manage security repository scan configs
+
+Usage:
+  orka security repo [command]
+
+Available Commands:
+  create      Create a repository scan resource from a manifest
+  delete      Delete a repository scan resource
+  get         Get a repository scan resource
+  list        List repository scan resources
+  update      Update a repository scan resource from a manifest
+
+Flags:
+  -h, --help   help for repo
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka security repo [command] --help" for more information about a command.
+```
+
+## `orka security repo list`
+
+```text
+List repository scan resources
+
+Usage:
+  orka security repo list [flags]
+
+Flags:
+      --continue string   Continue/cursor token for the next page
+      --cursor string     Cursor token for the next page
+  -h, --help              help for list
+      --limit int         Maximum number of results (default 100)
+  -o, --output string     Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security repo get`
+
+```text
+Get a repository scan resource
+
+Usage:
+  orka security repo get <name> [flags]
+
+Flags:
+  -h, --help            help for get
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security repo create`
+
+```text
+Create a repository scan resource from a manifest
+
+Usage:
+  orka security repo create -f <file> [flags]
+
+Flags:
+  -f, --file string   Path to YAML/JSON manifest (use - for stdin)
+  -h, --help          help for create
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security repo update`
+
+```text
+Update a repository scan resource from a manifest
+
+Usage:
+  orka security repo update <name> -f <file> [flags]
+
+Flags:
+  -f, --file string   Path to YAML/JSON manifest (use - for stdin)
+  -h, --help          help for update
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security repo delete`
+
+```text
+Delete a repository scan resource
+
+Usage:
+  orka security repo delete <name> [flags]
+
+Flags:
+  -h, --help   help for delete
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security scan`
+
+```text
+Run and list security scan runs
+
+Usage:
+  orka security scan [command]
+
+Available Commands:
+  list        List security scan runs
+  run         Run a manual security scan
+
+Flags:
+  -h, --help   help for scan
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka security scan [command] --help" for more information about a command.
+```
+
+## `orka security scan run`
+
+```text
+Run a manual security scan
+
+Usage:
+  orka security scan run <repo> [flags]
+
+Flags:
+  -h, --help   help for run
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security scan list`
+
+```text
+List security scan runs
+
+Usage:
+  orka security scan list <repo> [flags]
+
+Flags:
+      --continue string   Continue token
+      --cursor string     Cursor token
+  -h, --help              help for list
+      --limit int         Maximum number of results (default 20)
+  -o, --output string     Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security threat-model`
+
+```text
+Manage security threat models
+
+Usage:
+  orka security threat-model [command]
+
+Available Commands:
+  get         Get latest threat model
+  update      Update threat model
+
+Flags:
+  -h, --help   help for threat-model
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka security threat-model [command] --help" for more information about a command.
+```
+
+## `orka security threat-model get`
+
+```text
+Get latest threat model
+
+Usage:
+  orka security threat-model get <repo> [flags]
+
+Flags:
+  -h, --help            help for get
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security threat-model update`
+
+```text
+Update threat model
+
+Usage:
+  orka security threat-model update <repo> [flags]
+
+Flags:
+      --content string   Threat model content
+  -f, --file string      Path to threat model content
+  -h, --help             help for update
+      --source string    Threat model source (default "edited")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security finding`
+
+```text
+Manage security findings
+
+Usage:
+  orka security finding [command]
+
+Available Commands:
+  dismiss     dismiss a security finding
+  get         Get a security finding
+  list        List security findings
+  patch       patch a security finding
+  patches     List security patch proposals
+  pr          Create a pull request for the latest patch proposal
+  reopen      reopen a security finding
+  validate    validate a security finding
+
+Flags:
+  -h, --help   help for finding
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka security finding [command] --help" for more information about a command.
+```
+
+## `orka security finding list`
+
+```text
+List security findings
+
+Usage:
+  orka security finding list <repo> [flags]
+
+Flags:
+      --category string            Filter by category
+      --continue string            Continue token
+      --cursor string              Cursor token
+  -h, --help                       help for list
+      --limit int                  Maximum number of results (default 50)
+  -o, --output string              Output format: table, json, yaml (default "table")
+      --recommended                Only recommended findings
+      --severity string            Filter by severity
+      --slice-id string            Filter by slice ID
+      --state string               Filter by state
+      --validation-status string   Filter by validation status
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security finding get`
+
+```text
+Get a security finding
+
+Usage:
+  orka security finding get <id> [flags]
+
+Flags:
+  -h, --help            help for get
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security finding dismiss`
+
+```text
+dismiss a security finding
+
+Usage:
+  orka security finding dismiss <id> [flags]
+
+Flags:
+  -h, --help   help for dismiss
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security finding reopen`
+
+```text
+reopen a security finding
+
+Usage:
+  orka security finding reopen <id> [flags]
+
+Flags:
+  -h, --help   help for reopen
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security finding validate`
+
+```text
+validate a security finding
+
+Usage:
+  orka security finding validate <id> [flags]
+
+Flags:
+  -h, --help   help for validate
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security finding patch`
+
+```text
+patch a security finding
+
+Usage:
+  orka security finding patch <id> [flags]
+
+Flags:
+  -h, --help            help for patch
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security finding patches`
+
+```text
+List security patch proposals
+
+Usage:
+  orka security finding patches <id> [flags]
+
+Flags:
+  -h, --help            help for patches
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security finding pr`
+
+```text
+Create a pull request for the latest patch proposal
+
+Usage:
+  orka security finding pr <id> [flags]
+
+Flags:
+  -h, --help            help for pr
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security slice`
+
+```text
+Inspect security review slices
+
+Usage:
+  orka security slice [command]
+
+Available Commands:
+  get         Get a security review slice
+  list        List security review slices
+
+Flags:
+  -h, --help   help for slice
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka security slice [command] --help" for more information about a command.
+```
+
+## `orka security slice list`
+
+```text
+List security review slices
+
+Usage:
+  orka security slice list <repo> [flags]
+
+Flags:
+      --continue string   Continue token
+      --cursor string     Cursor token
+  -h, --help              help for list
+      --limit int         Maximum number of results (default 100)
+  -o, --output string     Output format: table, json, yaml (default "table")
+      --status string     Filter by status
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security slice get`
+
+```text
+Get a security review slice
+
+Usage:
+  orka security slice get <repo> <slice-id> [flags]
+
+Flags:
+  -h, --help            help for get
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka security dropped-findings`
+
+```text
+Inspect dropped findings
+
+Usage:
+  orka security dropped-findings [command]
+
+Available Commands:
+  list        List dropped security findings
+
+Flags:
+  -h, --help   help for dropped-findings
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka security dropped-findings [command] --help" for more information about a command.
+```
+
+## `orka security dropped-findings list`
+
+```text
+List dropped security findings
+
+Usage:
+  orka security dropped-findings list <repo> [flags]
+
+Flags:
+      --continue string   Continue token
+      --cursor string     Cursor token
+  -h, --help              help for list
+      --limit int         Maximum number of results (default 50)
+  -o, --output string     Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka monitor`
+
+```text
+Manage repository monitors
+
+Usage:
+  orka monitor [command]
+
+Available Commands:
+  create      Create a repository monitor resource from a manifest
+  delete      Delete a repository monitor resource
+  events      List repository monitor events
+  get         Get a repository monitor resource
+  items       List repository monitor items
+  list        List repository monitor resources
+  run         Trigger a manual repository monitor run
+  runs        List repository monitor runs
+  update      Update a repository monitor resource from a manifest
+
+Flags:
+  -h, --help   help for monitor
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka monitor [command] --help" for more information about a command.
+```
+
+## `orka monitor list`
+
+```text
+List repository monitor resources
+
+Usage:
+  orka monitor list [flags]
+
+Flags:
+      --continue string   Continue/cursor token for the next page
+      --cursor string     Cursor token for the next page
+  -h, --help              help for list
+      --limit int         Maximum number of results (default 100)
+  -o, --output string     Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka monitor get`
+
+```text
+Get a repository monitor resource
+
+Usage:
+  orka monitor get <name> [flags]
+
+Flags:
+  -h, --help            help for get
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka monitor create`
+
+```text
+Create a repository monitor resource from a manifest
+
+Usage:
+  orka monitor create -f <file> [flags]
+
+Flags:
+  -f, --file string   Path to YAML/JSON manifest (use - for stdin)
+  -h, --help          help for create
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka monitor update`
+
+```text
+Update a repository monitor resource from a manifest
+
+Usage:
+  orka monitor update <name> -f <file> [flags]
+
+Flags:
+  -f, --file string   Path to YAML/JSON manifest (use - for stdin)
+  -h, --help          help for update
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka monitor delete`
+
+```text
+Delete a repository monitor resource
+
+Usage:
+  orka monitor delete <name> [flags]
+
+Flags:
+  -h, --help   help for delete
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka monitor run`
+
+```text
+Trigger a manual repository monitor run
+
+Usage:
+  orka monitor run <name> [flags]
+
+Flags:
+  -h, --help                 help for run
+      --target-kind string   Target kind (e.g. pull_request)
+      --target-number int    Target number
+      --target-sha string    Target commit SHA
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka monitor runs`
+
+```text
+List repository monitor runs
+
+Usage:
+  orka monitor runs <name> [flags]
+
+Flags:
+      --continue string      Continue token
+      --cursor string        Cursor token
+  -h, --help                 help for runs
+      --limit int            Maximum number of results (default 20)
+  -o, --output string        Output format: table, json, yaml (default "table")
+      --target-kind string   Filter by target kind
+      --trigger string       Filter by trigger
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka monitor items`
+
+```text
+List repository monitor items
+
+Usage:
+  orka monitor items <name> [flags]
+
+Flags:
+      --automerge-state string   Filter by automerge state
+      --continue string          Continue token
+      --cursor string            Cursor token
+  -h, --help                     help for items
+      --kind string              Filter by item kind
+      --limit int                Maximum number of results (default 50)
+  -o, --output string            Output format: table, json, yaml (default "table")
+      --repair-state string      Filter by repair state
+      --state string             Filter by state
+      --verdict string           Filter by review verdict
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka monitor events`
+
+```text
+List repository monitor events
+
+Usage:
+  orka monitor events [name] [flags]
+
+Flags:
+      --continue string     Continue token
+      --cursor string       Cursor token
+      --event-type string   Filter by event type
+  -h, --help                help for events
+      --item-kind string    Filter by item kind
+      --item-number int     Filter by item number
+      --limit int           Maximum number of results (default 50)
+      --name string         Repository monitor name
+  -o, --output string       Output format: table, json, yaml (default "table")
+      --run-id string       Filter by run ID
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka substrate`
+
+```text
+Inspect and manage substrate resources
+
+Usage:
+  orka substrate [command]
+
+Available Commands:
+  pool        Manage substrate actor pools
+
+Flags:
+  -h, --help   help for substrate
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka substrate [command] --help" for more information about a command.
+```
+
+## `orka substrate pool`
+
+```text
+Manage substrate actor pools
+
+Usage:
+  orka substrate pool [command]
+
+Available Commands:
+  create      Create a substrate pool resource from a manifest
+  delete      Delete a substrate pool resource
+  get         Get a substrate pool resource
+  list        List substrate pool resources
+  update      Update a substrate pool resource from a manifest
+
+Flags:
+  -h, --help   help for pool
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka substrate pool [command] --help" for more information about a command.
+```
+
+## `orka substrate pool list`
+
+```text
+List substrate pool resources
+
+Usage:
+  orka substrate pool list [flags]
+
+Flags:
+      --continue string   Continue/cursor token for the next page
+      --cursor string     Cursor token for the next page
+  -h, --help              help for list
+      --limit int         Maximum number of results (default 100)
+  -o, --output string     Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka substrate pool get`
+
+```text
+Get a substrate pool resource
+
+Usage:
+  orka substrate pool get <name> [flags]
+
+Flags:
+  -h, --help            help for get
+  -o, --output string   Output format: table, json, yaml (default "json")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka substrate pool create`
+
+```text
+Create a substrate pool resource from a manifest
+
+Usage:
+  orka substrate pool create -f <file> [flags]
+
+Flags:
+  -f, --file string   Path to YAML/JSON manifest (use - for stdin)
+  -h, --help          help for create
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka substrate pool update`
+
+```text
+Update a substrate pool resource from a manifest
+
+Usage:
+  orka substrate pool update <name> -f <file> [flags]
+
+Flags:
+  -f, --file string   Path to YAML/JSON manifest (use - for stdin)
+  -h, --help          help for update
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka substrate pool delete`
+
+```text
+Delete a substrate pool resource
+
+Usage:
+  orka substrate pool delete <name> [flags]
+
+Flags:
+  -h, --help   help for delete
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka completion`
+
+```text
+Generate the autocompletion script for orka for the specified shell.
+See each sub-command's help for details on how to use the generated script.
+
+Usage:
+  orka completion [command]
+
+Available Commands:
+  bash        Generate the autocompletion script for bash
+  fish        Generate the autocompletion script for fish
+  powershell  Generate the autocompletion script for powershell
+  zsh         Generate the autocompletion script for zsh
+
+Flags:
+  -h, --help   help for completion
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+
+Use "orka completion [command] --help" for more information about a command.
+```
+

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -13,7 +13,7 @@ make build-cli
 bin/orka --help
 ```
 
-Install or copy `bin/orka` wherever you keep developer tools if you want `orka` on your `PATH`.
+Install or copy `bin/orka` wherever you keep developer tools if you want `orka` on your `PATH`. For exhaustive flag and subcommand help generated from Cobra, see [CLI Command Reference](./cli-commands.md).
 
 ## Connection and authentication
 
@@ -32,11 +32,12 @@ The CLI reads persistent config from `~/.orka/config.yaml`:
 
 ```bash
 orka config set-server http://127.0.0.1:8080
-orka config set-token "$(kubectl create token orka-client -n orka-system)"
+orka config set-namespace orka-system
+kubectl create token orka-client -n orka-system | orka config set-token --file -
 orka config view
 ```
 
-`config view` masks the token. `config set-token` necessarily receives the token as a process argument, so use short-lived tokens and avoid pasting long-lived secrets into shell history.
+`config view` masks the token. Prefer `config set-token --file <path>` or `--file -` over passing real tokens as process arguments. If you use `config set-token <token>` directly, use short-lived tokens and avoid pasting long-lived secrets into shell history.
 
 Validate auth before running larger workflows:
 
@@ -116,7 +117,19 @@ It may depend on live provider credentials, model configuration, and server-side
 orka login --service-account orka-client --namespace orka-system
 ```
 
-Do not use `login` in logs or shared terminals where the generated browser URL might be captured.
+For automation, tests, or terminals where token-bearing URLs could be captured, use the safe print-only mode:
+
+```bash
+orka login \
+  --service-account orka-client \
+  --namespace orka-system \
+  --no-open \
+  --redact-token
+```
+
+`--no-open` skips browser launch. `--redact-token` prints `<redacted>` instead of the raw token while still using the full token internally if browser opening is enabled. A redacted URL is not usable for manual login; rerun without `--redact-token` only in a trusted terminal if you need to copy the full URL.
+
+Do not use default `login` output in logs or shared terminals where the generated browser URL might be captured.
 
 ## Resource management commands
 
@@ -197,6 +210,47 @@ orka monitor delete my-monitor
 ```
 
 Manual run/action commands such as `orka security scan run`, `orka monitor run`, and finding patch/PR actions can create downstream Tasks and may require live GitHub, provider, and agent configuration.
+
+## Live-gated workflows
+
+Some commands intentionally create downstream work or require external services. Keep these behind explicit operator intent in automation and e2e tests.
+
+### `orka run`
+
+`orka run` streams chat responses over the Orka chat API. A positive smoke needs server-side chat enabled plus a configured provider/model or agent:
+
+```bash
+ORKA_API=http://127.0.0.1:8080
+ORKA_TOKEN="$(kubectl create token orka-client -n orka-system)"
+
+orka --server "$ORKA_API" --token "$ORKA_TOKEN" \
+  run --session cli-live-smoke "Reply with one short sentence."
+```
+
+For normal non-live validation, prefer a negative smoke against an unreachable or deliberately unconfigured server and assert a clean error without printing tokens.
+
+### `orka security scan run`
+
+Manual security scan runs can create scan Tasks and may require GitHub credentials, analysis agents, provider credentials, and repository network access:
+
+```bash
+orka security scan run my-repository-scan
+orka security scan list my-repository-scan -o json
+```
+
+Gate this path with explicit environment variables in CI, for example `ORKA_CLI_E2E_LIVE_ACTIONS=1`, and skip by default when credentials or fixtures are missing.
+
+### `orka monitor run`
+
+Manual repository monitor runs can enqueue repository review/repair work and may require GitHub credentials plus reviewer/repair agents:
+
+```bash
+orka monitor run my-monitor --target-kind pull_request --target-number 123
+orka monitor runs my-monitor -o json
+orka monitor items my-monitor -o json
+```
+
+Use live-gated tests or manual verification for this path until stable GitHub/provider fixtures are available.
 
 ## Substrate actor pools
 
@@ -282,9 +336,9 @@ Normal binary e2e tests build and invoke `bin/orka` directly with isolated confi
 | `security` | Partially covered | Repository scan create/get/list/delete, threat model update/get, scan/finding/slice/dropped-finding list; repository scan update is not covered. |
 | `monitor` | Partially covered | Repository monitor create/get/list/delete plus runs/items/events list; monitor update is not covered. |
 | `substrate` | Covered | Pool create/get/list/update/delete. |
-| `run` | Deferred/live-gated | Depends on chat/SSE/provider fixtures. |
-| `login` | Deferred | Browser-open behavior and token-bearing URL make normal e2e unsafe until a no-open/redacted test mode exists. |
-| `completion` | Not custom-covered | Cobra-generated shell completion; add binary e2e only if project-specific completion behavior is added. |
+| `run` | Negative covered; positive live-gated | Unreachable-server error path is safe for normal e2e; positive chat/SSE flow needs provider fixtures. |
+| `login` | Safe mode covered | `--no-open --redact-token` is covered; full browser-open token URL remains unsuitable for normal e2e logs. |
+| `completion` | Covered | Binary smoke generates bash, zsh, fish, and PowerShell completion output. |
 | `security scan run` | Deferred/live-gated | Creates downstream scan Tasks and requires live agent/GitHub/provider setup. |
 | `monitor run` | Deferred/live-gated | Creates downstream monitor work and can require GitHub/provider setup. |
 | security finding actions | Deferred/live-gated | Need stable finding fixtures or live scan data. |

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -41,6 +41,7 @@ const sidebars = {
       items: [
         'reference/api-reference',
         'reference/cli',
+        'reference/cli-commands',
         'reference/openai-compat',
         'reference/anthropic-compat',
       ],


### PR DESCRIPTION
## Summary

Follow-up CLI polish after #180/#185:

- Add safe dashboard login modes:
  - `orka login --no-open`
  - `orka login --redact-token`
- Add safer CLI config helpers:
  - `orka config set-token --file <path>` / `--file -`
  - `orka config set-namespace <namespace>`
- Add compiled-binary e2e smokes for:
  - shell completions (`bash`, `zsh`, `fish`, `powershell`)
  - safe redacted login output
  - clean `orka run` unreachable-server failure
  - optional live-gated security/monitor action paths behind `ORKA_CLI_E2E_LIVE_ACTIONS=1`
- Add generated CLI command reference docs:
  - `scripts/generate-cli-docs.sh`
  - `make docs-cli`
  - `make docs-cli-check`
  - `website/docs/reference/cli-commands.md`
- Expand the hand-written CLI reference with safe login/config guidance and live-gated workflow notes.

## Why

The CLI surface now has broad binary e2e coverage. This follow-up closes the remaining safety/docs gaps: login can be tested without browser launch or token-bearing output, config can avoid putting tokens in argv, and generated command docs reduce drift from Cobra help.

## Validation

Passed:

- `go test -tags=e2e ./test/e2e -run '^$'`
- `go test ./cmd/cli ./internal/cli/client ./internal/api ./internal/tools`
- `make lint-fix`
- `make docs-cli-check`
- `cd website && yarn build`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Additional check:

- `go test -p 1 ./internal/api -count=1`

Note: one full local `make test` attempt hit an `internal/api` timeout in `TestHandleChatCompletions_NonStreamingResponse`; the named test passed in isolation and the package passed with `-p 1`, indicating a local concurrency flake unrelated to these CLI changes.

No agent transcript included, following maintainer preference from the preceding PRs.
