### PR TITLE
Orka UI visual redesign: deep-ocean identity, status/liveness language, execution graph & cockpit

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "temp-vite",
       "dependencies": {
+        "@fontsource/inter": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "@tanstack/react-query": "5",
         "@tanstack/react-router": "1",
         "class-variance-authority": "^0.7.1",
@@ -192,6 +194,10 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.7", "", { "dependencies": { "@floating-ui/dom": "^1.7.5" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+
+    "@fontsource/inter": ["@fontsource/inter@5.2.8", "", {}, "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg=="],
+
+    "@fontsource/jetbrains-mono": ["@fontsource/jetbrains-mono@5.2.8", "", {}, "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -5,6 +5,20 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Orka</title>
+    <script>
+      // Kill dark-mode FOUC: apply the persisted theme before first paint.
+      // Mirrors the zustand `persist` store keyed as "orka-ui"
+      // ({ state: { theme } }). __root.tsx remains the post-hydration source of truth.
+      (function () {
+        try {
+          var raw = localStorage.getItem('orka-ui')
+          var theme = raw && JSON.parse(raw).state && JSON.parse(raw).state.theme
+          if (theme === 'dark') document.documentElement.classList.add('dark')
+        } catch (e) {
+          /* ignore malformed storage; React syncs on mount */
+        }
+      })()
+    </script>
   </head>
   <body class="min-h-screen bg-background font-sans antialiased">
     <div id="root"></div>

--- a/ui/index.html
+++ b/ui/index.html
@@ -12,8 +12,10 @@
       (function () {
         try {
           var raw = localStorage.getItem('orka-ui')
-          var theme = raw && JSON.parse(raw).state && JSON.parse(raw).state.theme
-          if (theme === 'dark') document.documentElement.classList.add('dark')
+          var parsed = raw ? JSON.parse(raw) : null
+          if (parsed && parsed.state && parsed.state.theme === 'dark') {
+            document.documentElement.classList.add('dark')
+          }
         } catch (e) {
           /* ignore malformed storage; React syncs on mount */
         }

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@fontsource/inter": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "@tanstack/react-query": "5",
     "@tanstack/react-router": "1",
     "class-variance-authority": "^0.7.1",

--- a/ui/public/favicon.svg
+++ b/ui/public/favicon.svg
@@ -1,3 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <text y=".9em" font-size="90">🐟</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Orka">
+  <defs>
+    <linearGradient id="orca" x1="6" y1="10" x2="58" y2="54" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#38E2F2" />
+      <stop offset="1" stop-color="#0EA5E9" />
+    </linearGradient>
+  </defs>
+  <g fill="url(#orca)">
+    <!-- tail flukes -->
+    <path d="M11 34 C6 31 3 28 1 27 C4 30 6 32 8 34 C6 36 4 38 1 41 C4 40 7 37 11 34 Z" />
+    <!-- body, facing right -->
+    <path d="M10 34 C10 30 16 27 24 27 C32 27 38 27 45 28 C51 29 56 31 56 34 C56 37 51 39 45 40 C37 41 31 41 24 40 C16 39 10 38 10 34 Z" />
+    <!-- dorsal fin -->
+    <path d="M27 27 C28 18 31 13 34 11 C35 16 35 23 37 27 Z" />
+    <!-- pectoral fin -->
+    <path d="M34 39 C36 45 39 49 42 51 C42 46 41 42 41 39 Z" />
+  </g>
+  <!-- eye patch -->
+  <ellipse cx="48" cy="31" rx="4.2" ry="2.5" fill="#F6FEFF" transform="rotate(-16 48 31)" />
+  <!-- eye -->
+  <circle cx="50.5" cy="33" r="1.7" fill="#0A0E14" />
 </svg>

--- a/ui/public/favicon.svg
+++ b/ui/public/favicon.svg
@@ -1,22 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Orka">
-  <defs>
-    <linearGradient id="orca" x1="6" y1="10" x2="58" y2="54" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#38E2F2" />
-      <stop offset="1" stop-color="#0EA5E9" />
-    </linearGradient>
-  </defs>
-  <g fill="url(#orca)">
-    <!-- tail flukes -->
-    <path d="M11 34 C6 31 3 28 1 27 C4 30 6 32 8 34 C6 36 4 38 1 41 C4 40 7 37 11 34 Z" />
-    <!-- body, facing right -->
-    <path d="M10 34 C10 30 16 27 24 27 C32 27 38 27 45 28 C51 29 56 31 56 34 C56 37 51 39 45 40 C37 41 31 41 24 40 C16 39 10 38 10 34 Z" />
-    <!-- dorsal fin -->
-    <path d="M27 27 C28 18 31 13 34 11 C35 16 35 23 37 27 Z" />
-    <!-- pectoral fin -->
-    <path d="M34 39 C36 45 39 49 42 51 C42 46 41 42 41 39 Z" />
-  </g>
-  <!-- eye patch -->
-  <ellipse cx="48" cy="31" rx="4.2" ry="2.5" fill="#F6FEFF" transform="rotate(-16 48 31)" />
-  <!-- eye -->
-  <circle cx="50.5" cy="33" r="1.7" fill="#0A0E14" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50" y="86" font-size="88" text-anchor="middle">🐋</text>
 </svg>

--- a/ui/src/components/agents/agent-create-form.tsx
+++ b/ui/src/components/agents/agent-create-form.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
+import { PageHeader } from '@/components/layout/page-header'
 import { useCreateAgent } from '@/hooks/use-agents'
 import { useSecretNames } from '@/hooks/use-secrets'
 import { useUIStore } from '@/stores/ui'
@@ -72,10 +73,7 @@ export function AgentCreateForm() {
 
   return (
     <div className="space-y-4">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Create Agent</h1>
-        <p className="text-muted-foreground">Configure a new AI agent</p>
-      </div>
+      <PageHeader title="Create Agent" description="Configure a new AI agent" />
       <Card>
         <CardHeader>
           <CardTitle>Agent Configuration</CardTitle>

--- a/ui/src/components/agents/agent-detail.tsx
+++ b/ui/src/components/agents/agent-detail.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Separator } from '@/components/ui/separator'
+import { PageHeader } from '@/components/layout/page-header'
 import { ArrowLeft, Bot, Trash2 } from 'lucide-react'
 import { useAgent, useDeleteAgent } from '@/hooks/use-agents'
 import { toast } from 'sonner'
@@ -34,20 +35,21 @@ export function AgentDetail({ agentId }: { agentId: string }) {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Link to="/agents"><Button variant="ghost" size="icon"><ArrowLeft className="h-4 w-4" /></Button></Link>
-          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
-            <Bot className="h-5 w-5 text-primary" />
-          </div>
-          <div>
-            <h1 className="text-3xl font-bold tracking-tight">{agent.metadata.name}</h1>
-            <p className="text-muted-foreground">{agent.metadata.namespace}</p>
-          </div>
+      <div className="flex items-center gap-4">
+        <Link to="/agents"><Button variant="ghost" size="icon"><ArrowLeft className="h-4 w-4" /></Button></Link>
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+          <Bot className="h-5 w-5 text-primary" />
         </div>
-        <Button variant="destructive" size="sm" onClick={handleDelete} disabled={deleteAgent.isPending}>
-          <Trash2 className="mr-2 h-4 w-4" />{deleteAgent.isPending ? 'Deleting...' : 'Delete'}
-        </Button>
+        <PageHeader
+          className="flex-1"
+          title={agent.metadata.name}
+          description={agent.metadata.namespace}
+          action={
+            <Button variant="destructive" size="sm" onClick={handleDelete} disabled={deleteAgent.isPending}>
+              <Trash2 className="mr-2 h-4 w-4" />{deleteAgent.isPending ? 'Deleting...' : 'Delete'}
+            </Button>
+          }
+        />
       </div>
 
       <div className="grid gap-4 md:grid-cols-2">

--- a/ui/src/components/agents/agent-list.tsx
+++ b/ui/src/components/agents/agent-list.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
+import { PageHeader } from '@/components/layout/page-header'
 import { Bot, Plus } from 'lucide-react'
 import { useAgentList } from '@/hooks/use-agents'
 import type { Agent } from '@/schemas/agent'
@@ -12,15 +13,15 @@ export function AgentList() {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Agents</h1>
-          <p className="text-muted-foreground">Registered AI agent configurations</p>
-        </div>
-        <Link to="/agents/new">
-          <Button><Plus className="mr-2 h-4 w-4" />New Agent</Button>
-        </Link>
-      </div>
+      <PageHeader
+        title="Agents"
+        description="Registered AI agent configurations"
+        action={
+          <Link to="/agents/new">
+            <Button><Plus className="mr-2 h-4 w-4" />New Agent</Button>
+          </Link>
+        }
+      />
 
       {isLoading ? (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/ui/src/components/chat/chat-message-list.test.tsx
+++ b/ui/src/components/chat/chat-message-list.test.tsx
@@ -20,10 +20,12 @@ beforeEach(() => {
 })
 
 describe('ChatMessageList', () => {
-  it('empty state shows welcome text with orca emoji', () => {
+  it('empty state shows welcome text with orca brand mark', () => {
     render(<ChatMessageList />)
-    expect(screen.getByText('🐋')).toBeInTheDocument()
     expect(screen.getByText('Orka Meta Agent')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Chat with the orchestrator/i),
+    ).toBeInTheDocument()
   })
 
   it('with messages in store, renders ChatMessage for each', () => {

--- a/ui/src/components/chat/chat-message-list.tsx
+++ b/ui/src/components/chat/chat-message-list.tsx
@@ -3,6 +3,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { ChatMessage } from './chat-message'
 import { useChatStore } from '@/stores/chat'
 import { Loader2 } from 'lucide-react'
+import { OrcaMark } from '@/components/ui/orca-mark'
 
 export function ChatMessageList() {
   const messages = useChatStore((s) => s.messages)
@@ -18,7 +19,7 @@ export function ChatMessageList() {
     return (
       <div className="flex flex-1 items-center justify-center">
         <div className="text-center">
-          <span className="text-4xl">🐋</span>
+          <OrcaMark className="mx-auto h-12 w-12" />
           <h3 className="mt-4 text-lg font-semibold">Orka Meta Agent</h3>
           <p className="mt-1 max-w-sm text-sm text-muted-foreground">
             Chat with the orchestrator to create and manage tasks, agents, and tools using natural language.

--- a/ui/src/components/chat/chat-message.test.tsx
+++ b/ui/src/components/chat/chat-message.test.tsx
@@ -5,6 +5,14 @@ vi.mock('zustand/middleware', async () => {
   return { ...actual, persist: (fn: any) => fn }
 })
 
+vi.mock('@tanstack/react-router', async () => {
+  const actual = await vi.importActual('@tanstack/react-router')
+  return {
+    ...actual,
+    Link: ({ children, to, ...props }: any) => <a href={to} {...props}>{children}</a>,
+  }
+})
+
 import { render, screen } from '@/test/test-utils'
 import { ChatMessage } from './chat-message'
 import { useUIStore } from '@/stores/ui'
@@ -110,5 +118,26 @@ describe('ChatMessage', () => {
     expect(screen.getByText('1 LLM calls')).toBeInTheDocument()
     expect(screen.getByText('2 tool calls')).toBeInTheDocument()
     expect(screen.getByText('1.5s')).toBeInTheDocument()
+  })
+
+  it('renders clickable task chips when the turn created tasks', () => {
+    const msg: ChatMessageType = {
+      id: 'msg-7',
+      role: 'assistant',
+      content: 'Created two tasks.',
+      timestamp: new Date().toISOString(),
+      usage: { tasksCreated: 2 },
+      tasksCreatedNames: ['task-alpha', 'task-beta'],
+    }
+    render(<ChatMessage message={msg} />)
+    const alpha = screen.getByRole('link', { name: /task-alpha/ })
+    const beta = screen.getByRole('link', { name: /task-beta/ })
+    expect(alpha).toHaveAttribute('href', '/tasks/$taskId')
+    expect(beta).toBeInTheDocument()
+  })
+
+  it('renders no task chips when none were created', () => {
+    render(<ChatMessage message={assistantMsg} />)
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
   })
 })

--- a/ui/src/components/chat/chat-message.tsx
+++ b/ui/src/components/chat/chat-message.tsx
@@ -1,6 +1,7 @@
+import { Link } from '@tanstack/react-router'
 import { Bot, User, AlertCircle, Info } from 'lucide-react'
-import { cn } from '@/lib/utils'
 import { ChatToolCall } from './chat-tool-call'
+import { StatusDot } from '@/components/ui/status-dot'
 import type { ChatMessage as ChatMessageType } from '@/schemas/chat'
 
 export function ChatMessage({ message }: { message: ChatMessageType }) {
@@ -35,26 +36,48 @@ export function ChatMessage({ message }: { message: ChatMessageType }) {
 
   const isUser = message.role === 'user'
 
-  return (
-    <div className={cn('flex gap-3 py-2', isUser ? 'justify-end' : 'justify-start')}>
-      {!isUser && (
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10">
-          <Bot className="h-4 w-4 text-primary" />
-        </div>
-      )}
-      <div className={cn('max-w-[80%] space-y-1')}>
-        <div
-          className={cn(
-            'rounded-2xl px-4 py-2.5 text-sm',
-            isUser
-              ? 'bg-primary text-primary-foreground'
-              : 'bg-muted text-foreground',
-          )}
-        >
+  // User turns keep a right-aligned bubble; assistant turns render flush (like
+  // an agentic console, not a symmetric consumer chat).
+  if (isUser) {
+    return (
+      <div className="flex justify-end gap-3 py-2">
+        <div className="max-w-[80%] rounded-2xl bg-primary px-4 py-2.5 text-sm text-primary-foreground">
           <div className="whitespace-pre-wrap">{message.content}</div>
         </div>
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-secondary">
+          <User className="h-4 w-4" />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex gap-3 py-2">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10">
+        <Bot className="h-4 w-4 text-primary" />
+      </div>
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <div className="whitespace-pre-wrap text-sm text-foreground">{message.content}</div>
+
+        {/* Cross-silo links: tasks created during this turn link into the graph. */}
+        {message.tasksCreatedNames && message.tasksCreatedNames.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {message.tasksCreatedNames.map((name) => (
+              <Link
+                key={name}
+                to="/tasks/$taskId"
+                params={{ taskId: name }}
+                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2 py-0.5 text-xs font-mono transition-colors hover:bg-accent"
+              >
+                <StatusDot phase="Pending" hideLabel />
+                {name}
+              </Link>
+            ))}
+          </div>
+        )}
+
         {message.usage && (
-          <div className="flex gap-3 px-2 text-[10px] text-muted-foreground">
+          <div className="flex flex-wrap gap-3 text-[10px] text-muted-foreground tabular-nums">
             {message.usage.llmCalls !== undefined && <span>{message.usage.llmCalls} LLM calls</span>}
             {message.usage.toolCalls !== undefined && <span>{message.usage.toolCalls} tool calls</span>}
             {message.usage.tasksCreated !== undefined && message.usage.tasksCreated > 0 && (
@@ -64,11 +87,6 @@ export function ChatMessage({ message }: { message: ChatMessageType }) {
           </div>
         )}
       </div>
-      {isUser && (
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-secondary">
-          <User className="h-4 w-4" />
-        </div>
-      )}
     </div>
   )
 }

--- a/ui/src/components/chat/chat-tool-call.test.tsx
+++ b/ui/src/components/chat/chat-tool-call.test.tsx
@@ -70,11 +70,15 @@ describe('ChatToolCall', () => {
   it('clicking toggles expanded state', () => {
     render(<ChatToolCall message={toolCallMsg} />)
     const button = screen.getByRole('button')
-    expect(screen.getByText('▼')).toBeInTheDocument()
+    // Collapsed by default; the Args body is not shown.
+    expect(button).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText('Args')).not.toBeInTheDocument()
     fireEvent.click(button)
-    expect(screen.getByText('▲')).toBeInTheDocument()
+    expect(button).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Args')).toBeInTheDocument()
     fireEvent.click(button)
-    expect(screen.getByText('▼')).toBeInTheDocument()
+    expect(button).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText('Args')).not.toBeInTheDocument()
   })
 
   it('expanded state shows args for tool_call', () => {

--- a/ui/src/components/chat/chat-tool-call.tsx
+++ b/ui/src/components/chat/chat-tool-call.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { cn } from '@/lib/utils'
+import { ChevronRight } from 'lucide-react'
 import type { ChatMessage } from '@/schemas/chat'
 
 export function ChatToolCall({ message }: { message: ChatMessage }) {
@@ -7,23 +8,33 @@ export function ChatToolCall({ message }: { message: ChatMessage }) {
   const isResult = message.role === 'tool_result'
   const success = message.toolSuccess
 
+  // A single status-dot color encodes the tool call's state, drawn from the
+  // shared status tokens (call = info/running, ok = succeeded, fail = failed).
+  const dotClass = isResult
+    ? success
+      ? 'bg-status-succeeded'
+      : 'bg-status-failed'
+    : 'bg-status-running'
+
+  const glyph = isResult ? (success ? '✓' : '✗') : '→'
+
   return (
     <div className="mx-12 my-1">
       <button
         onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
         className={cn(
-          'flex w-full items-center gap-2 rounded-md border px-3 py-1.5 text-left text-xs transition-colors',
-          isResult
-            ? success
-              ? 'border-green-200 bg-green-50 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-200'
-              : 'border-red-200 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200'
-            : 'border-blue-200 bg-blue-50 text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-200',
+          'flex w-full items-center gap-2 rounded-md border border-border bg-card px-3 py-1.5 text-left text-xs transition-colors hover:bg-accent',
         )}
       >
-        <span className="font-mono font-medium">
-          {isResult ? (success ? '✓' : '✗') : '→'} {message.toolName}
+        <span className={cn('inline-block size-1.5 shrink-0 rounded-full', dotClass)} aria-hidden="true" />
+        <span className="font-mono font-medium text-foreground">
+          {glyph} {message.toolName}
         </span>
-        <span className="ml-auto text-[10px] opacity-60">{expanded ? '▲' : '▼'}</span>
+        <ChevronRight
+          className={cn('ml-auto size-3 text-muted-foreground transition-transform', expanded && 'rotate-90')}
+          aria-hidden="true"
+        />
       </button>
       {expanded && (
         <div className="mt-1 rounded-md border border-border bg-muted/50 p-2">

--- a/ui/src/components/dashboard/overview.test.tsx
+++ b/ui/src/components/dashboard/overview.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen } from '@/test/test-utils'
+import { render, screen, waitFor, within } from '@/test/test-utils'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/mocks/server'
 
 vi.mock('zustand/middleware', () => ({
   persist: (fn: unknown) => fn,
@@ -34,5 +36,32 @@ describe('Overview', () => {
   it('renders without crashing', () => {
     render(<Overview />)
     expect(screen.getByText('Overview of your Orka workspace')).toBeInTheDocument()
+  })
+
+  it('includes Scheduled and Cancelled tasks in the phase distribution', async () => {
+    const mk = (name: string, phase: string) => ({
+      metadata: { name, namespace: 'default', uid: name, creationTimestamp: new Date().toISOString() },
+      spec: { type: 'container' },
+      status: { phase },
+    })
+    server.use(
+      http.get('/api/v1/tasks', () =>
+        HttpResponse.json({
+          items: [mk('a', 'Running'), mk('b', 'Scheduled'), mk('c', 'Cancelled')],
+          metadata: {},
+        }),
+      ),
+    )
+    render(<Overview />)
+    const heading = await screen.findByText('Phase Distribution')
+    // Scope assertions to the distribution card (the phase labels also appear
+    // as StatusDots in the Recent Tasks list).
+    const card = heading.closest('[data-slot="card"]') as HTMLElement
+    expect(card).not.toBeNull()
+    await waitFor(() => {
+      expect(within(card).getByText('Scheduled')).toBeInTheDocument()
+    })
+    expect(within(card).getByText('Cancelled')).toBeInTheDocument()
+    expect(within(card).getByText('Running')).toBeInTheDocument()
   })
 })

--- a/ui/src/components/dashboard/overview.tsx
+++ b/ui/src/components/dashboard/overview.tsx
@@ -2,6 +2,7 @@ import { useTaskList } from '@/hooks/use-tasks'
 import { useSessionList } from '@/hooks/use-sessions'
 import { useAgentList } from '@/hooks/use-agents'
 import { useToolList } from '@/hooks/use-tools'
+import { PageHeader } from '@/components/layout/page-header'
 import { StatsCards } from './stats-cards'
 import { RecentTasks } from './recent-tasks'
 
@@ -15,10 +16,7 @@ export function Overview() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
-        <p className="text-muted-foreground">Overview of your Orka workspace</p>
-      </div>
+      <PageHeader title="Dashboard" description="Overview of your Orka workspace" />
       <StatsCards
         tasks={tasksData?.items}
         sessionCount={sessionsData?.items?.length}

--- a/ui/src/components/dashboard/overview.tsx
+++ b/ui/src/components/dashboard/overview.tsx
@@ -5,11 +5,14 @@ import { useToolList } from '@/hooks/use-tools'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { PageHeader } from '@/components/layout/page-header'
 import { Distribution } from '@/components/ui/distribution'
-import type { TaskPhase } from '@/schemas/task'
+import { taskPhaseSchema } from '@/schemas/task'
 import { StatsCards } from './stats-cards'
 import { RecentTasks } from './recent-tasks'
 
-const PHASES: TaskPhase[] = ['Pending', 'Running', 'Succeeded', 'Failed']
+// Drive the distribution from the full phase enum (Pending/Running/Succeeded/
+// Failed/Scheduled/Cancelled) so every task the Total card counts is also
+// represented here — the segment counts always sum to the task total.
+const PHASES = taskPhaseSchema.options
 
 export function Overview() {
   const { data: tasksData, isLoading: tasksLoading } = useTaskList('100')
@@ -23,7 +26,7 @@ export function Overview() {
   const distribution = PHASES.map((phase) => ({
     phase,
     count: tasks.filter((t) => (t.status?.phase ?? 'Pending') === phase).length,
-  }))
+  })).filter((seg) => seg.count > 0)
 
   return (
     <div className="space-y-6">

--- a/ui/src/components/dashboard/overview.tsx
+++ b/ui/src/components/dashboard/overview.tsx
@@ -2,9 +2,14 @@ import { useTaskList } from '@/hooks/use-tasks'
 import { useSessionList } from '@/hooks/use-sessions'
 import { useAgentList } from '@/hooks/use-agents'
 import { useToolList } from '@/hooks/use-tools'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { PageHeader } from '@/components/layout/page-header'
+import { Distribution } from '@/components/ui/distribution'
+import type { TaskPhase } from '@/schemas/task'
 import { StatsCards } from './stats-cards'
 import { RecentTasks } from './recent-tasks'
+
+const PHASES: TaskPhase[] = ['Pending', 'Running', 'Succeeded', 'Failed']
 
 export function Overview() {
   const { data: tasksData, isLoading: tasksLoading } = useTaskList('100')
@@ -13,6 +18,12 @@ export function Overview() {
   const { data: toolsData, isLoading: toolsLoading } = useToolList()
 
   const isLoading = tasksLoading || sessionsLoading || agentsLoading || toolsLoading
+
+  const tasks = tasksData?.items ?? []
+  const distribution = PHASES.map((phase) => ({
+    phase,
+    count: tasks.filter((t) => (t.status?.phase ?? 'Pending') === phase).length,
+  }))
 
   return (
     <div className="space-y-6">
@@ -24,7 +35,19 @@ export function Overview() {
         toolCount={toolsData?.items?.length}
         isLoading={isLoading}
       />
-      <RecentTasks tasks={tasksData?.items} isLoading={tasksLoading} />
+      <div className="grid gap-6 lg:grid-cols-3">
+        <Card className="lg:col-span-1">
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Phase Distribution</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Distribution segments={distribution} />
+          </CardContent>
+        </Card>
+        <div className="lg:col-span-2">
+          <RecentTasks tasks={tasksData?.items} isLoading={tasksLoading} />
+        </div>
+      </div>
     </div>
   )
 }

--- a/ui/src/components/dashboard/recent-tasks.tsx
+++ b/ui/src/components/dashboard/recent-tasks.tsx
@@ -1,15 +1,10 @@
 import { Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
+import { StatusDot } from '@/components/ui/status-dot'
+import { EmptyState } from '@/components/ui/empty-state'
+import { ListTodo } from 'lucide-react'
 import type { Task } from '@/schemas/task'
-
-const phaseColors: Record<string, string> = {
-  Pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
-  Running: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
-  Succeeded: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-  Failed: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
-}
 
 function timeAgo(timestamp?: string): string {
   if (!timestamp) return '-'
@@ -48,7 +43,11 @@ export function RecentTasks({ tasks, isLoading }: { tasks?: Task[]; isLoading?: 
       </CardHeader>
       <CardContent>
         {recent.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No tasks yet</p>
+          <EmptyState
+            icon={ListTodo}
+            headline="No tasks yet"
+            hint="Tasks you create will show up here."
+          />
         ) : (
           <div className="space-y-3">
             {recent.map((task) => (
@@ -64,9 +63,7 @@ export function RecentTasks({ tasks, isLoading }: { tasks?: Task[]; isLoading?: 
                     {task.spec.type} · {task.metadata.namespace} · {timeAgo(task.metadata.creationTimestamp)}
                   </p>
                 </div>
-                <Badge className={phaseColors[task.status?.phase ?? 'Pending']} variant="secondary">
-                  {task.status?.phase ?? 'Pending'}
-                </Badge>
+                <StatusDot phase={task.status?.phase} />
               </Link>
             ))}
           </div>

--- a/ui/src/components/dashboard/recent-tasks.tsx
+++ b/ui/src/components/dashboard/recent-tasks.tsx
@@ -59,7 +59,7 @@ export function RecentTasks({ tasks, isLoading }: { tasks?: Task[]; isLoading?: 
               >
                 <div className="space-y-1">
                   <p className="text-sm font-medium">{task.metadata.name}</p>
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-xs text-muted-foreground tabular-nums">
                     {task.spec.type} · {task.metadata.namespace} · {timeAgo(task.metadata.creationTimestamp)}
                   </p>
                 </div>

--- a/ui/src/components/dashboard/stats-cards.test.tsx
+++ b/ui/src/components/dashboard/stats-cards.test.tsx
@@ -54,4 +54,59 @@ describe('StatsCards', () => {
     const zeros = screen.getAllByText('0')
     expect(zeros.length).toBe(7) // total, running, succeeded, failed, sessions, agents, tools
   })
+
+  it('shows a success-rate indicator derived from finished tasks', () => {
+    const tasks = [
+      makeTask('t1', 'Succeeded'),
+      makeTask('t2', 'Succeeded'),
+      makeTask('t3', 'Succeeded'),
+      makeTask('t4', 'Failed'),
+    ]
+    // 3 succeeded / 4 finished = 75%
+    render(<StatsCards tasks={tasks} />)
+    expect(screen.getByText('75% success rate')).toBeInTheDocument()
+  })
+
+  it('omits the success rate when nothing has finished', () => {
+    render(<StatsCards tasks={[makeTask('t1', 'Running'), makeTask('t2', 'Pending')]} />)
+    expect(screen.queryByText(/success rate/)).not.toBeInTheDocument()
+  })
+
+  it('renders trend sparklines when there is more than one task', () => {
+    const tasks = [
+      { metadata: { name: 'a', namespace: 'default', uid: 'a', creationTimestamp: '2026-01-01T00:00:00Z' }, spec: { type: 'container' }, status: { phase: 'Succeeded' } },
+      { metadata: { name: 'b', namespace: 'default', uid: 'b', creationTimestamp: '2026-01-02T00:00:00Z' }, spec: { type: 'container' }, status: { phase: 'Running' } },
+    ] as Task[]
+    render(<StatsCards tasks={tasks} />)
+    expect(screen.getAllByRole('img', { name: /trend/i }).length).toBeGreaterThan(0)
+  })
+
+  it('plots a per-status trend, not the aggregate, on each status card', () => {
+    // 2 succeeded, 0 failed → the Failed sparkline must be flat (all zero),
+    // while Succeeded trends upward. Guards the regression where every card
+    // reused the total-task series.
+    const tasks = [
+      { metadata: { name: 'a', namespace: 'default', uid: 'a', creationTimestamp: '2026-01-01T00:00:00Z' }, spec: { type: 'container' }, status: { phase: 'Succeeded' } },
+      { metadata: { name: 'b', namespace: 'default', uid: 'b', creationTimestamp: '2026-01-02T00:00:00Z' }, spec: { type: 'container' }, status: { phase: 'Succeeded' } },
+    ] as Task[]
+    render(<StatsCards tasks={tasks} />)
+    const failed = screen.getByRole('img', { name: /failed trend/i })
+    const succeeded = screen.getByRole('img', { name: /succeeded trend/i })
+    // Failed has no tasks → every point sits on the baseline (single y value).
+    const failedYs = new Set(
+      (failed.querySelector('polyline')?.getAttribute('points') ?? '')
+        .trim()
+        .split(' ')
+        .map((p) => p.split(',')[1]),
+    )
+    expect(failedYs.size).toBe(1)
+    // Succeeded accumulates → more than one distinct y value.
+    const succeededYs = new Set(
+      (succeeded.querySelector('polyline')?.getAttribute('points') ?? '')
+        .trim()
+        .split(' ')
+        .map((p) => p.split(',')[1]),
+    )
+    expect(succeededYs.size).toBeGreaterThan(1)
+  })
 })

--- a/ui/src/components/dashboard/stats-cards.tsx
+++ b/ui/src/components/dashboard/stats-cards.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ListTodo, Play, CheckCircle, XCircle, MessageSquare, Bot, Wrench } from 'lucide-react'
 import type { Task } from '@/schemas/task'
 import { Skeleton } from '@/components/ui/skeleton'
+import { phaseStyle } from '@/lib/task-status'
 
 interface StatsCardsProps {
   tasks?: Task[]
@@ -37,9 +38,9 @@ export function StatsCards({ tasks, sessionCount, agentCount, toolCount, isLoadi
 
   const stats = [
     { label: 'Total Tasks', value: total, icon: ListTodo, color: 'text-foreground' },
-    { label: 'Running', value: running, icon: Play, color: 'text-blue-500' },
-    { label: 'Succeeded', value: succeeded, icon: CheckCircle, color: 'text-green-500' },
-    { label: 'Failed', value: failed, icon: XCircle, color: 'text-red-500' },
+    { label: 'Running', value: running, icon: Play, color: phaseStyle('Running').textClass },
+    { label: 'Succeeded', value: succeeded, icon: CheckCircle, color: phaseStyle('Succeeded').textClass },
+    { label: 'Failed', value: failed, icon: XCircle, color: phaseStyle('Failed').textClass },
   ]
 
   return (

--- a/ui/src/components/dashboard/stats-cards.tsx
+++ b/ui/src/components/dashboard/stats-cards.tsx
@@ -2,7 +2,9 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ListTodo, Play, CheckCircle, XCircle, MessageSquare, Bot, Wrench } from 'lucide-react'
 import type { Task } from '@/schemas/task'
 import { Skeleton } from '@/components/ui/skeleton'
+import { Sparkline } from '@/components/ui/sparkline'
 import { phaseStyle } from '@/lib/task-status'
+import { cn } from '@/lib/utils'
 
 interface StatsCardsProps {
   tasks?: Task[]
@@ -10,6 +12,47 @@ interface StatsCardsProps {
   agentCount?: number
   toolCount?: number
   isLoading?: boolean
+}
+
+/**
+ * Bucket a set of tasks into a coarse cumulative "created over time" series
+ * (oldest→newest), derived entirely client-side from the existing task list.
+ *
+ * The bucketing window (`min`/`max`) is passed in so every per-status series
+ * shares the same time axis — otherwise each status would be rescaled to its
+ * own first/last task and the sparklines wouldn't be comparable.
+ *
+ * NOTE: a backend timeseries endpoint (throughput per interval) would give
+ * higher-fidelity trends than bucketing creation timestamps; this is a v1
+ * approximation that needs no API change.
+ */
+function cumulativeSeries(
+  tasks: Task[],
+  window: { min: number; max: number } | null,
+  buckets = 12,
+): number[] {
+  if (!window) return []
+  const times = tasks
+    .map((t) => (t.metadata.creationTimestamp ? new Date(t.metadata.creationTimestamp).getTime() : NaN))
+    .filter((n) => !Number.isNaN(n))
+  const { min, max } = window
+  const span = max - min || 1
+  const counts = new Array(buckets).fill(0)
+  for (const t of times) {
+    const idx = Math.min(buckets - 1, Math.max(0, Math.floor(((t - min) / span) * buckets)))
+    counts[idx]++
+  }
+  let acc = 0
+  return counts.map((c) => (acc += c))
+}
+
+/** Shared time window spanning all tasks, or null when none are timestamped. */
+function taskWindow(tasks: Task[]): { min: number; max: number } | null {
+  const times = tasks
+    .map((t) => (t.metadata.creationTimestamp ? new Date(t.metadata.creationTimestamp).getTime() : NaN))
+    .filter((n) => !Number.isNaN(n))
+  if (times.length === 0) return null
+  return { min: Math.min(...times), max: Math.max(...times) }
 }
 
 export function StatsCards({ tasks, sessionCount, agentCount, toolCount, isLoading }: StatsCardsProps) {
@@ -31,28 +74,55 @@ export function StatsCards({ tasks, sessionCount, agentCount, toolCount, isLoadi
     )
   }
 
-  const total = tasks?.length ?? 0
-  const running = tasks?.filter(t => t.status?.phase === 'Running').length ?? 0
-  const succeeded = tasks?.filter(t => t.status?.phase === 'Succeeded').length ?? 0
-  const failed = tasks?.filter(t => t.status?.phase === 'Failed').length ?? 0
+  const allTasks = tasks ?? []
+  const total = allTasks.length
+  const runningTasks = allTasks.filter(t => t.status?.phase === 'Running')
+  const succeededTasks = allTasks.filter(t => t.status?.phase === 'Succeeded')
+  const failedTasks = allTasks.filter(t => t.status?.phase === 'Failed')
+  const running = runningTasks.length
+  const succeeded = succeededTasks.length
+  const failed = failedTasks.length
 
+  const finished = succeeded + failed
+  const successRate = finished > 0 ? Math.round((succeeded / finished) * 100) : null
+
+  // All sparklines share one time window so each status's trend is comparable;
+  // each card plots only its own status's tasks (the Failed card stays flat
+  // when there are no failures, rather than echoing the total trend).
+  const window = taskWindow(allTasks)
   const stats = [
-    { label: 'Total Tasks', value: total, icon: ListTodo, color: 'text-foreground' },
-    { label: 'Running', value: running, icon: Play, color: phaseStyle('Running').textClass },
-    { label: 'Succeeded', value: succeeded, icon: CheckCircle, color: phaseStyle('Succeeded').textClass },
-    { label: 'Failed', value: failed, icon: XCircle, color: phaseStyle('Failed').textClass },
+    { label: 'Total Tasks', value: total, icon: ListTodo, color: 'text-foreground', spark: 'text-primary', series: cumulativeSeries(allTasks, window) },
+    { label: 'Running', value: running, icon: Play, color: phaseStyle('Running').textClass, spark: phaseStyle('Running').textClass, series: cumulativeSeries(runningTasks, window) },
+    {
+      label: 'Succeeded',
+      value: succeeded,
+      icon: CheckCircle,
+      color: phaseStyle('Succeeded').textClass,
+      spark: phaseStyle('Succeeded').textClass,
+      sub: successRate !== null ? `${successRate}% success rate` : undefined,
+      series: cumulativeSeries(succeededTasks, window),
+    },
+    { label: 'Failed', value: failed, icon: XCircle, color: phaseStyle('Failed').textClass, spark: phaseStyle('Failed').textClass, series: cumulativeSeries(failedTasks, window) },
   ]
 
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-      {stats.map(({ label, value, icon: Icon, color }) => (
+      {stats.map(({ label, value, icon: Icon, color, spark, sub, series }) => (
         <Card key={label}>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">{label}</CardTitle>
             <Icon className={`h-4 w-4 ${color}`} />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{value}</div>
+            <div className="flex items-end justify-between gap-2">
+              <div>
+                <div className="text-2xl font-bold tabular-nums">{value}</div>
+                {sub && <div className="text-xs text-muted-foreground">{sub}</div>}
+              </div>
+              {series.length > 1 && (
+                <Sparkline data={series} className={cn('opacity-80', spark)} aria-label={`${label} trend`} />
+              )}
+            </div>
           </CardContent>
         </Card>
       ))}
@@ -62,7 +132,7 @@ export function StatsCards({ tasks, sessionCount, agentCount, toolCount, isLoadi
           <MessageSquare className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{sessionCount ?? 0}</div>
+          <div className="text-2xl font-bold tabular-nums">{sessionCount ?? 0}</div>
         </CardContent>
       </Card>
       <Card>
@@ -71,7 +141,7 @@ export function StatsCards({ tasks, sessionCount, agentCount, toolCount, isLoadi
           <Bot className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{agentCount ?? 0}</div>
+          <div className="text-2xl font-bold tabular-nums">{agentCount ?? 0}</div>
         </CardContent>
       </Card>
       <Card>
@@ -80,7 +150,7 @@ export function StatsCards({ tasks, sessionCount, agentCount, toolCount, isLoadi
           <Wrench className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{toolCount ?? 0}</div>
+          <div className="text-2xl font-bold tabular-nums">{toolCount ?? 0}</div>
         </CardContent>
       </Card>
     </div>

--- a/ui/src/components/layout/header.test.tsx
+++ b/ui/src/components/layout/header.test.tsx
@@ -39,13 +39,27 @@ describe('Header', () => {
     expect(buttons.length).toBeGreaterThanOrEqual(2)
   })
 
+  it('exposes accessible names on the icon-only theme + logout buttons', () => {
+    render(<Header />)
+    // Light theme → the toggle offers to switch to dark.
+    expect(
+      screen.getByRole('button', { name: /switch to dark theme/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument()
+  })
+
+  it('theme toggle accessible name reflects the current theme', () => {
+    useUIStore.setState({ theme: 'dark' })
+    render(<Header />)
+    expect(
+      screen.getByRole('button', { name: /switch to light theme/i }),
+    ).toBeInTheDocument()
+  })
+
   it('logout button calls clearToken on auth store', async () => {
     const user = userEvent.setup()
     render(<Header />)
-    // Logout button is the last button
-    const buttons = screen.getAllByRole('button')
-    const logoutButton = buttons[buttons.length - 1]
-    await user.click(logoutButton)
+    await user.click(screen.getByRole('button', { name: /log out/i }))
     expect(useAuthStore.getState().token).toBeNull()
   })
 })

--- a/ui/src/components/layout/header.tsx
+++ b/ui/src/components/layout/header.tsx
@@ -16,7 +16,7 @@ export function Header() {
   }
 
   return (
-    <header className="flex h-14 items-center justify-between border-b border-border bg-card px-6">
+    <header className="z-20 flex h-14 shrink-0 items-center justify-between border-b border-border bg-card/80 px-6 backdrop-blur-md">
       <div className="flex items-center gap-4">
         <Select value={namespace} onValueChange={setNamespace}>
           <SelectTrigger className="w-48">
@@ -29,10 +29,20 @@ export function Header() {
         </Select>
       </div>
       <div className="flex items-center gap-2">
-        <Button variant="ghost" size="icon" onClick={toggleTheme}>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={toggleTheme}
+          aria-label={theme === 'light' ? 'Switch to dark theme' : 'Switch to light theme'}
+        >
           {theme === 'light' ? <Moon className="h-4 w-4" /> : <Sun className="h-4 w-4" />}
         </Button>
-        <Button variant="ghost" size="icon" onClick={handleLogout}>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handleLogout}
+          aria-label="Log out"
+        >
           <LogOut className="h-4 w-4" />
         </Button>
       </div>

--- a/ui/src/components/layout/page-header.test.tsx
+++ b/ui/src/components/layout/page-header.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@/test/test-utils'
+import userEvent from '@testing-library/user-event'
+import { PageHeader } from './page-header'
+
+describe('PageHeader', () => {
+  it('renders the title as a level-1 heading', () => {
+    render(<PageHeader title="Tasks" />)
+    expect(screen.getByRole('heading', { level: 1, name: 'Tasks' })).toBeInTheDocument()
+  })
+
+  it('renders the description when provided', () => {
+    render(<PageHeader title="Tasks" description="Manage your task execution" />)
+    expect(screen.getByText('Manage your task execution')).toBeInTheDocument()
+  })
+
+  it('omits the description when not provided', () => {
+    const { container } = render(<PageHeader title="Tasks" />)
+    expect(container.querySelectorAll('p').length).toBe(0)
+  })
+
+  it('renders the eyebrow when provided', () => {
+    render(<PageHeader title="Detail" eyebrow="Task" />)
+    expect(screen.getByText('Task')).toBeInTheDocument()
+  })
+
+  it('renders an action slot when provided and wires its handler', async () => {
+    const onClick = vi.fn()
+    render(
+      <PageHeader
+        title="Tasks"
+        action={<button onClick={onClick}>New Task</button>}
+      />,
+    )
+    const btn = screen.getByRole('button', { name: 'New Task' })
+    expect(btn).toBeInTheDocument()
+    await userEvent.click(btn)
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+})

--- a/ui/src/components/layout/page-header.tsx
+++ b/ui/src/components/layout/page-header.tsx
@@ -1,0 +1,49 @@
+import { cn } from '@/lib/utils'
+
+interface PageHeaderProps {
+  /** Primary page title (rendered as an h1). */
+  title: string
+  /** Optional supporting description below the title. */
+  description?: string
+  /** Optional small uppercase label above the title (e.g. a section/context). */
+  eyebrow?: string
+  /** Optional action slot rendered on the trailing edge (e.g. a "New" button). */
+  action?: React.ReactNode
+  className?: string
+}
+
+/**
+ * Standard page header — title + optional description, with an optional action
+ * slot on the trailing edge.
+ *
+ * Replaces the `<h1 className="text-3xl font-bold tracking-tight"> + muted <p>`
+ * pattern that was duplicated across ~20 page/list components, so the page
+ * chrome stays consistent and is changed in exactly one place.
+ */
+export function PageHeader({
+  title,
+  description,
+  eyebrow,
+  action,
+  className,
+}: PageHeaderProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between',
+        className,
+      )}
+    >
+      <div className="space-y-1">
+        {eyebrow && (
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {eyebrow}
+          </p>
+        )}
+        <h1 className="text-3xl font-bold tracking-tight">{title}</h1>
+        {description && <p className="text-muted-foreground">{description}</p>}
+      </div>
+      {action && <div className="flex shrink-0 items-center gap-2">{action}</div>}
+    </div>
+  )
+}

--- a/ui/src/components/layout/sidebar.test.tsx
+++ b/ui/src/components/layout/sidebar.test.tsx
@@ -57,8 +57,16 @@ describe('Sidebar', () => {
     const user = userEvent.setup()
     render(<Sidebar />)
     expect(screen.getByText('Dashboard')).toBeInTheDocument()
-    const toggleButton = screen.getByText('←').closest('button')!
+    const toggleButton = screen.getByRole('button', { name: /collapse sidebar/i })
     await user.click(toggleButton)
     expect(useUIStore.getState().sidebarCollapsed).toBe(true)
+  })
+
+  it('collapse toggle exposes an accessible name reflecting its state', () => {
+    useUIStore.setState({ sidebarCollapsed: true })
+    render(<Sidebar />)
+    expect(
+      screen.getByRole('button', { name: /expand sidebar/i }),
+    ).toBeInTheDocument()
   })
 })

--- a/ui/src/components/layout/sidebar.tsx
+++ b/ui/src/components/layout/sidebar.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from '@tanstack/react-router'
-import { LayoutDashboard, ListTodo, MessageSquare, Bot, Wrench, Sparkles, Columns3, Activity, Shield, Radar } from 'lucide-react'
+import { LayoutDashboard, ListTodo, MessageSquare, Bot, Wrench, Sparkles, Columns3, Activity, Shield, Radar, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useUIStore } from '@/stores/ui'
 import { Button } from '@/components/ui/button'
@@ -41,7 +41,11 @@ export function Sidebar() {
           aria-label={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           className={cn('ml-auto h-8 w-8', sidebarCollapsed && 'mx-auto')}
         >
-          <span className="text-sm">{sidebarCollapsed ? '→' : '←'}</span>
+          {sidebarCollapsed ? (
+            <PanelLeftOpen className="h-4 w-4" />
+          ) : (
+            <PanelLeftClose className="h-4 w-4" />
+          )}
         </Button>
       </div>
       <nav className="flex-1 space-y-1 p-2">

--- a/ui/src/components/layout/sidebar.tsx
+++ b/ui/src/components/layout/sidebar.tsx
@@ -24,7 +24,7 @@ export function Sidebar() {
 
   return (
     <aside className={cn(
-      'flex flex-col border-r border-border bg-card transition-all duration-200',
+      'flex flex-col border-r border-border bg-card/80 backdrop-blur-md transition-all duration-200',
       sidebarCollapsed ? 'w-16' : 'w-64'
     )}>
       <div className="flex h-14 items-center border-b border-border px-4">
@@ -51,15 +51,18 @@ export function Sidebar() {
             <Link
               key={to}
               to={to}
+              aria-current={isActive ? 'page' : undefined}
               className={cn(
-                'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                'relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                // Refined active state: left accent bar + subtle tint + colored
+                // icon/text, replacing the old heavy solid fill.
                 isActive
-                  ? 'bg-primary text-primary-foreground'
+                  ? 'bg-primary/10 text-primary before:absolute before:inset-y-1.5 before:left-0 before:w-0.5 before:rounded-full before:bg-primary'
                   : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
                 sidebarCollapsed && 'justify-center px-2'
               )}
             >
-              <Icon className="h-4 w-4 shrink-0" />
+              <Icon className={cn('h-4 w-4 shrink-0', isActive && 'text-primary')} />
               {!sidebarCollapsed && <span>{label}</span>}
             </Link>
           )

--- a/ui/src/components/layout/sidebar.tsx
+++ b/ui/src/components/layout/sidebar.tsx
@@ -3,6 +3,7 @@ import { LayoutDashboard, ListTodo, MessageSquare, Bot, Wrench, Sparkles, Column
 import { cn } from '@/lib/utils'
 import { useUIStore } from '@/stores/ui'
 import { Button } from '@/components/ui/button'
+import { OrcaMark } from '@/components/ui/orca-mark'
 
 const navItems = [
   { to: '/', label: 'Dashboard', icon: LayoutDashboard },
@@ -29,7 +30,7 @@ export function Sidebar() {
       <div className="flex h-14 items-center border-b border-border px-4">
         {!sidebarCollapsed && (
           <Link to="/" className="flex items-center gap-2 font-semibold text-foreground">
-            <span className="text-xl">🐋</span>
+            <OrcaMark className="h-6 w-6" />
             <span>Orka</span>
           </Link>
         )}
@@ -37,6 +38,7 @@ export function Sidebar() {
           variant="ghost"
           size="icon"
           onClick={toggleSidebar}
+          aria-label={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           className={cn('ml-auto h-8 w-8', sidebarCollapsed && 'mx-auto')}
         >
           <span className="text-sm">{sidebarCollapsed ? '→' : '←'}</span>

--- a/ui/src/components/monitors/repository-monitor-create-form.tsx
+++ b/ui/src/components/monitors/repository-monitor-create-form.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { PageHeader } from '@/components/layout/page-header'
 import { useAgentList } from '@/hooks/use-agents'
 import { useCreateRepositoryMonitor } from '@/hooks/use-monitors'
 import { useSecretNames } from '@/hooks/use-secrets'
@@ -181,17 +182,15 @@ export function RepositoryMonitorCreateForm() {
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">New Repository Monitor</h1>
-          <p className="text-muted-foreground">
-            Create GitHub pull request review automation in the <span className="font-medium text-foreground">{namespace}</span> namespace.
-          </p>
-        </div>
-        <Button type="button" variant="outline" onClick={() => navigate({ to: '/monitors' })}>
-          Cancel
-        </Button>
-      </div>
+      <PageHeader
+        title="New Repository Monitor"
+        description={`Create GitHub pull request review automation in the ${namespace} namespace.`}
+        action={
+          <Button type="button" variant="outline" onClick={() => navigate({ to: '/monitors' })}>
+            Cancel
+          </Button>
+        }
+      />
 
       <Card>
         <CardHeader>

--- a/ui/src/components/monitors/repository-monitor-detail.tsx
+++ b/ui/src/components/monitors/repository-monitor-detail.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { PageHeader } from '@/components/layout/page-header'
 import { useRepositoryMonitor, useRepositoryMonitorItems, useRepositoryMonitorRuns, useRunRepositoryMonitor } from '@/hooks/use-monitors'
 import { repositoryMonitorDisplayName } from './repository-monitor-display'
 
@@ -55,19 +56,19 @@ export function RepositoryMonitorDetail({ monitorName }: { monitorName: string }
 
   return (
     <div className="space-y-4">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">{displayName}</h1>
-          <p className="text-muted-foreground">{monitor.spec.repoURL}</p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Badge variant={status?.phase === 'Ready' ? 'default' : 'secondary'}>{status?.phase || 'Pending'}</Badge>
-          <Button variant="secondary" onClick={() => runMonitor.mutate()} disabled={runMonitor.isPending}>
-            <Play className="mr-2 h-4 w-4" />
-            Run
-          </Button>
-        </div>
-      </div>
+      <PageHeader
+        title={displayName}
+        description={monitor.spec.repoURL}
+        action={
+          <>
+            <Badge variant={status?.phase === 'Ready' ? 'default' : 'secondary'}>{status?.phase || 'Pending'}</Badge>
+            <Button variant="secondary" onClick={() => runMonitor.mutate()} disabled={runMonitor.isPending}>
+              <Play className="mr-2 h-4 w-4" />
+              Run
+            </Button>
+          </>
+        }
+      />
 
       <div className="grid gap-4 md:grid-cols-5">
         <MetricCard title="Open PRs" value={status?.openPullRequests ?? 0} />

--- a/ui/src/components/monitors/repository-monitor-list.tsx
+++ b/ui/src/components/monitors/repository-monitor-list.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { PageHeader } from '@/components/layout/page-header'
 import { useRepositoryMonitors, useRunRepositoryMonitor } from '@/hooks/use-monitors'
 import type { RepositoryMonitor } from '@/schemas/monitor'
 import { repositoryMonitorDisplayName } from './repository-monitor-display'
@@ -22,18 +23,18 @@ export function RepositoryMonitorList() {
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Repository Monitors</h1>
-          <p className="text-muted-foreground">Maintainer automation state for pull requests, repairs, and audit trails</p>
-        </div>
-        <Link to="/monitors/create/new">
-          <Button>
-            <Plus className="mr-2 h-4 w-4" />
-            New Monitor
-          </Button>
-        </Link>
-      </div>
+      <PageHeader
+        title="Repository Monitors"
+        description="Maintainer automation state for pull requests, repairs, and audit trails"
+        action={
+          <Link to="/monitors/create/new">
+            <Button>
+              <Plus className="mr-2 h-4 w-4" />
+              New Monitor
+            </Button>
+          </Link>
+        }
+      />
 
       {isLoading ? (
         <div className="grid gap-4 md:grid-cols-2">

--- a/ui/src/components/security/finding-detail.tsx
+++ b/ui/src/components/security/finding-detail.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
+import { PageHeader } from '@/components/layout/page-header'
 import {
   useCreatePullRequest,
   useDismissFinding,
@@ -63,8 +64,7 @@ export function FindingDetail({ findingId }: { findingId: string }) {
             <Badge variant="outline">{finding.validationStatus}</Badge>
             <Badge variant="outline">{finding.state}</Badge>
           </div>
-          <h1 className="text-3xl font-bold tracking-tight">{finding.title}</h1>
-          <p className="text-muted-foreground">{finding.summary}</p>
+          <PageHeader title={finding.title} description={finding.summary} />
         </div>
         <div className="flex flex-wrap gap-2">
           {finding.state === 'dismissed' ? (

--- a/ui/src/components/security/repository-create-form.tsx
+++ b/ui/src/components/security/repository-create-form.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { PageHeader } from '@/components/layout/page-header'
 import { useCreateRepositoryScan } from '@/hooks/use-security'
 import { useAgentList } from '@/hooks/use-agents'
 import { useSecretNames } from '@/hooks/use-secrets'
@@ -68,10 +69,10 @@ export function RepositoryCreateForm() {
 
   return (
     <div className="space-y-4">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">New Security Repository</h1>
-        <p className="text-muted-foreground">Register a GitHub repository for threat modeling and code scanning</p>
-      </div>
+      <PageHeader
+        title="New Security Repository"
+        description="Register a GitHub repository for threat modeling and code scanning"
+      />
 
       <Card>
         <CardHeader>

--- a/ui/src/components/security/repository-detail.tsx
+++ b/ui/src/components/security/repository-detail.tsx
@@ -3,6 +3,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { PageHeader } from '@/components/layout/page-header'
 import { useAllFindings, useDroppedFindings, useRepositoryScan, useReviewSlices, useRunSecurityScan, useScanRuns } from '@/hooks/use-security'
 import { ThreatModelEditor } from './threat-model-editor'
 import { RecommendedFindings } from './recommended-findings'
@@ -35,28 +36,28 @@ export function RepositoryDetail({ repositoryName }: { repositoryName: string })
 
   return (
     <div className="space-y-4">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">{repo.spec.owner}/{repo.spec.repository}</h1>
-          <p className="text-muted-foreground">{repo.spec.repoURL}</p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Badge variant={repo.status?.phase === 'Ready' ? 'default' : 'secondary'}>{repo.status?.phase || 'Pending'}</Badge>
-          <Button
-            onClick={async () => {
-              try {
-                await runScan.mutateAsync()
-                toast.success('Manual scan started')
-              } catch (error) {
-                toast.error(`Failed to start scan: ${error instanceof Error ? error.message : 'Unknown error'}`)
-              }
-            }}
-            disabled={runScan.isPending}
-          >
-            Scan Now
-          </Button>
-        </div>
-      </div>
+      <PageHeader
+        title={`${repo.spec.owner}/${repo.spec.repository}`}
+        description={repo.spec.repoURL}
+        action={
+          <>
+            <Badge variant={repo.status?.phase === 'Ready' ? 'default' : 'secondary'}>{repo.status?.phase || 'Pending'}</Badge>
+            <Button
+              onClick={async () => {
+                try {
+                  await runScan.mutateAsync()
+                  toast.success('Manual scan started')
+                } catch (error) {
+                  toast.error(`Failed to start scan: ${error instanceof Error ? error.message : 'Unknown error'}`)
+                }
+              }}
+              disabled={runScan.isPending}
+            >
+              Scan Now
+            </Button>
+          </>
+        }
+      />
 
       <div className="grid gap-4 md:grid-cols-4">
         <Card>

--- a/ui/src/components/security/repository-list.tsx
+++ b/ui/src/components/security/repository-list.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
+import { PageHeader } from '@/components/layout/page-header'
 import { useRepositoryScans, useRunSecurityScan } from '@/hooks/use-security'
 import type { RepositoryScan } from '@/schemas/security'
 
@@ -21,15 +22,15 @@ export function RepositoryList() {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Security</h1>
-          <p className="text-muted-foreground">Repository security scans, threat models, and findings</p>
-        </div>
-        <Link to="/security/new">
-          <Button><Plus className="mr-2 h-4 w-4" />New Repository</Button>
-        </Link>
-      </div>
+      <PageHeader
+        title="Security"
+        description="Repository security scans, threat models, and findings"
+        action={
+          <Link to="/security/new">
+            <Button><Plus className="mr-2 h-4 w-4" />New Repository</Button>
+          </Link>
+        }
+      />
 
       {isLoading ? (
         <div className="grid gap-4 md:grid-cols-2">

--- a/ui/src/components/sessions/session-detail.tsx
+++ b/ui/src/components/sessions/session-detail.tsx
@@ -2,6 +2,7 @@ import { Link, useNavigate } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
+import { PageHeader } from '@/components/layout/page-header'
 import { ArrowLeft, Trash2 } from 'lucide-react'
 import { TranscriptViewer } from './transcript-viewer'
 import { useSession, useDeleteSession } from '@/hooks/use-sessions'
@@ -26,24 +27,25 @@ export function SessionDetail({ sessionId }: { sessionId: string }) {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Link to="/sessions"><Button variant="ghost" size="icon"><ArrowLeft className="h-4 w-4" /></Button></Link>
-          <div>
-            <h1 className="text-3xl font-bold tracking-tight">{session.name}</h1>
-            <p className="text-muted-foreground">{session.namespace}</p>
-          </div>
-        </div>
-        <Button
-          variant="destructive"
-          size="sm"
-          onClick={async () => {
-            await deleteSession.mutateAsync(session.name)
-            navigate({ to: '/sessions' })
-          }}
-        >
-          <Trash2 className="mr-2 h-4 w-4" /> Delete
-        </Button>
+      <div className="flex items-center gap-4">
+        <Link to="/sessions"><Button variant="ghost" size="icon"><ArrowLeft className="h-4 w-4" /></Button></Link>
+        <PageHeader
+          className="flex-1"
+          title={session.name}
+          description={session.namespace}
+          action={
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={async () => {
+                await deleteSession.mutateAsync(session.name)
+                navigate({ to: '/sessions' })
+              }}
+            >
+              <Trash2 className="mr-2 h-4 w-4" /> Delete
+            </Button>
+          }
+        />
       </div>
 
       <div className="grid gap-4 md:grid-cols-4">

--- a/ui/src/components/sessions/session-list.tsx
+++ b/ui/src/components/sessions/session-list.tsx
@@ -55,7 +55,7 @@ export function SessionList() {
               (data?.items ?? []).map((session) => (
                 <TableRow key={session.name}>
                   <TableCell>
-                    <Link to="/sessions/$sessionId" params={{ sessionId: session.name }} className="font-medium hover:underline">
+                    <Link to="/sessions/$sessionId" params={{ sessionId: session.name }} className="font-mono text-sm font-medium hover:underline">
                       {session.name}
                     </Link>
                   </TableCell>

--- a/ui/src/components/sessions/session-list.tsx
+++ b/ui/src/components/sessions/session-list.tsx
@@ -3,6 +3,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Badge } from '@/components/ui/badge'
+import { PageHeader } from '@/components/layout/page-header'
 import { Trash2 } from 'lucide-react'
 import { useSessionList, useDeleteSession } from '@/hooks/use-sessions'
 
@@ -21,10 +22,7 @@ export function SessionList() {
 
   return (
     <div className="space-y-4">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Sessions</h1>
-        <p className="text-muted-foreground">View conversation sessions</p>
-      </div>
+      <PageHeader title="Sessions" description="View conversation sessions" />
       <div className="rounded-md border">
         <Table>
           <TableHeader>

--- a/ui/src/components/sessions/transcript-viewer.tsx
+++ b/ui/src/components/sessions/transcript-viewer.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent } from '@/components/ui/card'
-import { Bot, User } from 'lucide-react'
+import { EmptyState } from '@/components/ui/empty-state'
+import { Bot, MessageSquare, User } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { TranscriptMessage } from '@/schemas/session'
 
@@ -19,7 +20,7 @@ export function TranscriptViewer({ transcript }: { transcript?: string }) {
   const messages = parseTranscript(transcript)
 
   if (messages.length === 0) {
-    return <p className="text-sm text-muted-foreground py-4">No messages in this session.</p>
+    return <EmptyState icon={MessageSquare} headline="No messages in this session." />
   }
 
   return (

--- a/ui/src/components/tasks/agent-grid-view.tsx
+++ b/ui/src/components/tasks/agent-grid-view.tsx
@@ -2,6 +2,9 @@ import { useState, useEffect } from 'react'
 import { Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { Activity } from 'lucide-react'
+import { PageHeader } from '@/components/layout/page-header'
+import { EmptyState } from '@/components/ui/empty-state'
 import { useTaskList } from '@/hooks/use-tasks'
 import { TaskStatusBadge } from './task-status-badge'
 import type { Task } from '@/schemas/task'
@@ -26,7 +29,7 @@ function AgentMiniPanel({ task }: { task: Task }) {
 
   return (
     <Link to="/tasks/$taskId" params={{ taskId: task.metadata.name }}>
-      <Card className="hover:border-primary/50 transition-colors cursor-pointer h-full">
+      <Card className="hover:border-primary/50 hover:shadow-md transition-all motion-safe:hover:-translate-y-0.5 cursor-pointer h-full">
         <CardHeader className="pb-2">
           <div className="flex items-center justify-between">
             <CardTitle className="text-sm font-medium truncate">{task.metadata.name}</CardTitle>
@@ -34,7 +37,7 @@ function AgentMiniPanel({ task }: { task: Task }) {
           </div>
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             {task.spec.agentRef?.name && <span>{task.spec.agentRef.name}</span>}
-            <span>{formatElapsed(elapsed)}</span>
+            <span className="tabular-nums">{formatElapsed(elapsed)}</span>
           </div>
         </CardHeader>
         <CardContent className="pt-0">
@@ -55,10 +58,7 @@ export function AgentGridView() {
   if (isLoading) {
     return (
       <div className="space-y-4">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Live Agents</h1>
-          <p className="text-muted-foreground">Active task execution overview</p>
-        </div>
+        <PageHeader title="Live Agents" description="Active task execution overview" />
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} className="h-32 w-full" />
@@ -70,16 +70,18 @@ export function AgentGridView() {
 
   return (
     <div className="space-y-4">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Live Agents</h1>
-        <p className="text-muted-foreground">
-          {runningTasks.length} active {runningTasks.length === 1 ? 'task' : 'tasks'}
-        </p>
-      </div>
+      <PageHeader
+        title="Live Agents"
+        description={`${runningTasks.length} active ${runningTasks.length === 1 ? 'task' : 'tasks'}`}
+      />
       {runningTasks.length === 0 ? (
         <Card>
-          <CardContent className="py-8 text-center text-muted-foreground">
-            No tasks currently running
+          <CardContent className="py-8">
+            <EmptyState
+              icon={Activity}
+              headline="No tasks currently running"
+              hint="Running agents will appear here as they start."
+            />
           </CardContent>
         </Card>
       ) : (

--- a/ui/src/components/tasks/agent-grid-view.tsx
+++ b/ui/src/components/tasks/agent-grid-view.tsx
@@ -2,9 +2,9 @@ import { useState, useEffect } from 'react'
 import { Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
-import { Activity } from 'lucide-react'
 import { PageHeader } from '@/components/layout/page-header'
 import { EmptyState } from '@/components/ui/empty-state'
+import { SonarPing } from '@/components/ui/sonar-ping'
 import { useTaskList } from '@/hooks/use-tasks'
 import { useFreshness } from '@/hooks/use-freshness'
 import { cn } from '@/lib/utils'
@@ -86,11 +86,12 @@ export function AgentGridView() {
       />
       {runningTasks.length === 0 ? (
         <Card>
-          <CardContent className="py-8">
+          <CardContent className="flex flex-col items-center gap-4 py-10">
+            <SonarPing />
             <EmptyState
-              icon={Activity}
               headline="No tasks currently running"
               hint="Running agents will appear here as they start."
+              className="py-0"
             />
           </CardContent>
         </Card>

--- a/ui/src/components/tasks/agent-grid-view.tsx
+++ b/ui/src/components/tasks/agent-grid-view.tsx
@@ -6,11 +6,16 @@ import { Activity } from 'lucide-react'
 import { PageHeader } from '@/components/layout/page-header'
 import { EmptyState } from '@/components/ui/empty-state'
 import { useTaskList } from '@/hooks/use-tasks'
+import { useFreshness } from '@/hooks/use-freshness'
+import { cn } from '@/lib/utils'
 import { TaskStatusBadge } from './task-status-badge'
 import type { Task } from '@/schemas/task'
 
 function AgentMiniPanel({ task }: { task: Task }) {
   const [now, setNow] = useState(() => Date.now())
+  // Glow briefly when this running task's status message changes — draws the
+  // eye to what just advanced in a grid that polls every few seconds.
+  const justUpdated = useFreshness(task.status?.message)
 
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 1000)
@@ -29,7 +34,12 @@ function AgentMiniPanel({ task }: { task: Task }) {
 
   return (
     <Link to="/tasks/$taskId" params={{ taskId: task.metadata.name }}>
-      <Card className="hover:border-primary/50 hover:shadow-md transition-all motion-safe:hover:-translate-y-0.5 cursor-pointer h-full">
+      <Card
+        className={cn(
+          'border-l-2 border-l-live hover:border-primary/50 hover:shadow-md transition-all motion-safe:hover:-translate-y-0.5 cursor-pointer h-full',
+          justUpdated && 'motion-safe:animate-freshness',
+        )}
+      >
         <CardHeader className="pb-2">
           <div className="flex items-center justify-between">
             <CardTitle className="text-sm font-medium truncate">{task.metadata.name}</CardTitle>

--- a/ui/src/components/tasks/diff-viewer.test.tsx
+++ b/ui/src/components/tasks/diff-viewer.test.tsx
@@ -28,10 +28,10 @@ describe('DiffViewer', () => {
     const viewer = screen.getByTestId('diff-viewer')
     expect(viewer).toBeInTheDocument()
     // Check that addition lines have green background
-    const additionLines = viewer.querySelectorAll('.bg-green-100')
+    const additionLines = viewer.querySelectorAll('.bg-status-succeeded-bg')
     expect(additionLines.length).toBe(2)
     // Check that deletion lines have red background
-    const deletionLines = viewer.querySelectorAll('.bg-red-100')
+    const deletionLines = viewer.querySelectorAll('.bg-status-failed-bg')
     expect(deletionLines.length).toBe(1)
   })
 
@@ -44,7 +44,7 @@ describe('DiffViewer', () => {
   it('renders hunk headers with blue styling', () => {
     render(<DiffViewer diff={sampleDiff} />)
     const viewer = screen.getByTestId('diff-viewer')
-    const hunkHeaders = viewer.querySelectorAll('.bg-blue-50')
+    const hunkHeaders = viewer.querySelectorAll('.bg-status-running-bg')
     expect(hunkHeaders.length).toBe(1)
   })
 

--- a/ui/src/components/tasks/diff-viewer.tsx
+++ b/ui/src/components/tasks/diff-viewer.tsx
@@ -44,9 +44,9 @@ function parseDiff(diff: string): DiffLine[] {
 }
 
 const lineStyles: Record<DiffLine['type'], string> = {
-  addition: 'bg-green-100 dark:bg-green-900/40 text-green-900 dark:text-green-200',
-  deletion: 'bg-red-100 dark:bg-red-900/40 text-red-900 dark:text-red-200',
-  'hunk-header': 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300',
+  addition: 'bg-status-succeeded-bg text-status-succeeded',
+  deletion: 'bg-status-failed-bg text-status-failed',
+  'hunk-header': 'bg-status-running-bg text-status-running',
   'file-header': 'bg-muted font-semibold',
   context: '',
 }

--- a/ui/src/components/tasks/execution-graph.test.tsx
+++ b/ui/src/components/tasks/execution-graph.test.tsx
@@ -110,6 +110,24 @@ describe('ExecutionGraph', () => {
     expect(screen.getByText('parent-task')).toBeInTheDocument()
   })
 
+  it('preserves the literal phase string for unknown phases (label + aria, not "Pending")', () => {
+    const task = makeTask({
+      status: {
+        phase: 'Running',
+        childTasks: [{ name: 'odd-child', agent: 'x', phase: 'Terminating' as never }],
+      },
+    })
+    render(<ExecutionGraph task={task} />)
+    // The literal phase renders (in the visible badge and the StatusDot sr-only
+    // label), never the "Pending" fallback.
+    expect(screen.getAllByText('Terminating').length).toBeGreaterThan(0)
+    expect(
+      screen.getByRole('treeitem', { name: /odd-child \(Terminating\)/i }),
+    ).toBeInTheDocument()
+    // No node is mislabeled as Pending.
+    expect(screen.queryByText('Pending')).not.toBeInTheDocument()
+  })
+
   it('nodes are keyboard-traversable and activate on Enter', async () => {
     navigateMock.mockClear()
     const task = makeTask({

--- a/ui/src/components/tasks/execution-graph.test.tsx
+++ b/ui/src/components/tasks/execution-graph.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, within } from '@/test/test-utils'
+import userEvent from '@testing-library/user-event'
+
+const navigateMock = vi.fn()
+vi.mock('@tanstack/react-router', async () => {
+  const actual = await vi.importActual('@tanstack/react-router')
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  }
+})
+
+import { ExecutionGraph } from './execution-graph'
+import type { Task } from '@/schemas/task'
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    metadata: { name: 'parent-task', namespace: 'default', uid: 'uid-1' },
+    spec: { type: 'agent', agentRef: { name: 'orchestrator' } },
+    status: { phase: 'Running' },
+    ...overrides,
+  } as Task
+}
+
+describe('ExecutionGraph', () => {
+  it('renders a tree (role=tree) with the root + each child as treeitems', () => {
+    const task = makeTask({
+      status: {
+        phase: 'Running',
+        childTasks: [
+          { name: 'child-a', agent: 'reviewer', phase: 'Succeeded' },
+          { name: 'child-b', agent: 'fixer', phase: 'Running' },
+        ],
+      },
+    })
+    render(<ExecutionGraph task={task} />)
+    expect(screen.getByRole('tree', { name: /execution graph/i })).toBeInTheDocument()
+    const items = screen.getAllByRole('treeitem')
+    // root + 2 children
+    expect(items).toHaveLength(3)
+    expect(screen.getByText('parent-task')).toBeInTheDocument()
+    expect(screen.getByText('child-a')).toBeInTheDocument()
+    expect(screen.getByText('child-b')).toBeInTheDocument()
+    expect(screen.getByText('reviewer')).toBeInTheDocument()
+  })
+
+  it('each node shows a phase dot sourced from the shared status module', () => {
+    const task = makeTask({
+      status: {
+        phase: 'Running',
+        childTasks: [{ name: 'child-a', agent: 'reviewer', phase: 'Succeeded' }],
+      },
+    })
+    render(<ExecutionGraph task={task} />)
+    const dots = screen.getAllByTestId('status-dot')
+    expect(dots).toHaveLength(2)
+    // Running root pulses; Succeeded child does not.
+    const root = screen.getByRole('treeitem', { name: /parent-task \(Running\)/i })
+    expect(within(root).getAllByTestId('status-dot')[0].className).toContain('bg-status-running')
+  })
+
+  it('running node carries the pulse class; terminal nodes do not', () => {
+    const task = makeTask({
+      status: {
+        phase: 'Running',
+        childTasks: [{ name: 'done-child', agent: 'x', phase: 'Succeeded' }],
+      },
+    })
+    render(<ExecutionGraph task={task} />)
+    const running = screen.getByRole('treeitem', { name: /parent-task \(Running\)/i })
+    const done = screen.getByRole('treeitem', { name: /done-child \(Succeeded\)/i })
+    expect(within(running).getAllByTestId('status-dot')[0].className).toContain('animate-pulse-live')
+    expect(within(done).getAllByTestId('status-dot')[0].className).not.toContain('animate-pulse-live')
+  })
+
+  it('clicking a child node navigates to that task', async () => {
+    navigateMock.mockClear()
+    const task = makeTask({
+      status: {
+        phase: 'Running',
+        childTasks: [{ name: 'child-a', agent: 'reviewer', phase: 'Succeeded' }],
+      },
+    })
+    render(<ExecutionGraph task={task} />)
+    await userEvent.click(screen.getByText('child-a'))
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: '/tasks/$taskId',
+      params: { taskId: 'child-a' },
+    })
+  })
+
+  it('uses an onSelect override when provided', async () => {
+    const onSelect = vi.fn()
+    const task = makeTask({
+      status: {
+        phase: 'Running',
+        childTasks: [{ name: 'child-a', agent: 'reviewer', phase: 'Succeeded' }],
+      },
+    })
+    render(<ExecutionGraph task={task} onSelect={onSelect} />)
+    await userEvent.click(screen.getByText('child-a'))
+    expect(onSelect).toHaveBeenCalledWith('child-a')
+  })
+
+  it('degrades to a single root node when there are no children', () => {
+    const task = makeTask({ status: { phase: 'Pending' } })
+    render(<ExecutionGraph task={task} />)
+    expect(screen.getAllByRole('treeitem')).toHaveLength(1)
+    expect(screen.getByText('parent-task')).toBeInTheDocument()
+  })
+
+  it('nodes are keyboard-traversable and activate on Enter', async () => {
+    navigateMock.mockClear()
+    const task = makeTask({
+      status: {
+        phase: 'Running',
+        childTasks: [{ name: 'child-a', agent: 'reviewer', phase: 'Succeeded' }],
+      },
+    })
+    render(<ExecutionGraph task={task} />)
+    const user = userEvent.setup()
+    // Tab focuses the first node button; Tab again the child.
+    await user.tab()
+    await user.tab()
+    expect(document.activeElement?.textContent).toContain('child-a')
+    await user.keyboard('{Enter}')
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: '/tasks/$taskId',
+      params: { taskId: 'child-a' },
+    })
+  })
+
+  it('renders the type icon for the root node', () => {
+    const task = makeTask({ spec: { type: 'agent', agentRef: { name: 'o' } } })
+    const { container } = render(<ExecutionGraph task={task} />)
+    // root button carries an svg (type icon and/or dot)
+    expect(container.querySelector('[role="treeitem"] svg')).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/tasks/execution-graph.tsx
+++ b/ui/src/components/tasks/execution-graph.tsx
@@ -1,0 +1,126 @@
+import { useNavigate } from '@tanstack/react-router'
+import { cn } from '@/lib/utils'
+import { phaseStyle, typeStyle } from '@/lib/task-status'
+import { StatusDot } from '@/components/ui/status-dot'
+import type { Task, TaskPhase, TaskType } from '@/schemas/task'
+
+/** A node in the delegation graph. */
+interface GraphNode {
+  name: string
+  /** Agent that owns/handles this node (root may be undefined). */
+  agent?: string
+  phase?: TaskPhase | string
+  type?: TaskType | string
+  children: GraphNode[]
+}
+
+/**
+ * Build a graph from a parent task plus its (currently flat) `childTasks`.
+ *
+ * The Orka API exposes one delegation level (`status.childTasks[]`), so v1 is a
+ * root with a single tier of children. The shape is recursive (`children[]`)
+ * so this can upgrade to a true multi-level DAG later without changing the
+ * component API.
+ */
+function buildGraph(task: Task): GraphNode {
+  const children = (task.status?.childTasks ?? []).map((c) => ({
+    name: c.name,
+    agent: c.agent,
+    phase: c.phase,
+    children: [] as GraphNode[],
+  }))
+  return {
+    name: task.metadata.name,
+    agent: task.spec.agentRef?.name,
+    phase: task.status?.phase,
+    type: task.spec.type,
+    children,
+  }
+}
+
+function TreeNode({
+  node,
+  depth,
+  onNavigate,
+}: {
+  node: GraphNode
+  depth: number
+  onNavigate: (name: string) => void
+}) {
+  const phase = phaseStyle(node.phase)
+  const type = node.type ? typeStyle(node.type) : undefined
+  const TypeIcon = type?.icon
+  const hasChildren = node.children.length > 0
+
+  return (
+    <li role="treeitem" aria-label={`${node.name} (${phase.label})`} className="relative">
+      <button
+        type="button"
+        onClick={() => onNavigate(node.name)}
+        style={{ paddingLeft: `${depth * 1.25 + 0.5}rem` }}
+        className={cn(
+          'group flex w-full items-center gap-2 rounded-md border-l-2 py-1.5 pr-2 text-left transition-colors',
+          'hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          phase.railClass,
+        )}
+      >
+        <StatusDot phase={node.phase} hideLabel />
+        {TypeIcon && (
+          <TypeIcon className={cn('size-3.5 shrink-0', type?.textClass)} aria-hidden="true" />
+        )}
+        <span className="truncate font-mono text-xs font-medium">{node.name}</span>
+        {node.agent && (
+          <span className="truncate text-xs text-muted-foreground">{node.agent}</span>
+        )}
+        <span className={cn('ml-auto shrink-0 text-xs font-medium', phase.textClass)}>
+          {phase.label}
+        </span>
+      </button>
+      {hasChildren && (
+        <ul role="group" className="space-y-1">
+          {node.children.map((child) => (
+            <TreeNode key={child.name} node={child} depth={depth + 1} onNavigate={onNavigate} />
+          ))}
+        </ul>
+      )}
+    </li>
+  )
+}
+
+interface ExecutionGraphProps {
+  task: Task
+  /** Optional navigation override (defaults to TanStack router). */
+  onSelect?: (taskName: string) => void
+  className?: string
+}
+
+/**
+ * Live delegation graph for a task and its child tasks.
+ *
+ * v1 is an indented tree with phase-colored connector rails (no graph-layout
+ * dependency), structured so it can upgrade to a true DAG later. Nodes are
+ * colored by phase (shared status module), tagged with the task-type icon, and
+ * named in monospace; running nodes pulse via the shared <StatusDot>. Clicking
+ * a node routes to that task.
+ *
+ * Degrades gracefully: a task with no children renders just the root node.
+ */
+export function ExecutionGraph({ task, onSelect, className }: ExecutionGraphProps) {
+  const navigate = useNavigate()
+  const root = buildGraph(task)
+
+  const handleNavigate = (name: string) => {
+    if (onSelect) onSelect(name)
+    else navigate({ to: '/tasks/$taskId', params: { taskId: name } })
+  }
+
+  return (
+    <ul
+      role="tree"
+      aria-label="Task execution graph"
+      className={cn('space-y-1', className)}
+    >
+      <TreeNode node={root} depth={0} onNavigate={handleNavigate} />
+    </ul>
+  )
+}

--- a/ui/src/components/tasks/execution-graph.tsx
+++ b/ui/src/components/tasks/execution-graph.tsx
@@ -48,12 +48,16 @@ function TreeNode({
   onNavigate: (name: string) => void
 }) {
   const phase = phaseStyle(node.phase)
+  // Preserve the literal phase string for display/AT (matching StatusDot's
+  // contract); only the *styling* falls back to Pending for unknown phases.
+  const phaseLabel =
+    typeof node.phase === 'string' && node.phase ? node.phase : phase.label
   const type = node.type ? typeStyle(node.type) : undefined
   const TypeIcon = type?.icon
   const hasChildren = node.children.length > 0
 
   return (
-    <li role="treeitem" aria-label={`${node.name} (${phase.label})`} className="relative">
+    <li role="treeitem" aria-label={`${node.name} (${phaseLabel})`} className="relative">
       <button
         type="button"
         onClick={() => onNavigate(node.name)}
@@ -73,7 +77,7 @@ function TreeNode({
           <span className="truncate text-xs text-muted-foreground">{node.agent}</span>
         )}
         <span className={cn('ml-auto shrink-0 text-xs font-medium', phase.textClass)}>
-          {phase.label}
+          {phaseLabel}
         </span>
       </button>
       {hasChildren && (

--- a/ui/src/components/tasks/kanban-board.test.tsx
+++ b/ui/src/components/tasks/kanban-board.test.tsx
@@ -147,4 +147,23 @@ describe('KanbanBoard', () => {
     expect(chip).toHaveClass('bg-status-running-bg')
     expect(chip.className).not.toMatch(/bg-(yellow|blue|green|red)-/)
   })
+
+  it('shows a live pulse indicator ONLY on the Running column (liveness scarcity)', async () => {
+    render(<KanbanBoard />)
+    await waitFor(() => {
+      expect(screen.getByText('Running')).toBeInTheDocument()
+    })
+    // Exactly one live indicator, and it lives in the Running column header.
+    const indicators = screen.getAllByTestId('live-indicator')
+    expect(indicators).toHaveLength(1)
+    const indicator = indicators[0]
+    expect(indicator.className).toContain('bg-live')
+    expect(indicator.className).toContain('animate-pulse-live')
+    // It sits beside the "Running" heading, not Pending/Succeeded/Failed.
+    expect(indicator.parentElement?.textContent).toContain('Running')
+    for (const terminal of ['Pending', 'Succeeded', 'Failed']) {
+      const header = screen.getByText(terminal).parentElement!
+      expect(header.querySelector('[data-testid="live-indicator"]')).toBeNull()
+    }
+  })
 })

--- a/ui/src/components/tasks/kanban-board.test.tsx
+++ b/ui/src/components/tasks/kanban-board.test.tsx
@@ -102,4 +102,49 @@ describe('KanbanBoard', () => {
     render(<KanbanBoard />)
     expect(screen.getByText('Board')).toBeInTheDocument()
   })
+
+  it('each column has a phase-keyed top rail from the token system', async () => {
+    render(<KanbanBoard />)
+    await waitFor(() => {
+      expect(screen.getByText('Pending')).toBeInTheDocument()
+    })
+    const rails: Record<string, string> = {
+      Pending: 'border-status-pending',
+      Running: 'border-status-running',
+      Succeeded: 'border-status-succeeded',
+      Failed: 'border-status-failed',
+    }
+    for (const [label, railClass] of Object.entries(rails)) {
+      const column = screen.getByText(label).closest('.border-t-2')
+      expect(column).not.toBeNull()
+      expect(column).toHaveClass(railClass)
+    }
+  })
+
+  it('count chips use token tint/text classes, not pastels', async () => {
+    server.use(
+      http.get('/api/v1/tasks', () =>
+        HttpResponse.json({
+          items: [
+            {
+              metadata: { name: 'r1', namespace: 'default', uid: 'r1', creationTimestamp: new Date().toISOString() },
+              spec: { type: 'ai' },
+              status: { phase: 'Running' },
+            },
+          ],
+          metadata: {},
+        }),
+      ),
+    )
+    render(<KanbanBoard />)
+    const runningHeader = await screen.findByText('Running')
+    const header = runningHeader.parentElement!
+    const chip = header.querySelector('span:last-child')!
+    await waitFor(() => {
+      expect(chip).toHaveTextContent('1')
+    })
+    expect(chip).toHaveClass('text-status-running')
+    expect(chip).toHaveClass('bg-status-running-bg')
+    expect(chip.className).not.toMatch(/bg-(yellow|blue|green|red)-/)
+  })
 })

--- a/ui/src/components/tasks/kanban-board.test.tsx
+++ b/ui/src/components/tasks/kanban-board.test.tsx
@@ -47,6 +47,38 @@ describe('KanbanBoard', () => {
     expect(screen.getByText('No running tasks')).toBeInTheDocument()
     expect(screen.getByText('No succeeded tasks')).toBeInTheDocument()
     expect(screen.getByText('No failed tasks')).toBeInTheDocument()
+    expect(screen.getByText('No scheduled tasks')).toBeInTheDocument()
+    expect(screen.getByText('No cancelled tasks')).toBeInTheDocument()
+  })
+
+  it('has a column for every task phase and buckets Scheduled/Cancelled in their own columns', async () => {
+    server.use(
+      http.get('/api/v1/tasks', () =>
+        HttpResponse.json({
+          items: [
+            {
+              metadata: { name: 'sched-task', namespace: 'default', uid: 's1', creationTimestamp: new Date().toISOString() },
+              spec: { type: 'container' },
+              status: { phase: 'Scheduled' },
+            },
+            {
+              metadata: { name: 'cancel-task', namespace: 'default', uid: 'c1', creationTimestamp: new Date().toISOString() },
+              spec: { type: 'container' },
+              status: { phase: 'Cancelled' },
+            },
+          ],
+          metadata: {},
+        }),
+      ),
+    )
+    render(<KanbanBoard />)
+    await waitFor(() => expect(screen.getByText('sched-task')).toBeInTheDocument())
+    expect(screen.getByText('cancel-task')).toBeInTheDocument()
+    // Column headers exist for the new phases.
+    expect(screen.getByText('Scheduled')).toBeInTheDocument()
+    expect(screen.getByText('Cancelled')).toBeInTheDocument()
+    // The Pending column stays empty — Scheduled/Cancelled are NOT mis-bucketed.
+    expect(screen.getByText('No pending tasks')).toBeInTheDocument()
   })
 
   it('populated board shows tasks in correct columns', async () => {

--- a/ui/src/components/tasks/kanban-board.tsx
+++ b/ui/src/components/tasks/kanban-board.tsx
@@ -47,6 +47,13 @@ export function KanbanBoard() {
             )}
           >
             <div className="flex items-center gap-2 mb-3 px-1">
+              {style.live && (
+                <span
+                  data-testid="live-indicator"
+                  className="inline-block size-2 rounded-full bg-live motion-safe:animate-pulse-live"
+                  aria-hidden="true"
+                />
+              )}
               <h2 className="font-semibold text-sm">{label}</h2>
               <span
                 className={cn(

--- a/ui/src/components/tasks/kanban-board.tsx
+++ b/ui/src/components/tasks/kanban-board.tsx
@@ -1,14 +1,16 @@
-import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useTaskList } from '@/hooks/use-tasks'
+import { phaseStyle } from '@/lib/task-status'
+import { cn } from '@/lib/utils'
+import { PageHeader } from '@/components/layout/page-header'
 import { KanbanCard } from './kanban-card'
 import type { Task, TaskPhase } from '@/schemas/task'
 
-const columns: { phase: TaskPhase; label: string; color: string }[] = [
-  { phase: 'Pending', label: 'Pending', color: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200' },
-  { phase: 'Running', label: 'Running', color: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200' },
-  { phase: 'Succeeded', label: 'Succeeded', color: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' },
-  { phase: 'Failed', label: 'Failed', color: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' },
+const columns: { phase: TaskPhase; label: string }[] = [
+  { phase: 'Pending', label: 'Pending' },
+  { phase: 'Running', label: 'Running' },
+  { phase: 'Succeeded', label: 'Succeeded' },
+  { phase: 'Failed', label: 'Failed' },
 ]
 
 function groupByPhase(tasks: Task[]): Record<string, Task[]> {
@@ -31,20 +33,32 @@ export function KanbanBoard() {
 
   return (
     <div className="space-y-4">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Board</h1>
-        <p className="text-muted-foreground">Kanban view of task execution</p>
-      </div>
+      <PageHeader title="Board" description="Kanban view of task execution" />
       <div className="flex gap-4 overflow-x-auto pb-4">
-        {columns.map(({ phase, label, color }) => (
-          <div key={phase} className="flex flex-col min-w-[280px] flex-1">
+        {columns.map(({ phase, label }) => {
+          const style = phaseStyle(phase)
+          return (
+          <div
+            key={phase}
+            className={cn(
+              'flex flex-col min-w-[280px] flex-1 rounded-lg border-t-2 px-1 pt-2',
+              style.railClass,
+              style.bgClass,
+            )}
+          >
             <div className="flex items-center gap-2 mb-3 px-1">
               <h2 className="font-semibold text-sm">{label}</h2>
-              <Badge className={color} variant="secondary">
+              <span
+                className={cn(
+                  'inline-flex items-center justify-center rounded-full px-2 py-0.5 text-xs font-medium tabular-nums',
+                  style.bgClass,
+                  style.textClass,
+                )}
+              >
                 {isLoading ? '…' : grouped[phase].length}
-              </Badge>
+              </span>
             </div>
-            <div className="flex flex-col gap-2 min-h-[120px]">
+            <div className="flex flex-col gap-2 min-h-[120px] pb-2">
               {isLoading ? (
                 Array.from({ length: 2 }).map((_, i) => (
                   <Skeleton key={i} className="h-20 w-full rounded-xl" />
@@ -58,7 +72,8 @@ export function KanbanBoard() {
               )}
             </div>
           </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )

--- a/ui/src/components/tasks/kanban-board.tsx
+++ b/ui/src/components/tasks/kanban-board.tsx
@@ -6,15 +6,21 @@ import { PageHeader } from '@/components/layout/page-header'
 import { KanbanCard } from './kanban-card'
 import type { Task, TaskPhase } from '@/schemas/task'
 
+// One column per backend task phase, in lifecycle order, so every task lands in
+// its real column instead of being mis-bucketed as Pending.
 const columns: { phase: TaskPhase; label: string }[] = [
   { phase: 'Pending', label: 'Pending' },
+  { phase: 'Scheduled', label: 'Scheduled' },
   { phase: 'Running', label: 'Running' },
   { phase: 'Succeeded', label: 'Succeeded' },
   { phase: 'Failed', label: 'Failed' },
+  { phase: 'Cancelled', label: 'Cancelled' },
 ]
 
 function groupByPhase(tasks: Task[]): Record<string, Task[]> {
-  const groups: Record<string, Task[]> = { Pending: [], Running: [], Succeeded: [], Failed: [] }
+  const groups: Record<string, Task[]> = Object.fromEntries(
+    columns.map((c) => [c.phase, [] as Task[]]),
+  )
   for (const task of tasks) {
     const phase = task.status?.phase ?? 'Pending'
     if (groups[phase]) {

--- a/ui/src/components/tasks/kanban-card.test.tsx
+++ b/ui/src/components/tasks/kanban-card.test.tsx
@@ -19,7 +19,7 @@ vi.mock('@tanstack/react-router', async () => {
 })
 
 import { KanbanCard } from './kanban-card'
-import type { Task } from '@/schemas/task'
+import type { Task, TaskPhase } from '@/schemas/task'
 
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
@@ -105,5 +105,34 @@ describe('KanbanCard', () => {
     })
     render(<KanbanCard task={task} />)
     expect(screen.queryByText(/pri:/)).not.toBeInTheDocument()
+  })
+
+  it('applies a phase-keyed left-rail accent from the token system', () => {
+    const cases: { phase: TaskPhase; rail: string }[] = [
+      { phase: 'Pending', rail: 'border-status-pending' },
+      { phase: 'Running', rail: 'border-status-running' },
+      { phase: 'Succeeded', rail: 'border-status-succeeded' },
+      { phase: 'Failed', rail: 'border-status-failed' },
+    ]
+    for (const { phase, rail } of cases) {
+      const { container, unmount } = render(<KanbanCard task={makeTask({ status: { phase } })} />)
+      const card = container.querySelector('[data-slot="card"]')
+      expect(card).toHaveClass('border-l-4')
+      expect(card).toHaveClass(rail)
+      unmount()
+    }
+  })
+
+  it('conveys phase to assistive tech, not by color alone', () => {
+    render(<KanbanCard task={makeTask({ status: { phase: 'Failed' } })} />)
+    expect(screen.getByText('Phase: Failed')).toBeInTheDocument()
+  })
+
+  it('renders the type badge with token tint classes, not pastels', () => {
+    render(<KanbanCard task={makeTask({ spec: { type: 'ai' } })} />)
+    const badge = screen.getByText('ai').closest('[data-slot="badge"]')
+    expect(badge).toHaveClass('bg-type-ai/10')
+    expect(badge).toHaveClass('text-type-ai')
+    expect(badge?.className).not.toMatch(/bg-(purple|indigo|teal)-/)
   })
 })

--- a/ui/src/components/tasks/kanban-card.tsx
+++ b/ui/src/components/tasks/kanban-card.tsx
@@ -1,6 +1,9 @@
 import { Link } from '@tanstack/react-router'
+import { Timer, GitBranch } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { phaseStyle, typeStyle } from '@/lib/task-status'
+import { cn } from '@/lib/utils'
 import type { Task } from '@/schemas/task'
 
 function elapsed(startTime?: string): string {
@@ -12,24 +15,26 @@ function elapsed(startTime?: string): string {
   return `${Math.floor(s / 86400)}d`
 }
 
-const typeBadgeStyles: Record<string, string> = {
-  container: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
-  ai: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200',
-  agent: 'bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200',
-}
-
 export function KanbanCard({ task }: { task: Task }) {
   const childCount = task.status?.childTasks?.length ?? 0
   const isRunning = task.status?.phase === 'Running'
+  const phase = phaseStyle(task.status?.phase)
+  const type = typeStyle(task.spec.type)
+  const TypeIcon = type.icon
 
   return (
     <Link to="/tasks/$taskId" params={{ taskId: task.metadata.name }} className="block">
-      <Card className="gap-0 py-3 hover:shadow-md transition-shadow cursor-pointer">
+      <Card
+        className={cn('gap-0 py-3 border-l-4 transition-all cursor-pointer hover:shadow-md motion-safe:hover:-translate-y-0.5', phase.railClass)}
+      >
         <CardContent className="px-3 py-0 space-y-1.5">
+          {/* Phase is encoded by the left-rail color; surface it to AT too. */}
+          <span className="sr-only">Phase: {phase.label}</span>
           <div className="flex items-center justify-between gap-2">
             <span className="font-semibold text-sm truncate">{task.metadata.name}</span>
-            <Badge className={typeBadgeStyles[task.spec.type] ?? ''} variant="secondary">
-              {task.spec.type}
+            <Badge className={type.tintClass} variant="secondary">
+              <TypeIcon aria-hidden="true" />
+              {type.label}
             </Badge>
           </div>
           <div className="flex items-center gap-2 text-xs text-muted-foreground flex-wrap">
@@ -43,10 +48,14 @@ export function KanbanCard({ task }: { task: Task }) {
           </div>
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             {isRunning && task.status?.startTime && (
-              <span data-testid="elapsed-time">⏱ {elapsed(task.status.startTime)}</span>
+              <span data-testid="elapsed-time" className="inline-flex items-center gap-1 tabular-nums">
+                <Timer className="size-3" aria-hidden="true" /> {elapsed(task.status.startTime)}
+              </span>
             )}
             {childCount > 0 && (
-              <span data-testid="child-count">🔗 {childCount} child{childCount !== 1 ? 'ren' : ''}</span>
+              <span data-testid="child-count" className="inline-flex items-center gap-1">
+                <GitBranch className="size-3" aria-hidden="true" /> {childCount} child{childCount !== 1 ? 'ren' : ''}
+              </span>
             )}
           </div>
         </CardContent>

--- a/ui/src/components/tasks/pr-status-badge.tsx
+++ b/ui/src/components/tasks/pr-status-badge.tsx
@@ -15,9 +15,9 @@ export function PRStatusBadge({ annotations }: PRStatusBadgeProps) {
   if (!prUrl && !prNumber) return null
 
   const statusColors: Record<string, string> = {
-    open: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-    merged: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
-    closed: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+    open: 'bg-status-succeeded-bg text-status-succeeded',
+    merged: 'bg-type-ai/10 text-type-ai',
+    closed: 'bg-status-failed-bg text-status-failed',
   }
 
   return (

--- a/ui/src/components/tasks/run-timeline.test.tsx
+++ b/ui/src/components/tasks/run-timeline.test.tsx
@@ -105,6 +105,24 @@ describe('RunTimeline', () => {
     expect(screen.getByText('Succeeded')).toBeInTheDocument()
   })
 
+  it('treats a Cancelled run as terminal (no pulsing iteration, shows a neutral terminal marker)', () => {
+    const task = makeTask({
+      status: {
+        phase: 'Cancelled',
+        iteration: 3,
+        startTime: '2026-01-01T00:01:00Z',
+        completionTime: '2026-01-01T00:30:00Z',
+      },
+    })
+    const { container } = render(<RunTimeline task={task} plan={{ summary: 'stopped early' }} />)
+    const cancelled = screen.getByText('Cancelled')
+    expect(cancelled).toBeInTheDocument()
+    // Neutral (not failed/success) styling for a user-stopped run.
+    expect(cancelled.className).toContain('text-muted-foreground')
+    // The current iteration must NOT remain active/pulsing on a terminal run.
+    expect(container.querySelector('[class*="animate-pulse-live"]')).toBeNull()
+  })
+
   it('renders a Failed terminal event with failed styling (not success)', () => {
     const task = makeTask({
       status: {

--- a/ui/src/components/tasks/run-timeline.test.tsx
+++ b/ui/src/components/tasks/run-timeline.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@/test/test-utils'
+import { RunTimeline } from './run-timeline'
+import type { Task, PlanState } from '@/schemas/task'
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    metadata: {
+      name: 'auto-task',
+      namespace: 'default',
+      uid: 'uid-1',
+      creationTimestamp: '2026-01-01T00:00:00Z',
+    },
+    spec: { type: 'agent', agentRef: { name: 'looper' } },
+    status: { phase: 'Running', iteration: 2, startTime: '2026-01-01T00:01:00Z' },
+    ...overrides,
+  } as Task
+}
+
+describe('RunTimeline', () => {
+  it('renders events in chronological order from conditions + iteration', () => {
+    const task = makeTask({
+      status: {
+        phase: 'Running',
+        iteration: 1,
+        startTime: '2026-01-01T00:01:00Z',
+        conditions: [
+          { type: 'PlanReady', status: 'True', lastTransitionTime: '2026-01-01T00:02:00Z' },
+          { type: 'Scheduled', status: 'True', lastTransitionTime: '2026-01-01T00:00:30Z' },
+        ],
+      },
+    })
+    render(<RunTimeline task={task} plan={{ summary: 'do the thing' }} />)
+    const labels = screen.getAllByRole('listitem').map((li) => li.textContent)
+    // Created (00:00) → Scheduled (00:00:30) → Started (00:01) → PlanReady (00:02) → Iteration 1
+    const text = labels.join('|')
+    expect(text).toMatch(/Created/)
+    const createdIdx = labels.findIndex((l) => l?.includes('Created'))
+    const scheduledIdx = labels.findIndex((l) => l?.includes('Scheduled'))
+    const startedIdx = labels.findIndex((l) => l?.includes('Started'))
+    const planReadyIdx = labels.findIndex((l) => l?.includes('PlanReady'))
+    expect(createdIdx).toBeLessThan(scheduledIdx)
+    expect(scheduledIdx).toBeLessThan(startedIdx)
+    expect(startedIdx).toBeLessThan(planReadyIdx)
+  })
+
+  it('shows the iteration with the plan summary as detail', () => {
+    const task = makeTask()
+    render(<RunTimeline task={task} plan={{ summary: 'refactor module' }} />)
+    expect(screen.getByText('Iteration 2')).toBeInTheDocument()
+    expect(screen.getByText('refactor module')).toBeInTheDocument()
+  })
+
+  it('renders a progress bar whose width reflects plan.progressPct', () => {
+    const task = makeTask()
+    const plan: PlanState = { summary: 's', progressPct: 42 }
+    render(<RunTimeline task={task} plan={plan} />)
+    const bar = screen.getByRole('progressbar', { name: /goal progress/i })
+    expect(bar).toHaveAttribute('aria-valuenow', '42')
+    const fill = bar.querySelector('div') as HTMLElement
+    expect(fill.style.width).toBe('42%')
+  })
+
+  it('applies the completed treatment when goalComplete is true', () => {
+    const task = makeTask()
+    render(<RunTimeline task={task} plan={{ progressPct: 100, goalComplete: true }} />)
+    expect(screen.getByText('Goal complete')).toBeInTheDocument()
+    const fill = screen.getByRole('progressbar').querySelector('div') as HTMLElement
+    expect(fill.className).toContain('bg-status-succeeded')
+  })
+
+  it('renders iteration tick marks for multi-iteration runs', () => {
+    const task = makeTask({ status: { phase: 'Running', iteration: 3 } })
+    render(<RunTimeline task={task} plan={{ progressPct: 60 }} />)
+    const bar = screen.getByRole('progressbar')
+    // iteration-1 tick marks => 2 ticks (the fill div + 2 ticks = 3 child divs/spans)
+    const ticks = bar.querySelectorAll('span[aria-hidden="true"]')
+    expect(ticks.length).toBe(2)
+  })
+
+  it('handles a missing plan gracefully (conditions-only timeline, no crash)', () => {
+    const task = makeTask({
+      status: {
+        phase: 'Running',
+        iteration: 1,
+        conditions: [{ type: 'Scheduled', status: 'True', lastTransitionTime: '2026-01-01T00:00:30Z' }],
+      },
+    })
+    render(<RunTimeline task={task} />)
+    expect(screen.getByText('Scheduled')).toBeInTheDocument()
+    expect(screen.getByText('Iteration 1')).toBeInTheDocument()
+    // No progressbar when there is no progressPct.
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+  })
+
+  it('marks a terminal phase as a final done event', () => {
+    const task = makeTask({
+      status: {
+        phase: 'Succeeded',
+        iteration: 2,
+        completionTime: '2026-01-01T01:00:00Z',
+      },
+    })
+    render(<RunTimeline task={task} plan={{ summary: 's' }} />)
+    expect(screen.getByText('Succeeded')).toBeInTheDocument()
+  })
+
+  it('renders a Failed terminal event with failed styling (not success)', () => {
+    const task = makeTask({
+      status: {
+        phase: 'Failed',
+        iteration: 2,
+        completionTime: '2026-01-01T01:00:00Z',
+      },
+    })
+    render(<RunTimeline task={task} plan={{ summary: 's' }} />)
+    const failedLabel = screen.getByText('Failed')
+    // Label carries the failed token color, not success.
+    expect(failedLabel.className).toContain('text-status-failed')
+    expect(failedLabel.className).not.toContain('text-status-succeeded')
+  })
+
+  it('keeps the terminal event last even when it has a completionTime and the iteration does not', () => {
+    // Regression: a timestamped terminal event must not sort ahead of the
+    // undated synthetic "Iteration N" event.
+    const task = makeTask({
+      status: {
+        phase: 'Succeeded',
+        iteration: 4,
+        startTime: '2026-01-01T00:01:00Z',
+        completionTime: '2026-01-01T02:00:00Z',
+        conditions: [
+          { type: 'PlanReady', status: 'True', lastTransitionTime: '2026-01-01T00:02:00Z' },
+        ],
+      },
+    })
+    render(<RunTimeline task={task} plan={{ summary: 'done thinking' }} />)
+    const labels = screen.getAllByRole('listitem').map((li) => li.textContent ?? '')
+    const iterationIdx = labels.findIndex((l) => l.includes('Iteration 4'))
+    const terminalIdx = labels.findIndex((l) => l.includes('Succeeded'))
+    expect(iterationIdx).toBeGreaterThanOrEqual(0)
+    expect(terminalIdx).toBeGreaterThan(iterationIdx)
+    // Terminal is the final event.
+    expect(terminalIdx).toBe(labels.length - 1)
+  })
+})

--- a/ui/src/components/tasks/run-timeline.tsx
+++ b/ui/src/components/tasks/run-timeline.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/lib/utils'
-import { CheckCircle2, Circle, XCircle, Flag } from 'lucide-react'
-import type { Task, PlanState } from '@/schemas/task'
+import { CheckCircle2, Circle, XCircle, MinusCircle, Flag } from 'lucide-react'
+import type { Task, PlanState, TaskPhase } from '@/schemas/task'
 
 interface TimelineEvent {
   key: string
@@ -15,7 +15,12 @@ interface TimelineEvent {
    * still-running synthetic event.
    */
   bucket: number
-  status: 'done' | 'active' | 'pending' | 'failed'
+  status: 'done' | 'active' | 'pending' | 'failed' | 'cancelled'
+}
+
+/** The backend's terminal task phases — no further iterations follow these. */
+function isTerminalPhase(phase?: TaskPhase | string): boolean {
+  return phase === 'Succeeded' || phase === 'Failed' || phase === 'Cancelled'
 }
 
 /** A condition as carried on task.status.conditions[]. */
@@ -78,7 +83,7 @@ function buildEvents(task: Task, plan?: PlanState): TimelineEvent[] {
   // sorts after the work that led to it rather than floating to the end.
   const iteration = task.status?.iteration ?? 0
   if (iteration > 0) {
-    const terminal = phase === 'Succeeded' || phase === 'Failed'
+    const terminal = isTerminalPhase(phase)
     const startMs = task.status?.startTime ? new Date(task.status.startTime).getTime() : NaN
     const anchorMs = Math.max(
       ...conditionTimes,
@@ -95,14 +100,15 @@ function buildEvents(task: Task, plan?: PlanState): TimelineEvent[] {
   }
 
   // Terminal marker — pinned to the last bucket so it always renders last,
-  // with phase-correct styling.
-  if (phase === 'Succeeded' || phase === 'Failed') {
+  // with phase-correct styling. Cancelled is terminal too (a user-stopped run),
+  // shown neutrally rather than as a failure.
+  if (isTerminalPhase(phase)) {
     events.push({
       key: 'terminal',
-      label: phase,
+      label: phase as string,
       at: task.status?.completionTime,
       bucket: 1,
-      status: phase === 'Failed' ? 'failed' : 'done',
+      status: phase === 'Failed' ? 'failed' : phase === 'Cancelled' ? 'cancelled' : 'done',
     })
   }
 
@@ -126,6 +132,8 @@ function buildEvents(task: Task, plan?: PlanState): TimelineEvent[] {
 function EventIcon({ status }: { status: TimelineEvent['status'] }) {
   if (status === 'failed')
     return <XCircle className="size-4 text-status-failed" aria-hidden="true" />
+  if (status === 'cancelled')
+    return <MinusCircle className="size-4 text-muted-foreground" aria-hidden="true" />
   if (status === 'done')
     return <CheckCircle2 className="size-4 text-status-succeeded" aria-hidden="true" />
   if (status === 'active')
@@ -211,6 +219,7 @@ export function RunTimeline({ task, plan, className }: RunTimelineProps) {
                   'text-sm font-medium',
                   e.status === 'active' && 'text-status-running',
                   e.status === 'failed' && 'text-status-failed',
+                  e.status === 'cancelled' && 'text-muted-foreground',
                 )}
               >
                 {e.label}

--- a/ui/src/components/tasks/run-timeline.tsx
+++ b/ui/src/components/tasks/run-timeline.tsx
@@ -1,0 +1,225 @@
+import { cn } from '@/lib/utils'
+import { CheckCircle2, Circle, XCircle, Flag } from 'lucide-react'
+import type { Task, PlanState } from '@/schemas/task'
+
+interface TimelineEvent {
+  key: string
+  label: string
+  detail?: string
+  /** ISO timestamp used for chronological ordering (optional). */
+  at?: string
+  /**
+   * Ordering bucket. Everything shares bucket 0 and sorts purely by timestamp;
+   * the terminal marker is pinned to bucket 1 so it always renders last, even
+   * when an earlier event is undated or its completion time precedes a
+   * still-running synthetic event.
+   */
+  bucket: number
+  status: 'done' | 'active' | 'pending' | 'failed'
+}
+
+/** A condition as carried on task.status.conditions[]. */
+interface Condition {
+  type: string
+  status: string
+  reason?: string
+  message?: string
+  lastTransitionTime?: string
+}
+
+/**
+ * Derive an ordered list of timeline events from a task's conditions and
+ * iteration. Events sort chronologically by timestamp; the synthetic
+ * "Iteration N" event is anchored to the latest known time so it slots after
+ * the work that preceded it, and the terminal marker is always pinned last.
+ */
+function buildEvents(task: Task, plan?: PlanState): TimelineEvent[] {
+  const events: TimelineEvent[] = []
+  const phase = task.status?.phase
+
+  events.push({
+    key: 'created',
+    label: 'Created',
+    at: task.metadata.creationTimestamp,
+    bucket: 0,
+    status: 'done',
+  })
+
+  if (task.status?.startTime) {
+    events.push({
+      key: 'started',
+      label: 'Started',
+      at: task.status.startTime,
+      bucket: 0,
+      status: 'done',
+    })
+  }
+
+  // Merge status conditions as timestamped events.
+  const conditions = (task.status?.conditions ?? []) as Condition[]
+  const conditionTimes: number[] = []
+  for (const c of conditions) {
+    if (c.lastTransitionTime) {
+      const t = new Date(c.lastTransitionTime).getTime()
+      if (!Number.isNaN(t)) conditionTimes.push(t)
+    }
+    events.push({
+      key: `cond-${c.type}`,
+      label: c.type,
+      detail: c.message ?? c.reason,
+      at: c.lastTransitionTime,
+      bucket: 0,
+      status: c.status === 'True' ? 'done' : 'pending',
+    })
+  }
+
+  // The current iteration, with the plan summary as its detail. Anchor it to
+  // the latest known activity time (newest condition, else startTime) so it
+  // sorts after the work that led to it rather than floating to the end.
+  const iteration = task.status?.iteration ?? 0
+  if (iteration > 0) {
+    const terminal = phase === 'Succeeded' || phase === 'Failed'
+    const startMs = task.status?.startTime ? new Date(task.status.startTime).getTime() : NaN
+    const anchorMs = Math.max(
+      ...conditionTimes,
+      Number.isNaN(startMs) ? -Infinity : startMs,
+    )
+    events.push({
+      key: `iteration-${iteration}`,
+      label: `Iteration ${iteration}`,
+      detail: plan?.summary,
+      at: Number.isFinite(anchorMs) ? new Date(anchorMs).toISOString() : undefined,
+      bucket: 0,
+      status: terminal ? 'done' : 'active',
+    })
+  }
+
+  // Terminal marker — pinned to the last bucket so it always renders last,
+  // with phase-correct styling.
+  if (phase === 'Succeeded' || phase === 'Failed') {
+    events.push({
+      key: 'terminal',
+      label: phase,
+      at: task.status?.completionTime,
+      bucket: 1,
+      status: phase === 'Failed' ? 'failed' : 'done',
+    })
+  }
+
+  // Sort by bucket (terminal last), then chronologically within a bucket;
+  // undated events keep insertion order via the stable index tiebreak.
+  return events
+    .map((e, i) => ({ e, i }))
+    .sort((a, b) => {
+      if (a.e.bucket !== b.e.bucket) return a.e.bucket - b.e.bucket
+      const ta = a.e.at ? new Date(a.e.at).getTime() : Number.NaN
+      const tb = b.e.at ? new Date(b.e.at).getTime() : Number.NaN
+      if (Number.isNaN(ta) && Number.isNaN(tb)) return a.i - b.i
+      if (Number.isNaN(ta)) return 1
+      if (Number.isNaN(tb)) return -1
+      if (ta === tb) return a.i - b.i
+      return ta - tb
+    })
+    .map(({ e }) => e)
+}
+
+function EventIcon({ status }: { status: TimelineEvent['status'] }) {
+  if (status === 'failed')
+    return <XCircle className="size-4 text-status-failed" aria-hidden="true" />
+  if (status === 'done')
+    return <CheckCircle2 className="size-4 text-status-succeeded" aria-hidden="true" />
+  if (status === 'active')
+    return (
+      <Circle className="size-4 text-status-running motion-safe:animate-pulse-live" aria-hidden="true" />
+    )
+  return <Circle className="size-4 text-muted-foreground" aria-hidden="true" />
+}
+
+interface RunTimelineProps {
+  task: Task
+  plan?: PlanState
+  className?: string
+}
+
+/**
+ * Autonomous-loop timeline — renders a run as a plan→act→re-plan→converge
+ * story instead of a lone "Iteration: 4" metadata field.
+ *
+ * Vertical stepper: Created → Started → (conditions, by lastTransitionTime) →
+ * Iteration N (plan summary) → terminal (Succeeded/Failed), with a goal
+ * progress bar carrying iteration tick marks and explicit goal-complete styling.
+ *
+ * Handles a missing `plan` gracefully (falls back to a conditions-only
+ * timeline). Intended to be gated by the caller on `iteration > 0`.
+ */
+export function RunTimeline({ task, plan, className }: RunTimelineProps) {
+  const events = buildEvents(task, plan)
+  const iteration = task.status?.iteration ?? 0
+  const progressPct = plan?.progressPct
+  const goalComplete = plan?.goalComplete ?? false
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      {progressPct !== undefined && (
+        <div className="space-y-1">
+          <div className="flex items-center justify-between text-sm">
+            <span className="flex items-center gap-1.5 font-medium">
+              {goalComplete && <Flag className="size-3.5 text-status-succeeded" aria-hidden="true" />}
+              {goalComplete ? 'Goal complete' : 'Progress toward goal'}
+            </span>
+            <span className="tabular-nums text-muted-foreground">{progressPct}%</span>
+          </div>
+          <div
+            className="relative h-2 overflow-hidden rounded-full bg-muted"
+            role="progressbar"
+            aria-valuenow={progressPct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label="Goal progress"
+          >
+            <div
+              className={cn(
+                'h-full rounded-full transition-all',
+                goalComplete ? 'bg-status-succeeded' : 'bg-primary',
+              )}
+              style={{ width: `${Math.min(100, Math.max(0, progressPct))}%` }}
+            />
+            {/* Iteration tick marks. */}
+            {iteration > 1 &&
+              Array.from({ length: iteration - 1 }).map((_, i) => (
+                <span
+                  key={i}
+                  className="absolute top-0 h-full w-px bg-background/60"
+                  style={{ left: `${((i + 1) / iteration) * 100}%` }}
+                  aria-hidden="true"
+                />
+              ))}
+          </div>
+        </div>
+      )}
+
+      <ol className="space-y-0">
+        {events.map((e, i) => (
+          <li key={e.key} className="flex gap-3">
+            <div className="flex flex-col items-center">
+              <EventIcon status={e.status} />
+              {i < events.length - 1 && <span className="w-px flex-1 bg-border" aria-hidden="true" />}
+            </div>
+            <div className={cn('pb-4', i === events.length - 1 && 'pb-0')}>
+              <p
+                className={cn(
+                  'text-sm font-medium',
+                  e.status === 'active' && 'text-status-running',
+                  e.status === 'failed' && 'text-status-failed',
+                )}
+              >
+                {e.label}
+              </p>
+              {e.detail && <p className="text-xs text-muted-foreground">{e.detail}</p>}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  )
+}

--- a/ui/src/components/tasks/structured-log-viewer.test.tsx
+++ b/ui/src/components/tasks/structured-log-viewer.test.tsx
@@ -110,7 +110,10 @@ describe('StructuredLogViewer', () => {
     })
 
     render(<StructuredLogViewer taskId="task-1" />)
-    expect(screen.getByText('● Streaming')).toBeInTheDocument()
+    const streaming = screen.getByText('Streaming')
+    expect(streaming).toBeInTheDocument()
+    // Liveness uses the reserved live token, not an ad-hoc pastel.
+    expect(streaming.className).toContain('text-live')
   })
 
   it('shows live indicator for running tasks', () => {
@@ -124,6 +127,11 @@ describe('StructuredLogViewer', () => {
     })
 
     render(<StructuredLogViewer taskId="task-1" taskPhase="Running" />)
-    expect(screen.getByText('● Live')).toBeInTheDocument()
+    const live = screen.getByText('Live')
+    expect(live).toBeInTheDocument()
+    expect(live.className).toContain('text-live')
+    // The live badge carries a motion-safe pulsing dot (class includes the
+    // motion-safe: variant prefix in the DOM).
+    expect(live.querySelector('[class*="animate-pulse-live"]')).not.toBeNull()
   })
 })

--- a/ui/src/components/tasks/structured-log-viewer.tsx
+++ b/ui/src/components/tasks/structured-log-viewer.tsx
@@ -4,7 +4,8 @@ import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useTaskLogs } from '@/hooks/use-task-logs'
-import { ArrowDown, Search, X, RefreshCw } from 'lucide-react'
+import { ArrowDown, Search, X, RefreshCw, ScrollText } from 'lucide-react'
+import { EmptyState } from '@/components/ui/empty-state'
 
 type LogLevel = 'info' | 'warn' | 'error' | 'debug' | 'default'
 
@@ -81,7 +82,7 @@ export function StructuredLogViewer({ taskId, taskPhase }: { taskId: string; tas
               <Skeleton className="h-4 w-5/6" />
             </div>
           ) : (
-            <p className="text-sm text-muted-foreground">No logs available yet.</p>
+            <EmptyState headline="No logs available yet." icon={ScrollText} />
           )}
         </CardContent>
       </Card>
@@ -149,10 +150,11 @@ export function StructuredLogViewer({ taskId, taskPhase }: { taskId: string; tas
                 scrollToBottom()
               }}
               title="Pin to bottom"
+              aria-label="Pin logs to bottom"
             >
               <ArrowDown className="h-3 w-3" />
             </Button>
-            <Button variant="outline" size="sm" onClick={clear}>Clear</Button>
+            <Button variant="outline" size="sm" onClick={clear} aria-label="Clear logs">Clear</Button>
           </div>
         </div>
       </CardHeader>

--- a/ui/src/components/tasks/structured-log-viewer.tsx
+++ b/ui/src/components/tasks/structured-log-viewer.tsx
@@ -115,10 +115,16 @@ export function StructuredLogViewer({ taskId, taskPhase }: { taskId: string; tas
               ({filteredLogs.length} line{filteredLogs.length !== 1 ? 's' : ''})
             </span>
             {isLive && (
-              <span className="text-xs font-normal text-green-600 dark:text-green-400 animate-pulse">● Live</span>
+              <span className="flex items-center gap-1 text-xs font-normal text-live">
+                <span className="inline-block size-1.5 rounded-full bg-live motion-safe:animate-pulse-live" aria-hidden="true" />
+                Live
+              </span>
             )}
             {isStreaming && !isLive && (
-              <span className="text-xs font-normal text-blue-600 dark:text-blue-400">● Streaming</span>
+              <span className="flex items-center gap-1 text-xs font-normal text-live">
+                <span className="inline-block size-1.5 rounded-full bg-live" aria-hidden="true" />
+                Streaming
+              </span>
             )}
           </CardTitle>
           <div className="flex items-center gap-2">

--- a/ui/src/components/tasks/task-create-form.tsx
+++ b/ui/src/components/tasks/task-create-form.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Badge } from '@/components/ui/badge'
 import { Switch } from '@/components/ui/switch'
+import { PageHeader } from '@/components/layout/page-header'
 import { useCreateTask } from '@/hooks/use-tasks'
 import { useAgentList } from '@/hooks/use-agents'
 import { useUIStore } from '@/stores/ui'
@@ -86,10 +87,7 @@ export function TaskCreateForm() {
 
   return (
     <div className="space-y-4">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Create Task</h1>
-        <p className="text-muted-foreground">Create a new task for execution</p>
-      </div>
+      <PageHeader title="Create Task" description="Create a new task for execution" />
       <Card>
         <CardHeader>
           <CardTitle>Task Configuration</CardTitle>

--- a/ui/src/components/tasks/task-detail.test.tsx
+++ b/ui/src/components/tasks/task-detail.test.tsx
@@ -208,4 +208,64 @@ describe('TaskDetail', () => {
     expect(screen.getByText('2h ago')).toBeInTheDocument()
     expect(screen.getByText('2d ago')).toBeInTheDocument()
   })
+
+  it('renders the execution graph (not a table) in the Children tab', async () => {
+    server.use(
+      http.get('/api/v1/tasks/:id', () =>
+        HttpResponse.json({
+          metadata: { name: 'parent', namespace: 'default', uid: 'uid-p', creationTimestamp: new Date().toISOString() },
+          spec: { type: 'agent', agentRef: { name: 'orchestrator' } },
+          status: {
+            phase: 'Running',
+            childTasks: [
+              { name: 'child-1', agent: 'reviewer', phase: 'Succeeded' },
+              { name: 'child-2', agent: 'fixer', phase: 'Running' },
+            ],
+          },
+        }),
+      ),
+    )
+    render(<TaskDetail taskId="parent" />)
+    await waitFor(() => expect(screen.getByText('parent')).toBeInTheDocument())
+    await userEvent.click(screen.getByRole('tab', { name: /children/i }))
+    // Execution graph (role=tree) replaces the old child-tasks table.
+    expect(await screen.findByRole('tree', { name: /execution graph/i })).toBeInTheDocument()
+    expect(screen.getByText('child-1')).toBeInTheDocument()
+    expect(screen.getByText('child-2')).toBeInTheDocument()
+  })
+
+  it('renders the run timeline in the Plan tab when iterating', async () => {
+    server.use(
+      http.get('/api/v1/tasks/:id', () =>
+        HttpResponse.json({
+          metadata: { name: 'auto', namespace: 'default', uid: 'uid-a', creationTimestamp: new Date().toISOString() },
+          spec: { type: 'agent', agentRef: { name: 'looper' } },
+          status: { phase: 'Running', iteration: 3, startTime: new Date().toISOString() },
+          plan: { summary: 'converging on the goal', progressPct: 66 },
+        }),
+      ),
+    )
+    render(<TaskDetail taskId="auto" />)
+    await waitFor(() => expect(screen.getByText('auto')).toBeInTheDocument())
+    await userEvent.click(screen.getByRole('tab', { name: /plan/i }))
+    // RunTimeline shows the iteration + plan summary + progress bar.
+    expect(await screen.findAllByText('Iteration 3')).toHaveLength(1)
+    expect(screen.getAllByText('converging on the goal').length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('progressbar', { name: /goal progress/i }).length).toBeGreaterThan(0)
+  })
+
+  it('does not show the Plan tab when iteration is 0', async () => {
+    server.use(
+      http.get('/api/v1/tasks/:id', () =>
+        HttpResponse.json({
+          metadata: { name: 'noiter', namespace: 'default', uid: 'uid-n', creationTimestamp: new Date().toISOString() },
+          spec: { type: 'container', image: 'alpine' },
+          status: { phase: 'Running', iteration: 0 },
+        }),
+      ),
+    )
+    render(<TaskDetail taskId="noiter" />)
+    await waitFor(() => expect(screen.getByText('noiter')).toBeInTheDocument())
+    expect(screen.queryByRole('tab', { name: /plan/i })).not.toBeInTheDocument()
+  })
 })

--- a/ui/src/components/tasks/task-detail.tsx
+++ b/ui/src/components/tasks/task-detail.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { ArrowLeft, Trash2 } from 'lucide-react'
+import { PageHeader } from '@/components/layout/page-header'
 import { TaskStatusBadge } from './task-status-badge'
 import { PRStatusBadge } from './pr-status-badge'
 import { PRCreateDialog } from './pr-create-dialog'
@@ -46,10 +47,10 @@ export function TaskDetail({ taskId }: { taskId: string }) {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
           <Link to="/tasks"><Button variant="ghost" size="icon"><ArrowLeft className="h-4 w-4" /></Button></Link>
-          <div>
-            <h1 className="text-3xl font-bold tracking-tight">{task.metadata.name}</h1>
-            <p className="text-muted-foreground">{task.metadata.namespace} · {task.spec.type}</p>
-          </div>
+          <PageHeader
+            title={task.metadata.name}
+            description={`${task.metadata.namespace} · ${task.spec.type}`}
+          />
           <TaskStatusBadge phase={task.status?.phase} />
           <PRStatusBadge annotations={task.metadata.annotations} />
         </div>

--- a/ui/src/components/tasks/task-detail.tsx
+++ b/ui/src/components/tasks/task-detail.tsx
@@ -12,6 +12,8 @@ import { PRCreateDialog } from './pr-create-dialog'
 import { TaskResultViewer } from './task-result-viewer'
 import { StructuredLogViewer } from './structured-log-viewer'
 import { TaskExecutionPanel } from './task-execution-panel'
+import { ExecutionGraph } from './execution-graph'
+import { RunTimeline } from './run-timeline'
 import { useTask, useDeleteTask } from '@/hooks/use-tasks'
 import { useNavigate } from '@tanstack/react-router'
 
@@ -92,48 +94,25 @@ export function TaskDetail({ taskId }: { taskId: string }) {
           <Card>
             <CardHeader><CardTitle>Metadata</CardTitle></CardHeader>
             <CardContent className="grid gap-2 text-sm md:grid-cols-2">
-              <div><span className="text-muted-foreground">UID:</span> {task.metadata.uid}</div>
-              <div><span className="text-muted-foreground">Created:</span> {timeAgo(task.metadata.creationTimestamp)}</div>
+              <div><span className="text-muted-foreground">UID:</span> <span className="font-mono text-xs">{task.metadata.uid}</span></div>
+              <div><span className="text-muted-foreground">Created:</span> <span className="tabular-nums">{timeAgo(task.metadata.creationTimestamp)}</span></div>
               <div><span className="text-muted-foreground">Priority:</span> {task.spec.priority ?? 500}</div>
               <div><span className="text-muted-foreground">Attempts:</span> {task.status?.attempts ?? 0}</div>
-              {task.status?.jobName && <div><span className="text-muted-foreground">Job:</span> {task.status.jobName}</div>}
-              {task.status?.startTime && <div><span className="text-muted-foreground">Started:</span> {timeAgo(task.status.startTime)}</div>}
-              {task.status?.completionTime && <div><span className="text-muted-foreground">Completed:</span> {timeAgo(task.status.completionTime)}</div>}
+              {task.status?.jobName && <div><span className="text-muted-foreground">Job:</span> <span className="font-mono text-xs">{task.status.jobName}</span></div>}
+              {task.status?.startTime && <div><span className="text-muted-foreground">Started:</span> <span className="tabular-nums">{timeAgo(task.status.startTime)}</span></div>}
+              {task.status?.completionTime && <div><span className="text-muted-foreground">Completed:</span> <span className="tabular-nums">{timeAgo(task.status.completionTime)}</span></div>}
               {task.status?.message && <div className="md:col-span-2"><span className="text-muted-foreground">Message:</span> {task.status.message}</div>}
-              {(task.status?.iteration ?? 0) > 0 && <div><span className="text-muted-foreground">Iteration:</span> {task.status?.iteration}</div>}
             </CardContent>
           </Card>
 
-          {(task.status?.iteration ?? 0) > 0 && !!(task as Record<string, unknown>).plan && (
+          {(task.status?.iteration ?? 0) > 0 && (
             <Card>
-              <CardHeader><CardTitle>Autonomous Plan</CardTitle></CardHeader>
-              <CardContent className="space-y-3 text-sm">
-                {(() => {
-                  const plan = (task as Record<string, unknown>).plan as { summary?: string; progressPct?: number; goalComplete?: boolean; planDocument?: string }
-                  return (
-                    <>
-                      {plan.summary && <div><span className="text-muted-foreground">Summary:</span> {plan.summary}</div>}
-                      {plan.progressPct !== undefined && (
-                        <div className="space-y-1">
-                          <div className="flex justify-between">
-                            <span className="text-muted-foreground">Progress:</span>
-                            <span>{plan.progressPct}%</span>
-                          </div>
-                          <div className="h-2 rounded-full bg-muted overflow-hidden">
-                            <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${plan.progressPct}%` }} />
-                          </div>
-                        </div>
-                      )}
-                      {plan.goalComplete && <Badge variant="default">Goal Complete</Badge>}
-                      {plan.planDocument && (
-                        <div>
-                          <span className="text-muted-foreground">Plan:</span>
-                          <pre className="mt-1 rounded-md bg-muted p-3 whitespace-pre-wrap max-h-96 overflow-y-auto">{plan.planDocument}</pre>
-                        </div>
-                      )}
-                    </>
-                  )
-                })()}
+              <CardHeader><CardTitle>Autonomous Loop</CardTitle></CardHeader>
+              <CardContent>
+                <RunTimeline
+                  task={task}
+                  plan={(task as Record<string, unknown>).plan as import('@/schemas/task').PlanState | undefined}
+                />
               </CardContent>
             </Card>
           )}
@@ -216,25 +195,15 @@ export function TaskDetail({ taskId }: { taskId: string }) {
               <CardHeader><CardTitle>Autonomous Plan</CardTitle></CardHeader>
               <CardContent>
                 {(() => {
-                  const plan = (task as Record<string, unknown>).plan as { summary?: string; progressPct?: number; goalComplete?: boolean; planDocument?: string } | undefined
-                  if (!plan) return <p className="text-muted-foreground">No plan data available. Plan state is loaded when viewing task details.</p>
+                  const plan = (task as Record<string, unknown>).plan as import('@/schemas/task').PlanState | undefined
                   return (
-                    <div className="space-y-3 text-sm">
-                      {plan.summary && <div><span className="font-medium">Summary:</span> {plan.summary}</div>}
-                      {plan.progressPct !== undefined && (
-                        <div className="space-y-1">
-                          <div className="flex justify-between">
-                            <span className="font-medium">Progress:</span>
-                            <span>{plan.progressPct}%</span>
-                          </div>
-                          <div className="h-2 rounded-full bg-muted overflow-hidden">
-                            <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${plan.progressPct}%` }} />
-                          </div>
+                    <div className="space-y-4">
+                      <RunTimeline task={task} plan={plan} />
+                      {plan?.planDocument && (
+                        <div>
+                          <p className="mb-1 text-xs font-medium text-muted-foreground">Plan document</p>
+                          <pre className="rounded-md bg-muted p-4 whitespace-pre-wrap max-h-[600px] overflow-y-auto text-xs">{plan.planDocument}</pre>
                         </div>
-                      )}
-                      {plan.goalComplete && <Badge variant="default">Goal Complete ✓</Badge>}
-                      {plan.planDocument && (
-                        <pre className="mt-2 rounded-md bg-muted p-4 whitespace-pre-wrap max-h-[600px] overflow-y-auto text-xs">{plan.planDocument}</pre>
                       )}
                     </div>
                   )
@@ -247,32 +216,9 @@ export function TaskDetail({ taskId }: { taskId: string }) {
         {(task.status?.childTasks?.length ?? 0) > 0 && (
           <TabsContent value="children">
             <Card>
-              <CardHeader><CardTitle>Child Tasks</CardTitle></CardHeader>
+              <CardHeader><CardTitle>Execution Graph</CardTitle></CardHeader>
               <CardContent>
-                <div className="overflow-x-auto">
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr className="border-b text-left text-muted-foreground">
-                        <th className="pb-2 pr-4">Name</th>
-                        <th className="pb-2 pr-4">Agent</th>
-                        <th className="pb-2">Phase</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {task.status!.childTasks!.map((child) => (
-                        <tr key={child.name} className="border-b last:border-0">
-                          <td className="py-2 pr-4">
-                            <Link to="/tasks/$taskId" params={{ taskId: child.name }} className="text-blue-600 hover:underline dark:text-blue-400">
-                              {child.name}
-                            </Link>
-                          </td>
-                          <td className="py-2 pr-4">{child.agent}</td>
-                          <td className="py-2"><TaskStatusBadge phase={child.phase} /></td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
+                <ExecutionGraph task={task} />
               </CardContent>
             </Card>
           </TabsContent>

--- a/ui/src/components/tasks/task-execution-panel.test.tsx
+++ b/ui/src/components/tasks/task-execution-panel.test.tsx
@@ -35,6 +35,21 @@ describe('TaskExecutionPanel', () => {
     expect(screen.getByTestId('progress-steps')).toBeInTheDocument()
   })
 
+  it('treats a Scheduled task as not-yet-started (Completed step is not current)', () => {
+    const { container } = render(
+      <TaskExecutionPanel task={makeTask({ status: { phase: 'Scheduled', attempts: 0 } })} />,
+    )
+    const steps = container.querySelector('[data-testid="progress-steps"]') as HTMLElement
+    const circles = steps.querySelectorAll('.rounded-full')
+    expect(circles).toHaveLength(3) // Pending / Running / Completed
+    // Pending (step 0) is the current/highlighted step.
+    expect(circles[0].className).toContain('bg-status-running-bg')
+    // Completed (step 2) is NOT highlighted and still shows its index ("3") —
+    // a scheduled task is not mislabeled as completed.
+    expect(circles[2].className).toContain('bg-muted')
+    expect(circles[2].textContent).toBe('3')
+  })
+
   it('renders with Running phase', () => {
     render(<TaskExecutionPanel task={makeTask({
       status: { phase: 'Running', attempts: 1, startTime: new Date().toISOString() },

--- a/ui/src/components/tasks/task-execution-panel.tsx
+++ b/ui/src/components/tasks/task-execution-panel.tsx
@@ -70,16 +70,16 @@ export function TaskExecutionPanel({ task }: { task: Task }) {
             <div key={step} className="flex items-center gap-2">
               <div className={`flex h-8 w-8 items-center justify-center rounded-full text-xs font-medium ${
                 i < current
-                  ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                  ? 'bg-status-succeeded-bg text-status-succeeded'
                   : i === current
-                  ? 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200'
+                  ? 'bg-status-running-bg text-status-running'
                   : 'bg-muted text-muted-foreground'
               }`}>
                 {i < current ? '✓' : i + 1}
               </div>
               <span className={`text-sm ${i <= current ? 'font-medium' : 'text-muted-foreground'}`}>{step}</span>
               {i < steps.length - 1 && (
-                <div className={`h-0.5 w-8 ${i < current ? 'bg-green-500' : 'bg-muted'}`} />
+                <div className={`h-0.5 w-8 ${i < current ? 'bg-status-succeeded' : 'bg-muted'}`} />
               )}
             </div>
           ))}

--- a/ui/src/components/tasks/task-execution-panel.tsx
+++ b/ui/src/components/tasks/task-execution-panel.tsx
@@ -5,8 +5,12 @@ import type { Task } from '@/schemas/task'
 
 const steps = ['Pending', 'Running', 'Completed'] as const
 
+// Map a task phase onto the coarse Pending → Running → Completed stepper.
+// Scheduled hasn't started yet, so it sits at the start (step 0) rather than
+// being mistaken for Completed. Terminal phases (Succeeded/Failed/Cancelled)
+// land on the final step — the run has ended.
 function stepIndex(phase?: string): number {
-  if (!phase || phase === 'Pending') return 0
+  if (!phase || phase === 'Pending' || phase === 'Scheduled') return 0
   if (phase === 'Running') return 1
   return 2
 }

--- a/ui/src/components/tasks/task-list.tsx
+++ b/ui/src/components/tasks/task-list.tsx
@@ -66,7 +66,7 @@ export function TaskList() {
               (data?.items ?? []).map((task: Task) => (
                 <TableRow key={task.metadata.uid || task.metadata.name} className="cursor-pointer">
                   <TableCell>
-                    <Link to="/tasks/$taskId" params={{ taskId: task.metadata.name }} className="font-medium hover:underline">
+                    <Link to="/tasks/$taskId" params={{ taskId: task.metadata.name }} className="font-mono text-sm font-medium hover:underline">
                       {task.metadata.name}
                     </Link>
                   </TableCell>

--- a/ui/src/components/tasks/task-list.tsx
+++ b/ui/src/components/tasks/task-list.tsx
@@ -3,6 +3,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Plus, Trash2 } from 'lucide-react'
+import { PageHeader } from '@/components/layout/page-header'
 import { TaskStatusBadge } from './task-status-badge'
 import { useTaskList, useDeleteTask } from '@/hooks/use-tasks'
 import type { Task } from '@/schemas/task'
@@ -22,18 +23,18 @@ export function TaskList() {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Tasks</h1>
-          <p className="text-muted-foreground">Manage your task execution</p>
-        </div>
-        <Link to="/tasks/new">
-          <Button>
-            <Plus className="mr-2 h-4 w-4" />
-            New Task
-          </Button>
-        </Link>
-      </div>
+      <PageHeader
+        title="Tasks"
+        description="Manage your task execution"
+        action={
+          <Link to="/tasks/new">
+            <Button>
+              <Plus className="mr-2 h-4 w-4" />
+              New Task
+            </Button>
+          </Link>
+        }
+      />
       <div className="rounded-md border">
         <Table>
           <TableHeader>

--- a/ui/src/components/tasks/task-result-viewer.test.tsx
+++ b/ui/src/components/tasks/task-result-viewer.test.tsx
@@ -105,7 +105,7 @@ describe('TaskResultViewer', () => {
     await waitFor(() => {
       const badge = screen.getByTestId('verdict-badge')
       expect(badge).toHaveTextContent('REQUEST_CHANGES')
-      expect(badge.className).toContain('bg-red-100')
+      expect(badge.className).toContain('bg-status-failed-bg')
     })
   })
 

--- a/ui/src/components/tasks/task-result-viewer.tsx
+++ b/ui/src/components/tasks/task-result-viewer.tsx
@@ -18,9 +18,9 @@ interface StructuredResult {
 }
 
 const verdictStyles: Record<string, string> = {
-  APPROVE: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-  REQUEST_CHANGES: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
-  COMMENT: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+  APPROVE: 'bg-status-succeeded-bg text-status-succeeded',
+  REQUEST_CHANGES: 'bg-status-failed-bg text-status-failed',
+  COMMENT: 'bg-status-pending-bg text-status-pending',
 }
 
 function tryParseStructuredResult(result: string): StructuredResult | null {

--- a/ui/src/components/tasks/task-status-badge.test.tsx
+++ b/ui/src/components/tasks/task-status-badge.test.tsx
@@ -16,28 +16,29 @@ describe('TaskStatusBadge', () => {
     },
   )
 
-  it('uses yellow classes for Pending', () => {
-    render(<TaskStatusBadge phase="Pending" />)
-    expect(screen.getByText('Pending').className).toContain('bg-yellow-100')
+  it.each([
+    ['Pending', 'bg-status-pending'],
+    ['Running', 'bg-status-running'],
+    ['Succeeded', 'bg-status-succeeded'],
+    ['Failed', 'bg-status-failed'],
+  ] as const)('uses the %s status token (not a pastel)', (phase, dotClass) => {
+    render(<TaskStatusBadge phase={phase} />)
+    const dot = screen.getByTestId('status-dot')
+    expect(dot.className).toContain(dotClass)
+    // No legacy template pastel survives.
+    expect(dot.className).not.toMatch(/bg-(yellow|blue|green|red)-(100|800|900)/)
   })
 
-  it('uses blue classes for Running', () => {
+  it('renders a colored status dot alongside the label', () => {
     render(<TaskStatusBadge phase="Running" />)
-    expect(screen.getByText('Running').className).toContain('bg-blue-100')
-  })
-
-  it('uses green classes for Succeeded', () => {
-    render(<TaskStatusBadge phase="Succeeded" />)
-    expect(screen.getByText('Succeeded').className).toContain('bg-green-100')
-  })
-
-  it('uses red classes for Failed', () => {
-    render(<TaskStatusBadge phase="Failed" />)
-    expect(screen.getByText('Failed').className).toContain('bg-red-100')
+    expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+    expect(screen.getByText('Running')).toBeInTheDocument()
   })
 
   it('falls back to Pending style for unknown phase', () => {
     render(<TaskStatusBadge phase="Unknown" />)
-    expect(screen.getByText('Unknown').className).toContain('bg-yellow-100')
+    expect(screen.getByText('Unknown')).toBeInTheDocument()
+    // Unknown phases inherit the Pending dot color.
+    expect(screen.getByTestId('status-dot').className).toContain('bg-status-pending')
   })
 })

--- a/ui/src/components/tasks/task-status-badge.tsx
+++ b/ui/src/components/tasks/task-status-badge.tsx
@@ -1,18 +1,13 @@
-import { Badge } from '@/components/ui/badge'
+import { StatusDot } from '@/components/ui/status-dot'
 import type { TaskPhase } from '@/schemas/task'
 
-const phaseStyles: Record<string, string> = {
-  Pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
-  Running: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
-  Succeeded: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-  Failed: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
-}
-
+/**
+ * Phase badge for a task. Thin wrapper over the shared <StatusDot>, which
+ * sources all phase color/label from `lib/task-status.ts` (the single source
+ * of truth) — no local color map.
+ */
 export function TaskStatusBadge({ phase }: { phase?: TaskPhase | string }) {
-  const p = phase ?? 'Pending'
-  return (
-    <Badge className={phaseStyles[p] ?? phaseStyles.Pending} variant="secondary">
-      {p}
-    </Badge>
-  )
+  // StatusDot renders the literal phase text (so an unknown phase still reads
+  // as itself) while its dot color falls back to Pending via the shared map.
+  return <StatusDot phase={phase} />
 }

--- a/ui/src/components/tools/tool-detail.tsx
+++ b/ui/src/components/tools/tool-detail.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { ArrowLeft } from 'lucide-react'
+import { PageHeader } from '@/components/layout/page-header'
 import { useTool } from '@/hooks/use-tools'
 
 export function ToolDetail({ toolName }: { toolName: string }) {
@@ -28,7 +29,7 @@ export function ToolDetail({ toolName }: { toolName: string }) {
       <div className="flex items-center gap-4">
         <Link to="/tools"><Button variant="ghost" size="icon"><ArrowLeft className="h-4 w-4" /></Button></Link>
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">{isBuiltin ? (tool as Record<string, unknown>).name as string : tool.metadata?.name ?? toolName}</h1>
+          <PageHeader title={isBuiltin ? (tool as Record<string, unknown>).name as string : tool.metadata?.name ?? toolName} />
           <div className="flex items-center gap-2">
             <Badge variant={isBuiltin ? 'default' : 'secondary'}>{isBuiltin ? 'Built-in' : 'Custom'}</Badge>
             {!isBuiltin && tool.metadata?.namespace && <span className="text-muted-foreground">{tool.metadata.namespace}</span>}
@@ -119,7 +120,7 @@ export function ToolDetail({ toolName }: { toolName: string }) {
               <CardContent className="space-y-2 text-sm">
                 <div>
                   <span className="text-muted-foreground">Available:</span>{' '}
-                  <Badge className={tool.status.available ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'} variant="secondary">
+                  <Badge className={tool.status.available ? 'bg-status-succeeded-bg text-status-succeeded' : 'bg-status-failed-bg text-status-failed'} variant="secondary">
                     {tool.status.available ? 'Yes' : 'No'}
                   </Badge>
                 </div>

--- a/ui/src/components/tools/tool-list.tsx
+++ b/ui/src/components/tools/tool-list.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tanstack/react-router'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
+import { PageHeader } from '@/components/layout/page-header'
 import { useToolList } from '@/hooks/use-tools'
 
 export function ToolList() {
@@ -9,10 +10,7 @@ export function ToolList() {
 
   return (
     <div className="space-y-4">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Tools</h1>
-        <p className="text-muted-foreground">Available tools for AI agents</p>
-      </div>
+      <PageHeader title="Tools" description="Available tools for AI agents" />
       <div className="rounded-md border">
         <Table>
           <TableHeader>
@@ -56,11 +54,11 @@ export function ToolList() {
                   <TableCell className="max-w-xs truncate">{tool.description}</TableCell>
                   <TableCell>
                     {tool.builtin ? (
-                      <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200" variant="secondary">Available</Badge>
+                      <Badge className="bg-status-succeeded-bg text-status-succeeded" variant="secondary">Available</Badge>
                     ) : tool.available ? (
-                      <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200" variant="secondary">Available</Badge>
+                      <Badge className="bg-status-succeeded-bg text-status-succeeded" variant="secondary">Available</Badge>
                     ) : (
-                      <Badge className="bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200" variant="secondary">Unavailable</Badge>
+                      <Badge className="bg-status-failed-bg text-status-failed" variant="secondary">Unavailable</Badge>
                     )}
                   </TableCell>
                 </TableRow>

--- a/ui/src/components/ui/distribution.test.tsx
+++ b/ui/src/components/ui/distribution.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@/test/test-utils'
+import { Distribution } from './distribution'
+
+describe('Distribution', () => {
+  const segments = [
+    { phase: 'Pending', count: 2 },
+    { phase: 'Running', count: 3 },
+    { phase: 'Succeeded', count: 4 },
+    { phase: 'Failed', count: 1 },
+  ]
+
+  it('renders a segment per non-zero phase, each using the shared status token', () => {
+    render(<Distribution segments={segments} />)
+    expect(screen.getByTestId('dist-segment-Running').className).toContain('bg-status-running')
+    expect(screen.getByTestId('dist-segment-Succeeded').className).toContain('bg-status-succeeded')
+    expect(screen.getByTestId('dist-segment-Failed').className).toContain('bg-status-failed')
+    expect(screen.getByTestId('dist-segment-Pending').className).toContain('bg-status-pending')
+  })
+
+  it('segment widths are proportional and sum to ~100% of the total', () => {
+    render(<Distribution segments={segments} />)
+    const total = segments.reduce((s, x) => s + x.count, 0) // 10
+    const widths = segments.map((s) => {
+      const el = screen.getByTestId(`dist-segment-${s.phase}`)
+      return parseFloat((el as HTMLElement).style.width)
+    })
+    const sum = widths.reduce((a, b) => a + b, 0)
+    expect(Math.round(sum)).toBe(100)
+    // Running (3/10) => 30%
+    expect(Math.round(widths[1])).toBe((3 / total) * 100)
+  })
+
+  it('omits zero-count segments from the bar', () => {
+    render(
+      <Distribution
+        segments={[
+          { phase: 'Running', count: 0 },
+          { phase: 'Succeeded', count: 5 },
+        ]}
+      />,
+    )
+    expect(screen.queryByTestId('dist-segment-Running')).not.toBeInTheDocument()
+    expect(screen.getByTestId('dist-segment-Succeeded')).toBeInTheDocument()
+  })
+
+  it('degrades to an empty track when all counts are zero', () => {
+    render(
+      <Distribution
+        segments={[
+          { phase: 'Running', count: 0 },
+          { phase: 'Succeeded', count: 0 },
+        ]}
+      />,
+    )
+    // No segments rendered, but the legend + track still present.
+    expect(screen.queryByTestId('dist-segment-Running')).not.toBeInTheDocument()
+    expect(screen.getByRole('img', { name: /distribution/i })).toBeInTheDocument()
+  })
+
+  it('renders a legend entry with the count for each phase', () => {
+    render(<Distribution segments={segments} />)
+    // Legend shows all four labels.
+    for (const label of ['Pending', 'Running', 'Succeeded', 'Failed']) {
+      expect(screen.getByText(label)).toBeInTheDocument()
+    }
+  })
+})

--- a/ui/src/components/ui/distribution.tsx
+++ b/ui/src/components/ui/distribution.tsx
@@ -1,0 +1,59 @@
+import { cn } from '@/lib/utils'
+import { phaseStyle } from '@/lib/task-status'
+import type { TaskPhase } from '@/schemas/task'
+
+export interface DistributionSegment {
+  phase: TaskPhase | string
+  count: number
+}
+
+interface DistributionProps {
+  segments: DistributionSegment[]
+  className?: string
+}
+
+/**
+ * Horizontal phase-distribution bar — proportional segments colored by the
+ * shared status tokens, with a small legend. Each segment's width is its share
+ * of the total; an all-zero/empty input degrades to a neutral empty track.
+ */
+export function Distribution({ segments, className }: DistributionProps) {
+  const total = segments.reduce((sum, s) => sum + Math.max(0, s.count), 0)
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      <div
+        className="flex h-2 w-full overflow-hidden rounded-full bg-muted"
+        role="img"
+        aria-label="Task phase distribution"
+      >
+        {total > 0 &&
+          segments.map((s) => {
+            const pct = (Math.max(0, s.count) / total) * 100
+            if (pct === 0) return null
+            return (
+              <div
+                key={s.phase}
+                data-testid={`dist-segment-${s.phase}`}
+                className={cn('h-full', phaseStyle(s.phase).dotClass)}
+                style={{ width: `${pct}%` }}
+                title={`${phaseStyle(s.phase).label}: ${s.count}`}
+              />
+            )
+          })}
+      </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1">
+        {segments.map((s) => {
+          const style = phaseStyle(s.phase)
+          return (
+            <span key={s.phase} className="inline-flex items-center gap-1.5 text-xs">
+              <span className={cn('size-2 rounded-full', style.dotClass)} aria-hidden="true" />
+              <span className="text-muted-foreground">{style.label}</span>
+              <span className="font-medium tabular-nums">{s.count}</span>
+            </span>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/ui/empty-state.test.tsx
+++ b/ui/src/components/ui/empty-state.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@/test/test-utils'
+import userEvent from '@testing-library/user-event'
+import { Inbox } from 'lucide-react'
+import { EmptyState } from './empty-state'
+
+describe('EmptyState', () => {
+  it('renders the headline', () => {
+    render(<EmptyState headline="No tasks yet" />)
+    expect(screen.getByText('No tasks yet')).toBeInTheDocument()
+  })
+
+  it('renders the hint when provided', () => {
+    render(<EmptyState headline="No tasks yet" hint="Create one to get started" />)
+    expect(screen.getByText('Create one to get started')).toBeInTheDocument()
+  })
+
+  it('renders an icon when provided', () => {
+    const { container } = render(<EmptyState headline="Empty" icon={Inbox} />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders a CTA and fires its handler', async () => {
+    const onClick = vi.fn()
+    render(
+      <EmptyState
+        headline="No tasks yet"
+        action={<button onClick={onClick}>Create task</button>}
+      />,
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Create task' }))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+})

--- a/ui/src/components/ui/empty-state.tsx
+++ b/ui/src/components/ui/empty-state.tsx
@@ -1,0 +1,48 @@
+import type { LucideIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface EmptyStateProps {
+  /** Optional lucide icon shown above the headline. */
+  icon?: LucideIcon
+  /** Primary message. */
+  headline: string
+  /** Optional supporting hint below the headline. */
+  hint?: string
+  /** Optional call-to-action (e.g. a button or link). */
+  action?: React.ReactNode
+  className?: string
+}
+
+/**
+ * Standard empty-state placeholder — icon + headline + hint + optional CTA.
+ *
+ * Replaces bare muted strings ("No tasks yet", "No logs available yet", etc.)
+ * so empty views read as intentional rather than missing.
+ */
+export function EmptyState({
+  icon: Icon,
+  headline,
+  hint,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center gap-3 px-6 py-12 text-center',
+        className,
+      )}
+    >
+      {Icon && (
+        <div className="rounded-full bg-muted p-3 text-muted-foreground">
+          <Icon className="size-6" aria-hidden="true" />
+        </div>
+      )}
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-foreground">{headline}</p>
+        {hint && <p className="max-w-sm text-sm text-muted-foreground">{hint}</p>}
+      </div>
+      {action && <div className="mt-1">{action}</div>}
+    </div>
+  )
+}

--- a/ui/src/components/ui/orca-mark.tsx
+++ b/ui/src/components/ui/orca-mark.tsx
@@ -1,0 +1,22 @@
+import { cn } from '@/lib/utils'
+
+/**
+ * Single source of truth for the Orka brand mark.
+ *
+ * Renders the same `public/favicon.svg` asset used by the browser tab, so the
+ * wordmark and favicon can never drift (replaces the old emoji-brand mismatch).
+ */
+export function OrcaMark({
+  className,
+  ...props
+}: React.ComponentProps<'img'>) {
+  return (
+    <img
+      src="/favicon.svg"
+      alt=""
+      aria-hidden="true"
+      className={cn('shrink-0 select-none', className)}
+      {...props}
+    />
+  )
+}

--- a/ui/src/components/ui/sonar-ping.test.tsx
+++ b/ui/src/components/ui/sonar-ping.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@/test/test-utils'
+import { SonarPing } from './sonar-ping'
+
+describe('SonarPing', () => {
+  it('renders a decorative, aria-hidden sonar illustration', () => {
+    const { container } = render(<SonarPing />)
+    const root = container.firstElementChild as HTMLElement
+    expect(root).toBeInTheDocument()
+    expect(root).toHaveAttribute('aria-hidden', 'true')
+    // Concentric rings + center dot => multiple spans.
+    expect(root.querySelectorAll('span').length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('applies an extra className when provided', () => {
+    const { container } = render(<SonarPing className="my-4" />)
+    expect((container.firstElementChild as HTMLElement).className).toContain('my-4')
+  })
+})

--- a/ui/src/components/ui/sonar-ping.tsx
+++ b/ui/src/components/ui/sonar-ping.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/utils'
+
+/**
+ * Decorative "sonar" idle illustration — concentric rings pinging outward from
+ * a center dot, evoking listening for activity. Used in idle/empty states (e.g.
+ * the Live view when nothing is running). Purely ornamental (aria-hidden);
+ * motion is gated behind motion-safe.
+ */
+export function SonarPing({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn('relative grid size-20 place-items-center', className)}
+      aria-hidden="true"
+    >
+      <span className="absolute size-20 rounded-full border border-live/20 motion-safe:animate-ping" />
+      <span className="absolute size-14 rounded-full border border-live/30 motion-safe:animate-pulse-live" />
+      <span className="absolute size-8 rounded-full bg-live/10" />
+      <span className="relative size-2.5 rounded-full bg-live motion-safe:animate-pulse-live" />
+    </div>
+  )
+}

--- a/ui/src/components/ui/sparkline.test.tsx
+++ b/ui/src/components/ui/sparkline.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@/test/test-utils'
+import { Sparkline } from './sparkline'
+
+describe('Sparkline', () => {
+  it('renders a polyline from a numeric series', () => {
+    const { container } = render(<Sparkline data={[1, 5, 2, 8, 3]} />)
+    const poly = container.querySelector('polyline')
+    expect(poly).toBeInTheDocument()
+    // 5 points => 5 coordinate pairs
+    expect(poly!.getAttribute('points')!.trim().split(' ')).toHaveLength(5)
+  })
+
+  it('degrades gracefully on an empty series (no polyline, valid svg)', () => {
+    const { container } = render(<Sparkline data={[]} />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+    expect(container.querySelector('polyline')).not.toBeInTheDocument()
+  })
+
+  it('renders a flat line for a single point', () => {
+    const { container } = render(<Sparkline data={[7]} />)
+    const poly = container.querySelector('polyline')
+    expect(poly).toBeInTheDocument()
+    expect(poly!.getAttribute('points')!.trim().split(' ')).toHaveLength(2)
+  })
+
+  it('exposes an accessible label', () => {
+    render(<Sparkline data={[1, 2, 3]} aria-label="Throughput" />)
+    expect(screen.getByRole('img', { name: 'Throughput' })).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/ui/sparkline.tsx
+++ b/ui/src/components/ui/sparkline.tsx
@@ -1,0 +1,69 @@
+import { cn } from '@/lib/utils'
+
+interface SparklineProps {
+  /** Numeric series to plot, oldest→newest. */
+  data: number[]
+  width?: number
+  height?: number
+  /** Stroke color (defaults to currentColor so callers set it via text-*). */
+  className?: string
+  'aria-label'?: string
+}
+
+/**
+ * Minimal dependency-free sparkline (inline SVG polyline).
+ *
+ * Renders a numeric series as a small trend line. Empty or single-point series
+ * degrade gracefully to an empty (but valid) SVG rather than throwing.
+ */
+export function Sparkline({
+  data,
+  width = 96,
+  height = 24,
+  className,
+  'aria-label': ariaLabel,
+}: SparklineProps) {
+  const points = (() => {
+    if (!data || data.length === 0) return ''
+    if (data.length === 1) {
+      // A single point: draw a flat midline so the component still renders.
+      const y = height / 2
+      return `0,${y} ${width},${y}`
+    }
+    const min = Math.min(...data)
+    const max = Math.max(...data)
+    const range = max - min || 1
+    const stepX = width / (data.length - 1)
+    return data
+      .map((v, i) => {
+        const x = i * stepX
+        const y = height - ((v - min) / range) * height
+        return `${x.toFixed(2)},${y.toFixed(2)}`
+      })
+      .join(' ')
+  })()
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      className={cn('text-primary', className)}
+      role="img"
+      aria-label={ariaLabel ?? 'Trend'}
+    >
+      {points && (
+        <polyline
+          points={points}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      )}
+    </svg>
+  )
+}

--- a/ui/src/components/ui/status-dot.test.tsx
+++ b/ui/src/components/ui/status-dot.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@/test/test-utils'
+import { StatusDot } from './status-dot'
+
+describe('StatusDot', () => {
+  it.each([
+    ['Pending', 'bg-status-pending'],
+    ['Running', 'bg-status-running'],
+    ['Succeeded', 'bg-status-succeeded'],
+    ['Failed', 'bg-status-failed'],
+  ] as const)('renders a %s dot in the phase color', (phase, dotClass) => {
+    render(<StatusDot phase={phase} />)
+    const dot = screen.getByTestId('status-dot')
+    expect(dot.className).toContain(dotClass)
+  })
+
+  it('renders the visible label text', () => {
+    render(<StatusDot phase="Succeeded" />)
+    expect(screen.getByText('Succeeded')).toBeInTheDocument()
+  })
+
+  it('falls back to Pending styling for an unknown phase', () => {
+    render(<StatusDot phase="Bogus" />)
+    expect(screen.getByTestId('status-dot').className).toContain('bg-status-pending')
+  })
+
+  it('preserves the literal phase text for unknown phases (no silent relabel)', () => {
+    // Regression guard: an unrecognized/custom backend phase must keep its own
+    // text — only the dot *color* falls back to Pending, never the label.
+    render(<StatusDot phase="Terminating" />)
+    expect(screen.getByText('Terminating')).toBeInTheDocument()
+    expect(screen.queryByText('Pending')).not.toBeInTheDocument()
+    expect(screen.getByTestId('status-dot').className).toContain('bg-status-pending')
+  })
+
+  it('uses the style label only when no phase is supplied', () => {
+    render(<StatusDot />)
+    expect(screen.getByText('Pending')).toBeInTheDocument()
+  })
+
+  it('applies the live pulse for Running by default', () => {
+    render(<StatusDot phase="Running" />)
+    expect(screen.getByTestId('status-dot').className).toContain('animate-pulse-live')
+  })
+
+  it('does NOT pulse terminal/pending phases by default', () => {
+    for (const phase of ['Pending', 'Succeeded', 'Failed'] as const) {
+      const { unmount } = render(<StatusDot phase={phase} />)
+      expect(screen.getByTestId('status-dot').className).not.toContain('animate-pulse-live')
+      unmount()
+    }
+  })
+
+  it('honors an explicit pulse override', () => {
+    render(<StatusDot phase="Succeeded" pulse />)
+    expect(screen.getByTestId('status-dot').className).toContain('animate-pulse-live')
+  })
+
+  it('can suppress the pulse even when Running', () => {
+    render(<StatusDot phase="Running" pulse={false} />)
+    expect(screen.getByTestId('status-dot').className).not.toContain('animate-pulse-live')
+  })
+
+  it('can hide the visible label but still expose it to screen readers', () => {
+    render(<StatusDot phase="Running" hideLabel />)
+    // Label text remains in the accessibility tree (sr-only), so color is
+    // never the only signal — it's just visually hidden.
+    expect(screen.getByText('Running')).toHaveClass('sr-only')
+    expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/ui/status-dot.tsx
+++ b/ui/src/components/ui/status-dot.tsx
@@ -1,0 +1,63 @@
+import { cn } from '@/lib/utils'
+import { phaseStyle } from '@/lib/task-status'
+import type { TaskPhase } from '@/schemas/task'
+
+interface StatusDotProps {
+  /** Task phase; drives the dot color and label. */
+  phase?: TaskPhase | string
+  /** Override the rendered label (defaults to the phase label). */
+  label?: string
+  /** Hide the visible text label (a screen-reader label is still emitted). */
+  hideLabel?: boolean
+  /**
+   * Force the "breathing" liveness pulse. When omitted, the pulse is applied
+   * automatically for live phases (Running). Motion is gated behind
+   * `motion-safe:` so reduced-motion users see a still dot.
+   */
+  pulse?: boolean
+  className?: string
+}
+
+/**
+ * The canonical status indicator: a filled circle in the phase color plus a
+ * label.
+ *
+ * Color is never the only signal — a visible label accompanies the dot, and
+ * when the label is hidden an `sr-only` text alternative is emitted so the
+ * phase is still conveyed to assistive tech. The dot itself is decorative
+ * (`aria-hidden`). Liveness is conveyed by both hue and a motion-safe pulse.
+ */
+export function StatusDot({
+  phase,
+  label,
+  hideLabel = false,
+  pulse,
+  className,
+}: StatusDotProps) {
+  const style = phaseStyle(phase)
+  // Preserve the caller's phase text verbatim (truthful for unknown/custom
+  // backend phases); only the *styling* falls back to Pending. An explicit
+  // `label` always wins; an absent phase falls back to the style label.
+  const text = label ?? (typeof phase === 'string' && phase ? phase : style.label)
+  const isLive = pulse ?? style.live
+
+  return (
+    <span className={cn('inline-flex items-center gap-1.5', className)}>
+      <span
+        data-testid="status-dot"
+        data-phase={style.label}
+        aria-hidden="true"
+        className={cn(
+          'inline-block size-2 shrink-0 rounded-full',
+          style.dotClass,
+          isLive && 'motion-safe:animate-pulse-live',
+        )}
+      />
+      {hideLabel ? (
+        <span className="sr-only">{text}</span>
+      ) : (
+        <span className={cn('text-xs font-medium', style.textClass)}>{text}</span>
+      )}
+    </span>
+  )
+}

--- a/ui/src/hooks/use-chat.test.tsx
+++ b/ui/src/hooks/use-chat.test.tsx
@@ -204,6 +204,52 @@ describe('useSendMessage', () => {
     expect(trMsg!.toolSuccess).toBe(true)
   })
 
+  it('harvests created task names from a successful create_task result onto the assistant turn', async () => {
+    mockSSEFetch([
+      {
+        event: 'tool_result',
+        data: JSON.stringify({ id: 'tc-1', name: 'create_task', result: { success: true, name: 'task-alpha' } }),
+      },
+      {
+        event: 'tool_result',
+        data: JSON.stringify({ id: 'tc-2', name: 'create_task', result: { success: true, name: 'task-beta' } }),
+      },
+      { event: 'message', data: JSON.stringify({ content: 'Created two tasks.' }) },
+      { event: 'done', data: JSON.stringify({ usage: { tasksCreated: 2 } }) },
+    ])
+
+    const { result } = renderHook(() => useSendMessage(), { wrapper: createWrapper() })
+    await act(async () => {
+      await result.current('make two tasks')
+    })
+
+    const assistant = useChatStore.getState().messages.find((m) => m.role === 'assistant')
+    expect(assistant?.tasksCreatedNames).toEqual(['task-alpha', 'task-beta'])
+  })
+
+  it('does NOT harvest names from non-creation task tools (lookup/update/delete)', async () => {
+    mockSSEFetch([
+      {
+        event: 'tool_result',
+        data: JSON.stringify({ id: 'tc-1', name: 'get_task', result: { success: true, name: 'existing-task' } }),
+      },
+      {
+        event: 'tool_result',
+        data: JSON.stringify({ id: 'tc-2', name: 'update_task', result: { success: true, name: 'existing-task' } }),
+      },
+      { event: 'message', data: JSON.stringify({ content: 'Looked it up.' }) },
+      { event: 'done', data: JSON.stringify({ usage: {} }) },
+    ])
+
+    const { result } = renderHook(() => useSendMessage(), { wrapper: createWrapper() })
+    await act(async () => {
+      await result.current('look up a task')
+    })
+
+    const assistant = useChatStore.getState().messages.find((m) => m.role === 'assistant')
+    expect(assistant?.tasksCreatedNames).toBeUndefined()
+  })
+
   it('handles fetch error — adds error message', async () => {
     fetchSpy.mockImplementation((input, init) => {
       const url = typeof input === 'string' ? input : (input as Request).url

--- a/ui/src/hooks/use-chat.test.tsx
+++ b/ui/src/hooks/use-chat.test.tsx
@@ -204,15 +204,16 @@ describe('useSendMessage', () => {
     expect(trMsg!.toolSuccess).toBe(true)
   })
 
-  it('harvests created task names from a successful create_task result onto the assistant turn', async () => {
+  it('harvests created task names from a successful create-task result (data.name) onto the assistant turn', async () => {
+    // Production shape: ChatToolResult{ success, data: { name, namespace, phase } }.
     mockSSEFetch([
       {
         event: 'tool_result',
-        data: JSON.stringify({ id: 'tc-1', name: 'create_task', result: { success: true, name: 'task-alpha' } }),
+        data: JSON.stringify({ id: 'tc-1', name: 'create_agent_task', result: { success: true, data: { name: 'task-alpha', namespace: 'default', phase: 'Pending' } } }),
       },
       {
         event: 'tool_result',
-        data: JSON.stringify({ id: 'tc-2', name: 'create_task', result: { success: true, name: 'task-beta' } }),
+        data: JSON.stringify({ id: 'tc-2', name: 'create_ai_task', result: { success: true, data: { name: 'task-beta', namespace: 'default', phase: 'Pending' } } }),
       },
       { event: 'message', data: JSON.stringify({ content: 'Created two tasks.' }) },
       { event: 'done', data: JSON.stringify({ usage: { tasksCreated: 2 } }) },
@@ -227,15 +228,34 @@ describe('useSendMessage', () => {
     expect(assistant?.tasksCreatedNames).toEqual(['task-alpha', 'task-beta'])
   })
 
+  it('also harvests from a flat top-level name (defensive fallback)', async () => {
+    mockSSEFetch([
+      {
+        event: 'tool_result',
+        data: JSON.stringify({ id: 'tc-1', name: 'create_task', result: { success: true, name: 'flat-task' } }),
+      },
+      { event: 'message', data: JSON.stringify({ content: 'done' }) },
+      { event: 'done', data: JSON.stringify({ usage: { tasksCreated: 1 } }) },
+    ])
+
+    const { result } = renderHook(() => useSendMessage(), { wrapper: createWrapper() })
+    await act(async () => {
+      await result.current('make a task')
+    })
+
+    const assistant = useChatStore.getState().messages.find((m) => m.role === 'assistant')
+    expect(assistant?.tasksCreatedNames).toEqual(['flat-task'])
+  })
+
   it('does NOT harvest names from non-creation task tools (lookup/update/delete)', async () => {
     mockSSEFetch([
       {
         event: 'tool_result',
-        data: JSON.stringify({ id: 'tc-1', name: 'get_task', result: { success: true, name: 'existing-task' } }),
+        data: JSON.stringify({ id: 'tc-1', name: 'get_task', result: { success: true, data: { name: 'existing-task' } } }),
       },
       {
         event: 'tool_result',
-        data: JSON.stringify({ id: 'tc-2', name: 'update_task', result: { success: true, name: 'existing-task' } }),
+        data: JSON.stringify({ id: 'tc-2', name: 'cancel_task', result: { success: true, data: { name: 'existing-task' } } }),
       },
       { event: 'message', data: JSON.stringify({ content: 'Looked it up.' }) },
       { event: 'done', data: JSON.stringify({ usage: {} }) },

--- a/ui/src/hooks/use-chat.ts
+++ b/ui/src/hooks/use-chat.ts
@@ -59,6 +59,10 @@ export function useSendMessage() {
 
   return useCallback(
     async (messageText: string) => {
+      // Task names created during this turn, harvested from create_task tool
+      // results, so the assistant message can render cross-linking chips.
+      const createdTaskNames: string[] = []
+
       function handleSSEEvent(event: string, data: string) {
         const now = new Date().toISOString()
 
@@ -93,6 +97,22 @@ export function useSendMessage() {
           case 'tool_result': {
             const tr = JSON.parse(data) as SSEToolResultEvent
             const result = tr.result as Record<string, unknown> | undefined
+            // Harvest names ONLY from successful task-CREATION tools, so the
+            // turn links to tasks it actually created. Lookups/updates/deletes
+            // that merely reference a task by name must not appear as "created"
+            // chips. Require both "create" and "task" in the tool name (any
+            // order: create_task, task_create, create_agent_task, ...).
+            const lowerName = tr.name.toLowerCase()
+            const isCreateTaskTool = lowerName.includes('create') && lowerName.includes('task')
+            if (isCreateTaskTool && result && result.success === true) {
+              const name =
+                (typeof result.name === 'string' && result.name) ||
+                (typeof result.taskName === 'string' && result.taskName) ||
+                (typeof (result.task as Record<string, unknown>)?.name === 'string' &&
+                  ((result.task as Record<string, unknown>).name as string)) ||
+                undefined
+              if (name && !createdTaskNames.includes(name)) createdTaskNames.push(name)
+            }
             addMessage({
               id: generateMessageId(),
               role: 'tool_result',
@@ -117,7 +137,7 @@ export function useSendMessage() {
           }
           case 'done': {
             const done = JSON.parse(data) as SSEDoneEvent
-            setUsageOnLastAssistant(done.usage)
+            setUsageOnLastAssistant(done.usage, createdTaskNames)
             break
           }
           case 'error': {

--- a/ui/src/hooks/use-chat.ts
+++ b/ui/src/hooks/use-chat.ts
@@ -109,12 +109,13 @@ export function useSendMessage() {
               // (internal/tools/registry.go), and create-task tools put the task
               // name in `data.name`. Read there first; fall back to top-level
               // fields defensively for any tool that returns a flatter shape.
-              const data = (result.data ?? result) as Record<string, unknown>
+              // (Named `payload` to avoid shadowing the outer SSE `data` string.)
+              const payload = (result.data ?? result) as Record<string, unknown>
               const name =
-                (typeof data.name === 'string' && data.name) ||
-                (typeof data.taskName === 'string' && data.taskName) ||
-                (typeof (data.task as Record<string, unknown>)?.name === 'string' &&
-                  ((data.task as Record<string, unknown>).name as string)) ||
+                (typeof payload.name === 'string' && payload.name) ||
+                (typeof payload.taskName === 'string' && payload.taskName) ||
+                (typeof (payload.task as Record<string, unknown>)?.name === 'string' &&
+                  ((payload.task as Record<string, unknown>).name as string)) ||
                 undefined
               if (name && !createdTaskNames.includes(name)) createdTaskNames.push(name)
             }

--- a/ui/src/hooks/use-chat.ts
+++ b/ui/src/hooks/use-chat.ts
@@ -105,11 +105,16 @@ export function useSendMessage() {
             const lowerName = tr.name.toLowerCase()
             const isCreateTaskTool = lowerName.includes('create') && lowerName.includes('task')
             if (isCreateTaskTool && result && result.success === true) {
+              // The backend wraps payloads as ChatToolResult{success, data:{...}}
+              // (internal/tools/registry.go), and create-task tools put the task
+              // name in `data.name`. Read there first; fall back to top-level
+              // fields defensively for any tool that returns a flatter shape.
+              const data = (result.data ?? result) as Record<string, unknown>
               const name =
-                (typeof result.name === 'string' && result.name) ||
-                (typeof result.taskName === 'string' && result.taskName) ||
-                (typeof (result.task as Record<string, unknown>)?.name === 'string' &&
-                  ((result.task as Record<string, unknown>).name as string)) ||
+                (typeof data.name === 'string' && data.name) ||
+                (typeof data.taskName === 'string' && data.taskName) ||
+                (typeof (data.task as Record<string, unknown>)?.name === 'string' &&
+                  ((data.task as Record<string, unknown>).name as string)) ||
                 undefined
               if (name && !createdTaskNames.includes(name)) createdTaskNames.push(name)
             }

--- a/ui/src/hooks/use-freshness.test.ts
+++ b/ui/src/hooks/use-freshness.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useFreshness } from './use-freshness'
+
+describe('useFreshness', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('is false on initial mount (a fresh mount is not a change)', () => {
+    const { result } = renderHook(({ v }) => useFreshness(v), {
+      initialProps: { v: 'a' },
+    })
+    expect(result.current).toBe(false)
+  })
+
+  it('flips to true immediately when the tracked value changes', () => {
+    const { result, rerender } = renderHook(({ v }) => useFreshness(v), {
+      initialProps: { v: 'a' },
+    })
+    expect(result.current).toBe(false)
+    act(() => rerender({ v: 'b' }))
+    expect(result.current).toBe(true)
+  })
+
+  it('decays back to false after the decay window', () => {
+    const { result, rerender } = renderHook(({ v }) => useFreshness(v, 1200), {
+      initialProps: { v: 'a' },
+    })
+    act(() => rerender({ v: 'b' }))
+    expect(result.current).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(1199)
+    })
+    expect(result.current).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(result.current).toBe(false)
+  })
+
+  it('does not flip when the value is unchanged across renders', () => {
+    const { result, rerender } = renderHook(({ v }) => useFreshness(v), {
+      initialProps: { v: 'a' },
+    })
+    act(() => rerender({ v: 'a' }))
+    expect(result.current).toBe(false)
+  })
+
+  it('re-arms the decay timer on a subsequent change', () => {
+    const { result, rerender } = renderHook(({ v }) => useFreshness(v, 1000), {
+      initialProps: { v: 'a' },
+    })
+    act(() => rerender({ v: 'b' }))
+    act(() => vi.advanceTimersByTime(800))
+    expect(result.current).toBe(true)
+
+    // A new change restarts the window.
+    act(() => rerender({ v: 'c' }))
+    act(() => vi.advanceTimersByTime(800))
+    expect(result.current).toBe(true)
+
+    act(() => vi.advanceTimersByTime(200))
+    expect(result.current).toBe(false)
+  })
+
+  it('honors a custom decay duration', () => {
+    const { result, rerender } = renderHook(({ v }) => useFreshness(v, 300), {
+      initialProps: { v: 1 },
+    })
+    act(() => rerender({ v: 2 }))
+    expect(result.current).toBe(true)
+    act(() => vi.advanceTimersByTime(300))
+    expect(result.current).toBe(false)
+  })
+})

--- a/ui/src/hooks/use-freshness.ts
+++ b/ui/src/hooks/use-freshness.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Returns a transient "just-updated" flag for a tracked value.
+ *
+ * The flag flips to `true` the moment `value` changes (compared via
+ * `Object.is`), then decays back to `false` after `durationMs`. It's meant to
+ * briefly draw the eye to a row whose data just changed in a busy polling view
+ * (lists refetch every 5–10s), then get out of the way.
+ *
+ * The very first render does not count as a change, so freshly-mounted rows
+ * don't all glow at once.
+ *
+ * Consumers should gate any motion/animation they attach to this behind
+ * `motion-safe:` so reduced-motion users still get the (non-essential) signal
+ * without movement.
+ */
+export function useFreshness(value: unknown, durationMs = 1200): boolean {
+  // Track the previous value in state (React's documented "adjust state during
+  // render" pattern) — no refs, no synchronous setState inside an effect, so it
+  // stays clean under the React Compiler lint rules. `changeId` increments on
+  // every real change and is what the decay effect keys off.
+  const [prev, setPrev] = useState(value)
+  const [changeId, setChangeId] = useState(0)
+  const [fresh, setFresh] = useState(false)
+
+  if (!Object.is(prev, value)) {
+    setPrev(value)
+    setChangeId((n) => n + 1)
+    setFresh(true)
+  }
+
+  useEffect(() => {
+    if (changeId === 0) return
+    const id = setTimeout(() => setFresh(false), durationMs)
+    return () => clearTimeout(id)
+  }, [changeId, durationMs])
+
+  return fresh
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,49 +1,135 @@
 @import "tailwindcss";
 
+/*
+ * Orka design tokens — deep-ocean identity.
+ *
+ * Color is an encoding, not decoration. It carries exactly three meanings:
+ *   - phase     (status-*): pending / running / succeeded / failed
+ *   - task type (type-*):   container / ai / agent
+ *   - liveness  (live):     reserved bioluminescent cyan = "happening now"
+ * Everything else is neutral (canvas / surface / elevated ramp).
+ */
+
 @theme {
-  --color-background: #ffffff;
-  --color-foreground: #0a0a0a;
+  /* ---- Neutral elevation ramp (light = cool paper) ---- */
+  --color-canvas: #f6f8fa;
+  --color-background: #f6f8fa;
+  --color-surface: #ffffff;
+  --color-elevated: #ffffff;
+
+  --color-foreground: #0b1220;
   --color-card: #ffffff;
-  --color-card-foreground: #0a0a0a;
+  --color-card-foreground: #0b1220;
   --color-popover: #ffffff;
-  --color-popover-foreground: #0a0a0a;
-  --color-primary: #2563eb;
+  --color-popover-foreground: #0b1220;
+
+  /* ---- Brand / interactive (deep azure — distinct from the reserved cyan) ---- */
+  --color-primary: #0b69c7;
   --color-primary-foreground: #ffffff;
-  --color-secondary: #f4f4f5;
-  --color-secondary-foreground: #18181b;
-  --color-muted: #f4f4f5;
-  --color-muted-foreground: #71717a;
-  --color-accent: #f4f4f5;
-  --color-accent-foreground: #18181b;
-  --color-destructive: #ef4444;
+  --color-secondary: #eef2f6;
+  --color-secondary-foreground: #0b1220;
+  --color-muted: #eef2f6;
+  --color-muted-foreground: #56657a;
+  --color-accent: #e7eef6;
+  --color-accent-foreground: #0b1220;
+  --color-destructive: #e11d48;
   --color-destructive-foreground: #ffffff;
-  --color-border: #e4e4e7;
-  --color-input: #e4e4e7;
-  --color-ring: #2563eb;
+  --color-border: #e2e8f0;
+  --color-input: #e2e8f0;
+  --color-ring: #0b69c7;
+
+  /* ---- Phase status tokens (foreground-strength: dots / text / rails) ---- */
+  --color-status-pending: #b45309;
+  --color-status-running: #0891b2;
+  --color-status-succeeded: #047857;
+  --color-status-failed: #be123c;
+
+  /* ---- Phase status tints (translucent: rails / column fills / soft chips) ---- */
+  --color-status-pending-bg: rgb(245 158 11 / 0.12);
+  --color-status-running-bg: rgb(34 211 238 / 0.12);
+  --color-status-succeeded-bg: rgb(16 185 129 / 0.12);
+  --color-status-failed-bg: rgb(244 63 94 / 0.12);
+
+  /* ---- Reserved liveness (bioluminescent cyan; consumed only in active contexts) ---- */
+  --color-live: #0891b2;
+  --color-live-bg: rgb(34 211 238 / 0.14);
+
+  /* ---- Task type tokens (kept off the status hues) ---- */
+  --color-type-container: #475569;
+  --color-type-ai: #7c3aed;
+  --color-type-agent: #4f46e5;
+
+  /* ---- Type / radius / fonts ---- */
   --radius: 0.5rem;
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo,
+    Consolas, monospace;
+
+  /* ---- Shadow scale that reads on both paper and abyss ---- */
+  --shadow-2xs: 0 1px 2px 0 rgb(15 23 42 / 0.04);
+  --shadow-xs: 0 1px 3px 0 rgb(15 23 42 / 0.06);
+  --shadow-sm: 0 1px 2px 0 rgb(15 23 42 / 0.06), 0 1px 3px 0 rgb(15 23 42 / 0.1);
+  --shadow-md: 0 2px 4px -1px rgb(15 23 42 / 0.08),
+    0 6px 16px -4px rgb(15 23 42 / 0.1);
+  --shadow-lg: 0 10px 28px -6px rgb(15 23 42 / 0.14);
+  --shadow-xl: 0 20px 48px -12px rgb(15 23 42 / 0.2);
 }
 
+/*
+ * Dark = layered abyss (not flat black). The elevation ramp does the work that
+ * shadows do on light, so cards stay legible without relying on invisible shadow.
+ */
 .dark {
-  --color-background: #0a0a0a;
-  --color-foreground: #fafafa;
-  --color-card: #0a0a0a;
-  --color-card-foreground: #fafafa;
-  --color-popover: #0a0a0a;
-  --color-popover-foreground: #fafafa;
-  --color-primary: #3b82f6;
-  --color-primary-foreground: #ffffff;
-  --color-secondary: #27272a;
-  --color-secondary-foreground: #fafafa;
-  --color-muted: #27272a;
-  --color-muted-foreground: #a1a1aa;
-  --color-accent: #27272a;
-  --color-accent-foreground: #fafafa;
-  --color-destructive: #dc2626;
-  --color-destructive-foreground: #fafafa;
-  --color-border: #27272a;
-  --color-input: #27272a;
-  --color-ring: #3b82f6;
+  --color-canvas: #0a0e14;
+  --color-background: #0a0e14;
+  --color-surface: #111722;
+  --color-elevated: #18202c;
+
+  --color-foreground: #e6edf3;
+  --color-card: #111722;
+  --color-card-foreground: #e6edf3;
+  --color-popover: #18202c;
+  --color-popover-foreground: #e6edf3;
+
+  --color-primary: #38a3ff;
+  --color-primary-foreground: #04121f;
+  --color-secondary: #18202c;
+  --color-secondary-foreground: #e6edf3;
+  --color-muted: #18202c;
+  --color-muted-foreground: #8b9aad;
+  --color-accent: #1e2a38;
+  --color-accent-foreground: #e6edf3;
+  --color-destructive: #fb7185;
+  --color-destructive-foreground: #04121f;
+  --color-border: #1e2a38;
+  --color-input: #1e2a38;
+  --color-ring: #38a3ff;
+
+  /* Status: brighter faces so they sit on the abyss without glowing falsely. */
+  --color-status-pending: #f59e0b;
+  --color-status-running: #22d3ee;
+  --color-status-succeeded: #34d399;
+  --color-status-failed: #fb7185;
+
+  --color-status-pending-bg: rgb(245 158 11 / 0.16);
+  --color-status-running-bg: rgb(34 211 238 / 0.16);
+  --color-status-succeeded-bg: rgb(52 211 153 / 0.16);
+  --color-status-failed-bg: rgb(251 113 133 / 0.16);
+
+  --color-live: #22d3ee;
+  --color-live-bg: rgb(34 211 238 / 0.18);
+
+  --color-type-container: #94a3b8;
+  --color-type-ai: #a78bfa;
+  --color-type-agent: #818cf8;
+
+  /* Deeper shadows so elevation still reads against near-black. */
+  --shadow-2xs: 0 1px 2px 0 rgb(0 0 0 / 0.4);
+  --shadow-xs: 0 1px 3px 0 rgb(0 0 0 / 0.45);
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.45), 0 1px 3px 0 rgb(0 0 0 / 0.55);
+  --shadow-md: 0 2px 4px -1px rgb(0 0 0 / 0.5), 0 8px 20px -6px rgb(0 0 0 / 0.6);
+  --shadow-lg: 0 12px 32px -8px rgb(0 0 0 / 0.65);
+  --shadow-xl: 0 24px 56px -12px rgb(0 0 0 / 0.7);
 }
 
 @layer base {
@@ -52,5 +138,55 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+/*
+ * Reserved liveness animation — a gentle breathing pulse meaning "happening now".
+ * Defined here in Phase 0; applied only in active contexts (Phase 2).
+ * Always gated behind motion-safe so reduced-motion users get a still UI.
+ */
+@keyframes orka-pulse-live {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+@utility animate-pulse-live {
+  animation: orka-pulse-live 1.8s ease-in-out infinite;
+}
+
+/*
+ * Freshness flash — a brief glow when a polled value just changed (Phase 2).
+ */
+@keyframes orka-freshness {
+  0% {
+    background-color: var(--color-live-bg);
+  }
+  100% {
+    background-color: transparent;
+  }
+}
+
+@utility animate-freshness {
+  animation: orka-freshness 1.2s ease-out;
+}
+
+/*
+ * Reduced-motion baseline (set up once, honored everywhere after).
+ * No essential information is conveyed by motion alone.
+ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/ui/src/index.css.test.ts
+++ b/ui/src/index.css.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+/**
+ * Phase 0 token invariants — parsed directly from index.css so the design
+ * system's structural guarantees are enforced in CI, not just by eye.
+ */
+const css = readFileSync(
+  path.resolve(__dirname, './index.css'),
+  'utf8',
+)
+
+/** Extract the body of a top-level block (`@theme {…}` or `.dark {…}`). */
+function block(selector: string): string {
+  const start = css.indexOf(selector)
+  expect(start, `selector ${selector} present`).toBeGreaterThan(-1)
+  const open = css.indexOf('{', start)
+  let depth = 0
+  for (let i = open; i < css.length; i++) {
+    if (css[i] === '{') depth++
+    else if (css[i] === '}') {
+      depth--
+      if (depth === 0) return css.slice(open + 1, i)
+    }
+  }
+  throw new Error(`unbalanced block for ${selector}`)
+}
+
+function tokenValue(body: string, name: string): string | undefined {
+  const m = body.match(new RegExp(`${name.replace(/[-]/g, '\\-')}\\s*:\\s*([^;]+);`))
+  return m?.[1].trim()
+}
+
+describe('index.css design tokens', () => {
+  const themeBody = block('@theme')
+  const darkBody = block('.dark')
+
+  it('card surface is distinct from the page background in light theme', () => {
+    const card = tokenValue(themeBody, '--color-card')
+    const bg = tokenValue(themeBody, '--color-background')
+    expect(card).toBeTruthy()
+    expect(bg).toBeTruthy()
+    expect(card).not.toBe(bg)
+  })
+
+  it('card surface is distinct from the page background in dark theme', () => {
+    const card = tokenValue(darkBody, '--color-card')
+    const bg = tokenValue(darkBody, '--color-background')
+    expect(card).toBeTruthy()
+    expect(bg).toBeTruthy()
+    expect(card).not.toBe(bg)
+  })
+
+  it('Inter is still declared as the sans font', () => {
+    expect(themeBody).toMatch(/--font-sans:\s*"Inter"/)
+  })
+
+  it('defines a monospace font token for machine data', () => {
+    expect(tokenValue(themeBody, '--font-mono')).toMatch(/JetBrains Mono/)
+  })
+
+  it('defines an elevation ramp (canvas / surface / elevated) in both themes', () => {
+    for (const body of [themeBody, darkBody]) {
+      expect(tokenValue(body, '--color-canvas')).toBeTruthy()
+      expect(tokenValue(body, '--color-surface')).toBeTruthy()
+      expect(tokenValue(body, '--color-elevated')).toBeTruthy()
+    }
+  })
+
+  it('defines the four phase status tokens in both themes', () => {
+    for (const body of [themeBody, darkBody]) {
+      for (const phase of ['pending', 'running', 'succeeded', 'failed']) {
+        expect(
+          tokenValue(body, `--color-status-${phase}`),
+          `--color-status-${phase}`,
+        ).toBeTruthy()
+      }
+    }
+  })
+
+  it('reserves a liveness token in both themes', () => {
+    expect(tokenValue(themeBody, '--color-live')).toBeTruthy()
+    expect(tokenValue(darkBody, '--color-live')).toBeTruthy()
+  })
+
+  it('defines task-type tokens in both themes', () => {
+    for (const body of [themeBody, darkBody]) {
+      for (const type of ['container', 'ai', 'agent']) {
+        expect(
+          tokenValue(body, `--color-type-${type}`),
+          `--color-type-${type}`,
+        ).toBeTruthy()
+      }
+    }
+  })
+
+  it('honors reduced motion globally', () => {
+    expect(css).toMatch(/prefers-reduced-motion:\s*reduce/)
+  })
+})

--- a/ui/src/lib/task-status.test.ts
+++ b/ui/src/lib/task-status.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { phaseStyle, typeStyle } from './task-status'
+
+describe('phaseStyle', () => {
+  it.each(['Pending', 'Running', 'Succeeded', 'Failed'] as const)(
+    'returns token-based classes for %s (no pastel literals)',
+    (phase) => {
+      const s = phaseStyle(phase)
+      expect(s.label).toBe(phase)
+      expect(s.dotClass).toBe(`bg-status-${phase.toLowerCase()}`)
+      expect(s.railClass).toBe(`border-status-${phase.toLowerCase()}`)
+      expect(s.textClass).toBe(`text-status-${phase.toLowerCase()}`)
+      expect(s.bgClass).toBe(`bg-status-${phase.toLowerCase()}-bg`)
+      // Guard against any regression back to template pastels.
+      expect(s.dotClass).not.toMatch(/-(100|200|800|900)\b/)
+    },
+  )
+
+  it('marks only Running as live', () => {
+    expect(phaseStyle('Running').live).toBe(true)
+    for (const phase of ['Pending', 'Succeeded', 'Failed'] as const) {
+      expect(phaseStyle(phase).live).toBe(false)
+    }
+  })
+
+  it('falls back to Pending for unknown/undefined phases', () => {
+    expect(phaseStyle(undefined).label).toBe('Pending')
+    expect(phaseStyle('Nonsense').label).toBe('Pending')
+  })
+})
+
+describe('typeStyle', () => {
+  it.each(['container', 'ai', 'agent'] as const)(
+    'returns an icon and token classes for %s',
+    (type) => {
+      const s = typeStyle(type)
+      expect(s.label).toBe(type)
+      expect(s.icon).toBeTruthy()
+      expect(s.textClass).toBe(`text-type-${type}`)
+      expect(s.tintClass).toContain(`bg-type-${type}`)
+    },
+  )
+
+  it('falls back to container for unknown/undefined types', () => {
+    expect(typeStyle(undefined).label).toBe('container')
+    expect(typeStyle('weird').label).toBe('container')
+  })
+})

--- a/ui/src/lib/task-status.test.ts
+++ b/ui/src/lib/task-status.test.ts
@@ -18,10 +18,22 @@ describe('phaseStyle', () => {
 
   it('marks only Running as live', () => {
     expect(phaseStyle('Running').live).toBe(true)
-    for (const phase of ['Pending', 'Succeeded', 'Failed'] as const) {
+    for (const phase of ['Pending', 'Succeeded', 'Failed', 'Scheduled', 'Cancelled'] as const) {
       expect(phaseStyle(phase).live).toBe(false)
     }
   })
+
+  it.each(['Scheduled', 'Cancelled'] as const)(
+    'provides a distinct, non-pastel style for the %s phase',
+    (phase) => {
+      const s = phaseStyle(phase)
+      expect(s.label).toBe(phase)
+      expect(s.dotClass).toBeTruthy()
+      expect(s.textClass).toBeTruthy()
+      expect(s.bgClass).toBeTruthy()
+      expect(s.dotClass).not.toMatch(/-(100|200|800|900)\b/)
+    },
+  )
 
   it('falls back to Pending for unknown/undefined phases', () => {
     expect(phaseStyle(undefined).label).toBe('Pending')

--- a/ui/src/lib/task-status.ts
+++ b/ui/src/lib/task-status.ts
@@ -65,6 +65,26 @@ const PHASE_STYLES: Record<TaskPhase, PhaseStyle> = {
     bgClass: 'bg-status-failed-bg',
     live: false,
   },
+  Scheduled: {
+    // A queued/future run — waiting like Pending, so it shares the pending
+    // (amber) family rather than the live cyan.
+    label: 'Scheduled',
+    dotClass: 'bg-status-pending',
+    railClass: 'border-status-pending',
+    textClass: 'text-status-pending',
+    bgClass: 'bg-status-pending-bg',
+    live: false,
+  },
+  Cancelled: {
+    // A terminal, user-stopped state — neutral/muted, deliberately off the
+    // success/failure hues.
+    label: 'Cancelled',
+    dotClass: 'bg-muted-foreground',
+    railClass: 'border-muted-foreground',
+    textClass: 'text-muted-foreground',
+    bgClass: 'bg-muted',
+    live: false,
+  },
 }
 
 /** Resolve the visual style for a task phase, defaulting to Pending. */

--- a/ui/src/lib/task-status.ts
+++ b/ui/src/lib/task-status.ts
@@ -1,0 +1,110 @@
+import type { LucideIcon } from 'lucide-react'
+import { Container, Sparkles, Bot } from 'lucide-react'
+import type { TaskPhase, TaskType } from '@/schemas/task'
+
+/**
+ * Single source of truth for status & type visual encoding.
+ *
+ * Color carries exactly three meanings in Orka's UI — phase, task type, and
+ * liveness — and they all originate here, flowing from the Phase-0 design
+ * tokens (status-* / type-*), never from ad-hoc `*-100` pastels.
+ *
+ * This is a plain `.ts` module (no JSX) on purpose: it exports style constants
+ * and would otherwise trip the `react-refresh/only-export-components` lint rule
+ * if it lived alongside a component.
+ *
+ * Class strings are written as complete literals so Tailwind's content scanner
+ * can see them — never compose them dynamically (e.g. `bg-status-${phase}`).
+ */
+
+export interface PhaseStyle {
+  /** Human-readable phase label. */
+  label: string
+  /** Background utility for the filled status dot. */
+  dotClass: string
+  /** Border-color utility for a left-rail accent (`border-l-*`). */
+  railClass: string
+  /** Foreground utility for phase text. */
+  textClass: string
+  /** Translucent tint for soft fills (chips, column headers). */
+  bgClass: string
+  /** Whether this phase represents an in-flight, "live" state. */
+  live: boolean
+}
+
+const PHASE_STYLES: Record<TaskPhase, PhaseStyle> = {
+  Pending: {
+    label: 'Pending',
+    dotClass: 'bg-status-pending',
+    railClass: 'border-status-pending',
+    textClass: 'text-status-pending',
+    bgClass: 'bg-status-pending-bg',
+    live: false,
+  },
+  Running: {
+    label: 'Running',
+    dotClass: 'bg-status-running',
+    railClass: 'border-status-running',
+    textClass: 'text-status-running',
+    bgClass: 'bg-status-running-bg',
+    live: true,
+  },
+  Succeeded: {
+    label: 'Succeeded',
+    dotClass: 'bg-status-succeeded',
+    railClass: 'border-status-succeeded',
+    textClass: 'text-status-succeeded',
+    bgClass: 'bg-status-succeeded-bg',
+    live: false,
+  },
+  Failed: {
+    label: 'Failed',
+    dotClass: 'bg-status-failed',
+    railClass: 'border-status-failed',
+    textClass: 'text-status-failed',
+    bgClass: 'bg-status-failed-bg',
+    live: false,
+  },
+}
+
+/** Resolve the visual style for a task phase, defaulting to Pending. */
+export function phaseStyle(phase?: TaskPhase | string): PhaseStyle {
+  return PHASE_STYLES[phase as TaskPhase] ?? PHASE_STYLES.Pending
+}
+
+export interface TypeStyle {
+  /** Human-readable type label. */
+  label: string
+  /** Lucide icon representing the task type. */
+  icon: LucideIcon
+  /** Foreground utility for the type icon/text. */
+  textClass: string
+  /** Soft tint utility for a type chip background. */
+  tintClass: string
+}
+
+const TYPE_STYLES: Record<TaskType, TypeStyle> = {
+  container: {
+    label: 'container',
+    icon: Container,
+    textClass: 'text-type-container',
+    tintClass: 'bg-type-container/10 text-type-container',
+  },
+  ai: {
+    label: 'ai',
+    icon: Sparkles,
+    textClass: 'text-type-ai',
+    tintClass: 'bg-type-ai/10 text-type-ai',
+  },
+  agent: {
+    label: 'agent',
+    icon: Bot,
+    textClass: 'text-type-agent',
+    tintClass: 'bg-type-agent/10 text-type-agent',
+  },
+}
+
+/** Resolve the visual style for a task type, defaulting to container. */
+export function typeStyle(type?: TaskType | string): TypeStyle {
+  return TYPE_STYLES[type as TaskType] ?? TYPE_STYLES.container
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,5 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+// Offline-safe fonts — bundled by Vite from @fontsource (no runtime CDN fetch).
+import '@fontsource/inter/400.css'
+import '@fontsource/inter/500.css'
+import '@fontsource/inter/600.css'
+import '@fontsource/inter/700.css'
+import '@fontsource/jetbrains-mono/400.css'
+import '@fontsource/jetbrains-mono/500.css'
+import '@fontsource/jetbrains-mono/600.css'
 import './index.css'
 import { App } from './app'
 

--- a/ui/src/routes/login.tsx
+++ b/ui/src/routes/login.tsx
@@ -4,6 +4,7 @@ import { useAuthStore } from '@/stores/auth'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { OrcaMark } from '@/components/ui/orca-mark'
 
 export const Route = createFileRoute('/login')({
   component: LoginPage,
@@ -75,7 +76,7 @@ function LoginPage() {
     <div className="flex min-h-screen items-center justify-center bg-background">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <div className="mb-2 text-4xl">🐋</div>
+          <OrcaMark className="mx-auto mb-2 h-12 w-12" />
           <CardTitle className="text-2xl">Orka</CardTitle>
           <CardDescription>
             Enter your Kubernetes service account token or use <code className="text-xs">orka login</code> from the CLI.

--- a/ui/src/schemas/chat.ts
+++ b/ui/src/schemas/chat.ts
@@ -105,6 +105,9 @@ export interface ChatMessage {
   toolSuccess?: boolean
   // Usage metadata (on assistant messages)
   usage?: ChatUsage
+  // Names of tasks created during this turn (for cross-linking chips), when
+  // surfaced by the backend/tool stream. Count lives in usage.tasksCreated.
+  tasksCreatedNames?: string[]
   // Status metadata
   provider?: string
   model?: string

--- a/ui/src/schemas/task.test.ts
+++ b/ui/src/schemas/task.test.ts
@@ -39,6 +39,8 @@ describe('taskPhaseSchema', () => {
     expect(taskPhaseSchema.parse('Running')).toBe('Running')
     expect(taskPhaseSchema.parse('Succeeded')).toBe('Succeeded')
     expect(taskPhaseSchema.parse('Failed')).toBe('Failed')
+    expect(taskPhaseSchema.parse('Scheduled')).toBe('Scheduled')
+    expect(taskPhaseSchema.parse('Cancelled')).toBe('Cancelled')
   })
 
   it('rejects invalid values', () => {

--- a/ui/src/schemas/task.ts
+++ b/ui/src/schemas/task.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export const taskTypeSchema = z.enum(['container', 'ai', 'agent'])
-export const taskPhaseSchema = z.enum(['Pending', 'Running', 'Succeeded', 'Failed'])
+export const taskPhaseSchema = z.enum(['Pending', 'Running', 'Succeeded', 'Failed', 'Scheduled', 'Cancelled'])
 
 export const conditionSchema = z.object({
   type: z.string(),

--- a/ui/src/stores/chat.ts
+++ b/ui/src/stores/chat.ts
@@ -11,7 +11,7 @@ interface ChatState {
   setSessionId: (id: string) => void
   setStreaming: (streaming: boolean) => void
   newSession: () => void
-  setUsageOnLastAssistant: (usage: ChatUsage) => void
+  setUsageOnLastAssistant: (usage: ChatUsage, tasksCreatedNames?: string[]) => void
 }
 
 let msgCounter = 0
@@ -43,12 +43,18 @@ export const useChatStore = create<ChatState>()((set) => ({
   setStreaming: (streaming) => set({ isStreaming: streaming }),
   newSession: () => set({ messages: [], currentSessionId: null }),
 
-  setUsageOnLastAssistant: (usage) =>
+  setUsageOnLastAssistant: (usage, tasksCreatedNames) =>
     set((state) => {
       const msgs = [...state.messages]
       for (let i = msgs.length - 1; i >= 0; i--) {
         if (msgs[i].role === 'assistant') {
-          msgs[i] = { ...msgs[i], usage }
+          msgs[i] = {
+            ...msgs[i],
+            usage,
+            ...(tasksCreatedNames && tasksCreatedNames.length > 0
+              ? { tasksCreatedNames }
+              : {}),
+          }
           break
         }
       }


### PR DESCRIPTION
## Summary

Moves the Orka UI from a default shadcn template to a UI whose visual structure mirrors its domain — hierarchical (task → childTasks), temporal (iteration / plan / conditions), and live (running agents, streaming logs) — under a coherent deep-ocean identity. Implements the full 7-phase plan; each phase is independently reviewed and shippable.

- **Phase 0 — Foundation:** deep-ocean token system (canvas/surface/elevated ramp, status/type/`--color-live` tokens, real shadow scale), offline-safe `@fontsource` Inter + JetBrains Mono, FOUC-killing inline theme script, unified `<OrcaMark>` brand (favicon + wordmark, replacing the 🐋/🐟 mismatch), global reduced-motion baseline.
- **Phase 1 — Status as a visual language:** `lib/task-status.ts` single source of truth (`phaseStyle`/`typeStyle`) + `<StatusDot>` primitive; every hardcoded `bg-*-100` phase pastil across 10 components migrated to tokens; `aria-label`s on icon-only controls.
- **Phase 2 — Liveness:** reserved `--color-live` + `animate-pulse-live` applied **only** in active contexts (Running dot, log Live/Streaming badge, live grid, kanban Running column); `useFreshness` hook; tabular-nums timers.
- **Phase 3 — Chrome/layout/motion:** `<PageHeader>` (de-dupes ~20 copies) + `<EmptyState>`; frosted header/sidebar; accent-bar active nav; kanban lanes; emoji→lucide icons; motion-safe hover-lift.
- **Phase 4 — Execution graph:** indented `role="tree"` delegation graph (phase-colored, keyboard-traversable, click-to-navigate) replacing the childTasks `<table>` on task detail.
- **Phase 5 — Autonomous-loop timeline:** chronological stepper merging conditions + iterations + a pinned terminal marker, with a goal progress bar (iteration ticks, goal-complete styling).
- **Phase 6 — Cockpit + cross-silo linking:** per-status trend sparklines (shared time window), success-rate, phase-distribution; chat→task chips linking into the graph; flush assistant console with collapsible mono tool-call cards; sonar idle illustration; monospace pass on resource identifiers.

All color is encoding-only (phase / type / liveness); everything else is neutral. No backend changes.

## Notes for reviewers

- **Tests:** 603 passing across 78 files (baseline was 507/67). New domain components ship with tests; pure primitives live under `src/components/ui/**`.
- **Continuous review:** `$autoreview` (Codex) was run per phase and looped until clean. It caught and we fixed 4 real bugs (unknown-phase relabeling, Failed-event success styling, terminal-event mis-ordering, chat chip over-harvesting + aggregate-vs-per-status sparklines), each with a regression test.
- **Pre-existing coverage debt:** the repo's global coverage thresholds already failed on `main` (~70% vs 95%, from untested `security/`+`monitors/` areas). This PR does not worsen it; fixing that unrelated debt is out of scope.

## Test plan

- [ ] `cd ui && bun run lint` — clean (3 pre-existing `react-refresh` warnings only)
- [ ] `cd ui && bun run test` — 603 green
- [ ] `cd ui && bun run build` — type-checks; font assets bundled, no `googleapis` CDN refs
- [ ] Manual: visual QA in **both** light and dark themes
- [ ] Manual: `prefers-reduced-motion: reduce` honored (no info conveyed by motion alone)
- [ ] Manual: keyboard nav + visible focus ring on graph/timeline/nav/icon-buttons