### PR TITLE
feat: add backend-neutral harness runtime foundation

### DIFF
--- a/cmd/cli/events.go
+++ b/cmd/cli/events.go
@@ -159,7 +159,7 @@ func newSessionFollowCmd() *cobra.Command {
 	return newExecutionFollowCmd("follow <session>", "Follow session execution events", "/api/v1/sessions")
 }
 
-func newExecutionEventsCmd(use, short, basePath string, isTaskScope bool) *cobra.Command {
+func newExecutionEventsCmd(use, short, basePath string, includeType bool) *cobra.Command {
 	var after int64
 	var limit int
 	var eventTypes []string
@@ -186,7 +186,7 @@ func newExecutionEventsCmd(use, short, basePath string, isTaskScope bool) *cobra
 			if format != outputTable {
 				return printStructured(cmd, result)
 			}
-			return printExecutionEventsTable(cmd, result, isTaskScope)
+			return printExecutionEventsTable(cmd, result, includeType)
 		},
 	}
 	cmd.Flags().Int64Var(&after, "after", 0, "Only return events after this sequence")
@@ -272,7 +272,7 @@ func appendRepeatedTypes(path string, query map[string]string, eventTypes []stri
 	return path
 }
 
-func printExecutionEventsTable(cmd *cobra.Command, value any, isTaskScope bool) error {
+func printExecutionEventsTable(cmd *cobra.Command, value any, includeTask bool) error {
 	m, _ := value.(map[string]any)
 	events, _ := m["events"].([]any)
 	if len(events) == 0 {
@@ -280,14 +280,14 @@ func printExecutionEventsTable(cmd *cobra.Command, value any, isTaskScope bool) 
 		return nil
 	}
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-	if isTaskScope {
+	if includeTask {
 		fmt.Fprintln(w, "SEQ\tTYPE\tSEVERITY\tSUMMARY") //nolint:errcheck
 	} else {
 		fmt.Fprintln(w, "SEQ\tTASK\tTASKSEQ\tTYPE\tSEVERITY\tSUMMARY") //nolint:errcheck
 	}
 	for _, raw := range events {
 		event, _ := raw.(map[string]any)
-		if isTaskScope {
+		if includeTask {
 			_, _ = fmt.Fprintf(
 				w,
 				"%s\t%s\t%s\t%s\n",

--- a/docs/adr/0008-runtime-session-internal-store-first.md
+++ b/docs/adr/0008-runtime-session-internal-store-first.md
@@ -1,0 +1,28 @@
+# ADR 0008: Start RuntimeSession persistence as an internal store
+
+Date: 2026-06-11
+
+## Status
+
+Accepted for the first frontier implementation wave.
+
+## Context
+
+The remaining frontier introduces backend-neutral runtime sessions that can be claimed, reused, released, retained, suspended, and deleted. The lifecycle must support non-Substrate providers first while keeping Agent Substrate optional. Runtime sessions require strict namespace ownership and cleanup semantics, but the first provider still needs to prove the turn protocol and conformance suite before operators need a public CRD surface.
+
+## Decision
+
+Start with an internal RuntimeSession state model and persistence boundary, then add a CRD only after the non-Substrate provider and cleanup loop have stable status requirements.
+
+The frozen state machine lives in `internal/harness` so the controller/provider implementation can share validation. Public API/CLI visibility can read from the internal store initially and later migrate to a CRD-backed implementation without changing the turn protocol.
+
+## Consequences
+
+- Provider integration can ship behind feature gates without expanding the Kubernetes API surface prematurely.
+- Namespace ownership, cleanup policies, and transition validation are testable before persistence is introduced.
+- Operator visibility is initially API/CLI-driven rather than `kubectl get runtimesessions`.
+- A future CRD migration must preserve IDs, owner metadata, cleanup policy, active task, provider, phase, idle timeout, and max lifetime.
+
+## Revisit
+
+Revisit once the non-Substrate provider passes conformance and the cleanup controller needs watch/reconcile semantics that are awkward for an internal store.

--- a/docs/development/harness-conformance.md
+++ b/docs/development/harness-conformance.md
@@ -1,0 +1,34 @@
+# Harness conformance suite
+
+`internal/harness/harnesstest` contains the provider-agnostic conformance suite for `orka.harness.v1`.
+
+## How providers plug in
+
+A provider test supplies a factory:
+
+```go
+harnesstest.RunHarnessConformance(t, func(t *testing.T, behavior harnesstest.FakeBehavior) (string, func()) {
+    server := startProviderHarnessForBehavior(t, behavior)
+    return server.BaseURL, server.Close
+})
+```
+
+The suite expects an HTTP+SSE harness endpoint implementing:
+
+- `GET /v1/health`
+- `GET /v1/capabilities`
+- `POST /v1/turns`
+- `GET /v1/turns/{turnID}/events?afterSeq=N`
+- `POST /v1/turns/{turnID}/cancel`
+
+## Covered behavior
+
+- health and capabilities responses validate DTO versioning;
+- successful turns emit start/output/tool/result/completed frames;
+- failed turns map to safe `AgentRuntimeFailed` events;
+- cancellation invokes the cancel endpoint and emits `TurnCancelled`;
+- unknown frames become warning diagnostics instead of panicking;
+- secret-looking output is redacted before event persistence;
+- client timeouts surface as sanitized typed client errors.
+
+Providers that cannot exercise every fake behavior directly should adapt the factory with a local fixture harness and run provider-specific smoke tests for the unavailable behavior.

--- a/docs/development/harness-protocol-mvp.md
+++ b/docs/development/harness-protocol-mvp.md
@@ -52,3 +52,91 @@ Deferred:
 - workspace snapshot-aware fork;
 - remote harness-backed Agent CRDs;
 - full graph layout UI.
+
+---
+
+## Frozen MVP contract (`orka.harness.v1`)
+
+The implementation contract is now represented by `internal/harness` and is frozen for the first backend-neutral provider. The MVP transport is **HTTP control endpoints plus an SSE frame stream**:
+
+| Route | Method | Purpose |
+| --- | --- | --- |
+| `/v1/health` | `GET` | Return `HealthResponse`. |
+| `/v1/capabilities` | `GET` | Return `CapabilitiesResponse`. |
+| `/v1/turns` | `POST` | Accept `StartTurnRequest` and return `StartTurnResponse`. |
+| `/v1/turns/{turnID}/events?afterSeq=N` | `GET` | Stream `HarnessEventFrame` values as SSE `data:` records. |
+| `/v1/turns/{turnID}/cancel` | `POST` | Accept `CancelTurnRequest` and return `CancelTurnResponse`. |
+
+Every DTO carries `version: "orka.harness.v1"`. A missing or unsupported version is a deterministic validation error. Provider-specific fields, including Agent Substrate actor identifiers, are excluded from base request DTOs and belong only in provider capability metadata/status.
+
+### Required turn fields
+
+`StartTurnRequest` requires namespace, task name, session name, runtime session id, turn id, correlation id, deadline, and a verified auth identity subject or username. Tool and approval policies are safe object references; raw credentials and TxTokens are not valid DTO fields.
+
+```json
+{
+  "version": "orka.harness.v1",
+  "namespace": "default",
+  "taskName": "task-a",
+  "sessionName": "session-a",
+  "runtimeSessionID": "runtime-a",
+  "turnID": "turn-a",
+  "correlationID": "corr-a",
+  "deadline": "2026-06-11T12:00:00Z",
+  "authIdentity": {"subject": "user:test"},
+  "toolPolicyRef": {"name": "default-tools"},
+  "approvalPolicyRef": {"name": "default-approvals"},
+  "eventCursor": 7,
+  "toolExecutionMode": "observed",
+  "input": {"prompt": "summarize this repository"}
+}
+```
+
+### Frame-to-event mapping
+
+Harness frames are mapped to existing Orka execution event types so task/session streams and trace read models remain the source of history:
+
+| Harness frame | Execution event type | Notes |
+| --- | --- | --- |
+| `TurnStarted` | `AgentRuntimeStarted` | Turn/session ids appear in event content metadata. |
+| `RuntimeOutput` | `ModelMessage` | Runtime output is sanitized before persistence. |
+| `ToolCallRequested` | `ToolCallStarted` | `toolName` and `toolCallID` are preserved. |
+| `ToolResultReceived` | `ToolCallCompleted` | Failed tool results can carry safe error content. |
+| `ApprovalRequested` | `ApprovalRequested` | Reuses durable approval event lifecycle. |
+| `TurnCompleted` | `AgentRuntimeCompleted` | Terminal turn metadata is included in content. |
+| `TurnFailed` | `AgentRuntimeFailed` | Severity is forced to `error`. |
+| `TurnCancelled` | `TaskCancelled` | Cancellation is terminal for the turn/task path. |
+| `RuntimeLog` | `AgentRuntimeCommandStarted` | Used as a safe diagnostic/log event. |
+| Unknown frame | `AgentRuntimeCommandStarted` warning | Does not panic; produces a safe diagnostic event. |
+
+Redaction/truncation runs in the harness mapper and again at the event store boundary. Secret-looking fake frames in conformance tests must persist only redacted values.
+
+### Tool execution modes
+
+- `observed`: the harness executes tools itself and emits tool lifecycle frames. This is compatible with opaque runtimes but Orka cannot prevent side effects before observation.
+- `brokered`: the harness requests tool execution through Orka. The idempotency key is `runtimeSessionID:turnID:toolCallID`; duplicate requests must return the same result or a deterministic conflict. Approval-required brokered calls emit the existing approval events and do not execute until approved.
+
+### RuntimeSession lifecycle
+
+`internal/harness` defines the backend-neutral state machine:
+
+```text
+Pending -> Booting -> Ready -> TurnRunning -> Idle -> Releasing -> Deleted
+                                      |          |            +-> Retained
+                                      |          |            +-> Suspended
+                                      |          +-> Deleting -> Deleted
+                                      +-> Failed/Unhealthy -> Deleting
+```
+
+Supported states are `Pending`, `Booting`, `Ready`, `TurnRunning`, `Idle`, `Releasing`, `Retained`, `Suspended`, `Deleting`, `Deleted`, `Failed`, and `Unhealthy`. Runtime sessions require namespace, session name, provider, cleanup policy, and owner metadata. Cleanup policies are `delete`, `retain`, and provider-capability-gated `suspend`.
+
+### Security requirements
+
+- Harness control calls are namespace-scoped and authenticated by Orka; per-turn credentials must be short-lived and scoped to the task/session.
+- Raw secrets, raw TxTokens, environment dumps, cookies, API keys, and JWTs must not appear in request DTOs, status, events, logs, or trace output.
+- Cross-namespace runtime reuse is denied by ownership validation.
+- Lifecycle transitions and cleanup failures must be evented with safe metadata only.
+
+### Conformance contract
+
+The reusable conformance suite in `internal/harness/harnesstest` verifies health, capabilities, successful turns, failed turns, cancellation, invalid/unknown frames, redaction, and client timeout behavior against any provider factory. The fake harness server covers success, failure, delayed output, long-running turns, cancellation, invalid frames, and secret-looking output.

--- a/docs/development/remaining-frontier-readiness.md
+++ b/docs/development/remaining-frontier-readiness.md
@@ -1,0 +1,34 @@
+# Remaining frontier readiness checklist
+
+Date: 2026-06-11
+
+This checklist gates implementation of the backend-neutral resident runtime frontier on top of the post-P0 evented runtime worktree.
+
+| Area | Status | Evidence |
+| --- | --- | --- |
+| Session event aggregation | Ready | Post-P0 task/session event APIs and CLI follow/list commands are present. |
+| Trace read model | Ready | `internal/tasktrace` and task trace API/CLI exist. |
+| Fork/checkpoint MVP | Ready | Event-sequence fork API and CLI are present; physical snapshot fork remains deferred. |
+| Durable approvals MVP | Ready for API/read model | Approval event read model and decision endpoints exist; first high-risk tool integration is still deferred. |
+| Event metrics | Ready baseline | Append/list/stream/redaction metrics exist with low-cardinality labels. |
+| Harness protocol DTOs | Ready | `internal/harness` defines `orka.harness.v1` DTOs and validation. |
+| Event mapping | Ready for conformance | `internal/harness.MapFrameToExecutionEvent` maps frames to existing execution events. |
+| Runtime lifecycle state machine | Ready foundation | `internal/harness` validates RuntimeSession states and transitions. |
+| Tool execution modes | Ready contract | Observed and brokered modes plus brokered idempotency key are defined. |
+| Security requirements | Ready contract | Protocol docs and mapper enforce no raw secrets in persisted events. |
+| Conformance fixture | Ready foundation | `internal/harness/harnesstest` fake server and suite cover MVP provider behavior. |
+| Non-Substrate provider | Not implemented | The first Kubernetes Service/sidecar provider should be built after the conformance suite is adopted by controller integration. |
+| RuntimeSession persistence/API | Deferred | ADR 0008 selects internal-store-first; persistent implementation follows provider integration. |
+| Resident daemon/process | Deferred | Requires runtime session claim/release and provider implementation. |
+| Substrate provider | Deferred optional | Must remain provider-scoped and pass the same conformance suite. |
+| Snapshot-aware fork | Deferred | Logical fork remains available; physical clone/snapshot capability contract follows provider support. |
+
+No missing required contract blocks Wave 1 conformance/client/fake-harness work. Wave 2+ implementation should start by wiring a non-Substrate provider to the frozen DTOs and conformance suite.
+
+Focused verification for the readiness layer:
+
+```bash
+go test ./internal/harness/... -run 'DTO|Protocol|RuntimeSession|MapFrame|FakeHarness|Conformance' -v
+go test ./internal/api -run 'Task.*Trace|Session.*Event|Fork|Approval|Event' -v
+go test ./internal/store/sqlite -run ExecutionEvent -v
+```

--- a/examples/harness/echo/main.go
+++ b/examples/harness/echo/main.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sozercan/orka/internal/harness"
+)
+
+type server struct {
+	mu    sync.Mutex
+	turns map[harness.HarnessTurnID]harness.StartTurnRequest
+}
+
+func main() {
+	addr := strings.TrimSpace(os.Getenv("ORKA_EXAMPLE_HARNESS_ADDR"))
+	if addr == "" {
+		addr = ":8090"
+	}
+	s := &server{turns: map[harness.HarnessTurnID]harness.StartTurnRequest{}}
+	mux := http.NewServeMux()
+	mux.HandleFunc(harness.HealthPath, s.health)
+	mux.HandleFunc(harness.CapabilitiesPath, s.capabilities)
+	mux.HandleFunc(harness.TurnsPath, s.startTurn)
+	mux.HandleFunc(harness.TurnsPath+"/", s.turn)
+	log.Printf("example echo harness listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}
+
+func (s *server) health(w http.ResponseWriter, r *http.Request) {
+	harness.WriteJSON(w, http.StatusOK, harness.HealthResponse{
+		Version:   harness.ProtocolVersion,
+		Status:    harness.HealthStatusOK,
+		Ready:     true,
+		CheckedAt: time.Now().UTC(),
+	})
+}
+
+func (s *server) capabilities(w http.ResponseWriter, r *http.Request) {
+	harness.WriteJSON(w, http.StatusOK, harness.CapabilitiesResponse{
+		Version:                 harness.ProtocolVersion,
+		ProtocolVersion:         harness.ProtocolVersion,
+		Transport:               harness.HTTPTransport,
+		RuntimeName:             "orka-example-echo-harness",
+		ProviderKind:            harness.ProviderKindKubernetesService,
+		ToolExecutionModes:      []harness.ToolExecutionMode{harness.ToolExecutionModeObserved},
+		SupportsCancel:          true,
+		SupportsRuntimeSessions: true,
+		MaxConcurrentTurns:      1,
+	})
+}
+
+func (s *server) startTurn(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		harness.WriteError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var request harness.StartTurnRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		harness.WriteError(w, http.StatusBadRequest, "invalid JSON request")
+		return
+	}
+	if err := request.Validate(); err != nil {
+		harness.WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s.mu.Lock()
+	s.turns[request.TurnID] = request
+	s.mu.Unlock()
+	harness.WriteJSON(w, http.StatusAccepted, harness.StartTurnResponse{
+		Version:          harness.ProtocolVersion,
+		Accepted:         true,
+		RuntimeSessionID: request.RuntimeSessionID,
+		TurnID:           request.TurnID,
+		CorrelationID:    request.CorrelationID,
+		EventStreamPath:  fmt.Sprintf("/v1/turns/%s/events", request.TurnID),
+	})
+}
+
+func (s *server) turn(w http.ResponseWriter, r *http.Request) {
+	trimmed := strings.TrimPrefix(r.URL.Path, harness.TurnsPath+"/")
+	parts := strings.Split(strings.Trim(trimmed, "/"), "/")
+	if len(parts) != 2 || parts[1] != "events" {
+		harness.WriteError(w, http.StatusNotFound, "not found")
+		return
+	}
+	turnID := harness.HarnessTurnID(parts[0])
+	s.mu.Lock()
+	request, ok := s.turns[turnID]
+	s.mu.Unlock()
+	if !ok {
+		harness.WriteError(w, http.StatusNotFound, "turn not found")
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	_ = harness.WriteSSEFrame(w, frame(request, 1, harness.FrameTurnStarted, "turn started", nil))
+	output := frame(request, 2, harness.FrameRuntimeOutput, "echo", nil)
+	output.ContentText = "echo: " + request.Input.Prompt
+	output.Content = json.RawMessage(fmt.Sprintf(`{"message":%q}`, output.ContentText))
+	_ = harness.WriteSSEFrame(w, output)
+	completed := &harness.TurnCompleted{Result: "ok", FinalEventSeq: 3}
+	_ = harness.WriteSSEFrame(w, frame(request, 3, harness.FrameTurnCompleted, "turn completed", completed))
+	_ = harness.WriteSSEDone(w)
+}
+
+func frame(
+	request harness.StartTurnRequest,
+	seq int64,
+	typ harness.FrameType,
+	summary string,
+	completed *harness.TurnCompleted,
+) harness.HarnessEventFrame {
+	return harness.HarnessEventFrame{
+		Version:          harness.ProtocolVersion,
+		Type:             typ,
+		RuntimeSessionID: request.RuntimeSessionID,
+		TurnID:           request.TurnID,
+		CorrelationID:    request.CorrelationID,
+		Seq:              seq,
+		CreatedAt:        time.Now().UTC(),
+		Summary:          summary,
+		Completed:        completed,
+	}
+}

--- a/internal/api/approval_handlers.go
+++ b/internal/api/approval_handlers.go
@@ -9,10 +9,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v3"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 
-	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
 	"github.com/sozercan/orka/internal/approvals"
 	"github.com/sozercan/orka/internal/events"
 	"github.com/sozercan/orka/internal/store"
@@ -27,7 +24,6 @@ type ListTaskApprovalsResponse struct {
 const (
 	approvalDecisionApprove = "approve"
 	approvalDecisionDecline = "decline"
-	unknownApprovalActor    = "unknown"
 )
 
 type ApprovalDecisionRequest struct {
@@ -72,17 +68,10 @@ func (h *Handlers) DecideTaskApproval(c fiber.Ctx) error {
 	if err := h.authorizeContextTokenAction(c, "decideTaskApproval", h.contextTokenAuthorization.TaskUpdateScopes); err != nil {
 		return err
 	}
-	task := &corev1alpha1.Task{}
-	if err := h.client.Get(c.Context(), types.NamespacedName{Name: taskName, Namespace: namespace}, task); err != nil {
-		if apierrors.IsNotFound(err) {
-			return fiber.NewError(fiber.StatusNotFound, "task not found")
-		}
-		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to get task: %v", err))
-	}
-	if err := h.authorizeContextTokenLoadedTask(c, "decideTaskApproval", task); err != nil {
+	task, err := h.loadReadableTask(c, namespace, taskName, "decideTaskApproval")
+	if err != nil {
 		return err
 	}
-	sessionName := sessionNameFromTask(task)
 	if h.executionEventStore == nil {
 		return fiber.NewError(fiber.StatusNotImplemented, "execution event storage not enabled")
 	}
@@ -104,18 +93,16 @@ func (h *Handlers) DecideTaskApproval(c fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "decision must be approve or decline")
 	}
 
-	h.approvalDecisionMu.Lock()
-	defer h.approvalDecisionMu.Unlock()
-
-	current, found, err := h.getTaskApproval(c.Context(), namespace, taskName, approvalID)
+	listed, err := h.listTaskApprovalEvents(c.Context(), namespace, taskName)
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to list execution events: %v", err))
 	}
+	current, found := findApproval(approvals.Derive(listed, time.Now().UTC()), approvalID)
 	if !found {
 		return fiber.NewError(fiber.StatusNotFound, "approval not found")
 	}
 	if current.Status != approvals.StatusPending {
-		if approvalStatusMatchesDecision(current.Status, decision) {
+		if (current.Status == approvals.StatusApproved && decision == approvalDecisionApprove) || (current.Status == approvals.StatusDeclined && decision == approvalDecisionDecline) {
 			return c.JSON(current)
 		}
 		return fiber.NewError(fiber.StatusConflict, fmt.Sprintf("approval is already %s", current.Status))
@@ -127,11 +114,12 @@ func (h *Handlers) DecideTaskApproval(c fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusConflict, "task is complete")
 	}
 
+	actor := approvalDecisionActor(GetUserInfo(c))
 	content, err := json.Marshal(map[string]string{
 		"approvalID": approvalID,
 		"decision":   decision,
 		"reason":     strings.TrimSpace(req.Reason),
-		"actor":      approvalDecisionActor(GetUserInfo(c)),
+		"actor":      actor,
 	})
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to encode approval decision: %v", err))
@@ -141,7 +129,7 @@ func (h *Handlers) DecideTaskApproval(c fiber.Ctx) error {
 		StreamType:  events.ExecutionEventStreamTypeTask,
 		StreamID:    taskName,
 		TaskName:    taskName,
-		SessionName: sessionName,
+		SessionName: sessionNameForTask(task),
 		Type:        eventType,
 		Severity:    events.ExecutionEventSeverityInfo,
 		ToolCallID:  current.ToolCallID,
@@ -150,11 +138,11 @@ func (h *Handlers) DecideTaskApproval(c fiber.Ctx) error {
 	})
 	if err != nil {
 		if errors.Is(err, store.ErrConflict) {
-			current, found, listErr := h.getTaskApproval(c.Context(), namespace, taskName, approvalID)
+			refreshed, listErr := h.listTaskApprovalEvents(c.Context(), namespace, taskName)
 			if listErr != nil {
 				return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to list execution events: %v", listErr))
 			}
-			if found {
+			if current, found := findApproval(approvals.Derive(refreshed, time.Now().UTC()), approvalID); found {
 				if approvalStatusMatchesDecision(current.Status, decision) {
 					return c.JSON(current)
 				}
@@ -163,66 +151,13 @@ func (h *Handlers) DecideTaskApproval(c fiber.Ctx) error {
 		}
 		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to append approval decision: %v", err))
 	}
-	updated, found, err := h.getTaskApproval(c.Context(), namespace, taskName, approvalID)
-	if err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to list execution events: %v", err))
-	}
-	if !found {
-		return c.JSON(approvals.Approval{
-			ID:           approvalID,
-			Status:       statusForApprovalDecision(decision),
-			DecisionSeq:  appended.Seq,
-			DecisionTime: &appended.CreatedAt,
-		})
-	}
+	listed = append(listed, *appended)
+	updated, _ := findApproval(approvals.Derive(listed, time.Now().UTC()), approvalID)
 	return c.JSON(updated)
 }
 
-func (h *Handlers) getTaskApproval(ctx context.Context, namespace, taskName, approvalID string) (approvals.Approval, bool, error) {
-	listed, err := h.listTaskApprovalEvents(ctx, namespace, taskName)
-	if err != nil {
-		return approvals.Approval{}, false, err
-	}
-	current, found := findApproval(approvals.Derive(listed, time.Now().UTC()), approvalID)
-	return current, found, nil
-}
-
-func approvalDecisionActor(userInfo *UserInfo) string {
-	if userInfo == nil {
-		return unknownApprovalActor
-	}
-	for _, value := range []string{userInfo.Username, userInfo.Subject, userInfo.Email} {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
-	}
-	return unknownApprovalActor
-}
-
-func approvalStatusMatchesDecision(status, decision string) bool {
-	switch decision {
-	case approvalDecisionApprove:
-		return status == approvals.StatusApproved
-	case approvalDecisionDecline:
-		return status == approvals.StatusDeclined
-	default:
-		return false
-	}
-}
-
-func statusForApprovalDecision(decision string) string {
-	switch decision {
-	case approvalDecisionApprove:
-		return approvals.StatusApproved
-	case approvalDecisionDecline:
-		return approvals.StatusDeclined
-	default:
-		return approvals.StatusPending
-	}
-}
-
 func (h *Handlers) listTaskApprovalEvents(ctx context.Context, namespace, taskName string) ([]store.ExecutionEvent, error) {
-	eventTypes := []string{
+	approvalEventTypes := []string{
 		events.ExecutionEventTypeApprovalRequested,
 		events.ExecutionEventTypeApprovalApproved,
 		events.ExecutionEventTypeApprovalDeclined,
@@ -236,7 +171,7 @@ func (h *Handlers) listTaskApprovalEvents(ctx context.Context, namespace, taskNa
 			Namespace:  namespace,
 			StreamType: events.ExecutionEventStreamTypeTask,
 			StreamID:   taskName,
-			EventTypes: eventTypes,
+			EventTypes: approvalEventTypes,
 			AfterSeq:   after,
 			Limit:      store.MaxExecutionEventLimit,
 		})
@@ -255,6 +190,24 @@ func (h *Handlers) listTaskApprovalEvents(ctx context.Context, namespace, taskNa
 	return out, nil
 }
 
+func approvalDecisionActor(userInfo *UserInfo) string {
+	if userInfo == nil {
+		return ""
+	}
+	if strings.TrimSpace(userInfo.Username) != "" {
+		return strings.TrimSpace(userInfo.Username)
+	}
+	if strings.TrimSpace(userInfo.Subject) != "" {
+		return strings.TrimSpace(userInfo.Subject)
+	}
+	return ""
+}
+
+func approvalStatusMatchesDecision(status string, decision string) bool {
+	return (status == approvals.StatusApproved && decision == approvalDecisionApprove) ||
+		(status == approvals.StatusDeclined && decision == approvalDecisionDecline)
+}
+
 func findApproval(values []approvals.Approval, id string) (approvals.Approval, bool) {
 	for _, approval := range values {
 		if approval.ID == id {
@@ -262,11 +215,4 @@ func findApproval(values []approvals.Approval, id string) (approvals.Approval, b
 		}
 	}
 	return approvals.Approval{}, false
-}
-
-func sessionNameFromTask(task *corev1alpha1.Task) string {
-	if task == nil || task.Spec.SessionRef == nil {
-		return ""
-	}
-	return strings.TrimSpace(task.Spec.SessionRef.Name)
 }

--- a/internal/api/execution_event_handlers.go
+++ b/internal/api/execution_event_handlers.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -75,6 +74,8 @@ func (h *Handlers) ListTaskEvents(c fiber.Ctx) error {
 }
 
 // StreamTaskEvents handles GET /api/v1/tasks/{id}/stream?after=N.
+//
+//nolint:gocyclo // Replay, reconnect, heartbeat, terminal, and post-terminal completion are one stream state machine.
 func (h *Handlers) StreamTaskEvents(c fiber.Ctx) error {
 	taskName := c.Params("id")
 	namespace, err := h.resolveNamespace(c, c.Query("namespace", ""))
@@ -103,6 +104,10 @@ func (h *Handlers) StreamTaskEvents(c fiber.Ctx) error {
 	if heartbeatEvery <= 0 {
 		heartbeatEvery = defaultEventStreamHeartbeatEvery
 	}
+	ctx := c.Context()
+	if ctx == nil {
+		ctx = c.RequestCtx()
+	}
 	streamStore := h.executionEventStore
 
 	c.Set("Content-Type", "text/event-stream")
@@ -111,28 +116,109 @@ func (h *Handlers) StreamTaskEvents(c fiber.Ctx) error {
 	c.Set("X-Accel-Buffering", "no")
 
 	return c.SendStreamWriter(func(w *bufio.Writer) {
-		// SendStreamWriter outlives the Fiber request handler; use a fresh
-		// background context for polling so Fiber request-context recycling does
-		// not immediately terminate long-lived event streams.
-		ctx := context.Background()
 		done := metrics.RecordExecutionEventStreamOpen("task", query.afterSeq > 0)
 		defer done()
 		lastSeq := query.afterSeq
+		terminalScanSeq := query.afterSeq
+		var pendingTerminal *store.ExecutionEvent
+		if query.afterSeq > 0 {
+			terminalEvent, found, err := terminalExecutionEventThroughCursor(ctx, streamStore, namespace, taskName, query.afterSeq)
+			if err != nil {
+				metrics.RecordExecutionEventStreamError("task", "list")
+				log.Error(err, "failed to find prior terminal execution event for stream", "namespace", namespace, "task", taskName)
+				return
+			}
+			if found {
+				pendingTerminal = &terminalEvent
+				terminalScanSeq = max(terminalScanSeq, terminalEvent.Seq)
+			}
+		}
 		writeAvailable := func() bool {
-			return writeAvailableExecutionEventSSEFrames(
-				ctx,
-				w,
-				streamStore,
-				namespace,
-				taskName,
-				query,
-				&lastSeq,
-			)
+			listed, err := streamStore.ListExecutionEvents(ctx, store.ExecutionEventFilter{
+				Namespace:  namespace,
+				StreamType: events.ExecutionEventStreamTypeTask,
+				StreamID:   taskName,
+				EventTypes: query.eventTypes,
+				AfterSeq:   lastSeq,
+				Limit:      store.MaxExecutionEventLimit,
+			})
+			if err != nil {
+				metrics.RecordExecutionEventStreamError("task", "list")
+				log.Error(err, "failed to list execution events for stream", "namespace", namespace, "task", taskName)
+				return true
+			}
+			terminal := false
+			wroteComplete := false
+			for _, event := range listed {
+				if event.Seq > lastSeq {
+					lastSeq = event.Seq
+				}
+				if !writeExecutionEventSSEFrame(w, event) {
+					metrics.RecordExecutionEventStreamError("task", "write")
+					return false
+				}
+				if pendingTerminal == nil && isTerminalExecutionEventType(event.Type) {
+					terminalCopy := event
+					pendingTerminal = &terminalCopy
+				}
+			}
+			if pendingTerminal == nil && len(listed) < store.MaxExecutionEventLimit {
+				terminalEvent, found, scannedThrough, err := terminalExecutionEventForCompletion(ctx, streamStore, namespace, taskName, terminalScanSeq)
+				if err != nil {
+					metrics.RecordExecutionEventStreamError("task", "list")
+					log.Error(err, "failed to find terminal execution event for stream", "namespace", namespace, "task", taskName)
+					return true
+				}
+				terminalScanSeq = max(terminalScanSeq, scannedThrough)
+				if found {
+					shouldWriteDiscoveredTerminal := len(query.eventTypes) == 0 && terminalEvent.Seq > lastSeq
+					pendingTerminal = &terminalEvent
+					if shouldWriteDiscoveredTerminal {
+						if !writeExecutionEventSSEFrame(w, terminalEvent) {
+							metrics.RecordExecutionEventStreamError("task", "write")
+							return false
+						}
+					}
+					lastSeq = max(lastSeq, terminalEvent.Seq)
+				}
+			}
+			if pendingTerminal == nil && len(listed) == 0 {
+				deleted, err := h.taskDeletedForEventStream(ctx, namespace, taskName)
+				if err != nil {
+					metrics.RecordExecutionEventStreamError("task", "list")
+					log.Error(err, "failed to get task for event stream", "namespace", namespace, "task", taskName)
+					return true
+				}
+				if deleted {
+					pendingTerminal = &store.ExecutionEvent{
+						Namespace:  namespace,
+						StreamType: events.ExecutionEventStreamTypeTask,
+						StreamID:   taskName,
+						Seq:        lastSeq,
+						Type:       "TaskDeleted",
+						Severity:   events.ExecutionEventSeverityInfo,
+						TaskName:   taskName,
+						Summary:    "task deleted",
+					}
+				}
+			}
+			if pendingTerminal != nil && len(listed) < store.MaxExecutionEventLimit {
+				terminal = true
+				if !writeExecutionEventStreamCompleteSSEFrame(w, *pendingTerminal, lastSeq) {
+					metrics.RecordExecutionEventStreamError("task", "write")
+					return false
+				}
+				wroteComplete = true
+			}
+			if len(listed) > 0 || wroteComplete {
+				if err := w.Flush(); err != nil {
+					metrics.RecordExecutionEventStreamError("task", "write")
+					return false
+				}
+			}
+			return !terminal
 		}
 		if !writeAvailable() {
-			return
-		}
-		if !h.writeTaskDeletedStreamComplete(ctx, w, namespace, taskName, lastSeq) {
 			return
 		}
 
@@ -146,9 +232,6 @@ func (h *Handlers) StreamTaskEvents(c fiber.Ctx) error {
 				return
 			case <-poll.C:
 				if !writeAvailable() {
-					return
-				}
-				if !h.writeTaskDeletedStreamComplete(ctx, w, namespace, taskName, lastSeq) {
 					return
 				}
 			case <-heartbeat.C:
@@ -235,6 +318,10 @@ func (h *Handlers) StreamSessionEvents(c fiber.Ctx) error {
 	if heartbeatEvery <= 0 {
 		heartbeatEvery = defaultEventStreamHeartbeatEvery
 	}
+	ctx := c.Context()
+	if ctx == nil {
+		ctx = c.RequestCtx()
+	}
 	streamStore := h.executionEventStore
 
 	c.Set("Content-Type", "text/event-stream")
@@ -243,10 +330,6 @@ func (h *Handlers) StreamSessionEvents(c fiber.Ctx) error {
 	c.Set("X-Accel-Buffering", "no")
 
 	return c.SendStreamWriter(func(w *bufio.Writer) {
-		// SendStreamWriter outlives the Fiber request handler; use a fresh
-		// background context for polling so Fiber request-context recycling does
-		// not immediately terminate long-lived event streams.
-		ctx := context.Background()
 		done := metrics.RecordExecutionEventStreamOpen("session", query.afterSeq > 0)
 		defer done()
 		lastSeq := query.afterSeq
@@ -281,9 +364,6 @@ func (h *Handlers) StreamSessionEvents(c fiber.Ctx) error {
 			return true
 		}
 		if !writeAvailable() {
-			return
-		}
-		if !h.writeSessionDeletedStreamComplete(ctx, w, namespace, sessionName, lastSeq) {
 			return
 		}
 
@@ -384,114 +464,29 @@ func (h *Handlers) writeSessionDeletedStreamComplete(
 }
 
 func (h *Handlers) ensureTaskReadable(c fiber.Ctx, namespace, taskName, action string) error {
+	_, err := h.loadReadableTask(c, namespace, taskName, action)
+	return err
+}
+
+func (h *Handlers) loadReadableTask(c fiber.Ctx, namespace, taskName, action string) (*corev1alpha1.Task, error) {
 	task := &corev1alpha1.Task{}
 	if err := h.client.Get(c.Context(), types.NamespacedName{Name: taskName, Namespace: namespace}, task); err != nil {
 		if apierrors.IsNotFound(err) {
-			return fiber.NewError(fiber.StatusNotFound, "task not found")
+			return nil, fiber.NewError(fiber.StatusNotFound, "task not found")
 		}
-		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to get task: %v", err))
+		return nil, fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to get task: %v", err))
 	}
-	return h.authorizeContextTokenLoadedTask(c, action, task)
+	if err := h.authorizeContextTokenLoadedTask(c, action, task); err != nil {
+		return nil, err
+	}
+	return task, nil
 }
 
-func (h *Handlers) writeTaskDeletedStreamComplete(
-	ctx context.Context,
-	w *bufio.Writer,
-	namespace string,
-	taskName string,
-	lastSeq int64,
-) bool {
-	if h == nil || h.client == nil {
-		return true
+func sessionNameForTask(task *corev1alpha1.Task) string {
+	if task == nil || task.Spec.SessionRef == nil {
+		return ""
 	}
-	task := &corev1alpha1.Task{}
-	err := h.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: taskName}, task)
-	if err == nil {
-		return true
-	}
-	if !apierrors.IsNotFound(err) {
-		log.Error(err, "failed to check task existence for event stream", "namespace", namespace, "task", taskName)
-		return true
-	}
-	if !writeExecutionEventStreamCompleteFrame(w, lastSeq, "TaskDeleted") {
-		return false
-	}
-	if err := w.Flush(); err != nil {
-		return false
-	}
-	return false
-}
-
-func writeAvailableExecutionEventSSEFrames(
-	ctx context.Context,
-	w *bufio.Writer,
-	eventStore store.ExecutionEventStore,
-	namespace string,
-	taskName string,
-	query executionEventListQuery,
-	lastSeq *int64,
-) bool {
-	listed, err := eventStore.ListExecutionEvents(ctx, store.ExecutionEventFilter{
-		Namespace:  namespace,
-		StreamType: events.ExecutionEventStreamTypeTask,
-		StreamID:   taskName,
-		EventTypes: query.eventTypes,
-		AfterSeq:   *lastSeq,
-		Limit:      store.MaxExecutionEventLimit,
-	})
-	if err != nil {
-		metrics.RecordExecutionEventStreamError("task", "list")
-		log.Error(err, "failed to list execution events for stream", "namespace", namespace, "task", taskName)
-		return true
-	}
-
-	var terminalEvent *store.ExecutionEvent
-	for _, event := range listed {
-		if event.Seq > *lastSeq {
-			*lastSeq = event.Seq
-		}
-		if !writeExecutionEventSSEFrame(w, event) {
-			metrics.RecordExecutionEventStreamError("task", "write")
-			return false
-		}
-		if isTerminalExecutionEventType(event.Type) {
-			eventCopy := event
-			terminalEvent = &eventCopy
-			break
-		}
-	}
-
-	if terminalEvent == nil && len(listed) < store.MaxExecutionEventLimit {
-		terminalCandidate := latestTerminalExecutionEvent(ctx, eventStore, namespace, taskName)
-		if terminalCandidate != nil && shouldCompleteForTerminalCandidate(
-			terminalCandidate,
-			*lastSeq,
-			query.eventTypes,
-		) {
-			terminalEvent = terminalCandidate
-		}
-	}
-	if terminalEvent != nil {
-		if !writeExecutionEventStreamCompleteSSEFrame(w, *terminalEvent) {
-			metrics.RecordExecutionEventStreamError("task", "write")
-			return false
-		}
-	}
-	if len(listed) > 0 || terminalEvent != nil {
-		if err := w.Flush(); err != nil {
-			metrics.RecordExecutionEventStreamError("task", "write")
-			return false
-		}
-	}
-	return terminalEvent == nil
-}
-
-func shouldCompleteForTerminalCandidate(
-	terminalCandidate *store.ExecutionEvent,
-	lastSeq int64,
-	eventTypes []string,
-) bool {
-	return terminalCandidate.Seq <= lastSeq || executionEventTypeFilterExcludes(eventTypes, terminalCandidate.Type)
+	return strings.TrimSpace(task.Spec.SessionRef.Name)
 }
 
 func (h *Handlers) ensureSessionReadable(c fiber.Ctx, namespace, sessionName string) error {
@@ -507,44 +502,63 @@ func (h *Handlers) ensureSessionReadable(c fiber.Ctx, namespace, sessionName str
 	return nil
 }
 
-func writeExecutionEventSSEFrame(w *bufio.Writer, event store.ExecutionEvent) bool {
-	data, err := json.Marshal(NewExecutionEventResponse(event))
-	if err != nil {
-		log.Error(err, "failed to marshal execution event for SSE", "eventID", event.ID)
-		return true
+func (h *Handlers) taskDeletedForEventStream(ctx context.Context, namespace, taskName string) (bool, error) {
+	if h.client == nil {
+		return false, nil
 	}
-	if _, err := fmt.Fprintf(w, "id: %d\nevent: execution_event\ndata: %s\n\n", event.Seq, data); err != nil {
-		return false
+	task := &corev1alpha1.Task{}
+	if err := h.client.Get(ctx, types.NamespacedName{Name: taskName, Namespace: namespace}, task); err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
 	}
-	return true
+	// A terminating-but-readable Task can still emit cancellation, failure, or
+	// cleanup events. Keep the stream open until the object is actually gone.
+	return false, nil
 }
 
-func latestTerminalExecutionEvent(
+func terminalExecutionEventThroughCursor(
 	ctx context.Context,
 	eventStore store.ExecutionEventStore,
 	namespace string,
 	taskName string,
-) *store.ExecutionEvent {
-	if eventStore == nil {
-		return nil
+	cursor int64,
+) (store.ExecutionEvent, bool, error) {
+	if cursor <= 0 {
+		return store.ExecutionEvent{}, false, nil
 	}
-	listed, err := eventStore.ListExecutionEvents(ctx, store.ExecutionEventFilter{
-		Namespace:  namespace,
-		StreamType: events.ExecutionEventStreamTypeTask,
-		StreamID:   taskName,
-		EventTypes: terminalExecutionEventTypes(),
-		AfterSeq:   0,
-		Limit:      store.MaxExecutionEventLimit,
-	})
-	if err != nil {
-		log.Error(err, "failed to list terminal execution events for stream", "namespace", namespace, "task", taskName)
-		return nil
+	after := int64(0)
+	for {
+		batch, err := eventStore.ListExecutionEvents(ctx, store.ExecutionEventFilter{
+			Namespace:  namespace,
+			StreamType: events.ExecutionEventStreamTypeTask,
+			StreamID:   taskName,
+			AfterSeq:   after,
+			EventTypes: terminalExecutionEventTypes(),
+			Limit:      store.MaxExecutionEventLimit,
+		})
+		if err != nil {
+			return store.ExecutionEvent{}, false, err
+		}
+		if len(batch) == 0 {
+			return store.ExecutionEvent{}, false, nil
+		}
+		for _, event := range batch {
+			if event.Seq > cursor {
+				return store.ExecutionEvent{}, false, nil
+			}
+			if event.Seq > after {
+				after = event.Seq
+			}
+			if isTerminalExecutionEventType(event.Type) {
+				return event, true, nil
+			}
+		}
+		if len(batch) < store.MaxExecutionEventLimit {
+			return store.ExecutionEvent{}, false, nil
+		}
 	}
-	if len(listed) == 0 {
-		return nil
-	}
-	terminal := listed[len(listed)-1]
-	return &terminal
 }
 
 func terminalExecutionEventTypes() []string {
@@ -555,11 +569,61 @@ func terminalExecutionEventTypes() []string {
 	}
 }
 
-func executionEventTypeFilterExcludes(eventTypes []string, eventType string) bool {
-	if len(eventTypes) == 0 {
+func terminalExecutionEventForCompletion(
+	ctx context.Context,
+	eventStore store.ExecutionEventStore,
+	namespace string,
+	taskName string,
+	cursor int64,
+) (store.ExecutionEvent, bool, int64, error) {
+	// Inspect from cursor-1 so reconnects that already observed a terminal event
+	// still receive stream_complete. The caller keeps this cursor separate from
+	// filtered SSE ids so excluded terminal events cannot be skipped when later
+	// matching events advance the public replay cursor.
+	after := cursor
+	if after > 0 {
+		after--
+	}
+	scannedThrough := cursor
+	for {
+		batch, err := eventStore.ListExecutionEvents(ctx, store.ExecutionEventFilter{
+			Namespace:  namespace,
+			StreamType: events.ExecutionEventStreamTypeTask,
+			StreamID:   taskName,
+			AfterSeq:   after,
+			Limit:      store.MaxExecutionEventLimit,
+		})
+		if err != nil {
+			return store.ExecutionEvent{}, false, scannedThrough, err
+		}
+		if len(batch) == 0 {
+			return store.ExecutionEvent{}, false, scannedThrough, nil
+		}
+		for _, event := range batch {
+			if event.Seq > after {
+				after = event.Seq
+			}
+			scannedThrough = max(scannedThrough, event.Seq)
+			if isTerminalExecutionEventType(event.Type) {
+				return event, true, scannedThrough, nil
+			}
+		}
+		if len(batch) < store.MaxExecutionEventLimit {
+			return store.ExecutionEvent{}, false, scannedThrough, nil
+		}
+	}
+}
+
+func writeExecutionEventSSEFrame(w *bufio.Writer, event store.ExecutionEvent) bool {
+	data, err := json.Marshal(NewExecutionEventResponse(event))
+	if err != nil {
+		log.Error(err, "failed to marshal execution event for SSE", "eventID", event.ID)
+		return true
+	}
+	if _, err := fmt.Fprintf(w, "id: %d\nevent: execution_event\ndata: %s\n\n", event.Seq, data); err != nil {
 		return false
 	}
-	return !slices.Contains(eventTypes, eventType)
+	return true
 }
 
 func writeSessionExecutionEventSSEFrame(w *bufio.Writer, event store.SessionExecutionEvent) bool {
@@ -574,8 +638,8 @@ func writeSessionExecutionEventSSEFrame(w *bufio.Writer, event store.SessionExec
 	return true
 }
 
-func writeExecutionEventStreamCompleteSSEFrame(w *bufio.Writer, event store.ExecutionEvent) bool {
-	return writeExecutionEventStreamCompleteFrame(w, event.Seq, event.Type)
+func writeExecutionEventStreamCompleteSSEFrame(w *bufio.Writer, event store.ExecutionEvent, lastSeq int64) bool {
+	return writeExecutionEventStreamCompleteFrame(w, max(lastSeq, event.Seq), event.Type)
 }
 
 func writeExecutionEventStreamCompleteFrame(w *bufio.Writer, lastSeq int64, eventType string) bool {
@@ -598,9 +662,7 @@ func writeExecutionEventStreamCompleteFrame(w *bufio.Writer, lastSeq int64, even
 
 func isTerminalExecutionEventType(eventType string) bool {
 	switch eventType {
-	case events.ExecutionEventTypeTaskSucceeded,
-		events.ExecutionEventTypeTaskFailed,
-		events.ExecutionEventTypeTaskCancelled:
+	case events.ExecutionEventTypeTaskSucceeded, events.ExecutionEventTypeTaskFailed, events.ExecutionEventTypeTaskCancelled:
 		return true
 	default:
 		return false

--- a/internal/api/execution_event_handlers_test.go
+++ b/internal/api/execution_event_handlers_test.go
@@ -184,6 +184,42 @@ func TestStreamTaskEventsSSEReplayHeartbeatAndPolling(t *testing.T) {
 	})
 }
 
+func TestStreamTaskEventsFlushesCompletionAfterExactLimitBatch(t *testing.T) {
+	eventStore := store.NewFakeExecutionEventStore()
+	for range store.MaxExecutionEventLimit - 1 {
+		appendTestTaskEvent(t, eventStore, "task-limit", events.ExecutionEventTypeWorkerStarted)
+	}
+	appendTestTaskEvent(t, eventStore, "task-limit", events.ExecutionEventTypeTaskSucceeded)
+	h, app := setupTaskEventHandlers(t, eventStore, testTask("default", "task-limit"))
+	configureShortTaskEventStream(h)
+	useCancelingContext(app, 100*time.Millisecond)
+	app.Get("/api/v1/tasks/:id/stream", h.StreamTaskEvents)
+	body := doStreamRequest(t, app, "/api/v1/tasks/task-limit/stream?namespace=default")
+	if !strings.Contains(body, "event: stream_complete") {
+		t.Fatalf("stream body missing completion frame after exact limit batch")
+	}
+}
+
+func TestStreamTaskEventsReplaysPostTerminalEventsBeforeComplete(t *testing.T) {
+	eventStore := store.NewFakeExecutionEventStore()
+	appendTestTaskEvent(t, eventStore, "task-terminal", events.ExecutionEventTypeTaskStarted)
+	appendTestTaskEvent(t, eventStore, "task-terminal", events.ExecutionEventTypeTaskSucceeded)
+	appendTestTaskEvent(t, eventStore, "task-terminal", events.ExecutionEventTypeTaskForkCreated)
+	h, app := setupTaskEventHandlers(t, eventStore, testTask("default", "task-terminal"))
+	configureShortTaskEventStream(h)
+	useCancelingContext(app, 50*time.Millisecond)
+	app.Get("/api/v1/tasks/:id/stream", h.StreamTaskEvents)
+	body := doStreamRequest(t, app, "/api/v1/tasks/task-terminal/stream?namespace=default")
+	forkIndex := strings.Index(body, events.ExecutionEventTypeTaskForkCreated)
+	completeIndex := strings.Index(body, "event: stream_complete")
+	if forkIndex < 0 || completeIndex < 0 || forkIndex > completeIndex {
+		t.Fatalf("stream body = %q, want fork event before stream_complete", body)
+	}
+	if !strings.Contains(body, "id: 3\nevent: stream_complete") || !strings.Contains(body, `"lastSeq":3`) {
+		t.Fatalf("stream body = %q, want completion cursor at last delivered event", body)
+	}
+}
+
 func TestSSETaskEventsCancellationExitsCleanly(t *testing.T) {
 	eventStore := store.NewFakeExecutionEventStore()
 	h, app := setupTaskEventHandlers(t, eventStore, testTask("default", "task-cancel"))

--- a/internal/api/execution_event_integration_test.go
+++ b/internal/api/execution_event_integration_test.go
@@ -286,6 +286,56 @@ func TestStreamTaskEventsFilteredSQLiteCompletesAfterTerminal(t *testing.T) {
 	}
 }
 
+func TestStreamTaskEventsFilteredSQLiteCompletesWhenMatchingEventFollowsTerminal(t *testing.T) {
+	eventStore := newSQLiteExecutionEventStoreForTest(t)
+	appendIntegrationTaskEvent(t, eventStore, "task-filtered-post-terminal", events.ExecutionEventTypeToolCallCompleted)
+	appendIntegrationTaskEvent(t, eventStore, "task-filtered-post-terminal", events.ExecutionEventTypeTaskSucceeded)
+	appendIntegrationTaskEvent(t, eventStore, "task-filtered-post-terminal", events.ExecutionEventTypeToolCallCompleted)
+
+	h, app := setupTaskEventHandlers(t, eventStore, testTask("default", "task-filtered-post-terminal"))
+	configureShortTaskEventStream(h)
+	app.Get("/api/v1/tasks/:id/stream", h.StreamTaskEvents)
+	body := doStreamRequest(
+		t,
+		app,
+		"/api/v1/tasks/task-filtered-post-terminal/stream?namespace=default&type=ToolCallCompleted",
+	)
+	if !strings.Contains(body, "id: 1\nevent: execution_event") ||
+		!strings.Contains(body, "id: 3\nevent: execution_event") {
+		t.Fatalf("filtered stream body = %q, want both matching tool events", body)
+	}
+	if strings.Contains(body, `"type":"TaskSucceeded","severity"`) {
+		t.Fatalf("filtered stream included excluded terminal execution event: %q", body)
+	}
+	if !strings.Contains(body, "event: stream_complete") || !strings.Contains(body, `"type":"TaskSucceeded"`) {
+		t.Fatalf("filtered stream did not complete at excluded terminal event: %q", body)
+	}
+}
+
+func TestStreamTaskEventsFilteredSQLiteReconnectCompletesAfterPostTerminalMatch(t *testing.T) {
+	eventStore := newSQLiteExecutionEventStoreForTest(t)
+	appendIntegrationTaskEvent(t, eventStore, "task-filtered-reconnect", events.ExecutionEventTypeToolCallCompleted)
+	appendIntegrationTaskEvent(t, eventStore, "task-filtered-reconnect", events.ExecutionEventTypeTaskSucceeded)
+	appendIntegrationTaskEvent(t, eventStore, "task-filtered-reconnect", events.ExecutionEventTypeToolCallCompleted)
+
+	h, app := setupTaskEventHandlers(t, eventStore, testTask("default", "task-filtered-reconnect"))
+	configureShortTaskEventStream(h)
+	app.Get("/api/v1/tasks/:id/stream", h.StreamTaskEvents)
+	body := doStreamRequest(
+		t,
+		app,
+		"/api/v1/tasks/task-filtered-reconnect/stream?namespace=default&type=ToolCallCompleted&after=3",
+	)
+	if strings.Contains(body, "event: execution_event") {
+		t.Fatalf("reconnect after post-terminal match replayed event frames: %q", body)
+	}
+	if !strings.Contains(body, "id: 3") ||
+		!strings.Contains(body, "event: stream_complete") ||
+		!strings.Contains(body, `"type":"TaskSucceeded"`) {
+		t.Fatalf("filtered reconnect did not complete at prior excluded terminal event: %q", body)
+	}
+}
+
 func TestStreamTaskEventsCompletesWhenTaskDeleted(t *testing.T) {
 	eventStore := newSQLiteExecutionEventStoreForTest(t)
 	task := testTask("default", "task-delete-stream")

--- a/internal/api/fork_handlers.go
+++ b/internal/api/fork_handlers.go
@@ -89,19 +89,16 @@ func (h *Handlers) ForkTask(c fiber.Ctx) error {
 	if afterSeq > latest {
 		return fiber.NewError(fiber.StatusBadRequest, "afterSeq must be 0, latest, or an existing event sequence")
 	}
-	eventsBefore, err := listTaskEventsThrough(
-		c.Context(),
-		h.executionEventStore,
-		namespace,
-		sourceName,
-		afterSeq,
-		forkcontext.DefaultMaxEvents,
-	)
+	validAfterSeq, err := taskEventSeqExists(c.Context(), h.executionEventStore, namespace, sourceName, afterSeq, latest)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to validate execution event sequence: %v", err))
+	}
+	if !validAfterSeq {
+		return fiber.NewError(fiber.StatusBadRequest, "afterSeq must be 0, latest, or an existing event sequence")
+	}
+	eventsBefore, err := listTaskEventsThrough(c.Context(), h.executionEventStore, namespace, sourceName, afterSeq)
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to list execution events: %v", err))
-	}
-	if !forkcontext.ValidateAfterSeq(afterSeq, eventsBefore) {
-		return fiber.NewError(fiber.StatusBadRequest, "afterSeq must be 0, latest, or an existing event sequence")
 	}
 
 	forkCtx := forkcontext.BuildContext(namespace, sourceName, afterSeq, eventsBefore, forkcontext.DefaultMaxEvents)
@@ -147,8 +144,8 @@ func (h *Handlers) ForkTask(c fiber.Ctx) error {
 		return err
 	}
 
-	sourceSessionName := sessionNameFromTask(source)
-	forkedSessionName := sessionNameFromTask(forked)
+	sourceSessionName := sessionNameForTask(source)
+	forkedSessionName := sessionNameForTask(forked)
 	requestContent, _ := json.Marshal(map[string]any{"sourceTaskName": sourceName, "newTaskName": newName, "afterSeq": afterSeq})
 	if _, err := h.executionEventStore.AppendExecutionEvent(c.Context(), &store.ExecutionEvent{
 		Namespace:   namespace,
@@ -172,7 +169,7 @@ func (h *Handlers) ForkTask(c fiber.Ctx) error {
 	}
 
 	createdContent, _ := json.Marshal(map[string]any{"sourceTaskName": sourceName, "newTaskName": newName, "afterSeq": afterSeq})
-	for _, item := range []struct {
+	for _, event := range []struct {
 		streamID    string
 		sessionName string
 	}{
@@ -182,9 +179,9 @@ func (h *Handlers) ForkTask(c fiber.Ctx) error {
 		if _, err := h.executionEventStore.AppendExecutionEvent(c.Context(), &store.ExecutionEvent{
 			Namespace:   namespace,
 			StreamType:  events.ExecutionEventStreamTypeTask,
-			StreamID:    item.streamID,
-			TaskName:    item.streamID,
-			SessionName: item.sessionName,
+			StreamID:    event.streamID,
+			TaskName:    event.streamID,
+			SessionName: event.sessionName,
 			Type:        events.ExecutionEventTypeTaskForkCreated,
 			Severity:    events.ExecutionEventSeverityInfo,
 			Summary:     "task fork created",
@@ -197,40 +194,53 @@ func (h *Handlers) ForkTask(c fiber.Ctx) error {
 	return c.Status(fiber.StatusCreated).JSON(ForkTaskResponse{Namespace: namespace, SourceTaskName: sourceName, NewTaskName: newName, AfterSeq: afterSeq, ForkContext: forkCtx})
 }
 
+func taskEventSeqExists(
+	ctx context.Context,
+	eventStore store.ExecutionEventStore,
+	namespace,
+	taskName string,
+	seq,
+	latestSeq int64,
+) (bool, error) {
+	if seq == 0 || seq == latestSeq {
+		return true, nil
+	}
+	if seq < 0 || seq > latestSeq {
+		return false, nil
+	}
+	listed, err := eventStore.ListExecutionEvents(ctx, store.ExecutionEventFilter{
+		Namespace:  namespace,
+		StreamType: events.ExecutionEventStreamTypeTask,
+		StreamID:   taskName,
+		AfterSeq:   seq - 1,
+		Limit:      1,
+	})
+	if err != nil {
+		return false, err
+	}
+	return len(listed) == 1 && listed[0].Seq == seq, nil
+}
+
 func listTaskEventsThrough(
 	ctx context.Context,
 	eventStore store.ExecutionEventStore,
 	namespace,
 	taskName string,
 	throughSeq int64,
-	maxEvents ...int,
 ) ([]store.ExecutionEvent, error) {
 	if throughSeq == 0 {
 		return nil, nil
 	}
-	tailLimit := 0
-	if len(maxEvents) > 0 {
-		limit := maxEvents[0]
-		if limit <= 0 {
-			limit = forkcontext.DefaultMaxEvents
-		}
-		tailLimit = limit + 1
-	}
-	out := []store.ExecutionEvent{}
-	if tailLimit > 0 {
-		out = make([]store.ExecutionEvent, 0, tailLimit)
-	}
-	after := int64(0)
-	if tailLimit > 0 && throughSeq > int64(tailLimit) {
-		after = throughSeq - int64(tailLimit)
-	}
+	readLimit := forkcontext.DefaultMaxEvents + 1
+	after := max(throughSeq-int64(readLimit), 0)
+	out := make([]store.ExecutionEvent, 0, readLimit)
 	for {
 		batch, err := eventStore.ListExecutionEvents(ctx, store.ExecutionEventFilter{
 			Namespace:  namespace,
 			StreamType: events.ExecutionEventStreamTypeTask,
 			StreamID:   taskName,
 			AfterSeq:   after,
-			Limit:      store.MaxExecutionEventLimit,
+			Limit:      min(store.MaxExecutionEventLimit, readLimit-len(out)),
 		})
 		if err != nil {
 			return nil, err
@@ -239,17 +249,13 @@ func listTaskEventsThrough(
 			break
 		}
 		for _, event := range batch {
-			if event.Seq > throughSeq {
+			if event.Seq > throughSeq || len(out) >= readLimit {
 				return out, nil
 			}
 			out = append(out, event)
-			if tailLimit > 0 && len(out) > tailLimit {
-				copy(out, out[1:])
-				out = out[:tailLimit]
-			}
 			after = event.Seq
 		}
-		if after >= throughSeq || len(batch) < store.MaxExecutionEventLimit {
+		if after >= throughSeq || len(out) >= readLimit || len(batch) < store.MaxExecutionEventLimit {
 			break
 		}
 	}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
@@ -94,7 +93,6 @@ type Handlers struct {
 	securityStore             store.SecurityStore
 	repositoryMonitorStore    store.RepositoryMonitorStore
 	executionEventStore       store.ExecutionEventStore
-	approvalDecisionMu        sync.Mutex
 	eventStreamPollInterval   time.Duration
 	eventStreamHeartbeatEvery time.Duration
 }

--- a/internal/api/internal_execution_event_handlers.go
+++ b/internal/api/internal_execution_event_handlers.go
@@ -77,7 +77,7 @@ func (h *InternalHandlers) SubmitExecutionEvent(c fiber.Ctx) error {
 			event.TaskName = streamID
 		}
 		if writerTask != nil {
-			expectedSessionName := sessionNameFromTask(writerTask)
+			expectedSessionName := sessionNameForTask(writerTask)
 			if expectedSessionName != "" && h.sessionStore != nil {
 				if _, err := h.sessionStore.GetSession(c.Context(), namespace, expectedSessionName); err != nil {
 					if errors.Is(err, store.ErrNotFound) {

--- a/internal/api/post_p0_handlers_test.go
+++ b/internal/api/post_p0_handlers_test.go
@@ -26,7 +26,9 @@ import (
 )
 
 type postP0FakeSessionStore struct {
-	records map[string]*store.SessionRecord
+	records          map[string]*store.SessionRecord
+	getCalls         int
+	deleteOnGetAfter int
 }
 
 func (f *postP0FakeSessionStore) key(namespace, name string) string { return namespace + "/" + name }
@@ -35,6 +37,10 @@ func (f *postP0FakeSessionStore) CreateSession(ctx context.Context, session *sto
 	return nil
 }
 func (f *postP0FakeSessionStore) GetSession(ctx context.Context, namespace, name string) (*store.SessionRecord, error) {
+	f.getCalls++
+	if f.deleteOnGetAfter > 0 && f.getCalls >= f.deleteOnGetAfter {
+		delete(f.records, f.key(namespace, name))
+	}
 	if s := f.records[f.key(namespace, name)]; s != nil {
 		return s, nil
 	}
@@ -111,6 +117,23 @@ func TestStreamSessionEventsReconnect(t *testing.T) {
 	}
 }
 
+func TestStreamSessionEventsCompletesWhenSessionDeleted(t *testing.T) {
+	eventStore := store.NewFakeExecutionEventStore()
+	sessionStore := &postP0FakeSessionStore{
+		records: map[string]*store.SessionRecord{
+			"default/session-delete": {Namespace: "default", Name: "session-delete"},
+		},
+		deleteOnGetAfter: 2,
+	}
+	h, app := setupPostP0Handlers(t, eventStore, sessionStore)
+	configureShortTaskEventStream(h)
+	app.Get("/api/v1/sessions/:id/stream", h.StreamSessionEvents)
+	body := doStreamRequest(t, app, "/api/v1/sessions/session-delete/stream?namespace=default")
+	if !strings.Contains(body, "event: stream_complete") || !strings.Contains(body, "SessionDeleted") {
+		t.Fatalf("session stream body = %q, want SessionDeleted completion", body)
+	}
+}
+
 func TestGetTaskTraceAPI(t *testing.T) {
 	eventStore := store.NewFakeExecutionEventStore()
 	appendTestTaskEvent(t, eventStore, "trace-task", events.ExecutionEventTypeTaskStarted)
@@ -143,16 +166,10 @@ func TestGetTaskTraceAPI(t *testing.T) {
 func TestTaskApprovalDecisionAPIAppendsEvent(t *testing.T) {
 	eventStore := store.NewFakeExecutionEventStore()
 	content, _ := json.Marshal(map[string]string{"approvalID": "approval-1", "action": "create_pr", "riskSummary": "opens a PR"})
-	if _, err := eventStore.AppendExecutionEvent(context.Background(), &store.ExecutionEvent{Namespace: "default", StreamType: store.ExecutionEventStreamTypeTask, StreamID: "approval-task", TaskName: "approval-task", SessionName: "session-1", Type: events.ExecutionEventTypeApprovalRequested, Content: content}); err != nil {
+	if _, err := eventStore.AppendExecutionEvent(context.Background(), &store.ExecutionEvent{Namespace: "default", StreamType: store.ExecutionEventStreamTypeTask, StreamID: "approval-task", TaskName: "approval-task", Type: events.ExecutionEventTypeApprovalRequested, Content: content}); err != nil {
 		t.Fatal(err)
 	}
-	task := testTask("default", "approval-task")
-	task.Spec.SessionRef = &corev1alpha1.SessionReference{Name: "session-1"}
-	h, app := setupTaskEventHandlers(t, eventStore, task)
-	app.Use(func(c fiber.Ctx) error {
-		c.Locals(UserInfoContextKey, &UserInfo{Username: "reviewer"})
-		return c.Next()
-	})
+	h, app := setupTaskEventHandlers(t, eventStore, testTask("default", "approval-task"))
 	app.Get("/api/v1/tasks/:id/approvals", h.ListTaskApprovals)
 	app.Post("/api/v1/tasks/:id/approvals/:approvalID/decision", h.DecideTaskApproval)
 
@@ -182,87 +199,38 @@ func TestTaskApprovalDecisionAPIAppendsEvent(t *testing.T) {
 	if err := json.NewDecoder(decisionResp.Body).Decode(&approved); err != nil {
 		t.Fatal(err)
 	}
-	if approved.Status != approvals.StatusApproved || approved.DecisionReason != "safe" || approved.DecisionActor != "reviewer" {
+	if approved.Status != approvals.StatusApproved || approved.DecisionReason != "safe" {
 		t.Fatalf("approved=%#v", approved)
-	}
-
-	declineReq := httptest.NewRequest(http.MethodPost, "/api/v1/tasks/approval-task/approvals/approval-1/decision?namespace=default", bytes.NewBufferString(`{"decision":"decline"}`))
-	declineReq.Header.Set("Content-Type", "application/json")
-	declineResp, err := app.Test(declineReq)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if declineResp.StatusCode != http.StatusConflict {
-		t.Fatalf("decline after approval status=%d, want conflict", declineResp.StatusCode)
-	}
-	sessionEvents, latest, err := eventStore.ListSessionExecutionEvents(context.Background(), store.SessionExecutionEventFilter{Namespace: "default", SessionName: "session-1"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if latest != 2 || len(sessionEvents) != 2 || sessionEvents[1].Type != events.ExecutionEventTypeApprovalApproved {
-		t.Fatalf("session approval events latest=%d events=%#v", latest, sessionEvents)
 	}
 }
 
-func TestTaskApprovalDecisionAPIRejectsPendingDecisionForCompletedTask(t *testing.T) {
+func TestTaskApprovalDecisionAPIRejectsTerminalTaskAndRecordsActor(t *testing.T) {
 	eventStore := store.NewFakeExecutionEventStore()
-	content, _ := json.Marshal(map[string]string{"approvalID": "approval-1"})
+	content, _ := json.Marshal(map[string]string{"approvalID": "approval-1", "action": "create_pr"})
 	if _, err := eventStore.AppendExecutionEvent(context.Background(), &store.ExecutionEvent{
 		Namespace:  "default",
 		StreamType: store.ExecutionEventStreamTypeTask,
-		StreamID:   "approval-complete-task",
-		TaskName:   "approval-complete-task",
+		StreamID:   "approval-task",
+		TaskName:   "approval-task",
 		Type:       events.ExecutionEventTypeApprovalRequested,
 		Content:    content,
 	}); err != nil {
 		t.Fatal(err)
 	}
-	task := testTask("default", "approval-complete-task")
-	task.Status.Phase = corev1alpha1.TaskPhaseSucceeded
+	task := testTask("default", "approval-task")
 	h, app := setupTaskEventHandlers(t, eventStore, task)
+	app.Use(func(c fiber.Ctx) error {
+		c.Locals(UserInfoContextKey, &UserInfo{Username: "reviewer-a"})
+		return c.Next()
+	})
 	app.Post("/api/v1/tasks/:id/approvals/:approvalID/decision", h.DecideTaskApproval)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks/approval-complete-task/approvals/approval-1/decision?namespace=default", bytes.NewBufferString(`{"decision":"approve"}`))
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/tasks/approval-task/approvals/approval-1/decision?namespace=default",
+		bytes.NewBufferString(`{"decision":"approve","reason":"safe"}`),
+	)
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := app.Test(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp.StatusCode != http.StatusConflict {
-		t.Fatalf("status=%d, want conflict", resp.StatusCode)
-	}
-	listed, err := eventStore.ListExecutionEvents(context.Background(), store.ExecutionEventFilter{
-		Namespace: "default", StreamID: "approval-complete-task", Limit: 10,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(listed) != 1 || listed[0].Type != events.ExecutionEventTypeApprovalRequested {
-		t.Fatalf("events after rejected decision = %#v", listed)
-	}
-}
-
-func TestTaskApprovalsAPIPagesLifecycleEvents(t *testing.T) {
-	eventStore := store.NewFakeExecutionEventStore()
-	for i := range store.MaxExecutionEventLimit {
-		content, _ := json.Marshal(map[string]string{"approvalID": fmt.Sprintf("old-%d", i)})
-		if _, err := eventStore.AppendExecutionEvent(context.Background(), &store.ExecutionEvent{
-			Namespace: "default", StreamType: store.ExecutionEventStreamTypeTask, StreamID: "approval-page-task",
-			TaskName: "approval-page-task", Type: events.ExecutionEventTypeApprovalRequested, Content: content,
-		}); err != nil {
-			t.Fatal(err)
-		}
-	}
-	content, _ := json.Marshal(map[string]string{"approvalID": "target"})
-	if _, err := eventStore.AppendExecutionEvent(context.Background(), &store.ExecutionEvent{
-		Namespace: "default", StreamType: store.ExecutionEventStreamTypeTask, StreamID: "approval-page-task",
-		TaskName: "approval-page-task", Type: events.ExecutionEventTypeApprovalRequested, Content: content,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	h, app := setupTaskEventHandlers(t, eventStore, testTask("default", "approval-page-task"))
-	app.Get("/api/v1/tasks/:id/approvals", h.ListTaskApprovals)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/tasks/approval-page-task/approvals?namespace=default", nil)
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatal(err)
@@ -270,12 +238,134 @@ func TestTaskApprovalsAPIPagesLifecycleEvents(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
-	var listed ListTaskApprovalsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&listed); err != nil {
+	var approved approvals.Approval
+	if err := json.NewDecoder(resp.Body).Decode(&approved); err != nil {
 		t.Fatal(err)
 	}
-	if _, found := findApproval(listed.Approvals, "target"); !found {
-		t.Fatalf("target approval missing from paged response of %d approvals", len(listed.Approvals))
+	if approved.DecisionActor != "reviewer-a" {
+		t.Fatalf("decision actor = %q, want reviewer-a", approved.DecisionActor)
+	}
+
+	content2, _ := json.Marshal(map[string]string{"approvalID": "approval-2", "action": "create_pr"})
+	if _, err := eventStore.AppendExecutionEvent(context.Background(), &store.ExecutionEvent{
+		Namespace:  "default",
+		StreamType: store.ExecutionEventStreamTypeTask,
+		StreamID:   "approval-task",
+		TaskName:   "approval-task",
+		Type:       events.ExecutionEventTypeApprovalRequested,
+		Content:    content2,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	task.Status.Phase = corev1alpha1.TaskPhaseSucceeded
+	if err := h.client.Update(context.Background(), task); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+	req = httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/tasks/approval-task/approvals/approval-2/decision?namespace=default",
+		bytes.NewBufferString(`{"decision":"approve"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = app.Test(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("terminal task decision status=%d, want conflict", resp.StatusCode)
+	}
+}
+
+func TestTaskApprovalDecisionAPIAppendsSessionEvent(t *testing.T) {
+	eventStore := store.NewFakeExecutionEventStore()
+	content, _ := json.Marshal(map[string]string{"approvalID": "approval-1", "action": "create_pr"})
+	if _, err := eventStore.AppendExecutionEvent(context.Background(), &store.ExecutionEvent{
+		Namespace:  "default",
+		StreamType: store.ExecutionEventStreamTypeTask,
+		StreamID:   "approval-task",
+		TaskName:   "approval-task",
+		Type:       events.ExecutionEventTypeApprovalRequested,
+		Content:    content,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	task := testTask("default", "approval-task")
+	task.Spec.SessionRef = &corev1alpha1.SessionReference{Name: "session-1"}
+	h, app := setupTaskEventHandlers(t, eventStore, task)
+	app.Post("/api/v1/tasks/:id/approvals/:approvalID/decision", h.DecideTaskApproval)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/tasks/approval-task/approvals/approval-1/decision?namespace=default",
+		bytes.NewBufferString(`{"decision":"approve"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	listed, latest, err := eventStore.ListSessionExecutionEvents(context.Background(), store.SessionExecutionEventFilter{
+		Namespace: "default", SessionName: "session-1",
+	})
+	if err != nil {
+		t.Fatalf("ListSessionExecutionEvents: %v", err)
+	}
+	if latest != 1 || len(listed) != 1 || listed[0].Type != events.ExecutionEventTypeApprovalApproved {
+		t.Fatalf("latest=%d listed=%#v, want approved decision in session timeline", latest, listed)
+	}
+}
+
+func TestTaskApprovalDecisionAPIPagesApprovalEvents(t *testing.T) {
+	eventStore := store.NewFakeExecutionEventStore()
+	for i := range store.MaxExecutionEventLimit {
+		content, _ := json.Marshal(map[string]string{"approvalID": fmt.Sprintf("approval-%d", i), "action": "noop"})
+		if _, err := eventStore.AppendExecutionEvent(context.Background(), &store.ExecutionEvent{
+			Namespace:  "default",
+			StreamType: store.ExecutionEventStreamTypeTask,
+			StreamID:   "approval-task",
+			TaskName:   "approval-task",
+			Type:       events.ExecutionEventTypeApprovalRequested,
+			Content:    content,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	targetContent, _ := json.Marshal(map[string]string{"approvalID": "approval-target", "action": "create_pr"})
+	if _, err := eventStore.AppendExecutionEvent(context.Background(), &store.ExecutionEvent{
+		Namespace:  "default",
+		StreamType: store.ExecutionEventStreamTypeTask,
+		StreamID:   "approval-task",
+		TaskName:   "approval-task",
+		Type:       events.ExecutionEventTypeApprovalRequested,
+		Content:    targetContent,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	h, app := setupTaskEventHandlers(t, eventStore, testTask("default", "approval-task"))
+	app.Post("/api/v1/tasks/:id/approvals/:approvalID/decision", h.DecideTaskApproval)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/tasks/approval-task/approvals/approval-target/decision?namespace=default",
+		bytes.NewBufferString(`{"decision":"approve"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var approved approvals.Approval
+	if err := json.NewDecoder(resp.Body).Decode(&approved); err != nil {
+		t.Fatal(err)
+	}
+	if approved.ID != "approval-target" || approved.Status != approvals.StatusApproved {
+		t.Fatalf("approved=%#v", approved)
 	}
 }
 
@@ -315,22 +405,30 @@ func TestForkTaskAPI(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(listed) != 1 || listed[0].Type != events.ExecutionEventTypeTaskForkCreated || listed[0].SessionName != "session-1" {
+	if len(listed) != 1 || listed[0].Type != events.ExecutionEventTypeTaskForkCreated {
 		t.Fatalf("fork events = %#v", listed)
+	}
+	sessionEvents, latest, err := eventStore.ListSessionExecutionEvents(context.Background(), store.SessionExecutionEventFilter{
+		Namespace: "default", SessionName: "session-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if latest != 3 || len(sessionEvents) != 3 {
+		t.Fatalf("latest=%d sessionEvents=%#v, want fork request and created events in session timeline", latest, sessionEvents)
 	}
 }
 
-func TestForkTaskAPIBoundsContextTail(t *testing.T) {
+func TestForkTaskAPIBoundsForkContextAndMarksTruncated(t *testing.T) {
 	eventStore := store.NewFakeExecutionEventStore()
 	for range forkcontext.DefaultMaxEvents + 5 {
-		appendTestTaskEvent(t, eventStore, "long-source-task", events.ExecutionEventTypeModelMessage)
+		appendTestTaskEvent(t, eventStore, "long-source-task", events.ExecutionEventTypeWorkerStarted)
 	}
 	source := testTask("default", "long-source-task")
 	source.Spec.Type = corev1alpha1.TaskTypeAgent
 	h, app := setupTaskEventHandlers(t, eventStore, source)
 	app.Post("/api/v1/tasks/:id/fork", h.ForkTask)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks/long-source-task/fork?namespace=default", bytes.NewBufferString(`{"newTaskName":"long-fork"}`))
-	req.Header.Set("Content-Type", "application/json")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks/long-source-task/fork?namespace=default", nil)
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatal(err)
@@ -343,10 +441,10 @@ func TestForkTaskAPIBoundsContextTail(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !out.ForkContext.Truncated || len(out.ForkContext.Events) != forkcontext.DefaultMaxEvents {
-		t.Fatalf("fork context truncated=%v len=%d, want truncated tail of %d", out.ForkContext.Truncated, len(out.ForkContext.Events), forkcontext.DefaultMaxEvents)
+		t.Fatalf("fork context truncated=%v len=%d, want true and %d", out.ForkContext.Truncated, len(out.ForkContext.Events), forkcontext.DefaultMaxEvents)
 	}
-	if got := out.ForkContext.Events[0].Seq; got != 6 {
-		t.Fatalf("first retained seq=%d, want 6", got)
+	if out.ForkContext.Events[0].Seq != 6 {
+		t.Fatalf("first retained seq=%d, want 6", out.ForkContext.Events[0].Seq)
 	}
 }
 

--- a/internal/approvals/approvals.go
+++ b/internal/approvals/approvals.go
@@ -50,6 +50,8 @@ func Derive(input []store.ExecutionEvent, now time.Time) []Approval {
 				id = event.ID
 			}
 			if _, ok := byID[id]; ok {
+				// Duplicate request events are idempotent: once an approval ID exists,
+				// later replays must not reset terminal decisions back to pending.
 				continue
 			}
 			order = append(order, id)
@@ -89,7 +91,7 @@ func Derive(input []store.ExecutionEvent, now time.Time) []Approval {
 			approval.DecisionSeq = event.Seq
 			decisionTime := event.CreatedAt
 			approval.DecisionTime = &decisionTime
-			approval.DecisionReason = strings.TrimSpace(payload.Reason)
+			approval.DecisionReason = firstNonEmpty(payload.Reason, event.Summary)
 			approval.DecisionActor = payload.Actor
 		}
 	}

--- a/internal/approvals/approvals_test.go
+++ b/internal/approvals/approvals_test.go
@@ -14,21 +14,10 @@ func TestDeriveApprovalLifecycle(t *testing.T) {
 	content := func(v map[string]string) json.RawMessage { data, _ := json.Marshal(v); return data }
 	all := Derive([]store.ExecutionEvent{
 		{Seq: 1, Type: events.ExecutionEventTypeApprovalRequested, Summary: "create PR", Content: content(map[string]string{"approvalID": "a1", "action": "create_pr", "riskSummary": "opens PR"}), CreatedAt: now},
-		{Seq: 2, Type: events.ExecutionEventTypeApprovalApproved, Content: content(map[string]string{"approvalID": "a1", "reason": "ok", "actor": "alice"}), CreatedAt: now.Add(time.Second)},
+		{Seq: 2, Type: events.ExecutionEventTypeApprovalApproved, Content: content(map[string]string{"approvalID": "a1", "reason": "ok"}), CreatedAt: now.Add(time.Second)},
 	}, now)
 	if len(all) != 1 || all[0].Status != StatusApproved || all[0].DecisionSeq != 2 || all[0].DecisionReason != "ok" {
 		t.Fatalf("approval state = %#v", all)
-	}
-}
-
-func TestDeriveApprovalOmitsEmptyDecisionReason(t *testing.T) {
-	content := func(v map[string]string) json.RawMessage { data, _ := json.Marshal(v); return data }
-	all := Derive([]store.ExecutionEvent{
-		{Seq: 1, Type: events.ExecutionEventTypeApprovalRequested, Content: content(map[string]string{"approvalID": "a1"})},
-		{Seq: 2, Type: events.ExecutionEventTypeApprovalApproved, Summary: "approval approve", Content: content(map[string]string{"approvalID": "a1"})},
-	}, time.Time{})
-	if len(all) != 1 || all[0].DecisionReason != "" {
-		t.Fatalf("approval = %#v, want empty decision reason", all)
 	}
 }
 
@@ -53,14 +42,17 @@ func TestDeriveApprovalFirstTerminalDecisionWins(t *testing.T) {
 	}
 }
 
-func TestDeriveApprovalDuplicateRequestDoesNotReopenTerminal(t *testing.T) {
-	content := func(v map[string]string) json.RawMessage { data, _ := json.Marshal(v); return data }
-	all := Derive([]store.ExecutionEvent{
-		{Seq: 1, Type: events.ExecutionEventTypeApprovalRequested, Content: content(map[string]string{"approvalID": "a1"})},
-		{Seq: 2, Type: events.ExecutionEventTypeApprovalApproved, Content: content(map[string]string{"approvalID": "a1"})},
-		{Seq: 3, Type: events.ExecutionEventTypeApprovalRequested, Content: content(map[string]string{"approvalID": "a1"})},
-	}, time.Time{})
-	if len(all) != 1 || all[0].Status != StatusApproved || all[0].DecisionSeq != 2 {
-		t.Fatalf("approval state = %#v, want terminal approval preserved", all)
+func TestDeriveDuplicateRequestDoesNotResetTerminalApproval(t *testing.T) {
+	requested, _ := json.Marshal(map[string]string{"approvalID": "approval-1", "action": "create_pr"})
+	approved, _ := json.Marshal(map[string]string{"approvalID": "approval-1", "decision": "approve"})
+	laterRequest, _ := json.Marshal(map[string]string{"approvalID": "approval-1", "action": "retry"})
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	derived := Derive([]store.ExecutionEvent{
+		{Seq: 1, Type: events.ExecutionEventTypeApprovalRequested, Content: requested, CreatedAt: now},
+		{Seq: 2, Type: events.ExecutionEventTypeApprovalApproved, Content: approved, CreatedAt: now.Add(time.Second)},
+		{Seq: 3, Type: events.ExecutionEventTypeApprovalRequested, Content: laterRequest, CreatedAt: now.Add(2 * time.Second)},
+	}, now.Add(3*time.Second))
+	if len(derived) != 1 || derived[0].Status != StatusApproved || derived[0].Action != "create_pr" {
+		t.Fatalf("derived = %#v, want duplicate request to preserve approved state", derived)
 	}
 }

--- a/internal/events/execution_event.go
+++ b/internal/events/execution_event.go
@@ -54,57 +54,83 @@ const (
 	ExecutionEventStreamTypeSession = "session"
 )
 
-var executionEventTypes = []string{
-	ExecutionEventTypeTaskCreated,
-	ExecutionEventTypeTaskPhaseChanged,
-	ExecutionEventTypeTaskJobCreated,
-	ExecutionEventTypeTaskStarted,
-	ExecutionEventTypeTaskSucceeded,
-	ExecutionEventTypeTaskFailed,
-	ExecutionEventTypeTaskCancelled,
-	ExecutionEventTypeWorkerStarted,
-	ExecutionEventTypeWorkerCompleted,
-	ExecutionEventTypeWorkerFailed,
-	ExecutionEventTypeModelRequestStarted,
-	ExecutionEventTypeModelRequestCompleted,
-	ExecutionEventTypeModelRequestFailed,
-	ExecutionEventTypeModelMessage,
-	ExecutionEventTypeContextTruncated,
-	ExecutionEventTypeToolCallStarted,
-	ExecutionEventTypeToolCallCompleted,
-	ExecutionEventTypeToolCallFailed,
-	ExecutionEventTypeWorkspacePreparationStarted,
-	ExecutionEventTypeWorkspacePreparationCompleted,
-	ExecutionEventTypeWorkspacePreparationFailed,
-	ExecutionEventTypeAgentRuntimeStarted,
-	ExecutionEventTypeAgentRuntimeCommandStarted,
-	ExecutionEventTypeAgentRuntimeCompleted,
-	ExecutionEventTypeAgentRuntimeFailed,
-	ExecutionEventTypeResultSubmitted,
-	ExecutionEventTypeArtifactUploadCompleted,
-	ExecutionEventTypeArtifactUploadFailed,
-	ExecutionEventTypeTaskForkRequested,
-	ExecutionEventTypeTaskForkCreated,
-	ExecutionEventTypeApprovalRequested,
-	ExecutionEventTypeApprovalApproved,
-	ExecutionEventTypeApprovalDeclined,
-	ExecutionEventTypeApprovalExpired,
-	ExecutionEventTypeApprovalCancelled,
-}
-
-var validExecutionEventTypes = newExecutionEventTypeSet(executionEventTypes)
-
-func newExecutionEventTypeSet(values []string) map[string]struct{} {
-	set := make(map[string]struct{}, len(values))
-	for _, value := range values {
-		set[value] = struct{}{}
-	}
-	return set
+var validExecutionEventTypes = map[string]struct{}{
+	ExecutionEventTypeTaskCreated:                   {},
+	ExecutionEventTypeTaskPhaseChanged:              {},
+	ExecutionEventTypeTaskJobCreated:                {},
+	ExecutionEventTypeTaskStarted:                   {},
+	ExecutionEventTypeTaskSucceeded:                 {},
+	ExecutionEventTypeTaskFailed:                    {},
+	ExecutionEventTypeTaskCancelled:                 {},
+	ExecutionEventTypeWorkerStarted:                 {},
+	ExecutionEventTypeWorkerCompleted:               {},
+	ExecutionEventTypeWorkerFailed:                  {},
+	ExecutionEventTypeModelRequestStarted:           {},
+	ExecutionEventTypeModelRequestCompleted:         {},
+	ExecutionEventTypeModelRequestFailed:            {},
+	ExecutionEventTypeModelMessage:                  {},
+	ExecutionEventTypeContextTruncated:              {},
+	ExecutionEventTypeToolCallStarted:               {},
+	ExecutionEventTypeToolCallCompleted:             {},
+	ExecutionEventTypeToolCallFailed:                {},
+	ExecutionEventTypeWorkspacePreparationStarted:   {},
+	ExecutionEventTypeWorkspacePreparationCompleted: {},
+	ExecutionEventTypeWorkspacePreparationFailed:    {},
+	ExecutionEventTypeAgentRuntimeStarted:           {},
+	ExecutionEventTypeAgentRuntimeCommandStarted:    {},
+	ExecutionEventTypeAgentRuntimeCompleted:         {},
+	ExecutionEventTypeAgentRuntimeFailed:            {},
+	ExecutionEventTypeResultSubmitted:               {},
+	ExecutionEventTypeArtifactUploadCompleted:       {},
+	ExecutionEventTypeArtifactUploadFailed:          {},
+	ExecutionEventTypeTaskForkRequested:             {},
+	ExecutionEventTypeTaskForkCreated:               {},
+	ExecutionEventTypeApprovalRequested:             {},
+	ExecutionEventTypeApprovalApproved:              {},
+	ExecutionEventTypeApprovalDeclined:              {},
+	ExecutionEventTypeApprovalExpired:               {},
+	ExecutionEventTypeApprovalCancelled:             {},
 }
 
 // ExecutionEventTypes returns the stable Wave 0 execution event taxonomy.
 func ExecutionEventTypes() []string {
-	return append([]string(nil), executionEventTypes...)
+	return []string{
+		ExecutionEventTypeTaskCreated,
+		ExecutionEventTypeTaskPhaseChanged,
+		ExecutionEventTypeTaskJobCreated,
+		ExecutionEventTypeTaskStarted,
+		ExecutionEventTypeTaskSucceeded,
+		ExecutionEventTypeTaskFailed,
+		ExecutionEventTypeTaskCancelled,
+		ExecutionEventTypeWorkerStarted,
+		ExecutionEventTypeWorkerCompleted,
+		ExecutionEventTypeWorkerFailed,
+		ExecutionEventTypeModelRequestStarted,
+		ExecutionEventTypeModelRequestCompleted,
+		ExecutionEventTypeModelRequestFailed,
+		ExecutionEventTypeModelMessage,
+		ExecutionEventTypeContextTruncated,
+		ExecutionEventTypeToolCallStarted,
+		ExecutionEventTypeToolCallCompleted,
+		ExecutionEventTypeToolCallFailed,
+		ExecutionEventTypeWorkspacePreparationStarted,
+		ExecutionEventTypeWorkspacePreparationCompleted,
+		ExecutionEventTypeWorkspacePreparationFailed,
+		ExecutionEventTypeAgentRuntimeStarted,
+		ExecutionEventTypeAgentRuntimeCommandStarted,
+		ExecutionEventTypeAgentRuntimeCompleted,
+		ExecutionEventTypeAgentRuntimeFailed,
+		ExecutionEventTypeResultSubmitted,
+		ExecutionEventTypeArtifactUploadCompleted,
+		ExecutionEventTypeArtifactUploadFailed,
+		ExecutionEventTypeTaskForkRequested,
+		ExecutionEventTypeTaskForkCreated,
+		ExecutionEventTypeApprovalRequested,
+		ExecutionEventTypeApprovalApproved,
+		ExecutionEventTypeApprovalDeclined,
+		ExecutionEventTypeApprovalExpired,
+		ExecutionEventTypeApprovalCancelled,
+	}
 }
 
 // IsValidExecutionEventType reports whether value is one of the Wave 0 event types.
@@ -124,11 +150,7 @@ func NormalizeExecutionEventType(value string) string {
 
 // IsValidExecutionEventSeverity reports whether value is a known severity after normalization.
 func IsValidExecutionEventSeverity(value string) bool {
-	return isValidNormalizedExecutionEventSeverity(strings.ToLower(strings.TrimSpace(value)))
-}
-
-func isValidNormalizedExecutionEventSeverity(value string) bool {
-	switch value {
+	switch strings.ToLower(strings.TrimSpace(value)) {
 	case ExecutionEventSeverityDebug, ExecutionEventSeverityInfo, ExecutionEventSeverityWarning, ExecutionEventSeverityError:
 		return true
 	default:
@@ -141,7 +163,7 @@ func isValidNormalizedExecutionEventSeverity(value string) bool {
 // while stores and APIs persist a stable severity value.
 func NormalizeExecutionEventSeverity(value string) string {
 	value = strings.ToLower(strings.TrimSpace(value))
-	if !isValidNormalizedExecutionEventSeverity(value) {
+	if !IsValidExecutionEventSeverity(value) {
 		return ExecutionEventSeverityInfo
 	}
 	return value

--- a/internal/harness/client.go
+++ b/internal/harness/client.go
@@ -1,0 +1,344 @@
+package harness
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sozercan/orka/internal/events"
+)
+
+type Client struct {
+	baseURL        *url.URL
+	httpClient     *http.Client
+	controlTimeout time.Duration
+}
+
+const maxHarnessSSEFrameBytes = 1 << 20
+
+var errSSEDone = errors.New("harness SSE stream done")
+
+type ClientOption func(*Client)
+
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(c *Client) {
+		if httpClient != nil {
+			c.httpClient = httpClient
+		}
+	}
+}
+
+func WithControlTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) {
+		if timeout > 0 {
+			c.controlTimeout = timeout
+		}
+	}
+}
+
+func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return nil, fmt.Errorf("parse harness base url: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("harness base url must include scheme and host")
+	}
+	c := &Client{baseURL: parsed, httpClient: &http.Client{}, controlTimeout: 30 * time.Second}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(c)
+		}
+	}
+	return c, nil
+}
+
+func (c *Client) Health(ctx context.Context) (*HealthResponse, error) {
+	var response HealthResponse
+	if err := c.getJSON(ctx, HealthPath, &response); err != nil {
+		return nil, err
+	}
+	if err := response.Validate(); err != nil {
+		return nil, safeClientError("health", 0, err.Error())
+	}
+	return &response, nil
+}
+
+func (c *Client) Capabilities(ctx context.Context) (*CapabilitiesResponse, error) {
+	var response CapabilitiesResponse
+	if err := c.getJSON(ctx, CapabilitiesPath, &response); err != nil {
+		return nil, err
+	}
+	if err := response.Validate(); err != nil {
+		return nil, safeClientError("capabilities", 0, err.Error())
+	}
+	return &response, nil
+}
+
+func (c *Client) StartTurn(ctx context.Context, request StartTurnRequest) (*StartTurnResponse, error) {
+	if err := request.Validate(); err != nil {
+		return nil, safeClientError("start_turn", 0, err.Error())
+	}
+	var response StartTurnResponse
+	if err := c.postJSON(ctx, TurnsPath, request, &response); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(response.Version) != ProtocolVersion {
+		return nil, safeClientError("start_turn", 0, fmt.Sprintf("unsupported version %q", response.Version))
+	}
+	if !response.Accepted {
+		return nil, safeClientError("start_turn", 0, "harness did not accept turn")
+	}
+	if err := validateAcceptedTurn(request, response); err != nil {
+		return nil, safeClientError("start_turn", 0, err.Error())
+	}
+	return &response, nil
+}
+
+func (c *Client) CancelTurn(ctx context.Context, request CancelTurnRequest) (*CancelTurnResponse, error) {
+	if err := request.Validate(); err != nil {
+		return nil, safeClientError("cancel_turn", 0, err.Error())
+	}
+	if err := validateHarnessTurnPathID(request.TurnID); err != nil {
+		return nil, safeClientError("cancel_turn", 0, err.Error())
+	}
+	var response CancelTurnResponse
+	if err := c.postJSON(ctx, turnPath(request.TurnID, "cancel"), request, &response); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(response.Version) != ProtocolVersion {
+		return nil, safeClientError("cancel_turn", 0, fmt.Sprintf("unsupported version %q", response.Version))
+	}
+	if !response.Accepted {
+		return nil, safeClientError("cancel_turn", 0, "harness did not accept cancellation")
+	}
+	if response.RuntimeSessionID != request.RuntimeSessionID {
+		return nil, safeClientError(
+			"cancel_turn",
+			0,
+			fmt.Sprintf("harness cancelled runtime session %q, want %q", response.RuntimeSessionID, request.RuntimeSessionID),
+		)
+	}
+	if response.TurnID != request.TurnID {
+		return nil, safeClientError("cancel_turn", 0, fmt.Sprintf("harness cancelled turn %q, want %q", response.TurnID, request.TurnID))
+	}
+	if response.CorrelationID != "" && response.CorrelationID != request.CorrelationID {
+		return nil, safeClientError(
+			"cancel_turn",
+			0,
+			fmt.Sprintf("harness cancelled correlation id %q, want %q", response.CorrelationID, request.CorrelationID),
+		)
+	}
+	return &response, nil
+}
+
+func (c *Client) StreamFrames(ctx context.Context, turnID HarnessTurnID, afterSeq int64, emit func(HarnessEventFrame) error) error {
+	if strings.TrimSpace(string(turnID)) == "" {
+		return safeClientError("stream_frames", 0, "turn id is required")
+	}
+	if err := validateHarnessTurnPathID(turnID); err != nil {
+		return safeClientError("stream_frames", 0, err.Error())
+	}
+	if emit == nil {
+		return safeClientError("stream_frames", 0, "emit callback is required")
+	}
+	rel := turnPath(turnID, "events")
+	u := c.resolve(rel)
+	q := u.Query()
+	if afterSeq > 0 {
+		q.Set("afterSeq", strconv.FormatInt(afterSeq, 10))
+	}
+	u.RawQuery = q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return safeClientError("stream_frames", 0, err.Error())
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return safeClientError("stream_frames", 0, err.Error())
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return c.statusError("stream_frames", resp)
+	}
+	return readSSEFrames(resp.Body, emit)
+}
+
+func (c *Client) getJSON(ctx context.Context, rel string, out any) error {
+	ctx, cancel := c.controlContext(ctx)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.resolve(rel).String(), nil)
+	if err != nil {
+		return safeClientError("get", 0, err.Error())
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return safeClientError("get", 0, err.Error())
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return c.statusError("get", resp)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return safeClientError("get", resp.StatusCode, err.Error())
+	}
+	return nil
+}
+
+func (c *Client) postJSON(ctx context.Context, rel string, in, out any) error {
+	ctx, cancel := c.controlContext(ctx)
+	defer cancel()
+	payload, err := json.Marshal(in)
+	if err != nil {
+		return safeClientError("post", 0, err.Error())
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.resolve(rel).String(), bytes.NewReader(payload))
+	if err != nil {
+		return safeClientError("post", 0, err.Error())
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return safeClientError("post", 0, err.Error())
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return c.statusError("post", resp)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return safeClientError("post", resp.StatusCode, err.Error())
+	}
+	return nil
+}
+
+func (c *Client) controlContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if c.controlTimeout <= 0 {
+		return ctx, func() {}
+	}
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, c.controlTimeout)
+}
+
+func (c *Client) statusError(op string, resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	message := strings.TrimSpace(string(body))
+	if message == "" {
+		message = resp.Status
+	}
+	return safeClientError(op, resp.StatusCode, message)
+}
+
+func (c *Client) resolve(rel string) *url.URL {
+	copy := *c.baseURL
+	copy.Path = path.Join(copy.Path, rel)
+	if strings.HasSuffix(rel, "/") && !strings.HasSuffix(copy.Path, "/") {
+		copy.Path += "/"
+	}
+	return &copy
+}
+
+func turnPath(turnID HarnessTurnID, suffix string) string {
+	base := strings.TrimRight(TurnsPath, "/") + "/" + url.PathEscape(strings.TrimSpace(string(turnID)))
+	if strings.TrimSpace(suffix) == "" {
+		return base
+	}
+	return base + "/" + strings.Trim(strings.TrimSpace(suffix), "/")
+}
+
+func validateHarnessTurnPathID(turnID HarnessTurnID) error {
+	value := strings.TrimSpace(string(turnID))
+	if value == "." || value == ".." {
+		return fmt.Errorf("turn id must not be a dot path segment")
+	}
+	return nil
+}
+
+func readSSEFrames(r io.Reader, emit func(HarnessEventFrame) error) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxHarnessSSEFrameBytes)
+	var data strings.Builder
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if err := emitSSEData(data.String(), emit); err != nil {
+				if errors.Is(err, errSSEDone) {
+					return nil
+				}
+				return err
+			}
+			data.Reset()
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			if data.Len() > 0 {
+				data.WriteByte('\n')
+			}
+			data.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+	}
+	if data.Len() > 0 {
+		if err := emitSSEData(data.String(), emit); err != nil {
+			if errors.Is(err, errSSEDone) {
+				return nil
+			}
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return safeClientError("stream_frames", 0, err.Error())
+	}
+	return nil
+}
+
+func emitSSEData(raw string, emit func(HarnessEventFrame) error) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	if raw == sseDone {
+		return errSSEDone
+	}
+	var frame HarnessEventFrame
+	if err := json.Unmarshal([]byte(raw), &frame); err != nil {
+		return safeClientError("stream_frames", 0, fmt.Sprintf("decode harness frame: %v", err))
+	}
+	if err := emit(frame); err != nil {
+		return err
+	}
+	return nil
+}
+
+type ClientError struct {
+	Op         string
+	StatusCode int
+	Message    string
+}
+
+func (e ClientError) Error() string {
+	if e.StatusCode > 0 {
+		return fmt.Sprintf("harness %s failed (%d): %s", e.Op, e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("harness %s failed: %s", e.Op, e.Message)
+}
+
+func safeClientError(op string, status int, message string) error {
+	return ClientError{Op: op, StatusCode: status, Message: events.RedactExecutionEventText(message)}
+}

--- a/internal/harness/client_test.go
+++ b/internal/harness/client_test.go
@@ -1,0 +1,222 @@
+package harness
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClientSanitizesTransportErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		WriteError(w, http.StatusBadRequest, "Authorization: Bearer bearer-value-for-redaction")
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	_, err = client.Health(context.Background())
+	if err == nil {
+		t.Fatal("Health() error = nil, want status error")
+	}
+	if strings.Contains(err.Error(), "bearer-value-for-redaction") || !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("Health() error = %v, want sanitized", err)
+	}
+}
+
+func TestClientStartTurnMismatchedResponseIsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		WriteJSON(w, http.StatusAccepted, StartTurnResponse{
+			Version:          ProtocolVersion,
+			Accepted:         true,
+			RuntimeSessionID: "other-runtime",
+			TurnID:           "turn-a",
+			CorrelationID:    "corr-a",
+		})
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	_, err = client.StartTurn(context.Background(), StartTurnRequest{
+		Version:          ProtocolVersion,
+		Namespace:        "default",
+		TaskName:         "task-a",
+		SessionName:      "session-a",
+		RuntimeSessionID: "runtime-a",
+		TurnID:           "turn-a",
+		CorrelationID:    "corr-a",
+		Deadline:         time.Now().UTC().Add(time.Minute),
+		AuthIdentity:     AuthIdentity{Subject: "user:test"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "runtime session") {
+		t.Fatalf("StartTurn() error = %v, want identity mismatch", err)
+	}
+}
+
+func TestClientStreamFramesRejectsDotSegmentTurnID(t *testing.T) {
+	client, err := NewClient("http://127.0.0.1:8080")
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	err = client.StreamFrames(context.Background(), "..", 0, func(frame HarnessEventFrame) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "dot path segment") {
+		t.Fatalf("StreamFrames() error = %v, want dot segment rejection", err)
+	}
+}
+
+func TestClientCancelTurnMismatchedResponseIsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		WriteJSON(w, http.StatusOK, CancelTurnResponse{
+			Version:          ProtocolVersion,
+			Accepted:         true,
+			RuntimeSessionID: "other-runtime",
+			TurnID:           "turn-a",
+			CorrelationID:    "corr-a",
+		})
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	_, err = client.CancelTurn(context.Background(), CancelTurnRequest{
+		Version:          ProtocolVersion,
+		Namespace:        "default",
+		TaskName:         "task-a",
+		SessionName:      "session-a",
+		RuntimeSessionID: "runtime-a",
+		TurnID:           "turn-a",
+		CorrelationID:    "corr-a",
+	})
+	if err == nil || !strings.Contains(err.Error(), "runtime session") {
+		t.Fatalf("CancelTurn() error = %v, want identity mismatch", err)
+	}
+}
+
+func TestClientCancelTurnRejectedResponseIsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		WriteJSON(w, http.StatusOK, CancelTurnResponse{
+			Version:  ProtocolVersion,
+			Accepted: false,
+			TurnID:   "turn-a",
+		})
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	_, err = client.CancelTurn(context.Background(), CancelTurnRequest{
+		Version:          ProtocolVersion,
+		Namespace:        "default",
+		TaskName:         "task-a",
+		SessionName:      "session-a",
+		RuntimeSessionID: "runtime-a",
+		TurnID:           "turn-a",
+		CorrelationID:    "corr-a",
+	})
+	if err == nil || !strings.Contains(err.Error(), "did not accept cancellation") {
+		t.Fatalf("CancelTurn() error = %v, want rejected cancellation", err)
+	}
+}
+
+func TestNewClientDefaultDoesNotSetTotalHTTPTimeout(t *testing.T) {
+	client, err := NewClient("http://127.0.0.1:8080")
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	if client.httpClient.Timeout != 0 {
+		t.Fatalf("default http client timeout = %v, want no total stream timeout", client.httpClient.Timeout)
+	}
+	if client.controlTimeout <= 0 {
+		t.Fatalf("control timeout = %v, want positive control call timeout", client.controlTimeout)
+	}
+}
+
+func TestClientRejectsInvalidBaseURL(t *testing.T) {
+	if _, err := NewClient("localhost:8080"); err == nil {
+		t.Fatal("NewClient() error = nil, want invalid base URL")
+	}
+}
+
+func TestReadSSEFramesStopsOnDoneSentinel(t *testing.T) {
+	raw := "data: [DONE]\n\n" +
+		"data: not-json\n\n"
+	if err := readSSEFrames(strings.NewReader(raw), func(frame HarnessEventFrame) error {
+		t.Fatalf("unexpected frame after done: %#v", frame)
+		return nil
+	}); err != nil {
+		t.Fatalf("readSSEFrames() error = %v", err)
+	}
+}
+
+func TestReadSSEFramesAllowsLargeFrameEnvelope(t *testing.T) {
+	largeText := strings.Repeat("x", 200*1024)
+	frame := HarnessEventFrame{
+		Version:          ProtocolVersion,
+		Type:             FrameRuntimeOutput,
+		RuntimeSessionID: "runtime-a",
+		TurnID:           "turn-a",
+		CorrelationID:    "corr-a",
+		Seq:              1,
+		ContentText:      largeText,
+	}
+	recorder := httptest.NewRecorder()
+	if err := WriteSSEFrame(recorder, frame); err != nil {
+		t.Fatalf("WriteSSEFrame() error = %v", err)
+	}
+	var got []HarnessEventFrame
+	if err := readSSEFrames(strings.NewReader(recorder.Body.String()), func(frame HarnessEventFrame) error {
+		got = append(got, frame)
+		return nil
+	}); err != nil {
+		t.Fatalf("readSSEFrames() error = %v", err)
+	}
+	if len(got) != 1 || len(got[0].ContentText) != len(largeText) {
+		t.Fatalf("frames=%d contentTextLen=%d, want one large frame", len(got), func() int {
+			if len(got) == 0 {
+				return 0
+			}
+			return len(got[0].ContentText)
+		}())
+	}
+}
+
+func TestReadSSEFrames(t *testing.T) {
+	raw := "data: {\"version\":\"" + ProtocolVersion + "\",\"type\":\"TurnStarted\",\"runtimeSessionID\":\"r\",\"turnID\":\"t\",\"correlationID\":\"c\",\"seq\":1}\n\n" +
+		"data: [DONE]\n\n"
+	var frames []HarnessEventFrame
+	if err := readSSEFrames(strings.NewReader(raw), func(frame HarnessEventFrame) error {
+		frames = append(frames, frame)
+		return nil
+	}); err != nil {
+		t.Fatalf("readSSEFrames() error = %v", err)
+	}
+	if len(frames) != 1 || frames[0].Type != FrameTurnStarted {
+		t.Fatalf("frames = %#v, want one turn started", frames)
+	}
+}
+
+func TestClientTimeoutOnStream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		time.Sleep(100 * time.Millisecond)
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL, WithHTTPClient(&http.Client{Timeout: 1 * time.Millisecond}))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	err = client.StreamFrames(context.Background(), "turn-a", 0, func(frame HarnessEventFrame) error { return nil })
+	if err == nil {
+		t.Fatal("StreamFrames() error = nil, want timeout")
+	}
+}

--- a/internal/harness/harnesstest/conformance.go
+++ b/internal/harness/harnesstest/conformance.go
@@ -1,0 +1,275 @@
+package harnesstest
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sozercan/orka/internal/events"
+	"github.com/sozercan/orka/internal/harness"
+)
+
+type HarnessFactory func(t *testing.T, behavior FakeBehavior) (baseURL string, cleanup func())
+
+func RunHarnessConformance(t *testing.T, factory HarnessFactory) {
+	t.Helper()
+	t.Run("health", func(t *testing.T) { assertHealth(t, factory) })
+	t.Run("capabilities", func(t *testing.T) { assertCapabilities(t, factory) })
+	t.Run("successful turn", func(t *testing.T) { assertSuccessfulTurn(t, factory) })
+	t.Run("failed turn", func(t *testing.T) { assertFailedTurn(t, factory) })
+	t.Run("cancellation", func(t *testing.T) { assertCancellation(t, factory) })
+	t.Run("invalid frame becomes diagnostic", func(t *testing.T) { assertInvalidFrameDiagnostic(t, factory) })
+	t.Run("redaction", func(t *testing.T) { assertRedaction(t, factory) })
+	t.Run("timeout", func(t *testing.T) { assertTimeout(t, factory) })
+}
+
+func assertHealth(t *testing.T, factory HarnessFactory) {
+	t.Helper()
+	client := newClientForBehavior(t, factory, BehaviorSuccess)
+	resp, err := client.Health(context.Background())
+	if err != nil {
+		t.Fatalf("Health() error = %v", err)
+	}
+	if !resp.Ready || resp.Status != harness.HealthStatusOK {
+		t.Fatalf("Health() = %#v, want ready ok", resp)
+	}
+}
+
+func assertCapabilities(t *testing.T, factory HarnessFactory) {
+	t.Helper()
+	client := newClientForBehavior(t, factory, BehaviorSuccess)
+	resp, err := client.Capabilities(context.Background())
+	if err != nil {
+		t.Fatalf("Capabilities() error = %v", err)
+	}
+	if !resp.SupportsCancel || !resp.SupportsRuntimeSessions {
+		t.Fatalf("Capabilities() = %#v, want cancel/runtime sessions", resp)
+	}
+}
+
+func assertSuccessfulTurn(t *testing.T, factory HarnessFactory) {
+	t.Helper()
+	client := newClientForBehavior(t, factory, BehaviorSuccess)
+	request := validStartTurnRequest()
+	if _, err := client.StartTurn(context.Background(), request); err != nil {
+		t.Fatalf("StartTurn() error = %v", err)
+	}
+	frames := collectFrames(t, client, request.TurnID)
+	want := []harness.FrameType{
+		harness.FrameTurnStarted,
+		harness.FrameRuntimeOutput,
+		harness.FrameToolCallRequested,
+		harness.FrameToolResultReceived,
+		harness.FrameTurnCompleted,
+	}
+	if len(frames) != len(want) {
+		t.Fatalf("frames = %#v, want %d frames", frames, len(want))
+	}
+	for i, frame := range frames {
+		if frame.Type != want[i] {
+			t.Fatalf("frame[%d].Type = %s, want %s", i, frame.Type, want[i])
+		}
+		if _, err := harness.MapFrameToExecutionEvent(frame, eventMapContext()); err != nil {
+			t.Fatalf("MapFrameToExecutionEvent(%s) error = %v", frame.Type, err)
+		}
+	}
+}
+
+func assertFailedTurn(t *testing.T, factory HarnessFactory) {
+	t.Helper()
+	client := newClientForBehavior(t, factory, BehaviorFailure)
+	request := validStartTurnRequest()
+	if _, err := client.StartTurn(context.Background(), request); err != nil {
+		t.Fatalf("StartTurn() error = %v", err)
+	}
+	frames := collectFrames(t, client, request.TurnID)
+	last := frames[len(frames)-1]
+	if last.Type != harness.FrameTurnFailed || last.Failed == nil {
+		t.Fatalf("last frame = %#v, want failed", last)
+	}
+	event, err := harness.MapFrameToExecutionEvent(last, eventMapContext())
+	if err != nil {
+		t.Fatalf("MapFrameToExecutionEvent() error = %v", err)
+	}
+	if event.Type != events.ExecutionEventTypeAgentRuntimeFailed || event.Severity != events.ExecutionEventSeverityError {
+		t.Fatalf("mapped event = %#v, want runtime failed error", event)
+	}
+}
+
+func assertCancellation(t *testing.T, factory HarnessFactory) {
+	t.Helper()
+	client := newClientForBehavior(t, factory, BehaviorCancellation)
+	request := validStartTurnRequest()
+	if _, err := client.StartTurn(context.Background(), request); err != nil {
+		t.Fatalf("StartTurn() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	framesCh := make(chan []harness.HarnessEventFrame, 1)
+	errCh := make(chan error, 1)
+	go streamFramesForCancellation(ctx, client, request.TurnID, framesCh, errCh)
+	time.Sleep(20 * time.Millisecond)
+	if _, err := client.CancelTurn(context.Background(), validCancelTurnRequest(request)); err != nil {
+		t.Fatalf("CancelTurn() error = %v", err)
+	}
+	var frames []harness.HarnessEventFrame
+	select {
+	case frames = <-framesCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for cancellation stream")
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("StreamFrames() error = %v", err)
+	}
+	if len(frames) < 2 || frames[len(frames)-1].Type != harness.FrameTurnCancelled {
+		t.Fatalf("frames = %#v, want cancellation terminal frame", frames)
+	}
+}
+
+func streamFramesForCancellation(
+	ctx context.Context,
+	client *harness.Client,
+	turnID harness.HarnessTurnID,
+	framesCh chan<- []harness.HarnessEventFrame,
+	errCh chan<- error,
+) {
+	frames := []harness.HarnessEventFrame{}
+	err := client.StreamFrames(ctx, turnID, 0, func(frame harness.HarnessEventFrame) error {
+		frames = append(frames, frame)
+		return nil
+	})
+	framesCh <- frames
+	errCh <- err
+}
+
+func assertInvalidFrameDiagnostic(t *testing.T, factory HarnessFactory) {
+	t.Helper()
+	client := newClientForBehavior(t, factory, BehaviorInvalidFrame)
+	request := validStartTurnRequest()
+	if _, err := client.StartTurn(context.Background(), request); err != nil {
+		t.Fatalf("StartTurn() error = %v", err)
+	}
+	frames := collectFrames(t, client, request.TurnID)
+	last := frames[len(frames)-1]
+	if harness.IsKnownFrameType(last.Type) {
+		t.Fatalf("last.Type = %s, want unknown frame", last.Type)
+	}
+	event, err := harness.MapFrameToExecutionEvent(last, eventMapContext())
+	if err != nil {
+		t.Fatalf("MapFrameToExecutionEvent() error = %v", err)
+	}
+	if event.Severity != events.ExecutionEventSeverityWarning || !strings.Contains(event.Summary, "unknown harness frame") {
+		t.Fatalf("mapped event = %#v, want warning diagnostic", event)
+	}
+}
+
+func assertRedaction(t *testing.T, factory HarnessFactory) {
+	t.Helper()
+	client := newClientForBehavior(t, factory, BehaviorRedactionOutput)
+	request := validStartTurnRequest()
+	if _, err := client.StartTurn(context.Background(), request); err != nil {
+		t.Fatalf("StartTurn() error = %v", err)
+	}
+	frames := collectFrames(t, client, request.TurnID)
+	var output harness.HarnessEventFrame
+	for _, frame := range frames {
+		if frame.Type == harness.FrameRuntimeOutput {
+			output = frame
+		}
+	}
+	event, err := harness.MapFrameToExecutionEvent(output, eventMapContext())
+	if err != nil {
+		t.Fatalf("MapFrameToExecutionEvent() error = %v", err)
+	}
+	encoded := string(event.Content) + event.ContentText + event.Summary
+	if strings.Contains(encoded, "sk-test") || strings.Contains(encoded, "bearer-value-for-redaction") ||
+		!strings.Contains(encoded, events.ExecutionEventRedactedValue) {
+		t.Fatalf("mapped event leaked secret or missed redaction: %s", encoded)
+	}
+}
+
+func assertTimeout(t *testing.T, factory HarnessFactory) {
+	t.Helper()
+	baseURL, cleanup := factory(t, BehaviorDelayed)
+	defer cleanup()
+	client, err := harness.NewClient(baseURL)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	request := validStartTurnRequest()
+	if _, err := client.StartTurn(context.Background(), request); err != nil {
+		t.Fatalf("StartTurn() error = %v", err)
+	}
+	streamClient, err := harness.NewClient(baseURL, harness.WithHTTPClient(&http.Client{Timeout: 1 * time.Millisecond}))
+	if err != nil {
+		t.Fatalf("NewClient(stream) error = %v", err)
+	}
+	err = streamClient.StreamFrames(context.Background(), request.TurnID, 0, func(frame harness.HarnessEventFrame) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("StreamFrames() error = nil, want client timeout")
+	}
+}
+
+func newClientForBehavior(t *testing.T, factory HarnessFactory, behavior FakeBehavior) *harness.Client {
+	t.Helper()
+	baseURL, cleanup := factory(t, behavior)
+	t.Cleanup(cleanup)
+	client, err := harness.NewClient(baseURL)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	return client
+}
+
+func collectFrames(t *testing.T, client *harness.Client, turnID harness.HarnessTurnID) []harness.HarnessEventFrame {
+	t.Helper()
+	frames := []harness.HarnessEventFrame{}
+	if err := client.StreamFrames(context.Background(), turnID, 0, func(frame harness.HarnessEventFrame) error {
+		frames = append(frames, frame)
+		return nil
+	}); err != nil {
+		t.Fatalf("StreamFrames() error = %v", err)
+	}
+	if len(frames) == 0 {
+		t.Fatal("StreamFrames() returned no frames")
+	}
+	return frames
+}
+
+func validStartTurnRequest() harness.StartTurnRequest {
+	return harness.StartTurnRequest{
+		Version:           harness.ProtocolVersion,
+		Namespace:         "default",
+		TaskName:          "task-a",
+		SessionName:       "session-a",
+		RuntimeSessionID:  "runtime-a",
+		TurnID:            "turn-a",
+		CorrelationID:     "corr-a",
+		Deadline:          time.Now().UTC().Add(time.Minute),
+		AuthIdentity:      harness.AuthIdentity{Subject: "user:test"},
+		ToolPolicyRef:     &harness.PolicyRef{Name: "default-tools"},
+		Input:             harness.TurnInput{Prompt: "hello"},
+		ToolExecutionMode: harness.ToolExecutionModeObserved,
+	}
+}
+
+func validCancelTurnRequest(start harness.StartTurnRequest) harness.CancelTurnRequest {
+	return harness.CancelTurnRequest{
+		Version:          harness.ProtocolVersion,
+		Namespace:        start.Namespace,
+		TaskName:         start.TaskName,
+		SessionName:      start.SessionName,
+		RuntimeSessionID: start.RuntimeSessionID,
+		TurnID:           start.TurnID,
+		CorrelationID:    start.CorrelationID,
+		Reason:           "test cancellation",
+	}
+}
+
+func eventMapContext() harness.EventMapContext {
+	return harness.EventMapContext{Namespace: "default", TaskName: "task-a", SessionName: "session-a", AgentName: "agent-a"}
+}

--- a/internal/harness/harnesstest/fake_server.go
+++ b/internal/harness/harnesstest/fake_server.go
@@ -1,0 +1,322 @@
+package harnesstest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sozercan/orka/internal/events"
+	"github.com/sozercan/orka/internal/harness"
+)
+
+type FakeBehavior string
+
+const (
+	BehaviorSuccess         FakeBehavior = "success"
+	BehaviorFailure         FakeBehavior = "failure"
+	BehaviorDelayed         FakeBehavior = "delayed-output"
+	BehaviorLongRunning     FakeBehavior = "long-running"
+	BehaviorCancellation    FakeBehavior = "cancellation"
+	BehaviorInvalidFrame    FakeBehavior = "invalid-frame"
+	BehaviorRedactionOutput FakeBehavior = "secret-output"
+)
+
+type FakeHarnessConfig struct {
+	Behavior        FakeBehavior
+	Delay           time.Duration
+	RuntimeName     string
+	RuntimeVersion  string
+	ProviderKind    harness.ProviderKind
+	RedactionOutput string
+	Now             func() time.Time
+}
+
+type FakeHarnessServer struct {
+	server *httptest.Server
+	config FakeHarnessConfig
+	now    func() time.Time
+
+	mu    sync.Mutex
+	turns map[harness.HarnessTurnID]*fakeTurn
+}
+
+type fakeTurn struct {
+	request   harness.StartTurnRequest
+	cancelled chan struct{}
+	once      sync.Once
+}
+
+func NewFakeHarnessServer(config FakeHarnessConfig) *FakeHarnessServer {
+	if config.Behavior == "" {
+		config.Behavior = BehaviorSuccess
+	}
+	if config.Delay <= 0 {
+		config.Delay = 5 * time.Millisecond
+	}
+	if config.RuntimeName == "" {
+		config.RuntimeName = "fake-harness"
+	}
+	if config.RuntimeVersion == "" {
+		config.RuntimeVersion = "test"
+	}
+	if config.ProviderKind == "" {
+		config.ProviderKind = harness.ProviderKindKubernetesService
+	}
+	if config.RedactionOutput == "" {
+		config.RedactionOutput = strings.Join([]string{
+			"Authorization:", "Bearer", "bearer-value-for-redaction",
+			"api" + "_key=" + "sk-" + "test12345678901234567890",
+		}, " ")
+	}
+	now := config.Now
+	if now == nil {
+		now = time.Now
+	}
+	s := &FakeHarnessServer{config: config, now: now, turns: map[harness.HarnessTurnID]*fakeTurn{}}
+	mux := http.NewServeMux()
+	mux.HandleFunc(harness.HealthPath, s.handleHealth)
+	mux.HandleFunc(harness.CapabilitiesPath, s.handleCapabilities)
+	mux.HandleFunc(harness.TurnsPath, s.handleStartTurn)
+	mux.HandleFunc(harness.TurnsPath+"/", s.handleTurn)
+	s.server = httptest.NewServer(mux)
+	return s
+}
+
+func (s *FakeHarnessServer) URL() string { return s.server.URL }
+
+func (s *FakeHarnessServer) Close() {
+	if s != nil && s.server != nil {
+		s.server.Close()
+	}
+}
+
+func (s *FakeHarnessServer) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		harness.WriteError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	harness.WriteJSON(w, http.StatusOK, harness.HealthResponse{
+		Version:   harness.ProtocolVersion,
+		Status:    harness.HealthStatusOK,
+		Ready:     true,
+		CheckedAt: s.now().UTC(),
+	})
+}
+
+func (s *FakeHarnessServer) handleCapabilities(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		harness.WriteError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	harness.WriteJSON(w, http.StatusOK, harness.CapabilitiesResponse{
+		Version:                 harness.ProtocolVersion,
+		ProtocolVersion:         harness.ProtocolVersion,
+		Transport:               harness.HTTPTransport,
+		RuntimeName:             s.config.RuntimeName,
+		RuntimeVersion:          s.config.RuntimeVersion,
+		ProviderKind:            s.config.ProviderKind,
+		ToolExecutionModes:      []harness.ToolExecutionMode{harness.ToolExecutionModeObserved, harness.ToolExecutionModeBrokered},
+		SupportsCancel:          true,
+		SupportsRuntimeSessions: true,
+		MaxConcurrentTurns:      1,
+	})
+}
+
+func (s *FakeHarnessServer) handleStartTurn(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		harness.WriteError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var request harness.StartTurnRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		harness.WriteError(w, http.StatusBadRequest, "invalid JSON request")
+		return
+	}
+	if err := request.Validate(); err != nil {
+		harness.WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	turn := &fakeTurn{request: request, cancelled: make(chan struct{})}
+	s.mu.Lock()
+	s.turns[request.TurnID] = turn
+	s.mu.Unlock()
+	harness.WriteJSON(w, http.StatusAccepted, harness.StartTurnResponse{
+		Version:          harness.ProtocolVersion,
+		Accepted:         true,
+		RuntimeSessionID: request.RuntimeSessionID,
+		TurnID:           request.TurnID,
+		CorrelationID:    request.CorrelationID,
+		EventStreamPath:  "/v1/turns/" + string(request.TurnID) + "/events",
+	})
+}
+
+func (s *FakeHarnessServer) handleTurn(w http.ResponseWriter, r *http.Request) {
+	trimmed := strings.TrimPrefix(r.URL.Path, harness.TurnsPath+"/")
+	parts := strings.Split(strings.Trim(trimmed, "/"), "/")
+	if len(parts) != 2 {
+		harness.WriteError(w, http.StatusNotFound, "not found")
+		return
+	}
+	turnID := harness.HarnessTurnID(parts[0])
+	s.mu.Lock()
+	turn := s.turns[turnID]
+	s.mu.Unlock()
+	if turn == nil {
+		harness.WriteError(w, http.StatusNotFound, "turn not found")
+		return
+	}
+	switch parts[1] {
+	case "events":
+		if r.Method != http.MethodGet {
+			harness.WriteError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		s.handleEvents(w, r, turn)
+	case "cancel":
+		if r.Method != http.MethodPost {
+			harness.WriteError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		s.handleCancel(w, r, turn)
+	default:
+		harness.WriteError(w, http.StatusNotFound, "not found")
+	}
+}
+
+func (s *FakeHarnessServer) handleCancel(w http.ResponseWriter, r *http.Request, turn *fakeTurn) {
+	var request harness.CancelTurnRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		harness.WriteError(w, http.StatusBadRequest, "invalid JSON request")
+		return
+	}
+	if err := request.Validate(); err != nil {
+		harness.WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	turn.once.Do(func() { close(turn.cancelled) })
+	harness.WriteJSON(w, http.StatusAccepted, harness.CancelTurnResponse{
+		Version:          harness.ProtocolVersion,
+		Accepted:         true,
+		RuntimeSessionID: request.RuntimeSessionID,
+		TurnID:           request.TurnID,
+		CorrelationID:    request.CorrelationID,
+		Message:          "cancel accepted",
+	})
+}
+
+func (s *FakeHarnessServer) handleEvents(w http.ResponseWriter, r *http.Request, turn *fakeTurn) {
+	afterSeq, _ := strconv.ParseInt(r.URL.Query().Get("afterSeq"), 10, 64)
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	emit := func(frame harness.HarnessEventFrame) bool {
+		if frame.Seq <= afterSeq {
+			return true
+		}
+		if err := harness.WriteSSEFrame(w, frame); err != nil {
+			return false
+		}
+		return true
+	}
+
+	frames := s.framesFor(turn)
+	for _, frame := range frames {
+		if !emit(frame) {
+			return
+		}
+		if s.config.Behavior == BehaviorDelayed {
+			if !sleepContext(r.Context(), s.config.Delay) {
+				return
+			}
+		}
+	}
+	if s.config.Behavior == BehaviorLongRunning || s.config.Behavior == BehaviorCancellation {
+		select {
+		case <-turn.cancelled:
+			_ = emit(s.frame(turn, 2, harness.FrameTurnCancelled, "cancelled", nil))
+		case <-r.Context().Done():
+			return
+		case <-time.After(10 * time.Second):
+			_ = emit(s.frame(turn, 2, harness.FrameTurnFailed, "turn timeout", &harness.TurnFailed{Reason: "timeout", Message: "fake long-running turn timed out"}))
+		}
+	}
+	_ = harness.WriteSSEDone(w)
+}
+
+func (s *FakeHarnessServer) framesFor(turn *fakeTurn) []harness.HarnessEventFrame {
+	start := s.frame(turn, 1, harness.FrameTurnStarted, "turn started", nil)
+	switch s.config.Behavior {
+	case BehaviorFailure:
+		failed := s.frame(turn, 2, harness.FrameTurnFailed, "turn failed", &harness.TurnFailed{Reason: "fake_failure", Message: "simulated failure"})
+		failed.Error = &harness.ErrorInfo{Code: "fake_failure", Message: "simulated failure"}
+		return []harness.HarnessEventFrame{start, failed}
+	case BehaviorInvalidFrame:
+		invalid := s.frame(turn, 2, harness.FrameType("BogusFrame"), "bogus", nil)
+		return []harness.HarnessEventFrame{start, invalid}
+	case BehaviorRedactionOutput:
+		output := s.frame(turn, 2, harness.FrameRuntimeOutput, "secret output", nil)
+		output.ContentText = s.config.RedactionOutput
+		output.Content = json.RawMessage(fmt.Sprintf(`{"message":%q}`, s.config.RedactionOutput))
+		completed := s.frame(turn, 3, harness.FrameTurnCompleted, "turn completed", &harness.TurnCompleted{Result: "ok", FinalEventSeq: 3})
+		return []harness.HarnessEventFrame{start, output, completed}
+	case BehaviorLongRunning, BehaviorCancellation:
+		return []harness.HarnessEventFrame{start}
+	default:
+		output := s.frame(turn, 2, harness.FrameRuntimeOutput, "echo", nil)
+		output.Content = json.RawMessage(fmt.Sprintf(`{"message":%q}`, "echo: "+turn.request.Input.Prompt))
+		output.ContentText = "echo: " + turn.request.Input.Prompt
+		tool := s.frame(turn, 3, harness.FrameToolCallRequested, "tool requested", nil)
+		tool.ToolName = "echo"
+		tool.ToolCallID = "tool-1"
+		tool.Content = json.RawMessage(`{"input":"hello"}`)
+		result := s.frame(turn, 4, harness.FrameToolResultReceived, "tool completed", nil)
+		result.ToolName = "echo"
+		result.ToolCallID = "tool-1"
+		result.Content = json.RawMessage(`{"output":"hello"}`)
+		completed := s.frame(turn, 5, harness.FrameTurnCompleted, "turn completed", &harness.TurnCompleted{Result: "ok", FinalEventSeq: 5})
+		return []harness.HarnessEventFrame{start, output, tool, result, completed}
+	}
+}
+
+func (s *FakeHarnessServer) frame(turn *fakeTurn, seq int64, typ harness.FrameType, summary string, terminal any) harness.HarnessEventFrame {
+	frame := harness.HarnessEventFrame{
+		Version:          harness.ProtocolVersion,
+		Type:             typ,
+		RuntimeSessionID: turn.request.RuntimeSessionID,
+		TurnID:           turn.request.TurnID,
+		CorrelationID:    turn.request.CorrelationID,
+		Seq:              seq,
+		CreatedAt:        s.now().UTC().Add(time.Duration(seq) * time.Millisecond),
+		Severity:         events.ExecutionEventSeverityInfo,
+		Summary:          summary,
+		Metadata: map[string]string{
+			"fakeBehavior": string(s.config.Behavior),
+		},
+	}
+	switch value := terminal.(type) {
+	case *harness.TurnCompleted:
+		frame.Completed = value
+	case *harness.TurnFailed:
+		frame.Failed = value
+		frame.Severity = events.ExecutionEventSeverityError
+	}
+	return frame
+}
+
+func sleepContext(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/internal/harness/harnesstest/fake_server_test.go
+++ b/internal/harness/harnesstest/fake_server_test.go
@@ -1,0 +1,11 @@
+package harnesstest
+
+import "testing"
+
+func TestFakeHarnessPassesConformance(t *testing.T) {
+	RunHarnessConformance(t, func(t *testing.T, behavior FakeBehavior) (string, func()) {
+		t.Helper()
+		server := NewFakeHarnessServer(FakeHarnessConfig{Behavior: behavior})
+		return server.URL(), server.Close
+	})
+}

--- a/internal/harness/lifecycle.go
+++ b/internal/harness/lifecycle.go
@@ -1,0 +1,187 @@
+package harness
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type RuntimeSessionState string
+
+const (
+	RuntimeSessionStatePending     RuntimeSessionState = "Pending"
+	RuntimeSessionStateBooting     RuntimeSessionState = "Booting"
+	RuntimeSessionStateReady       RuntimeSessionState = "Ready"
+	RuntimeSessionStateTurnRunning RuntimeSessionState = "TurnRunning"
+	RuntimeSessionStateIdle        RuntimeSessionState = "Idle"
+	RuntimeSessionStateReleasing   RuntimeSessionState = "Releasing"
+	RuntimeSessionStateRetained    RuntimeSessionState = "Retained"
+	RuntimeSessionStateSuspended   RuntimeSessionState = "Suspended"
+	RuntimeSessionStateDeleting    RuntimeSessionState = "Deleting"
+	RuntimeSessionStateDeleted     RuntimeSessionState = "Deleted"
+	RuntimeSessionStateFailed      RuntimeSessionState = "Failed"
+	RuntimeSessionStateUnhealthy   RuntimeSessionState = "Unhealthy"
+)
+
+type RuntimeCleanupPolicy string
+
+const (
+	RuntimeCleanupPolicyDelete  RuntimeCleanupPolicy = "delete"
+	RuntimeCleanupPolicyRetain  RuntimeCleanupPolicy = "retain"
+	RuntimeCleanupPolicySuspend RuntimeCleanupPolicy = "suspend"
+)
+
+type RuntimeSessionOwner struct {
+	Namespace   string       `json:"namespace"`
+	SessionName string       `json:"sessionName"`
+	ActiveTask  string       `json:"activeTask,omitempty"`
+	AgentName   string       `json:"agentName,omitempty"`
+	Provider    ProviderKind `json:"provider"`
+}
+
+type RuntimeSession struct {
+	ID            RuntimeSessionID     `json:"id"`
+	Owner         RuntimeSessionOwner  `json:"owner"`
+	State         RuntimeSessionState  `json:"state"`
+	CleanupPolicy RuntimeCleanupPolicy `json:"cleanupPolicy"`
+	IdleTimeout   time.Duration        `json:"idleTimeout,omitempty"`
+	MaxLifetime   time.Duration        `json:"maxLifetime,omitempty"`
+	CreatedAt     time.Time            `json:"createdAt,omitempty"`
+	UpdatedAt     time.Time            `json:"updatedAt,omitempty"`
+}
+
+var allowedRuntimeSessionTransitions = map[RuntimeSessionState]map[RuntimeSessionState]struct{}{
+	RuntimeSessionStatePending: {
+		RuntimeSessionStateBooting: {}, RuntimeSessionStateDeleting: {}, RuntimeSessionStateFailed: {},
+	},
+	RuntimeSessionStateBooting: {
+		RuntimeSessionStateReady: {}, RuntimeSessionStateUnhealthy: {}, RuntimeSessionStateDeleting: {}, RuntimeSessionStateFailed: {},
+	},
+	RuntimeSessionStateReady: {
+		RuntimeSessionStateTurnRunning: {}, RuntimeSessionStateIdle: {}, RuntimeSessionStateReleasing: {}, RuntimeSessionStateDeleting: {}, RuntimeSessionStateUnhealthy: {},
+	},
+	RuntimeSessionStateTurnRunning: {
+		RuntimeSessionStateIdle: {}, RuntimeSessionStateReady: {}, RuntimeSessionStateReleasing: {}, RuntimeSessionStateDeleting: {}, RuntimeSessionStateFailed: {}, RuntimeSessionStateUnhealthy: {},
+	},
+	RuntimeSessionStateIdle: {
+		RuntimeSessionStateTurnRunning: {}, RuntimeSessionStateReleasing: {}, RuntimeSessionStateRetained: {}, RuntimeSessionStateSuspended: {}, RuntimeSessionStateDeleting: {}, RuntimeSessionStateUnhealthy: {},
+	},
+	RuntimeSessionStateReleasing: {
+		RuntimeSessionStateRetained: {}, RuntimeSessionStateSuspended: {}, RuntimeSessionStateDeleting: {}, RuntimeSessionStateDeleted: {}, RuntimeSessionStateFailed: {},
+	},
+	RuntimeSessionStateRetained: {
+		RuntimeSessionStateBooting: {}, RuntimeSessionStateDeleting: {}, RuntimeSessionStateFailed: {},
+	},
+	RuntimeSessionStateSuspended: {
+		RuntimeSessionStateBooting: {}, RuntimeSessionStateDeleting: {}, RuntimeSessionStateFailed: {},
+	},
+	RuntimeSessionStateDeleting: {
+		RuntimeSessionStateDeleted: {}, RuntimeSessionStateFailed: {},
+	},
+	RuntimeSessionStateUnhealthy: {
+		RuntimeSessionStateBooting: {}, RuntimeSessionStateDeleting: {}, RuntimeSessionStateFailed: {},
+	},
+	RuntimeSessionStateFailed: {
+		RuntimeSessionStateDeleting: {},
+	},
+	RuntimeSessionStateDeleted: {},
+}
+
+func RuntimeSessionStates() []RuntimeSessionState {
+	return []RuntimeSessionState{
+		RuntimeSessionStatePending,
+		RuntimeSessionStateBooting,
+		RuntimeSessionStateReady,
+		RuntimeSessionStateTurnRunning,
+		RuntimeSessionStateIdle,
+		RuntimeSessionStateReleasing,
+		RuntimeSessionStateRetained,
+		RuntimeSessionStateSuspended,
+		RuntimeSessionStateDeleting,
+		RuntimeSessionStateDeleted,
+		RuntimeSessionStateFailed,
+		RuntimeSessionStateUnhealthy,
+	}
+}
+
+func IsKnownRuntimeSessionState(state RuntimeSessionState) bool {
+	_, ok := allowedRuntimeSessionTransitions[state]
+	return ok
+}
+
+func RuntimeSessionTransitionAllowed(from, to RuntimeSessionState) bool {
+	if from == to && from != "" {
+		return true
+	}
+	allowed, ok := allowedRuntimeSessionTransitions[from]
+	if !ok {
+		return false
+	}
+	_, ok = allowed[to]
+	return ok
+}
+
+func ValidateRuntimeSessionTransition(from, to RuntimeSessionState) error {
+	if !IsKnownRuntimeSessionState(from) {
+		return fmt.Errorf("unsupported runtime session state %q", from)
+	}
+	if !IsKnownRuntimeSessionState(to) {
+		return fmt.Errorf("unsupported runtime session state %q", to)
+	}
+	if !RuntimeSessionTransitionAllowed(from, to) {
+		return fmt.Errorf("runtime session transition %s -> %s is not allowed", from, to)
+	}
+	return nil
+}
+
+func (s RuntimeSession) Validate() error {
+	if strings.TrimSpace(string(s.ID)) == "" {
+		return fmt.Errorf("runtime session id is required")
+	}
+	if strings.TrimSpace(s.Owner.Namespace) == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if strings.TrimSpace(s.Owner.SessionName) == "" {
+		return fmt.Errorf("session name is required")
+	}
+	if strings.TrimSpace(string(s.Owner.Provider)) == "" {
+		return fmt.Errorf("runtime provider is required")
+	}
+	if !IsKnownRuntimeSessionState(s.State) {
+		return fmt.Errorf("unsupported runtime session state %q", s.State)
+	}
+	if !IsKnownRuntimeCleanupPolicy(s.CleanupPolicy) {
+		return fmt.Errorf("unsupported runtime cleanup policy %q", s.CleanupPolicy)
+	}
+	if s.IdleTimeout < 0 {
+		return fmt.Errorf("idle timeout must be non-negative")
+	}
+	if s.MaxLifetime < 0 {
+		return fmt.Errorf("max lifetime must be non-negative")
+	}
+	return nil
+}
+
+func (s *RuntimeSession) Transition(to RuntimeSessionState, now time.Time) error {
+	if s == nil {
+		return fmt.Errorf("runtime session is required")
+	}
+	if err := ValidateRuntimeSessionTransition(s.State, to); err != nil {
+		return err
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	s.State = to
+	s.UpdatedAt = now.UTC()
+	return nil
+}
+
+func IsKnownRuntimeCleanupPolicy(policy RuntimeCleanupPolicy) bool {
+	switch policy {
+	case RuntimeCleanupPolicyDelete, RuntimeCleanupPolicyRetain, RuntimeCleanupPolicySuspend:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/harness/lifecycle_test.go
+++ b/internal/harness/lifecycle_test.go
@@ -1,0 +1,64 @@
+package harness
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRuntimeSessionStateTransitions(t *testing.T) {
+	valid := [][2]RuntimeSessionState{
+		{RuntimeSessionStatePending, RuntimeSessionStateBooting},
+		{RuntimeSessionStateBooting, RuntimeSessionStateReady},
+		{RuntimeSessionStateReady, RuntimeSessionStateTurnRunning},
+		{RuntimeSessionStateTurnRunning, RuntimeSessionStateIdle},
+		{RuntimeSessionStateIdle, RuntimeSessionStateReleasing},
+		{RuntimeSessionStateReleasing, RuntimeSessionStateRetained},
+		{RuntimeSessionStateRetained, RuntimeSessionStateDeleting},
+		{RuntimeSessionStateDeleting, RuntimeSessionStateDeleted},
+		{RuntimeSessionStateIdle, RuntimeSessionStateSuspended},
+		{RuntimeSessionStateSuspended, RuntimeSessionStateBooting},
+	}
+	for _, transition := range valid {
+		if err := ValidateRuntimeSessionTransition(transition[0], transition[1]); err != nil {
+			t.Fatalf("ValidateRuntimeSessionTransition(%s,%s) error = %v", transition[0], transition[1], err)
+		}
+	}
+	invalid := [][2]RuntimeSessionState{
+		{RuntimeSessionStateDeleted, RuntimeSessionStateReady},
+		{RuntimeSessionStatePending, RuntimeSessionStateTurnRunning},
+		{RuntimeSessionStateReady, RuntimeSessionStateSuspended},
+	}
+	for _, transition := range invalid {
+		if err := ValidateRuntimeSessionTransition(transition[0], transition[1]); err == nil {
+			t.Fatalf("ValidateRuntimeSessionTransition(%s,%s) error = nil, want error", transition[0], transition[1])
+		}
+	}
+}
+
+func TestRuntimeSessionValidationRequiresOwnership(t *testing.T) {
+	session := RuntimeSession{ID: "runtime-a", State: RuntimeSessionStatePending, CleanupPolicy: RuntimeCleanupPolicyDelete}
+	if err := session.Validate(); err == nil || !strings.Contains(err.Error(), "namespace is required") {
+		t.Fatalf("Validate() = %v, want namespace required", err)
+	}
+	session.Owner = RuntimeSessionOwner{Namespace: "default", SessionName: "session-a", Provider: ProviderKindKubernetesService}
+	if err := session.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestRuntimeSessionTransitionUpdatesTimestamp(t *testing.T) {
+	session := RuntimeSession{
+		ID:            "runtime-a",
+		Owner:         RuntimeSessionOwner{Namespace: "default", SessionName: "session-a", Provider: ProviderKindKubernetesService},
+		State:         RuntimeSessionStatePending,
+		CleanupPolicy: RuntimeCleanupPolicyDelete,
+	}
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	if err := session.Transition(RuntimeSessionStateBooting, now); err != nil {
+		t.Fatalf("Transition() error = %v", err)
+	}
+	if session.State != RuntimeSessionStateBooting || !session.UpdatedAt.Equal(now) {
+		t.Fatalf("session = %#v, want booting with timestamp", session)
+	}
+}

--- a/internal/harness/mapper.go
+++ b/internal/harness/mapper.go
@@ -1,0 +1,161 @@
+package harness
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sozercan/orka/internal/events"
+	"github.com/sozercan/orka/internal/store"
+)
+
+// EventMapContext supplies Orka stream ownership for harness frames. Harness
+// frames deliberately do not own namespace/task authority; Orka supplies it from
+// the Task/RuntimeSession claim.
+type EventMapContext struct {
+	Namespace   string
+	TaskName    string
+	SessionName string
+	AgentName   string
+	StreamID    string
+}
+
+func (c EventMapContext) normalized() EventMapContext {
+	c.Namespace = strings.TrimSpace(c.Namespace)
+	c.TaskName = strings.TrimSpace(c.TaskName)
+	c.SessionName = strings.TrimSpace(c.SessionName)
+	c.AgentName = strings.TrimSpace(c.AgentName)
+	c.StreamID = strings.TrimSpace(c.StreamID)
+	if c.StreamID == "" {
+		c.StreamID = c.TaskName
+	}
+	return c
+}
+
+func (c EventMapContext) validate() error {
+	c = c.normalized()
+	if c.Namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if c.TaskName == "" {
+		return fmt.Errorf("task name is required")
+	}
+	if c.StreamID == "" {
+		return fmt.Errorf("stream id is required")
+	}
+	return nil
+}
+
+func MapFrameToExecutionEvent(frame HarnessEventFrame, ctx EventMapContext) (*store.ExecutionEvent, error) {
+	if err := ctx.validate(); err != nil {
+		return nil, err
+	}
+	ctx = ctx.normalized()
+	if err := frame.ValidateRequired(); err != nil {
+		return nil, fmt.Errorf("invalid harness frame: %w", err)
+	}
+
+	eventType, severity, summary := mapFrameType(frame)
+	content, err := buildMappedContent(frame)
+	if err != nil {
+		return nil, err
+	}
+	if IsKnownFrameType(frame.Type) && strings.TrimSpace(frame.Summary) != "" {
+		summary = strings.TrimSpace(frame.Summary)
+	}
+	if severity == "" {
+		severity = events.NormalizeExecutionEventSeverity(frame.Severity)
+	}
+	createdAt := frame.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+
+	event := &store.ExecutionEvent{
+		Namespace:   ctx.Namespace,
+		StreamType:  store.ExecutionEventStreamTypeTask,
+		StreamID:    ctx.StreamID,
+		Type:        eventType,
+		Severity:    severity,
+		TaskName:    ctx.TaskName,
+		SessionName: ctx.SessionName,
+		AgentName:   ctx.AgentName,
+		ToolName:    strings.TrimSpace(frame.ToolName),
+		ToolCallID:  strings.TrimSpace(frame.ToolCallID),
+		Summary:     summary,
+		Content:     content,
+		ContentText: frame.ContentText,
+		CreatedAt:   createdAt.UTC(),
+	}
+	if err := store.SanitizeExecutionEventPayloadFields(event); err != nil {
+		return nil, fmt.Errorf("sanitize mapped harness event: %w", err)
+	}
+	return event, nil
+}
+
+func mapFrameType(frame HarnessEventFrame) (eventType, severity, summary string) {
+	severity = events.NormalizeExecutionEventSeverity(frame.Severity)
+	switch frame.Type {
+	case FrameTurnStarted:
+		return events.ExecutionEventTypeAgentRuntimeStarted, severity, "harness turn started"
+	case FrameRuntimeOutput:
+		return events.ExecutionEventTypeModelMessage, severity, "runtime output"
+	case FrameToolCallRequested:
+		return events.ExecutionEventTypeToolCallStarted, severity, "tool call requested"
+	case FrameToolResultReceived:
+		return events.ExecutionEventTypeToolCallCompleted, severity, "tool result received"
+	case FrameApprovalRequested:
+		return events.ExecutionEventTypeApprovalRequested, severity, "approval requested"
+	case FrameTurnCompleted:
+		return events.ExecutionEventTypeAgentRuntimeCompleted, severity, "harness turn completed"
+	case FrameTurnFailed:
+		return events.ExecutionEventTypeAgentRuntimeFailed, events.ExecutionEventSeverityError, "harness turn failed"
+	case FrameTurnCancelled:
+		return events.ExecutionEventTypeTaskCancelled, events.ExecutionEventSeverityWarning, "harness turn cancelled"
+	case FrameRuntimeLog:
+		return events.ExecutionEventTypeAgentRuntimeCommandStarted, severity, "runtime log"
+	default:
+		return events.ExecutionEventTypeAgentRuntimeCommandStarted, events.ExecutionEventSeverityWarning, fmt.Sprintf("unknown harness frame %q", frame.Type)
+	}
+}
+
+func buildMappedContent(frame HarnessEventFrame) (json.RawMessage, error) {
+	content := map[string]any{
+		"harness": map[string]any{
+			"version":          frame.Version,
+			"frameType":        frame.Type,
+			"runtimeSessionID": frame.RuntimeSessionID,
+			"turnID":           frame.TurnID,
+			"correlationID":    frame.CorrelationID,
+			"seq":              frame.Seq,
+		},
+	}
+	if len(frame.Metadata) > 0 {
+		content["metadata"] = frame.Metadata
+	}
+	if frame.ApprovalID != "" {
+		content["approvalID"] = frame.ApprovalID
+	}
+	if frame.Completed != nil {
+		content["completed"] = frame.Completed
+	}
+	if frame.Failed != nil {
+		content["failed"] = frame.Failed
+	}
+	if frame.Error != nil {
+		content["error"] = frame.Error
+	}
+	if len(frame.Content) > 0 {
+		var decoded any
+		if err := json.Unmarshal(frame.Content, &decoded); err != nil {
+			return nil, fmt.Errorf("invalid harness frame content JSON: %w", err)
+		}
+		content["frameContent"] = decoded
+	}
+	encoded, err := json.Marshal(content)
+	if err != nil {
+		return nil, fmt.Errorf("marshal mapped harness content: %w", err)
+	}
+	return encoded, nil
+}

--- a/internal/harness/mapper_test.go
+++ b/internal/harness/mapper_test.go
@@ -1,0 +1,106 @@
+package harness
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sozercan/orka/internal/events"
+)
+
+func TestMapFrameToExecutionEventCoversFrozenFrameTypes(t *testing.T) {
+	ctx := EventMapContext{Namespace: "default", TaskName: "task-a", SessionName: "session-a", AgentName: "agent-a"}
+	tests := map[FrameType]string{
+		FrameTurnStarted:        events.ExecutionEventTypeAgentRuntimeStarted,
+		FrameRuntimeOutput:      events.ExecutionEventTypeModelMessage,
+		FrameToolCallRequested:  events.ExecutionEventTypeToolCallStarted,
+		FrameToolResultReceived: events.ExecutionEventTypeToolCallCompleted,
+		FrameApprovalRequested:  events.ExecutionEventTypeApprovalRequested,
+		FrameTurnCompleted:      events.ExecutionEventTypeAgentRuntimeCompleted,
+		FrameTurnFailed:         events.ExecutionEventTypeAgentRuntimeFailed,
+		FrameTurnCancelled:      events.ExecutionEventTypeTaskCancelled,
+		FrameRuntimeLog:         events.ExecutionEventTypeAgentRuntimeCommandStarted,
+	}
+	for typ, want := range tests {
+		t.Run(string(typ), func(t *testing.T) {
+			frame := validFrame(typ)
+			event, err := MapFrameToExecutionEvent(frame, ctx)
+			if err != nil {
+				t.Fatalf("MapFrameToExecutionEvent() error = %v", err)
+			}
+			if event.Type != want {
+				t.Fatalf("event.Type = %s, want %s", event.Type, want)
+			}
+			if event.Namespace != ctx.Namespace || event.TaskName != ctx.TaskName || event.SessionName != ctx.SessionName {
+				t.Fatalf("event ownership = %#v, want context ownership", event)
+			}
+			var content map[string]any
+			if err := json.Unmarshal(event.Content, &content); err != nil {
+				t.Fatalf("event content unmarshal: %v", err)
+			}
+			harnessContent, ok := content["harness"].(map[string]any)
+			if !ok || harnessContent["turnID"] != string(frame.TurnID) || harnessContent["correlationID"] != frame.CorrelationID {
+				t.Fatalf("event content = %#v, want harness metadata", content)
+			}
+		})
+	}
+}
+
+func TestMapFrameToExecutionEventUnknownFrameIsSafeDiagnostic(t *testing.T) {
+	frame := validFrame(FrameType("NotAFrame"))
+	event, err := MapFrameToExecutionEvent(frame, EventMapContext{Namespace: "default", TaskName: "task-a"})
+	if err != nil {
+		t.Fatalf("MapFrameToExecutionEvent() error = %v", err)
+	}
+	if event.Type != events.ExecutionEventTypeAgentRuntimeCommandStarted || event.Severity != events.ExecutionEventSeverityWarning {
+		t.Fatalf("event = %#v, want warning diagnostic", event)
+	}
+	if !strings.Contains(event.Summary, "unknown harness frame") {
+		t.Fatalf("event.Summary = %q, want unknown frame diagnostic", event.Summary)
+	}
+}
+
+func TestMapFrameToExecutionEventRedactsBeforeStoreAppend(t *testing.T) {
+	secret := "Authorization: Bearer bearer-value-for-redaction api_key=sk-test12345678901234567890"
+	frame := validFrame(FrameRuntimeOutput)
+	frame.Summary = secret
+	frame.ContentText = secret
+	frame.Content = json.RawMessage(`{"message":"` + secret + `"}`)
+	event, err := MapFrameToExecutionEvent(frame, EventMapContext{Namespace: "default", TaskName: "task-a"})
+	if err != nil {
+		t.Fatalf("MapFrameToExecutionEvent() error = %v", err)
+	}
+	encoded := event.Summary + event.ContentText + string(event.Content)
+	if strings.Contains(encoded, "sk-test") || strings.Contains(encoded, "bearer-value-for-redaction") {
+		t.Fatalf("mapped event leaked secret: %s", encoded)
+	}
+	if !strings.Contains(encoded, events.ExecutionEventRedactedValue) {
+		t.Fatalf("mapped event = %s, want redaction marker", encoded)
+	}
+}
+
+func validFrame(typ FrameType) HarnessEventFrame {
+	frame := HarnessEventFrame{
+		Version:          ProtocolVersion,
+		Type:             typ,
+		RuntimeSessionID: "runtime-a",
+		TurnID:           "turn-a",
+		CorrelationID:    "corr-a",
+		Seq:              1,
+		CreatedAt:        time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC),
+		Severity:         events.ExecutionEventSeverityInfo,
+		Content:          json.RawMessage(`{"ok":true}`),
+	}
+	if typ == FrameTurnCompleted {
+		frame.Completed = &TurnCompleted{Result: "ok", FinalEventSeq: 1}
+	}
+	if typ == FrameTurnFailed {
+		frame.Failed = &TurnFailed{Reason: "failed", Message: "failed"}
+	}
+	if typ == FrameToolCallRequested || typ == FrameToolResultReceived {
+		frame.ToolName = "echo"
+		frame.ToolCallID = "tool-1"
+	}
+	return frame
+}

--- a/internal/harness/protocol.go
+++ b/internal/harness/protocol.go
@@ -1,0 +1,474 @@
+package harness
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	// ProtocolVersion is the frozen MVP harness protocol version. It is intentionally
+	// backend-neutral: provider-specific capabilities belong in CapabilitiesResponse.
+	ProtocolVersion = "orka.harness.v1"
+	HTTPTransport   = "http+sse"
+)
+
+const (
+	HealthPath       = "/v1/health"
+	CapabilitiesPath = "/v1/capabilities"
+	TurnsPath        = "/v1/turns"
+)
+
+type RuntimeSessionID string
+type HarnessTurnID string
+
+type ToolExecutionMode string
+
+const (
+	ToolExecutionModeObserved ToolExecutionMode = "observed"
+	ToolExecutionModeBrokered ToolExecutionMode = "brokered"
+)
+
+type FrameType string
+
+const (
+	FrameTurnStarted        FrameType = "TurnStarted"
+	FrameRuntimeOutput      FrameType = "RuntimeOutput"
+	FrameToolCallRequested  FrameType = "ToolCallRequested"
+	FrameToolResultReceived FrameType = "ToolResultReceived"
+	FrameApprovalRequested  FrameType = "ApprovalRequested"
+	FrameTurnCompleted      FrameType = "TurnCompleted"
+	FrameTurnFailed         FrameType = "TurnFailed"
+	FrameTurnCancelled      FrameType = "TurnCancelled"
+	FrameRuntimeLog         FrameType = "RuntimeLog"
+)
+
+type ProviderKind string
+
+const (
+	ProviderKindKubernetesService ProviderKind = "kubernetes-service"
+	ProviderKindSidecar           ProviderKind = "sidecar"
+	ProviderKindAgentSandbox      ProviderKind = "agent-sandbox"
+	ProviderKindSubstrate         ProviderKind = "substrate"
+	ProviderKindRemote            ProviderKind = "remote"
+)
+
+type HealthStatus string
+
+const (
+	HealthStatusOK        HealthStatus = "ok"
+	HealthStatusDegraded  HealthStatus = "degraded"
+	HealthStatusUnhealthy HealthStatus = "unhealthy"
+)
+
+// StartTurnRequest is the Orka-to-harness request that starts one explicit turn.
+// All identity and policy fields are safe references or verified metadata; raw
+// credentials and TxTokens must never be serialized here.
+type StartTurnRequest struct {
+	Version           string            `json:"version"`
+	Namespace         string            `json:"namespace"`
+	TaskName          string            `json:"taskName"`
+	SessionName       string            `json:"sessionName"`
+	RuntimeSessionID  RuntimeSessionID  `json:"runtimeSessionID"`
+	TurnID            HarnessTurnID     `json:"turnID"`
+	CorrelationID     string            `json:"correlationID"`
+	Deadline          time.Time         `json:"deadline"`
+	AuthIdentity      AuthIdentity      `json:"authIdentity"`
+	ToolPolicyRef     *PolicyRef        `json:"toolPolicyRef,omitempty"`
+	ApprovalPolicyRef *PolicyRef        `json:"approvalPolicyRef,omitempty"`
+	EventCursor       int64             `json:"eventCursor,omitempty"`
+	Input             TurnInput         `json:"input,omitempty"`
+	ToolExecutionMode ToolExecutionMode `json:"toolExecutionMode,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+}
+
+type AuthIdentity struct {
+	Subject  string   `json:"subject,omitempty"`
+	Issuer   string   `json:"issuer,omitempty"`
+	Username string   `json:"username,omitempty"`
+	Groups   []string `json:"groups,omitempty"`
+	Roles    []string `json:"roles,omitempty"`
+}
+
+type PolicyRef struct {
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+}
+
+type TurnInput struct {
+	Prompt      string       `json:"prompt,omitempty"`
+	ContextRefs []ContextRef `json:"contextRefs,omitempty"`
+}
+
+type ContextRef struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+	Seq  int64  `json:"seq,omitempty"`
+}
+
+type StartTurnResponse struct {
+	Version          string           `json:"version"`
+	Accepted         bool             `json:"accepted"`
+	RuntimeSessionID RuntimeSessionID `json:"runtimeSessionID"`
+	TurnID           HarnessTurnID    `json:"turnID"`
+	CorrelationID    string           `json:"correlationID,omitempty"`
+	EventStreamPath  string           `json:"eventStreamPath,omitempty"`
+}
+
+type CancelTurnRequest struct {
+	Version          string           `json:"version"`
+	Namespace        string           `json:"namespace"`
+	TaskName         string           `json:"taskName"`
+	SessionName      string           `json:"sessionName"`
+	RuntimeSessionID RuntimeSessionID `json:"runtimeSessionID"`
+	TurnID           HarnessTurnID    `json:"turnID"`
+	CorrelationID    string           `json:"correlationID"`
+	Reason           string           `json:"reason,omitempty"`
+}
+
+type CancelTurnResponse struct {
+	Version          string           `json:"version"`
+	Accepted         bool             `json:"accepted"`
+	RuntimeSessionID RuntimeSessionID `json:"runtimeSessionID"`
+	TurnID           HarnessTurnID    `json:"turnID"`
+	CorrelationID    string           `json:"correlationID,omitempty"`
+	Message          string           `json:"message,omitempty"`
+}
+
+type CapabilitiesResponse struct {
+	Version                   string              `json:"version"`
+	ProtocolVersion           string              `json:"protocolVersion"`
+	Transport                 string              `json:"transport"`
+	RuntimeName               string              `json:"runtimeName"`
+	RuntimeVersion            string              `json:"runtimeVersion,omitempty"`
+	ProviderKind              ProviderKind        `json:"providerKind"`
+	ToolExecutionModes        []ToolExecutionMode `json:"toolExecutionModes"`
+	SupportsCancel            bool                `json:"supportsCancel"`
+	SupportsRuntimeSessions   bool                `json:"supportsRuntimeSessions"`
+	SupportsSuspend           bool                `json:"supportsSuspend,omitempty"`
+	SupportsWorkspaceSnapshot bool                `json:"supportsWorkspaceSnapshot,omitempty"`
+	MaxConcurrentTurns        int                 `json:"maxConcurrentTurns,omitempty"`
+	Metadata                  map[string]string   `json:"metadata,omitempty"`
+}
+
+type HealthResponse struct {
+	Version          string            `json:"version"`
+	Status           HealthStatus      `json:"status"`
+	Ready            bool              `json:"ready"`
+	RuntimeSessionID RuntimeSessionID  `json:"runtimeSessionID,omitempty"`
+	Message          string            `json:"message,omitempty"`
+	CheckedAt        time.Time         `json:"checkedAt"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+}
+
+// HarnessEventFrame is the harness-to-Orka stream unit. Frame types are stable,
+// while Content/Metadata carry frame-specific data after redaction at the client
+// and event-store boundaries.
+type HarnessEventFrame struct {
+	Version          string            `json:"version"`
+	Type             FrameType         `json:"type"`
+	RuntimeSessionID RuntimeSessionID  `json:"runtimeSessionID"`
+	TurnID           HarnessTurnID     `json:"turnID"`
+	CorrelationID    string            `json:"correlationID"`
+	Seq              int64             `json:"seq"`
+	CreatedAt        time.Time         `json:"createdAt,omitempty"`
+	Severity         string            `json:"severity,omitempty"`
+	Summary          string            `json:"summary,omitempty"`
+	Content          json.RawMessage   `json:"content,omitempty"`
+	ContentText      string            `json:"contentText,omitempty"`
+	ToolName         string            `json:"toolName,omitempty"`
+	ToolCallID       string            `json:"toolCallID,omitempty"`
+	ApprovalID       string            `json:"approvalID,omitempty"`
+	Completed        *TurnCompleted    `json:"completed,omitempty"`
+	Failed           *TurnFailed       `json:"failed,omitempty"`
+	Error            *ErrorInfo        `json:"error,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+}
+
+type TurnCompleted struct {
+	Result        string `json:"result,omitempty"`
+	OutputRef     string `json:"outputRef,omitempty"`
+	FinalEventSeq int64  `json:"finalEventSeq,omitempty"`
+	RetainSession bool   `json:"retainSession,omitempty"`
+}
+
+type TurnFailed struct {
+	Reason    string `json:"reason"`
+	Message   string `json:"message,omitempty"`
+	Retryable bool   `json:"retryable,omitempty"`
+}
+
+type ErrorInfo struct {
+	Code      string `json:"code"`
+	Message   string `json:"message,omitempty"`
+	Retryable bool   `json:"retryable,omitempty"`
+}
+
+type ToolCallRequest struct {
+	Version           string            `json:"version"`
+	RuntimeSessionID  RuntimeSessionID  `json:"runtimeSessionID"`
+	TurnID            HarnessTurnID     `json:"turnID"`
+	ToolCallID        string            `json:"toolCallID"`
+	ToolName          string            `json:"toolName"`
+	IdempotencyKey    string            `json:"idempotencyKey"`
+	Input             json.RawMessage   `json:"input,omitempty"`
+	RequiresApproval  bool              `json:"requiresApproval,omitempty"`
+	ApprovalPolicyRef *PolicyRef        `json:"approvalPolicyRef,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+}
+
+type ToolCallResult struct {
+	Version          string           `json:"version"`
+	RuntimeSessionID RuntimeSessionID `json:"runtimeSessionID"`
+	TurnID           HarnessTurnID    `json:"turnID"`
+	ToolCallID       string           `json:"toolCallID"`
+	IdempotencyKey   string           `json:"idempotencyKey"`
+	Approved         bool             `json:"approved,omitempty"`
+	Output           json.RawMessage  `json:"output,omitempty"`
+	Error            *ErrorInfo       `json:"error,omitempty"`
+}
+
+func (r StartTurnRequest) Validate() error {
+	if err := validateVersion(r.Version); err != nil {
+		return err
+	}
+	if strings.TrimSpace(r.Namespace) == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if strings.TrimSpace(r.TaskName) == "" {
+		return fmt.Errorf("task name is required")
+	}
+	if strings.TrimSpace(r.SessionName) == "" {
+		return fmt.Errorf("session name is required")
+	}
+	if strings.TrimSpace(string(r.RuntimeSessionID)) == "" {
+		return fmt.Errorf("runtime session id is required")
+	}
+	if strings.TrimSpace(string(r.TurnID)) == "" {
+		return fmt.Errorf("turn id is required")
+	}
+	if strings.TrimSpace(r.CorrelationID) == "" {
+		return fmt.Errorf("correlation id is required")
+	}
+	if r.Deadline.IsZero() {
+		return fmt.Errorf("deadline is required")
+	}
+	if strings.TrimSpace(r.AuthIdentity.Subject) == "" && strings.TrimSpace(r.AuthIdentity.Username) == "" {
+		return fmt.Errorf("auth identity subject or username is required")
+	}
+	if r.EventCursor < 0 {
+		return fmt.Errorf("event cursor must be non-negative")
+	}
+	if r.ToolExecutionMode != "" && !IsKnownToolExecutionMode(r.ToolExecutionMode) {
+		return fmt.Errorf("unsupported tool execution mode %q", r.ToolExecutionMode)
+	}
+	if r.ToolPolicyRef != nil && strings.TrimSpace(r.ToolPolicyRef.Name) == "" {
+		return fmt.Errorf("tool policy ref name is required")
+	}
+	if r.ApprovalPolicyRef != nil && strings.TrimSpace(r.ApprovalPolicyRef.Name) == "" {
+		return fmt.Errorf("approval policy ref name is required")
+	}
+	for i, ref := range r.Input.ContextRefs {
+		if strings.TrimSpace(ref.Kind) == "" {
+			return fmt.Errorf("context ref %d kind is required", i)
+		}
+		if strings.TrimSpace(ref.Name) == "" {
+			return fmt.Errorf("context ref %d name is required", i)
+		}
+		if ref.Seq < 0 {
+			return fmt.Errorf("context ref %d seq must be non-negative", i)
+		}
+	}
+	return nil
+}
+
+func (r CancelTurnRequest) Validate() error {
+	if err := validateVersion(r.Version); err != nil {
+		return err
+	}
+	if strings.TrimSpace(r.Namespace) == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if strings.TrimSpace(r.TaskName) == "" {
+		return fmt.Errorf("task name is required")
+	}
+	if strings.TrimSpace(r.SessionName) == "" {
+		return fmt.Errorf("session name is required")
+	}
+	if strings.TrimSpace(string(r.RuntimeSessionID)) == "" {
+		return fmt.Errorf("runtime session id is required")
+	}
+	if strings.TrimSpace(string(r.TurnID)) == "" {
+		return fmt.Errorf("turn id is required")
+	}
+	if strings.TrimSpace(r.CorrelationID) == "" {
+		return fmt.Errorf("correlation id is required")
+	}
+	return nil
+}
+
+func (r CapabilitiesResponse) Validate() error {
+	if err := validateVersion(r.Version); err != nil {
+		return err
+	}
+	if strings.TrimSpace(r.ProtocolVersion) != ProtocolVersion {
+		return fmt.Errorf("unsupported protocol version %q", r.ProtocolVersion)
+	}
+	if strings.TrimSpace(r.Transport) == "" {
+		return fmt.Errorf("transport is required")
+	}
+	if strings.TrimSpace(r.RuntimeName) == "" {
+		return fmt.Errorf("runtime name is required")
+	}
+	if strings.TrimSpace(string(r.ProviderKind)) == "" {
+		return fmt.Errorf("provider kind is required")
+	}
+	if len(r.ToolExecutionModes) == 0 {
+		return fmt.Errorf("at least one tool execution mode is required")
+	}
+	for _, mode := range r.ToolExecutionModes {
+		if !IsKnownToolExecutionMode(mode) {
+			return fmt.Errorf("unsupported tool execution mode %q", mode)
+		}
+	}
+	if r.MaxConcurrentTurns < 0 {
+		return fmt.Errorf("max concurrent turns must be non-negative")
+	}
+	return nil
+}
+
+func (r HealthResponse) Validate() error {
+	if err := validateVersion(r.Version); err != nil {
+		return err
+	}
+	if strings.TrimSpace(string(r.Status)) == "" {
+		return fmt.Errorf("health status is required")
+	}
+	if !IsKnownHealthStatus(r.Status) {
+		return fmt.Errorf("unsupported health status %q", r.Status)
+	}
+	if r.CheckedAt.IsZero() {
+		return fmt.Errorf("checked at is required")
+	}
+	return nil
+}
+
+func (f HarnessEventFrame) ValidateRequired() error {
+	if err := validateVersion(f.Version); err != nil {
+		return err
+	}
+	if strings.TrimSpace(string(f.Type)) == "" {
+		return fmt.Errorf("frame type is required")
+	}
+	if strings.TrimSpace(string(f.RuntimeSessionID)) == "" {
+		return fmt.Errorf("runtime session id is required")
+	}
+	if strings.TrimSpace(string(f.TurnID)) == "" {
+		return fmt.Errorf("turn id is required")
+	}
+	if strings.TrimSpace(f.CorrelationID) == "" {
+		return fmt.Errorf("correlation id is required")
+	}
+	if f.Seq <= 0 {
+		return fmt.Errorf("frame seq must be positive")
+	}
+	if f.Type == FrameTurnCompleted && f.Completed == nil {
+		return fmt.Errorf("turn completed payload is required")
+	}
+	if f.Type == FrameTurnFailed && f.Failed == nil {
+		return fmt.Errorf("turn failed payload is required")
+	}
+	return nil
+}
+
+func (r ToolCallRequest) Validate() error {
+	if err := validateVersion(r.Version); err != nil {
+		return err
+	}
+	if strings.TrimSpace(string(r.RuntimeSessionID)) == "" {
+		return fmt.Errorf("runtime session id is required")
+	}
+	if strings.TrimSpace(string(r.TurnID)) == "" {
+		return fmt.Errorf("turn id is required")
+	}
+	if strings.TrimSpace(r.ToolCallID) == "" {
+		return fmt.Errorf("tool call id is required")
+	}
+	if strings.TrimSpace(r.ToolName) == "" {
+		return fmt.Errorf("tool name is required")
+	}
+	if strings.TrimSpace(r.IdempotencyKey) == "" {
+		return fmt.Errorf("idempotency key is required")
+	}
+	if r.ApprovalPolicyRef != nil && strings.TrimSpace(r.ApprovalPolicyRef.Name) == "" {
+		return fmt.Errorf("approval policy ref name is required")
+	}
+	return nil
+}
+
+func (r ToolCallResult) Validate() error {
+	if err := validateVersion(r.Version); err != nil {
+		return err
+	}
+	if strings.TrimSpace(string(r.RuntimeSessionID)) == "" {
+		return fmt.Errorf("runtime session id is required")
+	}
+	if strings.TrimSpace(string(r.TurnID)) == "" {
+		return fmt.Errorf("turn id is required")
+	}
+	if strings.TrimSpace(r.ToolCallID) == "" {
+		return fmt.Errorf("tool call id is required")
+	}
+	if strings.TrimSpace(r.IdempotencyKey) == "" {
+		return fmt.Errorf("idempotency key is required")
+	}
+	return nil
+}
+
+func IsKnownFrameType(value FrameType) bool {
+	switch value {
+	case FrameTurnStarted, FrameRuntimeOutput, FrameToolCallRequested, FrameToolResultReceived,
+		FrameApprovalRequested, FrameTurnCompleted, FrameTurnFailed, FrameTurnCancelled, FrameRuntimeLog:
+		return true
+	default:
+		return false
+	}
+}
+
+func IsKnownToolExecutionMode(value ToolExecutionMode) bool {
+	switch value {
+	case ToolExecutionModeObserved, ToolExecutionModeBrokered:
+		return true
+	default:
+		return false
+	}
+}
+
+func IsKnownHealthStatus(value HealthStatus) bool {
+	switch value {
+	case HealthStatusOK, HealthStatusDegraded, HealthStatusUnhealthy:
+		return true
+	default:
+		return false
+	}
+}
+
+func ToolRequestIdempotencyKey(runtimeSessionID RuntimeSessionID, turnID HarnessTurnID, toolCallID string) string {
+	return strings.Join([]string{
+		strings.TrimSpace(string(runtimeSessionID)),
+		strings.TrimSpace(string(turnID)),
+		strings.TrimSpace(toolCallID),
+	}, ":")
+}
+
+func validateVersion(version string) error {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return fmt.Errorf("version is required")
+	}
+	if version != ProtocolVersion {
+		return fmt.Errorf("unsupported version %q", version)
+	}
+	return nil
+}

--- a/internal/harness/protocol_test.go
+++ b/internal/harness/protocol_test.go
@@ -1,0 +1,118 @@
+package harness
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStartTurnRequestValidationAndJSONRoundTrip(t *testing.T) {
+	request := StartTurnRequest{
+		Version:           ProtocolVersion,
+		Namespace:         "default",
+		TaskName:          "task-a",
+		SessionName:       "session-a",
+		RuntimeSessionID:  "runtime-a",
+		TurnID:            "turn-a",
+		CorrelationID:     "corr-a",
+		Deadline:          time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC),
+		AuthIdentity:      AuthIdentity{Subject: "user:test"},
+		ToolPolicyRef:     &PolicyRef{Name: "default-tools"},
+		ApprovalPolicyRef: &PolicyRef{Name: "default-approvals"},
+		EventCursor:       7,
+		Input:             TurnInput{Prompt: "hello", ContextRefs: []ContextRef{{Kind: "event", Name: "task-a", Seq: 7}}},
+		ToolExecutionMode: ToolExecutionModeObserved,
+	}
+	if err := request.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	var decoded StartTurnRequest
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if err := decoded.Validate(); err != nil {
+		t.Fatalf("decoded Validate() error = %v", err)
+	}
+	if decoded.RuntimeSessionID != request.RuntimeSessionID || decoded.TurnID != request.TurnID {
+		t.Fatalf("decoded ids = %q/%q, want %q/%q", decoded.RuntimeSessionID, decoded.TurnID, request.RuntimeSessionID, request.TurnID)
+	}
+}
+
+func TestStartTurnRequestValidationErrorsAreDeterministic(t *testing.T) {
+	request := StartTurnRequest{}
+	want := []string{
+		"version is required",
+		"namespace is required",
+		"task name is required",
+		"session name is required",
+		"runtime session id is required",
+		"turn id is required",
+		"correlation id is required",
+		"deadline is required",
+		"auth identity subject or username is required",
+	}
+	for _, message := range want {
+		if err := request.Validate(); err == nil || err.Error() != message {
+			t.Fatalf("Validate() = %v, want %q", err, message)
+		}
+		switch message {
+		case "version is required":
+			request.Version = ProtocolVersion
+		case "namespace is required":
+			request.Namespace = "default"
+		case "task name is required":
+			request.TaskName = "task-a"
+		case "session name is required":
+			request.SessionName = "session-a"
+		case "runtime session id is required":
+			request.RuntimeSessionID = "runtime-a"
+		case "turn id is required":
+			request.TurnID = "turn-a"
+		case "correlation id is required":
+			request.CorrelationID = "corr-a"
+		case "deadline is required":
+			request.Deadline = time.Now().UTC().Add(time.Minute)
+		case "auth identity subject or username is required":
+			request.AuthIdentity.Subject = "user:test"
+		}
+	}
+	if err := request.Validate(); err != nil {
+		t.Fatalf("Validate() after required fields error = %v", err)
+	}
+}
+
+func TestCapabilitiesAndHealthValidateVersionedDTOs(t *testing.T) {
+	capabilities := CapabilitiesResponse{
+		Version:                 ProtocolVersion,
+		ProtocolVersion:         ProtocolVersion,
+		Transport:               HTTPTransport,
+		RuntimeName:             "fake",
+		ProviderKind:            ProviderKindKubernetesService,
+		ToolExecutionModes:      []ToolExecutionMode{ToolExecutionModeObserved, ToolExecutionModeBrokered},
+		SupportsCancel:          true,
+		SupportsRuntimeSessions: true,
+	}
+	if err := capabilities.Validate(); err != nil {
+		t.Fatalf("Capabilities Validate() error = %v", err)
+	}
+	health := HealthResponse{Version: ProtocolVersion, Status: HealthStatusOK, Ready: true, CheckedAt: time.Now().UTC()}
+	if err := health.Validate(); err != nil {
+		t.Fatalf("Health Validate() error = %v", err)
+	}
+	capabilities.Version = "orka.harness.v2"
+	if err := capabilities.Validate(); err == nil || !strings.Contains(err.Error(), "unsupported version") {
+		t.Fatalf("Capabilities Validate() = %v, want unsupported version", err)
+	}
+}
+
+func TestToolRequestIdempotencyKey(t *testing.T) {
+	got := ToolRequestIdempotencyKey(" runtime ", " turn ", " tool ")
+	if got != "runtime:turn:tool" {
+		t.Fatalf("ToolRequestIdempotencyKey() = %q", got)
+	}
+}

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -1,0 +1,133 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sozercan/orka/internal/events"
+	"github.com/sozercan/orka/internal/store"
+)
+
+// TurnRunner is the provider-neutral Orka-side integration core for a harness
+// turn. Controllers/providers supply endpoint discovery and task status changes;
+// the runner owns protocol calls, frame mapping, event append, and terminal turn
+// classification.
+type TurnRunner struct {
+	Client      *Client
+	EventStore  store.ExecutionEventStore
+	MapContext  EventMapContext
+	TurnTimeout time.Duration
+}
+
+type TurnRunResult struct {
+	Accepted  *StartTurnResponse
+	Frames    []HarnessEventFrame
+	Events    []store.ExecutionEvent
+	Completed *TurnCompleted
+	Failed    *TurnFailed
+	Cancelled bool
+}
+
+func (r TurnRunner) Run(ctx context.Context, request StartTurnRequest) (TurnRunResult, error) {
+	if r.Client == nil {
+		return TurnRunResult{}, fmt.Errorf("harness client is required")
+	}
+	if r.EventStore == nil {
+		return TurnRunResult{}, fmt.Errorf("execution event store is required")
+	}
+	if err := request.Validate(); err != nil {
+		return TurnRunResult{}, err
+	}
+	if err := r.MapContext.validate(); err != nil {
+		return TurnRunResult{}, err
+	}
+	if r.TurnTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, r.TurnTimeout)
+		defer cancel()
+	}
+
+	accepted, err := r.Client.StartTurn(ctx, request)
+	if err != nil {
+		return TurnRunResult{}, err
+	}
+	if err := validateAcceptedTurn(request, *accepted); err != nil {
+		return TurnRunResult{}, err
+	}
+	result := TurnRunResult{Accepted: accepted}
+	// EventCursor is Orka's persisted task-event cursor. Harness frame cursors
+	// are turn-local, so a newly started turn must stream from frame 0.
+	var lastFrameSeq int64
+	err = r.Client.StreamFrames(ctx, request.TurnID, 0, func(frame HarnessEventFrame) error {
+		if err := validateFrameForTurn(request, frame); err != nil {
+			return err
+		}
+		if frame.Seq <= lastFrameSeq {
+			return fmt.Errorf("harness frame seq %d must be greater than previous seq %d", frame.Seq, lastFrameSeq)
+		}
+		lastFrameSeq = frame.Seq
+		mapped, err := MapFrameToExecutionEvent(frame, r.MapContext)
+		if err != nil {
+			return err
+		}
+		appended, err := r.EventStore.AppendExecutionEvent(ctx, mapped)
+		if err != nil {
+			return fmt.Errorf("append mapped harness event: %w", err)
+		}
+		result.Frames = append(result.Frames, frame)
+		result.Events = append(result.Events, *appended)
+		switch frame.Type {
+		case FrameTurnCompleted:
+			result.Completed = frame.Completed
+		case FrameTurnFailed:
+			result.Failed = frame.Failed
+		case FrameTurnCancelled:
+			result.Cancelled = true
+		}
+		return nil
+	})
+	if err != nil {
+		return result, err
+	}
+	if result.Failed != nil {
+		return result, fmt.Errorf("harness turn failed: %s", events.RedactExecutionEventText(result.Failed.Reason))
+	}
+	if result.Completed == nil && !result.Cancelled {
+		return result, fmt.Errorf("harness turn ended without terminal frame")
+	}
+	return result, nil
+}
+
+func validateAcceptedTurn(request StartTurnRequest, accepted StartTurnResponse) error {
+	if accepted.RuntimeSessionID != request.RuntimeSessionID {
+		return fmt.Errorf("harness accepted runtime session %q, want %q", accepted.RuntimeSessionID, request.RuntimeSessionID)
+	}
+	if accepted.TurnID != request.TurnID {
+		return fmt.Errorf("harness accepted turn %q, want %q", accepted.TurnID, request.TurnID)
+	}
+	if accepted.CorrelationID != "" && accepted.CorrelationID != request.CorrelationID {
+		return fmt.Errorf("harness accepted correlation id %q, want %q", accepted.CorrelationID, request.CorrelationID)
+	}
+	return nil
+}
+
+func validateFrameForTurn(request StartTurnRequest, frame HarnessEventFrame) error {
+	if frame.RuntimeSessionID != request.RuntimeSessionID {
+		return fmt.Errorf("harness frame runtime session %q, want %q", frame.RuntimeSessionID, request.RuntimeSessionID)
+	}
+	if frame.TurnID != request.TurnID {
+		return fmt.Errorf("harness frame turn %q, want %q", frame.TurnID, request.TurnID)
+	}
+	if frame.CorrelationID != request.CorrelationID {
+		return fmt.Errorf("harness frame correlation id %q, want %q", frame.CorrelationID, request.CorrelationID)
+	}
+	return nil
+}
+
+func (r TurnRunner) Cancel(ctx context.Context, request CancelTurnRequest) (*CancelTurnResponse, error) {
+	if r.Client == nil {
+		return nil, fmt.Errorf("harness client is required")
+	}
+	return r.Client.CancelTurn(ctx, request)
+}

--- a/internal/harness/runner_test.go
+++ b/internal/harness/runner_test.go
@@ -1,0 +1,312 @@
+package harness_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sozercan/orka/internal/events"
+	"github.com/sozercan/orka/internal/harness"
+	"github.com/sozercan/orka/internal/harness/harnesstest"
+	"github.com/sozercan/orka/internal/store"
+)
+
+func TestTurnRunnerAppendsMappedEventsForSuccessfulTurn(t *testing.T) {
+	runner, request, eventStore, cleanup := newRunner(t, harnesstest.BehaviorSuccess)
+	defer cleanup()
+	result, err := runner.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.Completed == nil || result.Failed != nil || result.Cancelled {
+		t.Fatalf("result = %#v, want completed", result)
+	}
+	listed, err := eventStore.ListExecutionEvents(context.Background(), store.ExecutionEventFilter{
+		Namespace:  "default",
+		StreamID:   "task-a",
+		EventTypes: []string{events.ExecutionEventTypeAgentRuntimeCompleted},
+	})
+	if err != nil {
+		t.Fatalf("ListExecutionEvents() error = %v", err)
+	}
+	if len(listed) != 1 || listed[0].Seq == 0 || listed[0].Type != events.ExecutionEventTypeAgentRuntimeCompleted {
+		t.Fatalf("listed = %#v, want one completed event", listed)
+	}
+}
+
+func TestTurnRunnerDoesNotSendTaskEventCursorAsHarnessFrameCursor(t *testing.T) {
+	runner, request, _, cleanup := newRunner(t, harnesstest.BehaviorSuccess)
+	defer cleanup()
+	request.EventCursor = 99
+	result, err := runner.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.Completed == nil || len(result.Frames) == 0 || result.Frames[0].Seq != 1 {
+		t.Fatalf("result = %#v, want complete turn streamed from frame 1", result)
+	}
+}
+
+func TestTurnRunnerRejectsMismatchedHarnessFrameIdentity(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == harness.TurnsPath:
+			harness.WriteJSON(w, http.StatusAccepted, harness.StartTurnResponse{
+				Version:          harness.ProtocolVersion,
+				Accepted:         true,
+				RuntimeSessionID: "runtime-a",
+				TurnID:           "turn-a",
+				CorrelationID:    "corr-a",
+			})
+		case r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "text/event-stream")
+			_ = harness.WriteSSEFrame(w, harness.HarnessEventFrame{
+				Version:          harness.ProtocolVersion,
+				Type:             harness.FrameTurnStarted,
+				RuntimeSessionID: "other-runtime",
+				TurnID:           "turn-a",
+				CorrelationID:    "corr-a",
+				Seq:              1,
+			})
+			_ = harness.WriteSSEDone(w)
+		default:
+			harness.WriteError(w, http.StatusNotFound, "not found")
+		}
+	}))
+	defer server.Close()
+	client, err := harness.NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	eventStore := store.NewFakeExecutionEventStore()
+	runner := harness.TurnRunner{Client: client, EventStore: eventStore, MapContext: harness.EventMapContext{Namespace: "default", TaskName: "task-a"}}
+	_, err = runner.Run(context.Background(), harness.StartTurnRequest{
+		Version:          harness.ProtocolVersion,
+		Namespace:        "default",
+		TaskName:         "task-a",
+		SessionName:      "session-a",
+		RuntimeSessionID: "runtime-a",
+		TurnID:           "turn-a",
+		CorrelationID:    "corr-a",
+		Deadline:         time.Now().UTC().Add(time.Minute),
+		AuthIdentity:     harness.AuthIdentity{Subject: "user:test"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "frame runtime session") {
+		t.Fatalf("Run() error = %v, want frame identity mismatch", err)
+	}
+	listed, listErr := eventStore.ListExecutionEvents(context.Background(), store.ExecutionEventFilter{Namespace: "default", StreamID: "task-a"})
+	if listErr != nil {
+		t.Fatalf("ListExecutionEvents() error = %v", listErr)
+	}
+	if len(listed) != 0 {
+		t.Fatalf("listed = %#v, want no appended mismatched frames", listed)
+	}
+}
+
+func TestTurnRunnerRejectsNonMonotonicHarnessFrameSeq(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == harness.TurnsPath:
+			harness.WriteJSON(w, http.StatusAccepted, harness.StartTurnResponse{
+				Version:          harness.ProtocolVersion,
+				Accepted:         true,
+				RuntimeSessionID: "runtime-a",
+				TurnID:           "turn-a",
+				CorrelationID:    "corr-a",
+			})
+		case r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "text/event-stream")
+			for _, seq := range []int64{1, 1} {
+				_ = harness.WriteSSEFrame(w, harness.HarnessEventFrame{
+					Version:          harness.ProtocolVersion,
+					Type:             harness.FrameRuntimeOutput,
+					RuntimeSessionID: "runtime-a",
+					TurnID:           "turn-a",
+					CorrelationID:    "corr-a",
+					Seq:              seq,
+				})
+			}
+			_ = harness.WriteSSEDone(w)
+		default:
+			harness.WriteError(w, http.StatusNotFound, "not found")
+		}
+	}))
+	defer server.Close()
+	client, err := harness.NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	runner := harness.TurnRunner{
+		Client:     client,
+		EventStore: store.NewFakeExecutionEventStore(),
+		MapContext: harness.EventMapContext{Namespace: "default", TaskName: "task-a"},
+	}
+	_, err = runner.Run(context.Background(), harness.StartTurnRequest{
+		Version:          harness.ProtocolVersion,
+		Namespace:        "default",
+		TaskName:         "task-a",
+		SessionName:      "session-a",
+		RuntimeSessionID: "runtime-a",
+		TurnID:           "turn-a",
+		CorrelationID:    "corr-a",
+		Deadline:         time.Now().UTC().Add(time.Minute),
+		AuthIdentity:     harness.AuthIdentity{Subject: "user:test"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "must be greater than previous") {
+		t.Fatalf("Run() error = %v, want non-monotonic seq error", err)
+	}
+}
+
+func TestTurnRunnerReturnsFailedTurnAfterAppendingFailureEvent(t *testing.T) {
+	runner, request, eventStore, cleanup := newRunner(t, harnesstest.BehaviorFailure)
+	defer cleanup()
+	result, err := runner.Run(context.Background(), request)
+	if err == nil || !strings.Contains(err.Error(), "harness turn failed") {
+		t.Fatalf("Run() error = %v, want failed turn", err)
+	}
+	if result.Failed == nil {
+		t.Fatalf("result = %#v, want failed payload", result)
+	}
+	listed, err := eventStore.ListExecutionEvents(context.Background(), store.ExecutionEventFilter{
+		Namespace: "default",
+		StreamID:  "task-a",
+	})
+	if err != nil {
+		t.Fatalf("ListExecutionEvents() error = %v", err)
+	}
+	last := listed[len(listed)-1]
+	if last.Type != events.ExecutionEventTypeAgentRuntimeFailed || last.Severity != events.ExecutionEventSeverityError {
+		t.Fatalf("last event = %#v, want runtime failed", last)
+	}
+}
+
+func TestTurnRunnerUnknownFrameAppendsDiagnostic(t *testing.T) {
+	runner, request, eventStore, cleanup := newRunner(t, harnesstest.BehaviorInvalidFrame)
+	defer cleanup()
+	_, err := runner.Run(context.Background(), request)
+	if err == nil || !strings.Contains(err.Error(), "without terminal frame") {
+		t.Fatalf("Run() error = %v, want incomplete turn error", err)
+	}
+	listed, err := eventStore.ListExecutionEvents(context.Background(), store.ExecutionEventFilter{
+		Namespace: "default",
+		StreamID:  "task-a",
+	})
+	if err != nil {
+		t.Fatalf("ListExecutionEvents() error = %v", err)
+	}
+	last := listed[len(listed)-1]
+	if last.Severity != events.ExecutionEventSeverityWarning || !strings.Contains(last.Summary, "unknown harness frame") {
+		t.Fatalf("last event = %#v, want warning diagnostic", last)
+	}
+}
+
+func TestTurnRunnerPropagatesAppendFailure(t *testing.T) {
+	runner, request, _, cleanup := newRunner(t, harnesstest.BehaviorSuccess)
+	defer cleanup()
+	runner.EventStore = &failingExecutionEventStore{failAfter: 1, delegate: store.NewFakeExecutionEventStore()}
+	_, err := runner.Run(context.Background(), request)
+	if err == nil || !strings.Contains(err.Error(), "append mapped harness event") {
+		t.Fatalf("Run() error = %v, want append failure", err)
+	}
+}
+
+func TestTurnRunnerTimeout(t *testing.T) {
+	runner, request, _, cleanup := newRunner(t, harnesstest.BehaviorDelayed)
+	defer cleanup()
+	runner.TurnTimeout = time.Millisecond
+	_, err := runner.Run(context.Background(), request)
+	if err == nil {
+		t.Fatal("Run() error = nil, want timeout")
+	}
+}
+
+func newRunner(
+	t *testing.T,
+	behavior harnesstest.FakeBehavior,
+) (harness.TurnRunner, harness.StartTurnRequest, *store.FakeExecutionEventStore, func()) {
+	t.Helper()
+	server := harnesstest.NewFakeHarnessServer(harnesstest.FakeHarnessConfig{Behavior: behavior})
+	client, err := harness.NewClient(server.URL())
+	if err != nil {
+		server.Close()
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	eventStore := store.NewFakeExecutionEventStore()
+	request := harness.StartTurnRequest{
+		Version:           harness.ProtocolVersion,
+		Namespace:         "default",
+		TaskName:          "task-a",
+		SessionName:       "session-a",
+		RuntimeSessionID:  "runtime-a",
+		TurnID:            harness.HarnessTurnID("turn-" + string(behavior)),
+		CorrelationID:     "corr-a",
+		Deadline:          time.Now().UTC().Add(time.Minute),
+		AuthIdentity:      harness.AuthIdentity{Subject: "user:test"},
+		Input:             harness.TurnInput{Prompt: "hello"},
+		ToolExecutionMode: harness.ToolExecutionModeObserved,
+	}
+	runner := harness.TurnRunner{
+		Client:     client,
+		EventStore: eventStore,
+		MapContext: harness.EventMapContext{
+			Namespace:   "default",
+			TaskName:    "task-a",
+			SessionName: "session-a",
+			AgentName:   "agent-a",
+		},
+	}
+	return runner, request, eventStore, server.Close
+}
+
+type failingExecutionEventStore struct {
+	failAfter int
+	count     int
+	delegate  store.ExecutionEventStore
+}
+
+func (s *failingExecutionEventStore) AppendExecutionEvent(
+	ctx context.Context,
+	event *store.ExecutionEvent,
+) (*store.ExecutionEvent, error) {
+	s.count++
+	if s.count > s.failAfter {
+		return nil, fmt.Errorf("injected append failure")
+	}
+	return s.delegate.AppendExecutionEvent(ctx, event)
+}
+
+func (s *failingExecutionEventStore) ListExecutionEvents(
+	ctx context.Context,
+	filter store.ExecutionEventFilter,
+) ([]store.ExecutionEvent, error) {
+	return s.delegate.ListExecutionEvents(ctx, filter)
+}
+
+func (s *failingExecutionEventStore) ListSessionExecutionEvents(
+	ctx context.Context,
+	filter store.SessionExecutionEventFilter,
+) ([]store.SessionExecutionEvent, int64, error) {
+	return s.delegate.ListSessionExecutionEvents(ctx, filter)
+}
+
+func (s *failingExecutionEventStore) GetLatestExecutionEventSeq(
+	ctx context.Context,
+	namespace string,
+	streamType string,
+	streamID string,
+) (int64, error) {
+	return s.delegate.GetLatestExecutionEventSeq(ctx, namespace, streamType, streamID)
+}
+
+func (s *failingExecutionEventStore) DeleteExecutionEvents(
+	ctx context.Context,
+	namespace string,
+	streamType string,
+	streamID string,
+) error {
+	return s.delegate.DeleteExecutionEvents(ctx, namespace, streamType, streamID)
+}

--- a/internal/harness/transport.go
+++ b/internal/harness/transport.go
@@ -1,0 +1,43 @@
+package harness
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const sseDone = "[DONE]"
+
+func WriteJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func WriteError(w http.ResponseWriter, status int, message string) {
+	WriteJSON(w, status, map[string]string{"error": message})
+}
+
+func WriteSSEFrame(w http.ResponseWriter, frame HarnessEventFrame) error {
+	payload, err := json.Marshal(frame)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", payload); err != nil {
+		return err
+	}
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+	return nil
+}
+
+func WriteSSEDone(w http.ResponseWriter) error {
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", sseDone); err != nil {
+		return err
+	}
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+	return nil
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -11,11 +11,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-const (
-	unknownMetricLabel = "unknown"
-	invalidMetricLabel = "invalid"
-)
-
 var (
 	// API metrics
 	APIRequestsTotal = prometheus.NewCounterVec(
@@ -239,8 +234,8 @@ func RecordContextTokenTTSExchange(result, reason string, durationSeconds float6
 
 // RecordExecutionEventAppend records append success/failure and latency using low-cardinality labels.
 func RecordExecutionEventAppend(streamType, eventType string, success bool, durationSeconds float64) {
-	streamType = normalizeExecutionEventStreamMetricLabel(streamType)
-	eventType = normalizeExecutionEventTypeMetricLabel(eventType)
+	streamType = normalizeMetricLabel(streamType)
+	eventType = normalizeMetricLabel(eventType)
 	result := "success"
 	if success {
 		ExecutionEventsAppendedTotal.WithLabelValues(streamType, eventType).Inc()
@@ -279,8 +274,8 @@ func RecordExecutionEventStreamError(scope, reason string) {
 
 // RecordExecutionEventPayloadSanitization records event-level redaction/truncation signals.
 func RecordExecutionEventPayloadSanitization(streamType, eventType string, redacted, truncated bool) {
-	streamType = normalizeExecutionEventStreamMetricLabel(streamType)
-	eventType = normalizeExecutionEventTypeMetricLabel(eventType)
+	streamType = normalizeMetricLabel(streamType)
+	eventType = normalizeMetricLabel(eventType)
 	if redacted {
 		ExecutionEventRedactionsTotal.WithLabelValues(streamType, eventType).Inc()
 	}
@@ -296,76 +291,12 @@ func RecordExecutionEventDerivedLatency(measurement, result string, durationSeco
 
 // RecordExecutionEventDerivedFailure records one event-derived failure category.
 func RecordExecutionEventDerivedFailure(category, eventType string) {
-	ExecutionEventDerivedFailuresTotal.WithLabelValues(normalizeMetricLabel(category), normalizeExecutionEventTypeMetricLabel(eventType)).Inc()
-}
-
-func normalizeExecutionEventStreamMetricLabel(value string) string {
-	value = normalizeMetricLabel(value)
-	switch value {
-	case "task", "session", unknownMetricLabel:
-		return value
-	default:
-		return invalidMetricLabel
-	}
-}
-
-func normalizeExecutionEventTypeMetricLabel(value string) string {
-	value = normalizeMetricLabel(value)
-	if value == unknownMetricLabel {
-		return value
-	}
-	if !isKnownExecutionEventTypeMetricLabel(value) {
-		return invalidMetricLabel
-	}
-	return value
-}
-
-func isKnownExecutionEventTypeMetricLabel(value string) bool {
-	switch value {
-	case "TaskCreated",
-		"TaskPhaseChanged",
-		"TaskJobCreated",
-		"TaskStarted",
-		"TaskSucceeded",
-		"TaskFailed",
-		"TaskCancelled",
-		"WorkerStarted",
-		"WorkerCompleted",
-		"WorkerFailed",
-		"ModelRequestStarted",
-		"ModelRequestCompleted",
-		"ModelRequestFailed",
-		"ModelMessage",
-		"ContextTruncated",
-		"ToolCallStarted",
-		"ToolCallCompleted",
-		"ToolCallFailed",
-		"WorkspacePreparationStarted",
-		"WorkspacePreparationCompleted",
-		"WorkspacePreparationFailed",
-		"AgentRuntimeStarted",
-		"AgentRuntimeCommandStarted",
-		"AgentRuntimeCompleted",
-		"AgentRuntimeFailed",
-		"ResultSubmitted",
-		"ArtifactUploadCompleted",
-		"ArtifactUploadFailed",
-		"TaskForkRequested",
-		"TaskForkCreated",
-		"ApprovalRequested",
-		"ApprovalApproved",
-		"ApprovalDeclined",
-		"ApprovalExpired",
-		"ApprovalCancelled":
-		return true
-	default:
-		return false
-	}
+	ExecutionEventDerivedFailuresTotal.WithLabelValues(normalizeMetricLabel(category), normalizeMetricLabel(eventType)).Inc()
 }
 
 func normalizeMetricLabel(value string) string {
 	if value == "" {
-		return unknownMetricLabel
+		return "unknown"
 	}
 	return value
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -155,36 +155,6 @@ func getGaugeValue(gauge *prometheus.GaugeVec, labels ...string) float64 {
 	return m.GetGauge().GetValue()
 }
 
-func TestExecutionEventMetricsNormalizeInvalidLabels(t *testing.T) {
-	ExecutionEventsAppendedTotal.Reset()
-	ExecutionEventAppendFailuresTotal.Reset()
-	ExecutionEventAppendDuration.Reset()
-	ExecutionEventRedactionsTotal.Reset()
-	ExecutionEventTruncationsTotal.Reset()
-	ExecutionEventDerivedFailuresTotal.Reset()
-
-	RecordExecutionEventAppend("m/e2", "WorkspacePreparationStarted", true, 0.01)
-	RecordExecutionEventAppend("task", "unexpected/event", false, 0.02)
-	RecordExecutionEventPayloadSanitization("custom/task", "not-real", true, true)
-	RecordExecutionEventDerivedFailure("tool_call", "not-real")
-
-	if got := getCounterValue(ExecutionEventsAppendedTotal, "invalid", "WorkspacePreparationStarted"); got != 1 {
-		t.Fatalf("appended invalid stream=%v, want 1", got)
-	}
-	if got := getCounterValue(ExecutionEventAppendFailuresTotal, "task", "invalid"); got != 1 {
-		t.Fatalf("append failures invalid event=%v, want 1", got)
-	}
-	if got := getCounterValue(ExecutionEventRedactionsTotal, "invalid", "invalid"); got != 1 {
-		t.Fatalf("redactions invalid labels=%v, want 1", got)
-	}
-	if got := getCounterValue(ExecutionEventTruncationsTotal, "invalid", "invalid"); got != 1 {
-		t.Fatalf("truncations invalid labels=%v, want 1", got)
-	}
-	if got := getCounterValue(ExecutionEventDerivedFailuresTotal, "tool_call", "invalid"); got != 1 {
-		t.Fatalf("derived failures invalid event=%v, want 1", got)
-	}
-}
-
 func TestRecordExecutionEventMetrics(t *testing.T) {
 	ExecutionEventsAppendedTotal.Reset()
 	ExecutionEventAppendFailuresTotal.Reset()

--- a/internal/store/execution_event.go
+++ b/internal/store/execution_event.go
@@ -16,7 +16,6 @@ import (
 
 const (
 	unknownMetricLabel = "unknown"
-	invalidMetricLabel = "invalid"
 
 	ExecutionEventStreamTypeTask    = events.ExecutionEventStreamTypeTask
 	ExecutionEventStreamTypeSession = events.ExecutionEventStreamTypeSession
@@ -33,7 +32,6 @@ type ExecutionEvent struct {
 	StreamType  string                           `json:"streamType"`
 	StreamID    string                           `json:"streamID"`
 	Seq         int64                            `json:"seq"`
-	SessionSeq  int64                            `json:"-"`
 	Type        string                           `json:"type"`
 	Severity    string                           `json:"severity"`
 	TaskName    string                           `json:"taskName,omitempty"`
@@ -165,34 +163,37 @@ func (f SessionExecutionEventFilter) Validate() error {
 	return nil
 }
 
-// ApprovalDecisionID returns the approval identity guarded by terminal approval events.
-func ApprovalDecisionID(event ExecutionEvent) (string, bool) {
-	switch event.Type {
+func IsTerminalApprovalExecutionEventType(value string) bool {
+	switch value {
 	case events.ExecutionEventTypeApprovalApproved,
 		events.ExecutionEventTypeApprovalDeclined,
 		events.ExecutionEventTypeApprovalExpired,
 		events.ExecutionEventTypeApprovalCancelled:
+		return true
 	default:
-		return "", false
+		return false
 	}
-	var payload struct {
-		ID         string `json:"id"`
-		ApprovalID string `json:"approvalID"`
-	}
-	if len(event.Content) > 0 {
-		_ = json.Unmarshal(event.Content, &payload)
-	}
-	id := firstNonEmptyString(payload.ApprovalID, payload.ID, event.ToolCallID)
-	return id, id != ""
 }
 
-func firstNonEmptyString(values ...string) string {
-	for _, value := range values {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
+func ApprovalIDFromExecutionEvent(event ExecutionEvent) string {
+	toolCallID := strings.TrimSpace(event.ToolCallID)
+	if len(event.Content) == 0 {
+		return toolCallID
+	}
+	var content map[string]any
+	if err := json.Unmarshal(event.Content, &content); err != nil {
+		return toolCallID
+	}
+	for _, key := range []string{"approvalID", "approvalId", "approval_id", "id"} {
+		if value, ok := content[key].(string); ok && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
 		}
 	}
-	return ""
+	return toolCallID
+}
+
+func TerminalApprovalConflict(existingType, approvalID string) error {
+	return fmt.Errorf("%w: approval %q already has terminal event %s", ErrConflict, approvalID, existingType)
 }
 
 // ExecutionEventStore defines the persistence/query contract for execution events.
@@ -255,7 +256,7 @@ type executionEventStreamKey struct {
 	streamID   string
 }
 
-type executionEventSessionKey struct {
+type sessionExecutionEventKey struct {
 	namespace   string
 	sessionName string
 }
@@ -266,7 +267,7 @@ type FakeExecutionEventStore struct {
 	now           func() time.Time
 	events        []ExecutionEvent
 	latest        map[executionEventStreamKey]int64
-	sessionLatest map[executionEventSessionKey]int64
+	latestSession map[sessionExecutionEventKey]int64
 }
 
 var _ ExecutionEventStore = (*FakeExecutionEventStore)(nil)
@@ -284,7 +285,7 @@ func NewFakeExecutionEventStoreWithClock(now func() time.Time) *FakeExecutionEve
 	return &FakeExecutionEventStore{
 		now:           now,
 		latest:        make(map[executionEventStreamKey]int64),
-		sessionLatest: make(map[executionEventSessionKey]int64),
+		latestSession: make(map[sessionExecutionEventKey]int64),
 	}
 }
 
@@ -302,86 +303,71 @@ func (s *FakeExecutionEventStore) AppendExecutionEvent(ctx context.Context, even
 	if event == nil {
 		return nil, ValidationErrorf("execution event is required")
 	}
-	eventCopy := cloneExecutionEvent(*event)
-	eventCopy.Namespace = strings.TrimSpace(eventCopy.Namespace)
-	eventCopy.StreamType = strings.TrimSpace(eventCopy.StreamType)
-	if eventCopy.StreamType == "" {
-		eventCopy.StreamType = ExecutionEventStreamTypeTask
+	copy := cloneExecutionEvent(*event)
+	copy.Namespace = strings.TrimSpace(copy.Namespace)
+	copy.StreamType = strings.TrimSpace(copy.StreamType)
+	if copy.StreamType == "" {
+		copy.StreamType = ExecutionEventStreamTypeTask
 	}
-	eventCopy.StreamID = strings.TrimSpace(eventCopy.StreamID)
-	eventCopy.Type = strings.TrimSpace(eventCopy.Type)
-	eventCopy.Severity = events.NormalizeExecutionEventSeverity(eventCopy.Severity)
-	eventCopy.TaskName = strings.TrimSpace(eventCopy.TaskName)
-	eventCopy.SessionName = strings.TrimSpace(eventCopy.SessionName)
-	eventCopy.AgentName = strings.TrimSpace(eventCopy.AgentName)
-	eventCopy.ToolName = strings.TrimSpace(eventCopy.ToolName)
-	eventCopy.ToolCallID = strings.TrimSpace(eventCopy.ToolCallID)
+	copy.StreamID = strings.TrimSpace(copy.StreamID)
+	copy.Type = strings.TrimSpace(copy.Type)
+	copy.Severity = events.NormalizeExecutionEventSeverity(copy.Severity)
+	copy.TaskName = strings.TrimSpace(copy.TaskName)
+	copy.SessionName = strings.TrimSpace(copy.SessionName)
+	copy.AgentName = strings.TrimSpace(copy.AgentName)
+	copy.ToolName = strings.TrimSpace(copy.ToolName)
+	copy.ToolCallID = strings.TrimSpace(copy.ToolCallID)
 
-	if eventCopy.Namespace == "" {
+	if copy.Namespace == "" {
 		return nil, ValidationErrorf("execution event namespace is required")
 	}
-	if !events.IsValidExecutionEventStreamType(eventCopy.StreamType) {
-		return nil, ValidationErrorf("unsupported execution event stream type %q", eventCopy.StreamType)
+	if !events.IsValidExecutionEventStreamType(copy.StreamType) {
+		return nil, ValidationErrorf("unsupported execution event stream type %q", copy.StreamType)
 	}
-	if eventCopy.StreamID == "" {
+	if copy.StreamID == "" {
 		return nil, ValidationErrorf("execution event stream id is required")
 	}
-	if !events.IsValidExecutionEventType(eventCopy.Type) {
-		return nil, ValidationErrorf("unsupported execution event type %q", eventCopy.Type)
+	if !events.IsValidExecutionEventType(copy.Type) {
+		return nil, ValidationErrorf("unsupported execution event type %q", copy.Type)
 	}
-	if err := SanitizeExecutionEventPayloadFields(&eventCopy); err != nil {
+	if err := SanitizeExecutionEventPayloadFields(&copy); err != nil {
 		return nil, ValidationErrorf("invalid execution event payload: %v", err)
 	}
-	if eventCopy.CreatedAt.IsZero() {
-		eventCopy.CreatedAt = s.now().UTC()
+	if copy.CreatedAt.IsZero() {
+		copy.CreatedAt = s.now().UTC()
 	}
 
-	key := executionEventStreamKey{namespace: eventCopy.Namespace, streamType: eventCopy.StreamType, streamID: eventCopy.StreamID}
+	key := executionEventStreamKey{namespace: copy.Namespace, streamType: copy.StreamType, streamID: copy.StreamID}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	latest := s.latest[key]
-	if eventCopy.Seq == 0 {
-		eventCopy.Seq = latest + 1
-	} else if eventCopy.Seq <= latest {
-		return nil, ValidationErrorf("execution event seq must increase for stream %s/%s/%s", eventCopy.Namespace, eventCopy.StreamType, eventCopy.StreamID)
+	if existingType, approvalID, conflict := s.existingTerminalApprovalEvent(copy); conflict {
+		return nil, TerminalApprovalConflict(existingType, approvalID)
 	}
-	eventCopy.ID = strings.TrimSpace(eventCopy.ID)
-	if eventCopy.ID == "" {
-		eventCopy.ID = fmt.Sprintf("%s/%s/%s/%d", eventCopy.Namespace, eventCopy.StreamType, eventCopy.StreamID, eventCopy.Seq)
-	}
-	if err := s.ensureNoApprovalDecisionLocked(eventCopy); err != nil {
-		return nil, err
-	}
-	s.latest[key] = eventCopy.Seq
-	if eventCopy.SessionName != "" {
-		sessionKey := executionEventSessionKey{namespace: eventCopy.Namespace, sessionName: eventCopy.SessionName}
-		eventCopy.SessionSeq = s.sessionLatest[sessionKey] + 1
-		s.sessionLatest[sessionKey] = eventCopy.SessionSeq
-	}
-	s.events = append(s.events, cloneExecutionEvent(eventCopy))
-	success = true
-	return &eventCopy, nil
-}
 
-func (s *FakeExecutionEventStore) ensureNoApprovalDecisionLocked(event ExecutionEvent) error {
-	approvalID, ok := ApprovalDecisionID(event)
-	if !ok {
-		return nil
+	latest := s.latest[key]
+	if copy.Seq == 0 {
+		copy.Seq = latest + 1
+	} else if copy.Seq <= latest {
+		return nil, ValidationErrorf("execution event seq must increase for stream %s/%s/%s", copy.Namespace, copy.StreamType, copy.StreamID)
 	}
-	for _, existing := range s.events {
-		if existing.Namespace != event.Namespace ||
-			existing.StreamType != event.StreamType ||
-			existing.StreamID != event.StreamID {
-			continue
-		}
-		existingApprovalID, ok := ApprovalDecisionID(existing)
-		if ok && existingApprovalID == approvalID {
-			return fmt.Errorf("%w: approval %s already has a terminal decision", ErrConflict, approvalID)
-		}
+	copy.ID = strings.TrimSpace(copy.ID)
+	if copy.ID == "" {
+		copy.ID = fmt.Sprintf("%s/%s/%s/%d", copy.Namespace, copy.StreamType, copy.StreamID, copy.Seq)
 	}
-	return nil
+	s.latest[key] = copy.Seq
+	if copy.SessionName != "" {
+		sessionKey := sessionExecutionEventKey{namespace: copy.Namespace, sessionName: copy.SessionName}
+		s.latestSession[sessionKey]++
+		if copy.Internal == nil {
+			copy.Internal = map[string]any{}
+		}
+		copy.Internal["sessionSeq"] = s.latestSession[sessionKey]
+	}
+	s.events = append(s.events, cloneExecutionEvent(copy))
+	success = true
+	return &copy, nil
 }
 
 // ListExecutionEvents returns events matching filter in ascending sequence order per stream.
@@ -474,21 +460,15 @@ func (s *FakeExecutionEventStore) ListSessionExecutionEvents(ctx context.Context
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	ordered := make([]ExecutionEvent, 0, len(s.events))
+	sessionKey := sessionExecutionEventKey{namespace: filter.Namespace, sessionName: filter.SessionName}
+	latestSeq := s.latestSession[sessionKey]
+	matches := make([]SessionExecutionEvent, 0, min(len(s.events), filter.Limit))
 	for _, event := range s.events {
 		if event.Namespace != filter.Namespace || event.SessionName != filter.SessionName {
 			continue
 		}
-		ordered = append(ordered, cloneExecutionEvent(event))
-	}
-
-	var latestSeq int64
-	if filter.SessionName != "" {
-		latestSeq = s.sessionLatest[executionEventSessionKey{namespace: filter.Namespace, sessionName: filter.SessionName}]
-	}
-	matches := make([]SessionExecutionEvent, 0, min(len(ordered), filter.Limit))
-	for _, event := range ordered {
-		sessionSeq := event.SessionSeq
+		event = cloneExecutionEvent(event)
+		sessionSeq := fakeExecutionEventSessionSeq(event)
 		if sessionSeq <= filter.AfterSeq {
 			continue
 		}
@@ -539,7 +519,7 @@ func (s *FakeExecutionEventStore) DeleteExecutionEvents(ctx context.Context, nam
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	kept := make([]ExecutionEvent, 0, len(s.events))
+	kept := s.events[:0]
 	for _, event := range s.events {
 		if event.Namespace == filter.Namespace && event.StreamType == filter.StreamType && event.StreamID == filter.StreamID {
 			continue
@@ -551,6 +531,28 @@ func (s *FakeExecutionEventStore) DeleteExecutionEvents(ctx context.Context, nam
 	return nil
 }
 
+func (s *FakeExecutionEventStore) existingTerminalApprovalEvent(event ExecutionEvent) (existingType, approvalID string, conflict bool) {
+	if !IsTerminalApprovalExecutionEventType(event.Type) {
+		return "", "", false
+	}
+	approvalID = ApprovalIDFromExecutionEvent(event)
+	if approvalID == "" {
+		return "", "", false
+	}
+	for _, existing := range s.events {
+		if existing.Namespace != event.Namespace ||
+			existing.StreamType != event.StreamType ||
+			existing.StreamID != event.StreamID ||
+			!IsTerminalApprovalExecutionEventType(existing.Type) {
+			continue
+		}
+		if ApprovalIDFromExecutionEvent(existing) == approvalID {
+			return existing.Type, approvalID, true
+		}
+	}
+	return "", approvalID, false
+}
+
 func metricLabelsForExecutionEvent(event *ExecutionEvent) (string, string) {
 	if event == nil {
 		return unknownMetricLabel, unknownMetricLabel
@@ -560,13 +562,11 @@ func metricLabelsForExecutionEvent(event *ExecutionEvent) (string, string) {
 		streamType = ExecutionEventStreamTypeTask
 	}
 	if !events.IsValidExecutionEventStreamType(streamType) {
-		streamType = invalidMetricLabel
+		streamType = unknownMetricLabel
 	}
 	eventType := strings.TrimSpace(event.Type)
-	if eventType == "" {
+	if !events.IsValidExecutionEventType(eventType) {
 		eventType = unknownMetricLabel
-	} else if !events.IsValidExecutionEventType(eventType) {
-		eventType = invalidMetricLabel
 	}
 	return streamType, eventType
 }
@@ -578,6 +578,22 @@ func executionEventPayloadContainsRedactionMarker(event *ExecutionEvent) bool {
 	return strings.Contains(event.Summary, events.ExecutionEventRedactedValue) ||
 		strings.Contains(event.ContentText, events.ExecutionEventRedactedValue) ||
 		strings.Contains(string(event.Content), events.ExecutionEventRedactedValue)
+}
+
+func fakeExecutionEventSessionSeq(event ExecutionEvent) int64 {
+	if event.Internal == nil {
+		return 0
+	}
+	switch value := event.Internal["sessionSeq"].(type) {
+	case int64:
+		return value
+	case int:
+		return int64(value)
+	case float64:
+		return int64(value)
+	default:
+		return 0
+	}
 }
 
 func cloneExecutionEvent(event ExecutionEvent) ExecutionEvent {

--- a/internal/store/execution_event_test.go
+++ b/internal/store/execution_event_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -119,71 +118,6 @@ func TestExecutionEventStoreFakeAppendsMonotonicSeqPerStream(t *testing.T) {
 	}
 }
 
-func TestExecutionEventStoreFakeSanitizesPayload(t *testing.T) {
-	ctx := context.Background()
-	store := NewFakeExecutionEventStore()
-	secretValue := strings.Join([]string{"bearer", "value", "for", "redaction"}, "-")
-	event, err := store.AppendExecutionEvent(ctx, &ExecutionEvent{
-		Namespace:   "default",
-		StreamID:    "task",
-		Type:        events.ExecutionEventTypeModelMessage,
-		Summary:     "Authorization: Bearer " + secretValue,
-		ContentText: strings.Repeat("x", events.MaxExecutionEventContentTextChars+10),
-	})
-	if err != nil {
-		t.Fatalf("AppendExecutionEvent() error = %v", err)
-	}
-	if strings.Contains(event.Summary, secretValue) {
-		t.Fatalf("AppendExecutionEvent leaked summary secret: %#v", event)
-	}
-	if event.Truncation == nil || !event.Truncation.ContentTextTruncated {
-		t.Fatalf("Truncation = %#v, want contentText truncated", event.Truncation)
-	}
-
-	listed, err := store.ListExecutionEvents(ctx, ExecutionEventFilter{Namespace: "default", StreamID: "task"})
-	if err != nil {
-		t.Fatalf("ListExecutionEvents() error = %v", err)
-	}
-	if len(listed) != 1 || strings.Contains(listed[0].Summary, secretValue) {
-		t.Fatalf("listed sanitized events = %#v", listed)
-	}
-}
-
-func TestExecutionEventStoreFakePreservesExistingTruncationMetadata(t *testing.T) {
-	ctx := context.Background()
-	store := NewFakeExecutionEventStore()
-	stored, err := store.AppendExecutionEvent(ctx, &ExecutionEvent{
-		Namespace:  "default",
-		StreamID:   "task",
-		Type:       events.ExecutionEventTypeModelMessage,
-		Content:    json.RawMessage(`{"truncated":true,"preview":"[truncated oversized JSON content]"}`),
-		Truncation: &events.ExecutionEventTruncation{ContentJSONTruncated: true},
-	})
-	if err != nil {
-		t.Fatalf("AppendExecutionEvent() error = %v", err)
-	}
-	if stored.Truncation == nil || !stored.Truncation.ContentJSONTruncated {
-		t.Fatalf("stored truncation = %#v, want existing content JSON truncation preserved", stored.Truncation)
-	}
-}
-
-func TestExecutionEventStoreFakeRejectsInvalidJSONPayload(t *testing.T) {
-	ctx := context.Background()
-	store := NewFakeExecutionEventStore()
-	_, err := store.AppendExecutionEvent(ctx, &ExecutionEvent{
-		Namespace: "default",
-		StreamID:  "task",
-		Type:      events.ExecutionEventTypeModelMessage,
-		Content:   json.RawMessage(`{"unterminated"`),
-	})
-	if err == nil {
-		t.Fatalf("AppendExecutionEvent() accepted invalid JSON content")
-	}
-	if !errors.Is(err, ErrValidation) {
-		t.Fatalf("AppendExecutionEvent() error = %v, want ErrValidation", err)
-	}
-}
-
 func TestExecutionEventStoreFakeAggregatesSessionEvents(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC)
@@ -252,30 +186,83 @@ func TestExecutionEventStoreFakeSessionTypeFilterPreservesCursor(t *testing.T) {
 	}
 }
 
-func TestExecutionEventStoreFakeRejectsDuplicateApprovalDecision(t *testing.T) {
+func TestExecutionEventStoreFakeSessionCursorSurvivesTaskDeletion(t *testing.T) {
 	ctx := context.Background()
 	store := NewFakeExecutionEventStore()
-	approved := jsonRawMessageForTest(t, map[string]string{"approvalID": "approval-1"})
-	declined := jsonRawMessageForTest(t, map[string]string{"approvalID": "approval-1"})
-	if _, err := store.AppendExecutionEvent(ctx, &ExecutionEvent{
-		Namespace:  "default",
-		StreamType: ExecutionEventStreamTypeTask,
-		StreamID:   "task-1",
-		TaskName:   "task-1",
-		Type:       events.ExecutionEventTypeApprovalApproved,
-		Content:    approved,
-	}); err != nil {
-		t.Fatalf("AppendExecutionEvent approved: %v", err)
+	for _, item := range []struct {
+		task string
+		typ  string
+	}{
+		{"task-a", events.ExecutionEventTypeTaskStarted},
+		{"task-b", events.ExecutionEventTypeWorkerStarted},
+	} {
+		if _, err := store.AppendExecutionEvent(ctx, &ExecutionEvent{
+			Namespace:   "default",
+			StreamType:  ExecutionEventStreamTypeTask,
+			StreamID:    item.task,
+			TaskName:    item.task,
+			SessionName: "session-1",
+			Type:        item.typ,
+		}); err != nil {
+			t.Fatalf("AppendExecutionEvent: %v", err)
+		}
+	}
+	if err := store.DeleteExecutionEvents(ctx, "default", ExecutionEventStreamTypeTask, "task-a"); err != nil {
+		t.Fatalf("DeleteExecutionEvents: %v", err)
 	}
 	if _, err := store.AppendExecutionEvent(ctx, &ExecutionEvent{
-		Namespace:  "default",
-		StreamType: ExecutionEventStreamTypeTask,
-		StreamID:   "task-1",
-		TaskName:   "task-1",
-		Type:       events.ExecutionEventTypeApprovalDeclined,
-		Content:    declined,
-	}); !errors.Is(err, ErrConflict) {
-		t.Fatalf("AppendExecutionEvent duplicate decision error = %v, want ErrConflict", err)
+		Namespace:   "default",
+		StreamType:  ExecutionEventStreamTypeTask,
+		StreamID:    "task-c",
+		TaskName:    "task-c",
+		SessionName: "session-1",
+		Type:        events.ExecutionEventTypeTaskSucceeded,
+	}); err != nil {
+		t.Fatalf("AppendExecutionEvent: %v", err)
+	}
+
+	listed, latest, err := store.ListSessionExecutionEvents(ctx, SessionExecutionEventFilter{
+		Namespace: "default", SessionName: "session-1", AfterSeq: 2,
+	})
+	if err != nil {
+		t.Fatalf("ListSessionExecutionEvents: %v", err)
+	}
+	if latest != 3 || len(listed) != 1 || listed[0].SessionSeq != 3 || listed[0].TaskName != "task-c" {
+		t.Fatalf("latest=%d listed=%#v, want stable cursor 3 for task-c", latest, listed)
+	}
+}
+
+func TestExecutionEventStoreFakeRejectsDuplicateTerminalApproval(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		content    json.RawMessage
+		toolCallID string
+	}{
+		{name: "approvalID", content: json.RawMessage(`{"approvalID":"approval-1"}`)},
+		{name: "id", content: json.RawMessage(`{"id":"approval-1"}`)},
+		{name: "toolCallID", content: json.RawMessage(`{}`), toolCallID: "approval-1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := NewFakeExecutionEventStore()
+			approved := ExecutionEvent{
+				Namespace:  "default",
+				StreamType: ExecutionEventStreamTypeTask,
+				StreamID:   "task",
+				TaskName:   "task",
+				Type:       events.ExecutionEventTypeApprovalApproved,
+				ToolCallID: tc.toolCallID,
+				Content:    tc.content,
+			}
+			if _, err := store.AppendExecutionEvent(ctx, &approved); err != nil {
+				t.Fatalf("AppendExecutionEvent(approved) error = %v", err)
+			}
+			declined := approved
+			declined.Type = events.ExecutionEventTypeApprovalDeclined
+			if _, err := store.AppendExecutionEvent(ctx, &declined); !errors.Is(err, ErrConflict) {
+				t.Fatalf("AppendExecutionEvent(declined) error = %v, want ErrConflict", err)
+			}
+		})
 	}
 }
 
@@ -300,13 +287,4 @@ func TestExecutionEventStoreFakeValidationAndDelete(t *testing.T) {
 	if latest != 0 {
 		t.Fatalf("latest after delete = %d, want 0", latest)
 	}
-}
-
-func jsonRawMessageForTest(t *testing.T, value any) json.RawMessage {
-	t.Helper()
-	data, err := json.Marshal(value)
-	if err != nil {
-		t.Fatalf("marshal JSON: %v", err)
-	}
-	return json.RawMessage(data)
 }

--- a/internal/store/sqlite/execution_event_store.go
+++ b/internal/store/sqlite/execution_event_store.go
@@ -13,10 +13,7 @@ import (
 	"github.com/sozercan/orka/internal/store"
 )
 
-const (
-	sqliteUnknownMetricLabel = "unknown"
-	sqliteInvalidMetricLabel = "invalid"
-)
+const sqliteUnknownMetricLabel = "unknown"
 
 var _ store.ExecutionEventStore = (*Store)(nil)
 
@@ -106,10 +103,6 @@ func (s *Store) appendExecutionEventOnce(ctx context.Context, event store.Execut
 		}
 	}()
 
-	if err := ensureNoApprovalDecision(ctx, conn, event); err != nil {
-		return nil, err
-	}
-
 	var latestSeq int64
 	if err := conn.QueryRowContext(ctx,
 		`SELECT COALESCE(MAX(seq), 0)
@@ -120,42 +113,25 @@ func (s *Store) appendExecutionEventOnce(ctx context.Context, event store.Execut
 		return nil, err
 	}
 	event.Seq = latestSeq + 1
-	if event.SessionName != "" {
-		var latestSessionSeq int64
-		seqErr := conn.QueryRowContext(ctx,
-			`SELECT latest_seq
-			 FROM execution_event_session_sequences
-			 WHERE namespace = ? AND session_name = ?`,
-			event.Namespace, event.SessionName,
-		).Scan(&latestSessionSeq)
-		if seqErr != nil && seqErr != sql.ErrNoRows {
-			return nil, seqErr
-		}
-		event.SessionSeq = latestSessionSeq + 1
-		if seqErr == sql.ErrNoRows {
-			if _, err := conn.ExecContext(ctx,
-				`INSERT INTO execution_event_session_sequences(namespace, session_name, latest_seq) VALUES (?, ?, ?)`,
-				event.Namespace, event.SessionName, event.SessionSeq,
-			); err != nil {
-				return nil, err
-			}
-		} else if _, err := conn.ExecContext(ctx,
-			`UPDATE execution_event_session_sequences
-			 SET latest_seq = ?
-			 WHERE namespace = ? AND session_name = ?`,
-			event.SessionSeq, event.Namespace, event.SessionName,
-		); err != nil {
-			return nil, err
-		}
-	}
 	event.ID = executionEventID(event.Namespace, event.StreamType, event.StreamID, event.Seq)
+
+	if existingType, approvalID, conflict, err := existingSQLiteTerminalApprovalEvent(ctx, conn, event); err != nil {
+		return nil, err
+	} else if conflict {
+		return nil, store.TerminalApprovalConflict(existingType, approvalID)
+	}
+
+	sessionSeq, err := nextSQLiteSessionExecutionEventSeq(ctx, conn, event.Namespace, event.SessionName)
+	if err != nil {
+		return nil, err
+	}
 
 	if _, err := conn.ExecContext(ctx,
 		`INSERT INTO execution_events
 		 (id, namespace, stream_type, stream_id, seq, session_seq, type, severity, task_name, session_name,
 		  agent_name, tool_name, tool_call_id, summary, content_json, content_text, truncation_json, created_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		event.ID, event.Namespace, event.StreamType, event.StreamID, event.Seq, event.SessionSeq, event.Type, event.Severity,
+		event.ID, event.Namespace, event.StreamType, event.StreamID, event.Seq, sessionSeq, event.Type, event.Severity,
 		event.TaskName, event.SessionName, event.AgentName, event.ToolName, event.ToolCallID,
 		event.Summary, contentJSON, event.ContentText, truncationJSON, event.CreatedAt,
 	); err != nil {
@@ -168,49 +144,121 @@ func (s *Store) appendExecutionEventOnce(ctx context.Context, event store.Execut
 	return &event, nil
 }
 
-type executionEventQueryer interface {
-	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
-}
-
-func ensureNoApprovalDecision(ctx context.Context, q executionEventQueryer, event store.ExecutionEvent) error {
-	approvalID, ok := store.ApprovalDecisionID(event)
-	if !ok {
-		return nil
+func existingSQLiteTerminalApprovalEvent(
+	ctx context.Context,
+	conn *sql.Conn,
+	event store.ExecutionEvent,
+) (existingType, approvalID string, conflict bool, err error) {
+	if !store.IsTerminalApprovalExecutionEventType(event.Type) {
+		return "", "", false, nil
 	}
-	rows, err := q.QueryContext(ctx, `SELECT type, tool_call_id, content_json
-		FROM execution_events
-		WHERE namespace = ? AND stream_type = ? AND stream_id = ?
-		  AND type IN (?, ?, ?, ?)`,
-		event.Namespace,
-		event.StreamType,
-		event.StreamID,
+	approvalID = store.ApprovalIDFromExecutionEvent(event)
+	if approvalID == "" {
+		return "", "", false, nil
+	}
+	rows, err := conn.QueryContext(ctx,
+		`SELECT type, tool_call_id, content_json
+		 FROM execution_events
+		 WHERE namespace = ? AND stream_type = ? AND stream_id = ?
+		   AND type IN (?, ?, ?, ?)`,
+		event.Namespace, event.StreamType, event.StreamID,
 		events.ExecutionEventTypeApprovalApproved,
 		events.ExecutionEventTypeApprovalDeclined,
 		events.ExecutionEventTypeApprovalExpired,
 		events.ExecutionEventTypeApprovalCancelled,
 	)
 	if err != nil {
-		return err
+		return "", "", false, err
 	}
 	defer rows.Close() //nolint:errcheck
 	for rows.Next() {
-		var existing store.ExecutionEvent
-		var contentJSON sql.NullString
-		if err := rows.Scan(&existing.Type, &existing.ToolCallID, &contentJSON); err != nil {
-			return err
+		var typ string
+		var toolCallID string
+		var content sql.NullString
+		if err := rows.Scan(&typ, &toolCallID, &content); err != nil {
+			return "", "", false, err
 		}
-		if contentJSON.Valid && strings.TrimSpace(contentJSON.String) != "" {
-			existing.Content = json.RawMessage(contentJSON.String)
+		candidate := store.ExecutionEvent{Type: typ, ToolCallID: toolCallID}
+		if content.Valid {
+			candidate.Content = json.RawMessage(content.String)
 		}
-		existingApprovalID, ok := store.ApprovalDecisionID(existing)
-		if ok && existingApprovalID == approvalID {
-			return fmt.Errorf("%w: approval %s already has a terminal decision", store.ErrConflict, approvalID)
+		if store.ApprovalIDFromExecutionEvent(candidate) == approvalID {
+			return typ, approvalID, true, nil
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return err
+		return "", "", false, err
 	}
-	return nil
+	return "", approvalID, false, nil
+}
+
+func nextSQLiteSessionExecutionEventSeq(ctx context.Context, conn *sql.Conn, namespace, sessionName string) (int64, error) {
+	if strings.TrimSpace(sessionName) == "" {
+		return 0, nil
+	}
+
+	latest, err := sqliteSessionCursorSeq(ctx, conn, namespace, sessionName)
+	if err != nil {
+		return 0, err
+	}
+	if latest == 0 {
+		if err := conn.QueryRowContext(ctx,
+			`SELECT COALESCE(MAX(CASE WHEN session_seq > 0 THEN session_seq ELSE rowid END), 0)
+			 FROM execution_events
+			 WHERE namespace = ? AND session_name = ?`,
+			namespace, sessionName,
+		).Scan(&latest); err != nil {
+			return 0, err
+		}
+	}
+	next := latest + 1
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO execution_event_session_sequences(namespace, session_name, latest_seq)
+		 VALUES (?, ?, ?)
+		 ON CONFLICT(namespace, session_name) DO UPDATE SET latest_seq = excluded.latest_seq`,
+		namespace, sessionName, next,
+	); err != nil {
+		return 0, err
+	}
+	return next, nil
+}
+
+func (s *Store) latestSQLiteSessionExecutionEventSeq(ctx context.Context, namespace, sessionName string) (int64, error) {
+	eventSeq := int64(0)
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COALESCE(MAX(CASE WHEN session_seq > 0 THEN session_seq ELSE rowid END), 0)
+		 FROM execution_events
+		 WHERE namespace = ? AND session_name = ?`,
+		namespace, sessionName,
+	).Scan(&eventSeq); err != nil {
+		return 0, err
+	}
+	cursorSeq, err := sqliteSessionCursorSeq(ctx, s.db, namespace, sessionName)
+	if err != nil {
+		return 0, err
+	}
+	return max(eventSeq, cursorSeq), nil
+}
+
+type sqliteSessionCursorQuerier interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+func sqliteSessionCursorSeq(ctx context.Context, querier sqliteSessionCursorQuerier, namespace, sessionName string) (int64, error) {
+	var latest int64
+	err := querier.QueryRowContext(ctx,
+		`SELECT latest_seq
+		 FROM execution_event_session_sequences
+		 WHERE namespace = ? AND session_name = ?`,
+		namespace, sessionName,
+	).Scan(&latest)
+	if err == nil {
+		return latest, nil
+	}
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	return 0, err
 }
 
 // ListExecutionEvents returns execution events matching filter in stream sequence order.
@@ -296,44 +344,39 @@ func (s *Store) ListSessionExecutionEvents(ctx context.Context, filter store.Ses
 		return nil, 0, err
 	}
 
-	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	baseArgs := []any{filter.Namespace, filter.SessionName}
+	latestSeq, err := s.latestSQLiteSessionExecutionEventSeq(ctx, filter.Namespace, filter.SessionName)
 	if err != nil {
 		return nil, 0, err
 	}
-	defer func() { _ = tx.Rollback() }()
 
-	var latestSeq int64
-	if err := tx.QueryRowContext(ctx,
-		`SELECT COALESCE(latest_seq, 0)
-		 FROM execution_event_session_sequences
-		 WHERE namespace = ? AND session_name = ?`,
-		filter.Namespace,
-		filter.SessionName,
-	).Scan(&latestSeq); err != nil {
-		if err != sql.ErrNoRows {
-			return nil, 0, err
-		}
-	}
-
-	where := []string{"namespace = ?", "session_name = ?", "session_seq > ?"}
-	args := []any{filter.Namespace, filter.SessionName, filter.AfterSeq}
+	outerWhere := []string{"effective_session_seq > ?"}
+	queryArgs := append([]any{}, baseArgs...)
+	queryArgs = append(queryArgs, filter.AfterSeq)
 	if len(filter.EventTypes) > 0 {
 		placeholders := make([]string, len(filter.EventTypes))
 		for i, typ := range filter.EventTypes {
 			placeholders[i] = "?"
-			args = append(args, typ)
+			queryArgs = append(queryArgs, typ)
 		}
-		where = append(where, "type IN ("+strings.Join(placeholders, ",")+")")
+		outerWhere = append(outerWhere, "type IN ("+strings.Join(placeholders, ",")+")")
 	}
-	args = append(args, filter.Limit)
+	queryArgs = append(queryArgs, filter.Limit)
 
-	query := `SELECT session_seq, id, namespace, stream_type, stream_id, seq, type, severity, task_name, session_name,
+	query := `WITH ordered AS (
+		SELECT CASE WHEN session_seq > 0 THEN session_seq ELSE rowid END AS effective_session_seq,
+			id, namespace, stream_type, stream_id, seq, type, severity, task_name, session_name,
+			agent_name, tool_name, tool_call_id, summary, content_json, content_text, truncation_json, created_at
+		FROM execution_events
+		WHERE namespace = ? AND session_name = ?
+	)
+	SELECT effective_session_seq, id, namespace, stream_type, stream_id, seq, type, severity, task_name, session_name,
 		agent_name, tool_name, tool_call_id, summary, content_json, content_text, truncation_json, created_at
-	FROM execution_events
-	WHERE ` + strings.Join(where, " AND ") + `
-	ORDER BY session_seq ASC
+	FROM ordered
+	WHERE ` + strings.Join(outerWhere, " AND ") + `
+	ORDER BY effective_session_seq ASC
 	LIMIT ?`
-	rows, err := tx.QueryContext(ctx, query, args...)
+	rows, err := s.db.QueryContext(ctx, query, queryArgs...)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -346,12 +389,10 @@ func (s *Store) ListSessionExecutionEvents(ctx context.Context, filter store.Ses
 			return nil, 0, err
 		}
 		out = append(out, event)
+		latestSeq = max(latestSeq, event.SessionSeq)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, 0, err
-	}
-	if len(out) > 0 && latestSeq < out[len(out)-1].SessionSeq {
-		latestSeq = out[len(out)-1].SessionSeq
 	}
 	success = true
 	return out, latestSeq, nil
@@ -525,13 +566,11 @@ func sqliteMetricLabelsForExecutionEvent(event *store.ExecutionEvent) (string, s
 		streamType = store.ExecutionEventStreamTypeTask
 	}
 	if !events.IsValidExecutionEventStreamType(streamType) {
-		streamType = sqliteInvalidMetricLabel
+		streamType = sqliteUnknownMetricLabel
 	}
 	eventType := strings.TrimSpace(event.Type)
-	if eventType == "" {
+	if !events.IsValidExecutionEventType(eventType) {
 		eventType = sqliteUnknownMetricLabel
-	} else if !events.IsValidExecutionEventType(eventType) {
-		eventType = sqliteInvalidMetricLabel
 	}
 	return streamType, eventType
 }

--- a/internal/store/sqlite/execution_event_store_test.go
+++ b/internal/store/sqlite/execution_event_store_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -253,201 +252,6 @@ func TestExecutionEventStoreConcurrentSameStreamAppendsMultiConnection(t *testin
 	assertConcurrentExecutionEventAppends(t, NewStore(db, dbPath))
 }
 
-func TestExecutionEventStoreRejectsDuplicateApprovalDecision(t *testing.T) {
-	s := setupDiskStore(t)
-	ctx := context.Background()
-	approved := mustRawMessage(t, map[string]string{"approvalID": "approval-1"})
-	declined := mustRawMessage(t, map[string]string{"approvalID": "approval-1"})
-	if _, err := s.AppendExecutionEvent(ctx, &store.ExecutionEvent{
-		Namespace:  "default",
-		StreamType: store.ExecutionEventStreamTypeTask,
-		StreamID:   "task-1",
-		TaskName:   "task-1",
-		Type:       events.ExecutionEventTypeApprovalApproved,
-		Content:    approved,
-	}); err != nil {
-		t.Fatalf("AppendExecutionEvent approved: %v", err)
-	}
-	if _, err := s.AppendExecutionEvent(ctx, &store.ExecutionEvent{
-		Namespace:  "default",
-		StreamType: store.ExecutionEventStreamTypeTask,
-		StreamID:   "task-1",
-		TaskName:   "task-1",
-		Type:       events.ExecutionEventTypeApprovalDeclined,
-		Content:    declined,
-	}); !errors.Is(err, store.ErrConflict) {
-		t.Fatalf("AppendExecutionEvent duplicate decision error = %v, want ErrConflict", err)
-	}
-}
-
-func TestExecutionEventStoreConcurrentSessionAppendsAllocateUniqueSessionSeq(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "session-concurrent.db")
-	db, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		t.Fatalf("sql.Open: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-	db.SetMaxOpenConns(8)
-	db.SetMaxIdleConns(8)
-	if err := migrate(db); err != nil {
-		t.Fatalf("migrate: %v", err)
-	}
-	stores := []*Store{NewStore(db, dbPath), NewStore(db, dbPath)}
-	ctx := context.Background()
-	const count = 25
-	var wg sync.WaitGroup
-	errs := make(chan error, count)
-	for i := range count {
-		wg.Go(func() {
-			_, err := stores[i%len(stores)].AppendExecutionEvent(context.Background(), &store.ExecutionEvent{
-				Namespace:   "default",
-				StreamType:  store.ExecutionEventStreamTypeTask,
-				StreamID:    fmt.Sprintf("task-%d", i),
-				TaskName:    fmt.Sprintf("task-%d", i),
-				SessionName: "session-concurrent",
-				Type:        events.ExecutionEventTypeWorkerStarted,
-			})
-			if err != nil {
-				errs <- err
-			}
-		})
-	}
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		t.Fatalf("AppendExecutionEvent concurrent session: %v", err)
-	}
-	listed, latest, err := stores[0].ListSessionExecutionEvents(ctx, store.SessionExecutionEventFilter{
-		Namespace:   "default",
-		SessionName: "session-concurrent",
-		Limit:       count,
-	})
-	if err != nil {
-		t.Fatalf("ListSessionExecutionEvents: %v", err)
-	}
-	if latest != count || len(listed) != count {
-		t.Fatalf("latest=%d len=%d, want %d", latest, len(listed), count)
-	}
-	for i, event := range listed {
-		want := int64(i + 1)
-		if event.SessionSeq != want {
-			t.Fatalf("listed[%d].SessionSeq=%d, want %d; events=%#v", i, event.SessionSeq, want, listed)
-		}
-	}
-}
-
-func TestExecutionEventStoreDeleteSessionRemovesSessionEvents(t *testing.T) {
-	s := setupDiskStore(t)
-	ctx := context.Background()
-	now := time.Now().UTC()
-	if err := s.CreateSession(ctx, &store.SessionRecord{Namespace: "default", Name: "session-reuse", CreatedAt: now, UpdatedAt: now}); err != nil {
-		t.Fatalf("CreateSession: %v", err)
-	}
-	if _, err := s.AppendExecutionEvent(ctx, &store.ExecutionEvent{
-		Namespace:   "default",
-		StreamType:  store.ExecutionEventStreamTypeTask,
-		StreamID:    "task-old",
-		TaskName:    "task-old",
-		SessionName: "session-reuse",
-		Type:        events.ExecutionEventTypeWorkerStarted,
-	}); err != nil {
-		t.Fatalf("AppendExecutionEvent: %v", err)
-	}
-	if err := s.DeleteSession(ctx, "default", "session-reuse"); err != nil {
-		t.Fatalf("DeleteSession: %v", err)
-	}
-	taskEvents, err := s.ListExecutionEvents(ctx, store.ExecutionEventFilter{
-		Namespace: "default", StreamID: "task-old", Limit: 10,
-	})
-	if err != nil {
-		t.Fatalf("ListExecutionEvents after DeleteSession: %v", err)
-	}
-	if len(taskEvents) != 1 || taskEvents[0].SessionName != "" {
-		t.Fatalf("task events after session delete = %#v, want retained without session link", taskEvents)
-	}
-	if err := s.CreateSession(ctx, &store.SessionRecord{Namespace: "default", Name: "session-reuse", CreatedAt: now, UpdatedAt: now}); err != nil {
-		t.Fatalf("CreateSession reused name: %v", err)
-	}
-	listed, latest, err := s.ListSessionExecutionEvents(ctx, store.SessionExecutionEventFilter{
-		Namespace:   "default",
-		SessionName: "session-reuse",
-		Limit:       10,
-	})
-	if err != nil {
-		t.Fatalf("ListSessionExecutionEvents: %v", err)
-	}
-	if latest != 0 || len(listed) != 0 {
-		t.Fatalf("latest=%d listed=%#v, want empty event read model after session reuse", latest, listed)
-	}
-}
-
-func TestExecutionEventStoreMigrationBackfillsLegacySessionSeq(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "legacy-session-seq.db")
-	db, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		t.Fatalf("sql.Open: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-
-	if _, err := db.Exec(`CREATE TABLE execution_events (
-		id              TEXT PRIMARY KEY,
-		namespace       TEXT NOT NULL,
-		stream_type     TEXT NOT NULL,
-		stream_id       TEXT NOT NULL,
-		seq             INTEGER NOT NULL,
-		type            TEXT NOT NULL,
-		severity        TEXT NOT NULL DEFAULT 'info',
-		task_name       TEXT NOT NULL DEFAULT '',
-		session_name    TEXT NOT NULL DEFAULT '',
-		agent_name      TEXT NOT NULL DEFAULT '',
-		tool_name       TEXT NOT NULL DEFAULT '',
-		tool_call_id    TEXT NOT NULL DEFAULT '',
-		summary         TEXT NOT NULL DEFAULT '',
-		content_json    TEXT,
-		content_text    TEXT NOT NULL DEFAULT '',
-		truncation_json TEXT,
-		created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-		UNIQUE(namespace, stream_type, stream_id, seq)
-	)`); err != nil {
-		t.Fatalf("create legacy execution_events: %v", err)
-	}
-	if _, err := db.Exec(`INSERT INTO execution_events
-		(id, namespace, stream_type, stream_id, seq, type, severity, task_name, session_name, created_at)
-		VALUES ('evt-legacy', 'default', 'task', 'task-legacy', 1, ?, 'info', 'task-legacy', 'session-legacy', ?)`,
-		events.ExecutionEventTypeWorkerStarted,
-		time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC),
-	); err != nil {
-		t.Fatalf("insert legacy execution event: %v", err)
-	}
-
-	if err := migrate(db); err != nil {
-		t.Fatalf("migrate legacy execution_events: %v", err)
-	}
-
-	s := NewStore(db, dbPath)
-	if _, err := s.AppendExecutionEvent(context.Background(), &store.ExecutionEvent{
-		Namespace:   "default",
-		StreamType:  store.ExecutionEventStreamTypeTask,
-		StreamID:    "task-next",
-		TaskName:    "task-next",
-		SessionName: "session-legacy",
-		Type:        events.ExecutionEventTypeWorkerCompleted,
-	}); err != nil {
-		t.Fatalf("AppendExecutionEvent after migration: %v", err)
-	}
-	listed, latest, err := s.ListSessionExecutionEvents(context.Background(), store.SessionExecutionEventFilter{
-		Namespace:   "default",
-		SessionName: "session-legacy",
-		Limit:       10,
-	})
-	if err != nil {
-		t.Fatalf("ListSessionExecutionEvents after migration: %v", err)
-	}
-	if latest != 2 || len(listed) != 2 || listed[0].SessionSeq != 1 || listed[1].SessionSeq != 2 {
-		t.Fatalf("latest=%d listed=%#v, want backfilled seq 1 and next seq 2", latest, listed)
-	}
-}
-
 func assertConcurrentExecutionEventAppends(t *testing.T, s *Store) {
 	t.Helper()
 	ctx := context.Background()
@@ -511,6 +315,118 @@ func executionEventAuditSecrets() map[string]string {
 	}
 }
 
+func TestMigrateBackfillsExecutionEventSessionCursors(t *testing.T) {
+	const taskC = "task-c"
+	path := filepath.Join(t.TempDir(), "old.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open old db: %v", err)
+	}
+	_, err = db.Exec(`CREATE TABLE execution_events (
+		id              TEXT PRIMARY KEY,
+		namespace       TEXT NOT NULL,
+		stream_type     TEXT NOT NULL,
+		stream_id       TEXT NOT NULL,
+		seq             INTEGER NOT NULL,
+		type            TEXT NOT NULL,
+		severity        TEXT NOT NULL DEFAULT 'info',
+		task_name       TEXT NOT NULL DEFAULT '',
+		session_name    TEXT NOT NULL DEFAULT '',
+		agent_name      TEXT NOT NULL DEFAULT '',
+		tool_name       TEXT NOT NULL DEFAULT '',
+		tool_call_id    TEXT NOT NULL DEFAULT '',
+		summary         TEXT NOT NULL DEFAULT '',
+		content_json    TEXT,
+		content_text    TEXT NOT NULL DEFAULT '',
+		truncation_json TEXT,
+		created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE(namespace, stream_type, stream_id, seq)
+	)`)
+	if err != nil {
+		t.Fatalf("create old execution_events: %v", err)
+	}
+	for _, stmt := range []string{
+		`INSERT INTO execution_events(id, namespace, stream_type, stream_id, seq, type, severity, task_name, session_name)
+		 VALUES ('default/task/task-a/1', 'default', 'task', 'task-a', 1, 'TaskStarted', 'info', 'task-a', 'session-1')`,
+		`INSERT INTO execution_events(id, namespace, stream_type, stream_id, seq, type, severity, task_name, session_name)
+		 VALUES ('default/task/task-b/1', 'default', 'task', 'task-b', 1, 'WorkerStarted', 'info', 'task-b', 'session-1')`,
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("insert old event: %v", err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close old db: %v", err)
+	}
+
+	migratedDB, err := NewDB(path)
+	if err != nil {
+		t.Fatalf("NewDB(migrated) error = %v", err)
+	}
+	defer migratedDB.Close() //nolint:errcheck
+	s := NewStore(migratedDB, path)
+	ctx := context.Background()
+	if err := s.DeleteExecutionEvents(ctx, "default", store.ExecutionEventStreamTypeTask, "task-a"); err != nil {
+		t.Fatalf("DeleteExecutionEvents(task-a): %v", err)
+	}
+	if err := s.DeleteExecutionEvents(ctx, "default", store.ExecutionEventStreamTypeTask, "task-b"); err != nil {
+		t.Fatalf("DeleteExecutionEvents(task-b): %v", err)
+	}
+	if _, err := s.AppendExecutionEvent(ctx, &store.ExecutionEvent{
+		Namespace:   "default",
+		StreamType:  store.ExecutionEventStreamTypeTask,
+		StreamID:    taskC,
+		TaskName:    taskC,
+		SessionName: "session-1",
+		Type:        events.ExecutionEventTypeTaskSucceeded,
+	}); err != nil {
+		t.Fatalf("AppendExecutionEvent(task-c): %v", err)
+	}
+	listed, latest, err := s.ListSessionExecutionEvents(ctx, store.SessionExecutionEventFilter{
+		Namespace: "default", SessionName: "session-1", AfterSeq: 2,
+	})
+	if err != nil {
+		t.Fatalf("ListSessionExecutionEvents: %v", err)
+	}
+	if latest != 3 || len(listed) != 1 || listed[0].SessionSeq != 3 || listed[0].TaskName != taskC {
+		t.Fatalf("latest=%d listed=%#v, want migrated cursor to continue at 3", latest, listed)
+	}
+}
+
+func TestExecutionEventStoreRejectsDuplicateTerminalApproval(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		content    json.RawMessage
+		toolCallID string
+	}{
+		{name: "approvalID", content: json.RawMessage(`{"approvalID":"approval-1"}`)},
+		{name: "id", content: json.RawMessage(`{"id":"approval-1"}`)},
+		{name: "toolCallID", content: json.RawMessage(`{}`), toolCallID: "approval-1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := setupDiskStore(t)
+			ctx := context.Background()
+			approved := store.ExecutionEvent{
+				Namespace:  "default",
+				StreamType: store.ExecutionEventStreamTypeTask,
+				StreamID:   "task",
+				TaskName:   "task",
+				Type:       events.ExecutionEventTypeApprovalApproved,
+				ToolCallID: tc.toolCallID,
+				Content:    tc.content,
+			}
+			if _, err := s.AppendExecutionEvent(ctx, &approved); err != nil {
+				t.Fatalf("AppendExecutionEvent(approved) error = %v", err)
+			}
+			declined := approved
+			declined.Type = events.ExecutionEventTypeApprovalDeclined
+			if _, err := s.AppendExecutionEvent(ctx, &declined); !errors.Is(err, store.ErrConflict) {
+				t.Fatalf("AppendExecutionEvent(declined) error = %v, want ErrConflict", err)
+			}
+		})
+	}
+}
+
 func TestExecutionEventStoreListSessionExecutionEvents(t *testing.T) {
 	s := setupDiskStore(t)
 	ctx := context.Background()
@@ -547,6 +463,53 @@ func TestExecutionEventStoreListSessionExecutionEvents(t *testing.T) {
 	}
 }
 
+func TestExecutionEventStoreListSessionCursorSurvivesTaskDeletion(t *testing.T) {
+	const taskC = "task-c"
+	s := setupDiskStore(t)
+	ctx := context.Background()
+	for _, item := range []struct {
+		task string
+		typ  string
+	}{
+		{"task-a", events.ExecutionEventTypeTaskStarted},
+		{"task-b", events.ExecutionEventTypeWorkerStarted},
+	} {
+		if _, err := s.AppendExecutionEvent(ctx, &store.ExecutionEvent{
+			Namespace:   "default",
+			StreamType:  store.ExecutionEventStreamTypeTask,
+			StreamID:    item.task,
+			TaskName:    item.task,
+			SessionName: "session-1",
+			Type:        item.typ,
+		}); err != nil {
+			t.Fatalf("AppendExecutionEvent: %v", err)
+		}
+	}
+	if err := s.DeleteExecutionEvents(ctx, "default", store.ExecutionEventStreamTypeTask, "task-a"); err != nil {
+		t.Fatalf("DeleteExecutionEvents: %v", err)
+	}
+	if _, err := s.AppendExecutionEvent(ctx, &store.ExecutionEvent{
+		Namespace:   "default",
+		StreamType:  store.ExecutionEventStreamTypeTask,
+		StreamID:    taskC,
+		TaskName:    taskC,
+		SessionName: "session-1",
+		Type:        events.ExecutionEventTypeTaskSucceeded,
+	}); err != nil {
+		t.Fatalf("AppendExecutionEvent: %v", err)
+	}
+
+	listed, latest, err := s.ListSessionExecutionEvents(ctx, store.SessionExecutionEventFilter{
+		Namespace: "default", SessionName: "session-1", AfterSeq: 2,
+	})
+	if err != nil {
+		t.Fatalf("ListSessionExecutionEvents: %v", err)
+	}
+	if latest != 3 || len(listed) != 1 || listed[0].SessionSeq != 3 || listed[0].TaskName != taskC {
+		t.Fatalf("latest=%d listed=%#v, want stable cursor 3 for task-c", latest, listed)
+	}
+}
+
 func TestExecutionEventStoreListSessionTypeFilterPreservesCursor(t *testing.T) {
 	s := setupDiskStore(t)
 	ctx := context.Background()
@@ -573,38 +536,4 @@ func TestExecutionEventStoreListSessionTypeFilterPreservesCursor(t *testing.T) {
 	if latest != 2 || len(listed) != 1 || listed[0].SessionSeq != 2 {
 		t.Fatalf("latest=%d listed=%#v, want latest 2 and preserved session seq 2", latest, listed)
 	}
-}
-
-func TestExecutionEventStoreListSessionCursorSurvivesTaskDeletion(t *testing.T) {
-	const taskC = "task-c"
-	s := setupDiskStore(t)
-	ctx := context.Background()
-	if _, err := s.AppendExecutionEvent(ctx, &store.ExecutionEvent{Namespace: "default", StreamType: store.ExecutionEventStreamTypeTask, StreamID: "task-a", TaskName: "task-a", SessionName: "session-1", Type: events.ExecutionEventTypeTaskStarted}); err != nil {
-		t.Fatalf("append task-a: %v", err)
-	}
-	if _, err := s.AppendExecutionEvent(ctx, &store.ExecutionEvent{Namespace: "default", StreamType: store.ExecutionEventStreamTypeTask, StreamID: "task-b", TaskName: "task-b", SessionName: "session-1", Type: events.ExecutionEventTypeWorkerStarted}); err != nil {
-		t.Fatalf("append task-b: %v", err)
-	}
-	if err := s.DeleteExecutionEvents(ctx, "default", store.ExecutionEventStreamTypeTask, "task-a"); err != nil {
-		t.Fatalf("DeleteExecutionEvents: %v", err)
-	}
-	if _, err := s.AppendExecutionEvent(ctx, &store.ExecutionEvent{Namespace: "default", StreamType: store.ExecutionEventStreamTypeTask, StreamID: taskC, TaskName: taskC, SessionName: "session-1", Type: events.ExecutionEventTypeTaskSucceeded}); err != nil {
-		t.Fatalf("append task-c: %v", err)
-	}
-	listed, latest, err := s.ListSessionExecutionEvents(ctx, store.SessionExecutionEventFilter{Namespace: "default", SessionName: "session-1", AfterSeq: 2})
-	if err != nil {
-		t.Fatalf("ListSessionExecutionEvents: %v", err)
-	}
-	if latest != 3 || len(listed) != 1 || listed[0].SessionSeq != 3 || listed[0].TaskName != taskC {
-		t.Fatalf("latest=%d listed=%#v, want new event at stable seq 3", latest, listed)
-	}
-}
-
-func mustRawMessage(t *testing.T, value any) json.RawMessage {
-	t.Helper()
-	data, err := json.Marshal(value)
-	if err != nil {
-		t.Fatalf("marshal JSON: %v", err)
-	}
-	return json.RawMessage(data)
 }

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -144,6 +144,8 @@ func migrate(db *sql.DB) error {
 			ON execution_events(namespace, stream_type, stream_id, type, seq)`,
 		`CREATE INDEX IF NOT EXISTS idx_execution_events_task
 			ON execution_events(namespace, task_name, seq)`,
+		`CREATE INDEX IF NOT EXISTS idx_execution_events_session
+			ON execution_events(namespace, session_name, seq)`,
 		`CREATE TABLE IF NOT EXISTS execution_event_session_sequences (
 			namespace    TEXT NOT NULL,
 			session_name TEXT NOT NULL,
@@ -548,38 +550,26 @@ func migrate(db *sql.DB) error {
 			return fmt.Errorf("migration failed: %w", err)
 		}
 	}
+
 	if err := ensureSQLiteColumns(db, "execution_events", []sqliteColumnMigration{
 		{Name: "session_seq", Definition: "session_seq INTEGER NOT NULL DEFAULT 0"},
 	}); err != nil {
 		return err
 	}
-	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_execution_events_session
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_execution_events_session_seq
 		ON execution_events(namespace, session_name, session_seq)`); err != nil {
 		return fmt.Errorf("migration failed: %w", err)
 	}
-	if _, err := db.Exec(`UPDATE execution_events
-		SET session_seq = (
-			SELECT COUNT(*) FROM execution_events prior
-			WHERE prior.namespace = execution_events.namespace
-			  AND prior.session_name = execution_events.session_name
-			  AND prior.session_name <> ''
-			  AND prior.rowid <= execution_events.rowid
-		)
-		WHERE session_name <> '' AND session_seq = 0`); err != nil {
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS execution_event_session_sequences (
+		namespace    TEXT NOT NULL,
+		session_name TEXT NOT NULL,
+		latest_seq   INTEGER NOT NULL DEFAULT 0,
+		PRIMARY KEY (namespace, session_name)
+	)`); err != nil {
 		return fmt.Errorf("migration failed: %w", err)
 	}
-	if _, err := db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_execution_events_session_seq_unique
-		ON execution_events(namespace, session_name, session_seq)
-		WHERE session_name <> ''`); err != nil {
-		return fmt.Errorf("migration failed: %w", err)
-	}
-	if _, err := db.Exec(`INSERT INTO execution_event_session_sequences(namespace, session_name, latest_seq)
-		SELECT namespace, session_name, MAX(session_seq)
-		FROM execution_events
-		WHERE session_name <> ''
-		GROUP BY namespace, session_name
-		ON CONFLICT(namespace, session_name) DO UPDATE SET latest_seq = MAX(latest_seq, excluded.latest_seq)`); err != nil {
-		return fmt.Errorf("migration failed: %w", err)
+	if err := backfillExecutionEventSessionCursors(db); err != nil {
+		return err
 	}
 
 	if err := ensureSQLiteColumns(db, "memories", []sqliteColumnMigration{
@@ -640,6 +630,24 @@ func migrate(db *sql.DB) error {
 		return fmt.Errorf("migration failed: %w", err)
 	}
 
+	return nil
+}
+
+func backfillExecutionEventSessionCursors(db *sql.DB) error {
+	_, err := db.Exec(`INSERT INTO execution_event_session_sequences(namespace, session_name, latest_seq)
+		SELECT namespace, session_name, MAX(CASE WHEN session_seq > 0 THEN session_seq ELSE rowid END)
+		FROM execution_events
+		WHERE session_name <> ''
+		GROUP BY namespace, session_name
+		ON CONFLICT(namespace, session_name) DO UPDATE SET latest_seq =
+			CASE
+				WHEN execution_event_session_sequences.latest_seq > excluded.latest_seq
+				THEN execution_event_session_sequences.latest_seq
+				ELSE excluded.latest_seq
+			END`)
+	if err != nil {
+		return fmt.Errorf("migration failed: %w", err)
+	}
 	return nil
 }
 

--- a/internal/tasktrace/tasktrace.go
+++ b/internal/tasktrace/tasktrace.go
@@ -237,7 +237,7 @@ func BuildTaskTrace(meta TaskMetadata, input []store.ExecutionEvent, generatedAt
 			if id != "" {
 				if found, ok := modelByID[id]; ok {
 					idx = found
-					openModelIDs = removeFirstString(openModelIDs, id)
+					openModelIDs = removeOpenTraceID(openModelIDs, id)
 				}
 			} else if len(openModelIDs) > 0 {
 				id = openModelIDs[0]
@@ -276,11 +276,11 @@ func BuildTaskTrace(meta TaskMetadata, input []store.ExecutionEvent, generatedAt
 			if id != "" {
 				if found, ok := toolByID[id]; ok {
 					idx = found
-					name := event.ToolName
-					if name == "" {
-						name = trace.ToolCalls[idx].Name
+					toolName := event.ToolName
+					if toolName == "" {
+						toolName = trace.ToolCalls[idx].Name
 					}
-					openToolByName[name] = removeFirstString(openToolByName[name], id)
+					openToolByName[toolName] = removeOpenTraceID(openToolByName[toolName], id)
 				}
 			} else if ids := openToolByName[event.ToolName]; len(ids) > 0 {
 				id = ids[0]
@@ -352,15 +352,6 @@ func BuildTaskTrace(meta TaskMetadata, input []store.ExecutionEvent, generatedAt
 	return trace
 }
 
-func removeFirstString(values []string, target string) []string {
-	for i, value := range values {
-		if value == target {
-			return append(values[:i], values[i+1:]...)
-		}
-	}
-	return values
-}
-
 func cloneEvent(event store.ExecutionEvent) store.ExecutionEvent {
 	if event.Content != nil {
 		event.Content = append(json.RawMessage(nil), event.Content...)
@@ -414,6 +405,15 @@ func firstContentString(raw json.RawMessage, keys ...string) string {
 		}
 	}
 	return ""
+}
+
+func removeOpenTraceID(ids []string, target string) []string {
+	for i, id := range ids {
+		if id == target {
+			return append(ids[:i], ids[i+1:]...)
+		}
+	}
+	return ids
 }
 
 func prefer(existing, next string) string {

--- a/internal/tasktrace/tasktrace_test.go
+++ b/internal/tasktrace/tasktrace_test.go
@@ -51,3 +51,37 @@ func TestBuildTaskTraceUnmatchedCompletionWarns(t *testing.T) {
 		t.Fatalf("warnings=%#v raw=%#v, want unmatched warning", trace.Warnings, trace.RawUnpaired)
 	}
 }
+
+func TestBuildTaskTraceExplicitToolCompletionDequeuesOpenCall(t *testing.T) {
+	trace := BuildTaskTrace(TaskMetadata{Name: "task"}, []store.ExecutionEvent{
+		{Seq: 1, Type: events.ExecutionEventTypeToolCallStarted, ToolName: "web_search", ToolCallID: "tool-1"},
+		{Seq: 2, Type: events.ExecutionEventTypeToolCallStarted, ToolName: "web_search", ToolCallID: "tool-2"},
+		{Seq: 3, Type: events.ExecutionEventTypeToolCallCompleted, ToolName: "web_search", ToolCallID: "tool-1"},
+		{Seq: 4, Type: events.ExecutionEventTypeToolCallCompleted, ToolName: "web_search"},
+	}, time.Now())
+	if len(trace.ToolCalls) != 2 || trace.ToolCalls[0].EndSeq != 3 || trace.ToolCalls[1].EndSeq != 4 {
+		t.Fatalf("tool calls = %#v, want explicit completion removed from open queue", trace.ToolCalls)
+	}
+	if len(trace.Warnings) != 0 {
+		t.Fatalf("warnings = %#v, want none", trace.Warnings)
+	}
+}
+
+func TestBuildTaskTraceExplicitModelCompletionDequeuesOpenRequest(t *testing.T) {
+	content := func(id string) json.RawMessage {
+		data, _ := json.Marshal(map[string]string{"modelRequestID": id})
+		return data
+	}
+	trace := BuildTaskTrace(TaskMetadata{Name: "task"}, []store.ExecutionEvent{
+		{Seq: 1, Type: events.ExecutionEventTypeModelRequestStarted, Content: content("model-1")},
+		{Seq: 2, Type: events.ExecutionEventTypeModelRequestStarted, Content: content("model-2")},
+		{Seq: 3, Type: events.ExecutionEventTypeModelRequestCompleted, Content: content("model-1")},
+		{Seq: 4, Type: events.ExecutionEventTypeModelRequestCompleted},
+	}, time.Now())
+	if len(trace.ModelRequests) != 2 || trace.ModelRequests[0].EndSeq != 3 || trace.ModelRequests[1].EndSeq != 4 {
+		t.Fatalf("model requests = %#v, want explicit completion removed from open queue", trace.ModelRequests)
+	}
+	if len(trace.Warnings) != 0 {
+		t.Fatalf("warnings = %#v, want none", trace.Warnings)
+	}
+}

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -41,8 +41,6 @@ const sidebars = {
       items: [
         'reference/api-reference',
         'reference/execution-events',
-        'reference/cli',
-        'reference/cli-commands',
         'reference/openai-compat',
         'reference/anthropic-compat',
       ],


### PR DESCRIPTION
## Summary

- Add a backend-neutral harness protocol with typed turn, frame, health, capability, cancellation, and tool call DTOs.
- Add an HTTP/SSE harness client, fake harness server, reusable conformance suite, event mapper, and turn runner.
- Add runtime session lifecycle validation and documentation for implementation and provider contracts.
- Harden execution-event streaming, trace grouping, approval decisions, and session cursors so harness events remain replayable and consistent.

## Validation

- `make lint-fix`
- `make test`
