### PR TITLE
fix(events): address follow-up readiness

### DIFF
--- a/internal/api/approval_handlers.go
+++ b/internal/api/approval_handlers.go
@@ -1,3 +1,9 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
 package api
 
 import (

--- a/internal/api/fork_handlers.go
+++ b/internal/api/fork_handlers.go
@@ -1,3 +1,9 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
 package api
 
 import (

--- a/internal/api/internal_execution_event_handlers.go
+++ b/internal/api/internal_execution_event_handlers.go
@@ -1,3 +1,9 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
 package api
 
 import (

--- a/internal/api/post_p0_handlers_test.go
+++ b/internal/api/post_p0_handlers_test.go
@@ -450,8 +450,9 @@ func TestForkTaskAPIBoundsForkContextAndMarksTruncated(t *testing.T) {
 
 func TestGetTaskTraceAPIPagesBeyondEventLimit(t *testing.T) {
 	eventStore := store.NewFakeExecutionEventStore()
+	appendToolEvent(t, eventStore, "long-trace-task", events.ExecutionEventTypeToolCallStarted, "early-call")
 	for range store.MaxExecutionEventLimit {
-		appendToolEvent(t, eventStore, "long-trace-task", events.ExecutionEventTypeToolCallStarted, "call")
+		appendTestTaskEvent(t, eventStore, "long-trace-task", events.ExecutionEventTypeWorkerStarted)
 	}
 	appendTestTaskEvent(t, eventStore, "long-trace-task", events.ExecutionEventTypeTaskSucceeded)
 	h, app := setupTaskEventHandlers(t, eventStore, testTask("default", "long-trace-task"))
@@ -468,8 +469,14 @@ func TestGetTaskTraceAPIPagesBeyondEventLimit(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&trace); err != nil {
 		t.Fatal(err)
 	}
-	if trace.LatestSeq != store.MaxExecutionEventLimit+1 || trace.TerminalEvent == nil {
+	if trace.LatestSeq != store.MaxExecutionEventLimit+2 || trace.TerminalEvent == nil {
 		t.Fatalf("trace latest=%d terminal=%#v", trace.LatestSeq, trace.TerminalEvent)
+	}
+	if len(trace.Timeline) != store.MaxExecutionEventLimit+2 || trace.Timeline[0].Seq != 1 {
+		t.Fatalf("trace timeline len=%d first=%#v, want full stream from seq 1", len(trace.Timeline), trace.Timeline[0])
+	}
+	if len(trace.ToolCalls) != 1 || trace.ToolCalls[0].ID != "early-call" || trace.ToolCalls[0].StartSeq != 1 {
+		t.Fatalf("trace tool calls = %#v, want early tool call from seq 1", trace.ToolCalls)
 	}
 }
 

--- a/internal/api/task_trace_handlers.go
+++ b/internal/api/task_trace_handlers.go
@@ -1,6 +1,13 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
 package api
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -10,6 +17,7 @@ import (
 
 	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
 	"github.com/sozercan/orka/internal/events"
+	"github.com/sozercan/orka/internal/store"
 	"github.com/sozercan/orka/internal/tasktrace"
 )
 
@@ -42,11 +50,54 @@ func (h *Handlers) GetTaskTrace(c fiber.Ctx) error {
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to get latest execution event sequence: %v", err))
 	}
-	listed, err := listTaskEventsThrough(c.Context(), h.executionEventStore, namespace, taskName, latestSeq)
+	listed, err := listAllTaskEventsThrough(c.Context(), h.executionEventStore, namespace, taskName, latestSeq)
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to list execution events: %v", err))
 	}
 	trace := tasktrace.BuildTaskTrace(tasktrace.MetadataFromTask(task), listed, time.Now().UTC())
 	trace.LatestSeq = latestSeq
 	return c.JSON(trace)
+}
+
+func listAllTaskEventsThrough(
+	ctx context.Context,
+	eventStore store.ExecutionEventStore,
+	namespace,
+	taskName string,
+	throughSeq int64,
+) ([]store.ExecutionEvent, error) {
+	if throughSeq == 0 {
+		return nil, nil
+	}
+	var out []store.ExecutionEvent
+	var after int64
+	for {
+		batch, err := eventStore.ListExecutionEvents(ctx, store.ExecutionEventFilter{
+			Namespace:  namespace,
+			StreamType: events.ExecutionEventStreamTypeTask,
+			StreamID:   taskName,
+			AfterSeq:   after,
+			Limit:      store.MaxExecutionEventLimit,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if len(batch) == 0 {
+			break
+		}
+		for _, event := range batch {
+			if event.Seq > throughSeq {
+				return out, nil
+			}
+			out = append(out, event)
+			after = event.Seq
+			if after >= throughSeq {
+				return out, nil
+			}
+		}
+		if len(batch) < store.MaxExecutionEventLimit {
+			break
+		}
+	}
+	return out, nil
 }

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -317,7 +317,7 @@ func (r *TaskReconciler) recordTaskLifecycleEvent(
 		StreamType:  store.ExecutionEventStreamTypeTask,
 		StreamID:    task.Name,
 		TaskName:    task.Name,
-		SessionName: taskSessionName(task),
+		SessionName: r.executionEventSessionName(ctx, task),
 		Type:        eventType,
 		Severity:    severity,
 		Summary:     summary,
@@ -331,6 +331,30 @@ func (r *TaskReconciler) recordTaskLifecycleEvent(
 			"eventType", eventType,
 		)
 	}
+}
+
+func (r *TaskReconciler) executionEventSessionName(ctx context.Context, task *corev1alpha1.Task) string {
+	sessionName := taskSessionName(task)
+	if sessionName == "" {
+		return ""
+	}
+	if r == nil || r.SessionManager == nil || r.SessionManager.store == nil {
+		return ""
+	}
+	if _, err := r.SessionManager.GetSession(ctx, task.Namespace, sessionName); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return ""
+		}
+		logf.FromContext(ctx).Error(
+			err,
+			"failed to check session before recording task lifecycle execution event",
+			"namespace", task.Namespace,
+			"task", task.Name,
+			"session", sessionName,
+		)
+		return sessionName
+	}
+	return sessionName
 }
 
 func taskSessionName(task *corev1alpha1.Task) string {

--- a/internal/controller/task_controller_unit_test.go
+++ b/internal/controller/task_controller_unit_test.go
@@ -93,6 +93,15 @@ func newUnitReconciler(scheme *runtime.Scheme, objs ...client.Object) *TaskRecon
 	}
 }
 
+type failingGetSessionStore struct {
+	store.SessionStore
+	err error
+}
+
+func (s failingGetSessionStore) GetSession(context.Context, string, string) (*store.SessionRecord, error) {
+	return nil, s.err
+}
+
 type recordingTaskWorkspaceExecutor struct {
 	deleteReqs  []workspace.DeleteRequest
 	deleteErr   error
@@ -6171,6 +6180,122 @@ func TestTaskControllerLifecycleEvents(t *testing.T) {
 		if event.Seq <= listed[0].Seq {
 			t.Fatalf("after query returned old seq <= %d: %#v", listed[0].Seq, afterFirst)
 		}
+	}
+}
+
+func TestTaskLifecycleEventOmitsMissingSessionName(t *testing.T) {
+	scheme := newTestScheme()
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "missing-session-event-task", Namespace: "default"},
+		Spec: corev1alpha1.TaskSpec{
+			Type:       corev1alpha1.TaskTypeAI,
+			SessionRef: &corev1alpha1.SessionReference{Name: "deleted-session"},
+		},
+	}
+	reconciler := newUnitReconciler(scheme, task)
+	eventStore := store.NewFakeExecutionEventStore()
+	reconciler.ExecutionEventStore = eventStore
+
+	reconciler.recordTaskLifecycleEvent(
+		context.Background(),
+		task,
+		events.ExecutionEventTypeTaskSucceeded,
+		events.ExecutionEventSeverityInfo,
+		"task completed",
+	)
+
+	listed, err := eventStore.ListExecutionEvents(context.Background(), store.ExecutionEventFilter{
+		Namespace:  "default",
+		StreamType: store.ExecutionEventStreamTypeTask,
+		StreamID:   "missing-session-event-task",
+		Limit:      10,
+	})
+	if err != nil {
+		t.Fatalf("ListExecutionEvents: %v", err)
+	}
+	if len(listed) != 1 || listed[0].SessionName != "" {
+		t.Fatalf("listed events = %#v, want lifecycle event without deleted session name", listed)
+	}
+}
+
+func TestTaskLifecycleEventKeepsSessionNameOnLookupFailure(t *testing.T) {
+	scheme := newTestScheme()
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "lookup-failure-session-event-task", Namespace: "default"},
+		Spec: corev1alpha1.TaskSpec{
+			Type:       corev1alpha1.TaskTypeAI,
+			SessionRef: &corev1alpha1.SessionReference{Name: "session-a"},
+		},
+	}
+	reconciler := newUnitReconciler(scheme, task)
+	reconciler.SessionManager = NewSessionManager(failingGetSessionStore{err: errors.New("session store unavailable")})
+	eventStore := store.NewFakeExecutionEventStore()
+	reconciler.ExecutionEventStore = eventStore
+
+	reconciler.recordTaskLifecycleEvent(
+		context.Background(),
+		task,
+		events.ExecutionEventTypeTaskSucceeded,
+		events.ExecutionEventSeverityInfo,
+		"task completed",
+	)
+
+	listed, err := eventStore.ListExecutionEvents(context.Background(), store.ExecutionEventFilter{
+		Namespace:  "default",
+		StreamType: store.ExecutionEventStreamTypeTask,
+		StreamID:   "lookup-failure-session-event-task",
+		Limit:      10,
+	})
+	if err != nil {
+		t.Fatalf("ListExecutionEvents: %v", err)
+	}
+	if len(listed) != 1 || listed[0].SessionName != "session-a" {
+		t.Fatalf("listed events = %#v, want lifecycle event to keep session name on ambiguous lookup failure", listed)
+	}
+}
+
+func TestTaskLifecycleEventKeepsExistingSessionName(t *testing.T) {
+	scheme := newTestScheme()
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "existing-session-event-task", Namespace: "default"},
+		Spec: corev1alpha1.TaskSpec{
+			Type:       corev1alpha1.TaskTypeAI,
+			SessionRef: &corev1alpha1.SessionReference{Name: "session-a"},
+		},
+	}
+	reconciler := newUnitReconciler(scheme, task)
+	now := time.Now()
+	if err := reconciler.SessionManager.store.CreateSession(context.Background(), &store.SessionRecord{
+		Namespace:   "default",
+		Name:        "session-a",
+		SessionType: "task",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	eventStore := store.NewFakeExecutionEventStore()
+	reconciler.ExecutionEventStore = eventStore
+
+	reconciler.recordTaskLifecycleEvent(
+		context.Background(),
+		task,
+		events.ExecutionEventTypeTaskSucceeded,
+		events.ExecutionEventSeverityInfo,
+		"task completed",
+	)
+
+	listed, err := eventStore.ListExecutionEvents(context.Background(), store.ExecutionEventFilter{
+		Namespace:  "default",
+		StreamType: store.ExecutionEventStreamTypeTask,
+		StreamID:   "existing-session-event-task",
+		Limit:      10,
+	})
+	if err != nil {
+		t.Fatalf("ListExecutionEvents: %v", err)
+	}
+	if len(listed) != 1 || listed[0].SessionName != "session-a" {
+		t.Fatalf("listed events = %#v, want lifecycle event with existing session name", listed)
 	}
 }
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -41,6 +41,8 @@ const sidebars = {
       items: [
         'reference/api-reference',
         'reference/execution-events',
+        'reference/cli',
+        'reference/cli-commands',
         'reference/openai-compat',
         'reference/anthropic-compat',
       ],


### PR DESCRIPTION
## Summary

- Adds small follow-up readiness fixes on top of the event timeline work.
- Keeps reference docs reachable and applies standard file headers.
- Tightens trace and session event handling with focused coverage.

## Validation

- `make lint-fix && make test`
- `cd website && yarn build`
- `go test ./internal/api -run 'ExecutionEvent|SubmitExecutionEvent|Task.*Events|Session.*Events|Stream|Reconnect|Trace|Fork|Approval' -v`
- `go test ./internal/controller -run 'Task.*Event|ExecutionEvent|Session.*Event' -v`
- `go test ./internal/events ./internal/store ./internal/store/sqlite -run ExecutionEvent -v`
- `go test ./workers/common -run 'Event|RunAgent.*Event|AgentRuntime.*Event' -v`
- `go test ./workers/ai -run Event -v`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/contract`
