### PR TITLE
docs(agents): note $kindctl and $vekil-reverse-proxy-deploy skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,8 @@ UI: `cd ui && bun install && bun run dev` (dev server on :5173). See @website/do
 
 For testing against a local Kubernetes cluster, use the `$kindctl` skill to manage repo/worktree-scoped kind clusters without touching the global kubeconfig.
 
+To stand up a reverse proxy for Anthropic/Gemini/OpenAI-compatible clients, use the `$vekil-reverse-proxy-deploy` skill. When it falls back to GitHub Copilot device-code login, surface the login code and URL to the user and wait for their confirmation before continuing — never complete the login on their behalf.
+
 ## Verification
 
 Run after every change:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ make deploy IMG=<registry>/orka:tag
 
 UI: `cd ui && bun install && bun run dev` (dev server on :5173). See @website/docs/development/development.md for full commands.
 
+For testing against a local Kubernetes cluster, use the `$kindctl` skill to manage repo/worktree-scoped kind clusters without touching the global kubeconfig.
+
 ## Verification
 
 Run after every change:


### PR DESCRIPTION
## Summary
- Note the `$kindctl` skill in `AGENTS.md` for testing against a local Kubernetes cluster (repo/worktree-scoped kind clusters, no global kubeconfig changes).
- Note the `$vekil-reverse-proxy-deploy` skill for standing up a reverse proxy for Anthropic/Gemini/OpenAI-compatible clients, and require surfacing the GitHub Copilot device-code login code/URL to the user and waiting for confirmation before continuing.

## Test plan
- [x] Docs-only change; no build/test impact.
- [x] Verified the diff adds the notes in the Build & Test section.