### PR TITLE
chore(skills): add agent-sandbox and agent-substrate deploy skills

### DIFF
--- a/.agents/skills/agent-sandbox-deploy
+++ b/.agents/skills/agent-sandbox-deploy
@@ -1,0 +1,1 @@
+../../.codex/skills/agent-sandbox-deploy

--- a/.agents/skills/agent-substrate-deploy
+++ b/.agents/skills/agent-substrate-deploy
@@ -1,0 +1,1 @@
+../../.codex/skills/agent-substrate-deploy

--- a/.claude/skills/agent-sandbox-deploy
+++ b/.claude/skills/agent-sandbox-deploy
@@ -1,0 +1,1 @@
+../../.codex/skills/agent-sandbox-deploy

--- a/.claude/skills/agent-substrate-deploy
+++ b/.claude/skills/agent-substrate-deploy
@@ -1,0 +1,1 @@
+../../.codex/skills/agent-substrate-deploy

--- a/.codex/skills/agent-sandbox-deploy/SKILL.md
+++ b/.codex/skills/agent-sandbox-deploy/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: agent-sandbox-deploy
+description: Stand up the upstream kubernetes-sigs agent-sandbox workspace provider on a local kind cluster and run an Orka agent Task through a sandbox-backed workspace. Use when the user asks to install, enable, deploy, configure, validate, demo, or troubleshoot agent-sandbox execution workspaces for Orka (Task.spec.execution.workspace with provider agent-sandbox).
+---
+
+# Agent Sandbox Deploy
+
+Stand up the experimental [`kubernetes-sigs/agent-sandbox`](https://github.com/kubernetes-sigs/agent-sandbox)
+workspace provider against an Orka controller on a local kind cluster, then
+validate it by running a `type: agent` Task whose `spec.execution.workspace`
+routes to an agent-sandbox workspace.
+
+This skill is for **local/kind evaluation and validation**, not production.
+Orka does not install or manage upstream agent-sandbox CRDs, the router,
+templates, or warm pools in production — install and operate those separately.
+See `website/docs/concepts/agent-sandbox.md` for the full design and the
+production controller flags.
+
+## What this skill orchestrates (do not retype)
+
+The repeatable standup already lives in
+`hack/demos/cluster/install-agent-sandbox.sh`. **Drive that script in place; do
+not copy it into the skill.** It pins the agent-sandbox version
+(`ORKA_AGENT_SANDBOX_VERSION`, default `v0.4.6`) and owns the gotchas (kind
+registry addressing, the SDK sandbox-router build from the Go module cache, the
+controller flag patch). Re-pin by overriding the env var, not by editing a copy.
+
+What the script does:
+
+1. **Base layer (always):** installs agent-sandbox CRDs + controllers, applies
+   the `orka-live-template` SandboxTemplate, and patches the existing Orka
+   controller Deployment with `--agent-sandbox-enabled=true`,
+   `--agent-sandbox-router-url`, `--agent-sandbox-default-template`,
+   `--agent-sandbox-cleanup-policy`, and
+   `--execution-workspace-default-provider=agent-sandbox`.
+2. **Agentic layer (`AGENTIC=1`, default):** builds + pushes the
+   `sandbox-runtime` image (real `codex` + `git` + `gh`) and the upstream
+   `sandbox-router` image to the local registry, deploys the router, deploys the
+   vekil model proxy (device-code login), and creates the model + git Secrets and
+   the Orka API client ServiceAccount.
+
+## Ordering matters — the script assumes Orka is already deployed
+
+`install-agent-sandbox.sh` **does not create the cluster and does not deploy
+Orka.** It patches an existing `orka-controller-manager` Deployment in
+`orka-system`. If the controller is not already running, the flag-patch step is
+skipped and the feature never turns on. So the correct sequence is:
+
+1. **Cluster** — via `$kindctl` (see below) or an existing kind cluster.
+2. **Orka controller** — via `$orka-kind-deploy`.
+3. **agent-sandbox** — this skill's script.
+4. **Model proxy** — vekil, with a **human-in-the-loop device-code login**.
+
+## Standard workflow (kindctl-scoped)
+
+Use `$kindctl` so the kubeconfig stays scoped to this repo/worktree and never
+touches `~/.kube/config`. Every command below runs against the kindctl
+kubeconfig.
+
+1. **Create the repo-scoped cluster.**
+
+   ```bash
+   .agents/skills/kindctl/bin/kindctl create
+   .agents/skills/kindctl/bin/kindctl kubectl get nodes
+   ```
+
+   > **Registry precondition for `AGENTIC=1`.** The agentic layer
+   > `docker push`es to `localhost:${KIND_REGISTRY_PORT}` (default `5001`) and
+   > expects the kind node to pull from it as a containerd mirror. A default
+   > kindctl cluster has **no** such image registry (kindctl's own "registry" is
+   > a JSON cluster-metadata store, not a Docker registry). Either:
+   > - commit a repo `.kind/cluster.yaml` + `.kind/setup.sh` that stands up a
+   >   `localhost:5001` registry and wires the containerd mirror before running
+   >   the agentic layer, **or**
+   > - run with `AGENTIC=0` for a base-layer-only install (no model run), **or**
+   > - point the script at pre-loaded images via `ORKA_SANDBOX_RUNTIME_IMAGE` /
+   >   `ORKA_SANDBOX_ROUTER_IMAGE` that you `kindctl load` yourself.
+   > Confirm the registry path with the user before assuming `AGENTIC=1` works on
+   > a bare kindctl cluster.
+
+2. **Deploy the Orka controller** into the cluster with `$orka-kind-deploy`
+   (build + load controller and worker images, install CRDs, roll out
+   `orka-controller-manager`). The harness wrapper image must be present too —
+   sandbox runs re-exec the agent CLI inside the sandbox.
+
+3. **Install agent-sandbox** by driving the canonical script against the kindctl
+   kubeconfig. Export `KUBECONFIG` from kindctl so the script's `kubectl` calls
+   hit the right cluster, and pass the kindctl cluster name through the env vars
+   the script reads:
+
+   ```bash
+   eval "$(.agents/skills/kindctl/bin/kindctl env)"   # exports scoped KUBECONFIG
+   kube="$(.agents/skills/kindctl/bin/kindctl path)"   # ~/.kube/kind/<name>.kubeconfig
+   ORKA_DEMO_CLUSTER="$(basename "$kube" .kubeconfig)" \
+   AGENTIC=0 \
+     bash hack/demos/cluster/install-agent-sandbox.sh
+   ```
+
+   The script selects its context by checking `kind get clusters` for
+   `ORKA_DEMO_CLUSTER`; when that name is not a plain `kind get clusters` entry
+   it falls back to the current context, which the exported `KUBECONFIG` makes
+   the kindctl cluster. Verify the selected context in the script's logs before
+   continuing. Use `AGENTIC=1` only once the registry precondition above is met.
+
+4. **Stand up the model proxy (vekil) — pause for the human.** The agentic layer
+   calls the vekil deploy script with `--skip-wait`, which starts a GitHub
+   device-code login. **Surface the login URL and code to the user and wait for
+   their confirmation; never complete the login on their behalf.** This mirrors
+   the `$vekil-reverse-proxy-deploy` guardrail.
+
+   ```bash
+   .agents/skills/kindctl/bin/kindctl kubectl -n vekil-system logs deploy/vekil | grep 'login/device'
+   ```
+
+   > **Login race (verified live 2026-06): disarm vekil's liveness probe before
+   > surfacing the code.** vekil binds its port only after the Copilot login
+   > completes, so its `livenessProbe` on `/healthz` fails and restarts the pod
+   > every ~60s — and **each restart mints a NEW device code**, so a human login
+   > against the old code can never land. Remove the probe and collapse to one
+   > pod before handing the user a code:
+   >
+   > ```bash
+   > .agents/skills/kindctl/bin/kindctl kubectl -n vekil-system patch deploy vekil \
+   >   --type=json -p '[{"op":"remove","path":"/spec/template/spec/containers/0/livenessProbe"}]'
+   > ```
+   >
+   > GitHub device codes expire in ~15 min; surface promptly, and if it expires,
+   > bounce the pod (`kindctl kubectl -n vekil-system delete pod -l app=vekil`)
+   > for a fresh code rather than waiting.
+
+   Then wait for readiness before any model-backed Task:
+
+   ```bash
+   .agents/skills/kindctl/bin/kindctl kubectl -n vekil-system exec deploy/vekil -- \
+     wget -qO- http://127.0.0.1:1337/readyz
+   ```
+
+   If you only need to validate Orka's sandbox plumbing (claim → ready →
+   exec → cleanup) without a real model, prefer the model-free e2e in step 6
+   instead of standing up vekil.
+
+## Validate
+
+> **Known gate (verified live 2026-06): agent Tasks with an execution workspace
+> are rejected by the current service-backed harness runtime.** The smoke Task
+> below fails immediately with
+> `status.executionWorkspace.reason=WorkspaceValidationFailed` and message
+> `execution workspace is not supported by harness runtime yet` — an
+> unconditional gate in `internal/controller/harness_wrapper.go`
+> (`runHarnessWrapperTask`), not a misconfiguration. The agent CLI runtimes now
+> run through the long-lived `agent-harness-wrapper` service, and the
+> Task→sandbox-workspace path for agents is not wired through it yet. A **plain**
+> agent Task (no `execution.workspace`) runs fine through the harness + model
+> proxy, so use that to confirm the model path; use the model-free e2e
+> (`scripts/live-agent-sandbox-e2e.sh`) to confirm sandbox plumbing. Treat the
+> Task YAML below as the intended API once the harness wires workspaces.
+
+Run the live smoke Task from the concept doc against the kindctl cluster
+(namespace, agent, and template match `install-agent-sandbox.sh`'s defaults):
+
+```bash
+.agents/skills/kindctl/bin/kindctl kubectl apply -f - <<'YAML'
+apiVersion: core.orka.ai/v1alpha1
+kind: Task
+metadata:
+  name: orka-live-sandbox-smoke
+  namespace: orka-system
+spec:
+  type: agent
+  agentRef:
+    name: claude-agent
+  agentRuntime:
+    maxTurns: 1
+  timeout: 10m0s
+  execution:
+    workspace:
+      enabled: true
+      templateRef:
+        name: orka-live-template
+      reusePolicy: none
+      cleanupPolicy: delete
+  prompt: "Reply exactly: ORKA_LIVE_SANDBOX_OK"
+YAML
+
+.agents/skills/kindctl/bin/kindctl kubectl -n orka-system \
+  wait --for=jsonpath='{.status.phase}'=Succeeded task/orka-live-sandbox-smoke --timeout=10m
+```
+
+A successful sandbox wrapper log includes the claimed workspace name, e.g.
+`completed in sandbox workspace sandbox-claim-...`. Orka Task status does **not**
+expose sandbox claim/exec/cleanup state — read worker logs and upstream
+agent-sandbox resources for lifecycle detail.
+
+### Model-free CI parity
+
+`scripts/live-agent-sandbox-e2e.sh` (run by the `Live Agent Sandbox E2E`
+workflow) stands up the whole path with a deterministic fake `claude` CLI and
+**no model access**. Use it to validate Orka's sandbox plumbing independently of
+provider availability:
+
+```bash
+bash scripts/live-agent-sandbox-e2e.sh
+```
+
+That script owns its own cluster lifecycle; do not run it against a kindctl
+cluster you want to keep.
+
+## Guardrails
+
+- **Local/kind eval only.** Do not present this as a production install. Orka
+  does not own upstream agent-sandbox lifecycle in production.
+- **Reference, don't fork.** Drive `hack/demos/cluster/install-agent-sandbox.sh`
+  and override pins via env (`ORKA_AGENT_SANDBOX_VERSION`, `AGENTIC`,
+  `KIND_REGISTRY_PORT`, `ORKA_SANDBOX_RUNTIME_IMAGE`). Copying the script into
+  the skill invites version-pin drift.
+- **Human-in-the-loop vekil login.** Surface the device-code URL + code and wait
+  for confirmation. Never complete the GitHub login yourself.
+- **No secrets in logs or status.** Provider credentials are forwarded as command
+  env into the sandbox; never print them. Do not paste tokens into prompts.
+- **kindctl invariant.** Never run bare `kubectl`/`kind` against a kindctl
+  cluster, and never read/write/switch `~/.kube/config`. Use
+  `kindctl kubectl` / `kindctl exec`, or export `KUBECONFIG` via `kindctl env`
+  for child scripts.
+
+## Troubleshooting
+
+- **Task rejected before Job creation:** confirm the controller actually has
+  `--agent-sandbox-enabled=true` (the flag patch is skipped if Orka was not
+  deployed first); check `templateRef.name` / default template, `reusePolicy`,
+  `cleanupPolicy`, and `sessionRef.name` for `reusePolicy: session`.
+- **ImagePullBackOff on sandbox/router pods:** the `localhost:5001` registry is
+  missing or not wired as a containerd mirror — see the registry precondition.
+- **Inner agent CLI connection refused:** exec into a retained sandbox and verify
+  DNS/TCP reachability to the model/proxy base URL from inside the sandbox pod.
+- **Controller rollout fails after the flag patch:** preserve the controller's
+  `/data` and `/tmp` volume mounts, probes, resources, and security context.
+- Full troubleshooting matrix: `website/docs/concepts/agent-sandbox.md`.

--- a/.codex/skills/agent-sandbox-deploy/SKILL.md
+++ b/.codex/skills/agent-sandbox-deploy/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: agent-sandbox-deploy
-description: Stand up the upstream kubernetes-sigs agent-sandbox workspace provider on a local kind cluster and run an Orka agent Task through a sandbox-backed workspace. Use when the user asks to install, enable, deploy, configure, validate, demo, or troubleshoot agent-sandbox execution workspaces for Orka (Task.spec.execution.workspace with provider agent-sandbox).
+description: Stand up the upstream kubernetes-sigs agent-sandbox workspace provider on a local kind cluster, validate the currently supported install/config and plain-agent paths, and treat workspace-backed Orka agent Tasks as expected-failure/future API checks until harness support lands. Use when the user asks to install, enable, deploy, configure, validate, demo, or troubleshoot agent-sandbox execution workspaces for Orka (Task.spec.execution.workspace with provider agent-sandbox).
 ---
 
 # Agent Sandbox Deploy
 
 Stand up the experimental [`kubernetes-sigs/agent-sandbox`](https://github.com/kubernetes-sigs/agent-sandbox)
-workspace provider against an Orka controller on a local kind cluster, then
-validate it by running a `type: agent` Task whose `spec.execution.workspace`
-routes to an agent-sandbox workspace.
+workspace provider against an Orka controller on a local kind cluster. Today,
+validate install/config and the plain harness-backed agent path; treat a
+`type: agent` Task with `spec.execution.workspace` as an expected-failure check
+for the documented harness gate until workspace-backed agent Tasks are wired.
 
 This skill is for **local/kind evaluation and validation**, not production.
 Orka does not install or manage upstream agent-sandbox CRDs, the router,
@@ -57,31 +58,53 @@ Use `$kindctl` so the kubeconfig stays scoped to this repo/worktree and never
 touches `~/.kube/config`. Every command below runs against the kindctl
 kubeconfig.
 
+Use a resolved `kindctl` binary for the snippets below. Prefer `KINDCTL_BIN` or
+`PATH`; fall back to the repo-local skill checkout when it exists:
+
+```bash
+kindctl="${KINDCTL_BIN:-$(command -v kindctl || true)}"
+if [ -z "$kindctl" ] && [ -x .agents/skills/kindctl/bin/kindctl ]; then
+  kindctl=.agents/skills/kindctl/bin/kindctl
+fi
+test -x "$kindctl"
+```
+
 1. **Create the repo-scoped cluster.**
 
-   ```bash
-   .agents/skills/kindctl/bin/kindctl create
-   .agents/skills/kindctl/bin/kindctl kubectl get nodes
-   ```
-
-   > **Registry precondition for `AGENTIC=1`.** The agentic layer
-   > `docker push`es to `localhost:${KIND_REGISTRY_PORT}` (default `5001`) and
-   > expects the kind node to pull from it as a containerd mirror. A default
-   > kindctl cluster has **no** such image registry (kindctl's own "registry" is
-   > a JSON cluster-metadata store, not a Docker registry). Either:
+   > **Registry precondition for `AGENTIC=1`: do this before cluster create.** The
+   > agentic layer `docker push`es to `localhost:${KIND_REGISTRY_PORT}` (default
+   > `5001`) and expects the kind node to pull from it as a containerd mirror. A
+   > default kindctl cluster has **no** such image registry (kindctl's own
+   > "registry" is a JSON cluster-metadata store, not a Docker registry). Either:
    > - commit a repo `.kind/cluster.yaml` + `.kind/setup.sh` that stands up a
-   >   `localhost:5001` registry and wires the containerd mirror before running
-   >   the agentic layer, **or**
-   > - run with `AGENTIC=0` for a base-layer-only install (no model run), **or**
-   > - point the script at pre-loaded images via `ORKA_SANDBOX_RUNTIME_IMAGE` /
-   >   `ORKA_SANDBOX_ROUTER_IMAGE` that you `kindctl load` yourself.
-   > Confirm the registry path with the user before assuming `AGENTIC=1` works on
-   > a bare kindctl cluster.
+   >   `localhost:5001` registry and wires the containerd mirror **before** running
+   >   `"$kindctl" create`; if the cluster already exists, delete/recreate it after
+   >   adding those files, **or**
+   > - run with `AGENTIC=0` for a base-layer-only install (no router/model run).
+   > `AGENTIC=1` always builds and `docker push`es the runtime and router images;
+   > `ORKA_SANDBOX_RUNTIME_IMAGE` only changes the runtime image tag/reference and
+   > there is no router-image override in the installer. Confirm the registry path
+   > with the user before assuming `AGENTIC=1` works on a bare kindctl cluster.
+
+   ```bash
+   "$kindctl" create
+   "$kindctl" kubectl get nodes
+   ```
 
 2. **Deploy the Orka controller** into the cluster with `$orka-kind-deploy`
    (build + load controller and worker images, install CRDs, roll out
-   `orka-controller-manager`). The harness wrapper image must be present too —
-   sandbox runs re-exec the agent CLI inside the sandbox.
+   `orka-controller-manager`). Run the deploy under the kindctl-scoped kubeconfig
+   so its `kubectl` discovery sees the repo-scoped cluster:
+
+   ```bash
+   orka_kind_deploy="${ORKA_KIND_DEPLOY_BIN:-.codex/skills/orka-kind-deploy/scripts/deploy_orka_kind.sh}"
+   test -x "$orka_kind_deploy"
+   eval "$("$kindctl" env)"
+   "$orka_kind_deploy"
+   ```
+
+   The harness wrapper image must be present too — sandbox runs re-exec the
+   agent CLI inside the sandbox.
 
 3. **Install agent-sandbox** by driving the canonical script against the kindctl
    kubeconfig. Export `KUBECONFIG` from kindctl so the script's `kubectl` calls
@@ -89,8 +112,8 @@ kubeconfig.
    the script reads:
 
    ```bash
-   eval "$(.agents/skills/kindctl/bin/kindctl env)"   # exports scoped KUBECONFIG
-   kube="$(.agents/skills/kindctl/bin/kindctl path)"   # ~/.kube/kind/<name>.kubeconfig
+   eval "$("$kindctl" env)"   # exports scoped KUBECONFIG
+   kube="$("$kindctl" path)"   # ~/.kube/kind/<name>.kubeconfig
    ORKA_DEMO_CLUSTER="$(basename "$kube" .kubeconfig)" \
    AGENTIC=0 \
      bash hack/demos/cluster/install-agent-sandbox.sh
@@ -102,15 +125,28 @@ kubeconfig.
    the kindctl cluster. Verify the selected context in the script's logs before
    continuing. Use `AGENTIC=1` only once the registry precondition above is met.
 
-4. **Stand up the model proxy (vekil) — pause for the human.** The agentic layer
-   calls the vekil deploy script with `--skip-wait`, which starts a GitHub
-   device-code login. **Surface the login URL and code to the user and wait for
-   their confirmation; never complete the login on their behalf.** This mirrors
-   the `$vekil-reverse-proxy-deploy` guardrail.
+4. **Optional: add the agentic/model layer (vekil) — pause for the human.**
+   Skip this step for base-layer-only or model-free validation. For a
+   model-backed smoke, first satisfy the registry/image precondition above, then
+   rerun the installer with `AGENTIC=1` so it deploys the sandbox runtime/router,
+   vekil, model/git Secrets, and the API client ServiceAccount:
 
    ```bash
-   .agents/skills/kindctl/bin/kindctl kubectl -n vekil-system logs deploy/vekil | grep 'login/device'
+   eval "$("$kindctl" env)"
+   kube="$("$kindctl" path)"
+   agent_sandbox_version="${ORKA_AGENT_SANDBOX_VERSION:-v0.4.6}"
+   go mod download "sigs.k8s.io/agent-sandbox@${agent_sandbox_version}"
+   test -d "$(go env GOMODCACHE)/sigs.k8s.io/agent-sandbox@${agent_sandbox_version}/clients/python/agentic-sandbox-client/sandbox-router"
+   ORKA_DEMO_CLUSTER="$(basename "$kube" .kubeconfig)" \
+   AGENTIC=1 \
+     bash hack/demos/cluster/install-agent-sandbox.sh
    ```
+
+   The agentic layer calls the vekil deploy script with `--skip-wait`, which
+   starts a GitHub device-code login. **Surface the login URL and code to the
+   user and wait for their confirmation; never complete the login on their
+   behalf.** This mirrors the `$vekil-reverse-proxy-deploy` guardrail. First
+   disarm the liveness race below; then read and surface the device-code prompt.
 
    > **Login race (verified live 2026-06): disarm vekil's liveness probe before
    > surfacing the code.** vekil binds its port only after the Copilot login
@@ -120,30 +156,53 @@ kubeconfig.
    > pod before handing the user a code:
    >
    > ```bash
-   > .agents/skills/kindctl/bin/kindctl kubectl -n vekil-system patch deploy vekil \
-   >   --type=json -p '[{"op":"remove","path":"/spec/template/spec/containers/0/livenessProbe"}]'
+   > "$kindctl" kubectl -n vekil-system get deploy vekil >/dev/null
+   > if "$kindctl" kubectl -n vekil-system get deploy vekil \
+   >   -o jsonpath='{.spec.template.spec.containers[0].livenessProbe.httpGet.path}' | grep -q .; then
+   >   "$kindctl" kubectl -n vekil-system patch deploy vekil \
+   >     --type=json -p '[{"op":"remove","path":"/spec/template/spec/containers/0/livenessProbe"}]'
+   > fi
+   > "$kindctl" kubectl -n vekil-system scale deploy/vekil --replicas=0
+   > for _ in $(seq 1 60); do
+   >   [ -z "$("$kindctl" kubectl -n vekil-system get pod -l app.kubernetes.io/name=vekil,app.kubernetes.io/instance=vekil -o name 2>/dev/null)" ] && break
+   >   sleep 2
+   > done
+   > test -z "$("$kindctl" kubectl -n vekil-system get pod -l app.kubernetes.io/name=vekil,app.kubernetes.io/instance=vekil -o name 2>/dev/null)"
+   > "$kindctl" kubectl -n vekil-system scale deploy/vekil --replicas=1
+   > for _ in $(seq 1 60); do
+   >   [ "$("$kindctl" kubectl -n vekil-system get pod -l app.kubernetes.io/name=vekil,app.kubernetes.io/instance=vekil --no-headers 2>/dev/null | wc -l | tr -d ' ')" = "1" ] && break
+   >   sleep 2
+   > done
+   > test "$("$kindctl" kubectl -n vekil-system get pod -l app.kubernetes.io/name=vekil,app.kubernetes.io/instance=vekil --no-headers 2>/dev/null | wc -l | tr -d ' ')" = "1"
    > ```
    >
-   > GitHub device codes expire in ~15 min; surface promptly, and if it expires,
-   > bounce the pod (`kindctl kubectl -n vekil-system delete pod -l app=vekil`)
-   > for a fresh code rather than waiting.
+   > Then read the code from the single fresh pod:
+   >
+   > ```bash
+   > "$kindctl" kubectl -n vekil-system logs deploy/vekil | grep 'login/device'
+   > ```
+   >
+   > GitHub device codes expire in
+   > ~15 min; surface promptly, and if it expires, bounce the pod
+   > (`"$kindctl" kubectl -n vekil-system delete pod -l app.kubernetes.io/name=vekil,app.kubernetes.io/instance=vekil`) for a fresh code
+   > rather than waiting.
 
    Then wait for readiness before any model-backed Task:
 
    ```bash
-   .agents/skills/kindctl/bin/kindctl kubectl -n vekil-system exec deploy/vekil -- \
+   "$kindctl" kubectl -n vekil-system exec deploy/vekil -- \
      wget -qO- http://127.0.0.1:1337/readyz
    ```
 
-   If you only need to validate Orka's sandbox plumbing (claim → ready →
-   exec → cleanup) without a real model, prefer the model-free e2e in step 6
-   instead of standing up vekil.
+   If you only need model-free confidence, run the CI parity script below. It
+   validates installation/configuration only while workspace-backed agent Tasks
+   remain gated; it is not a claim/readiness/exec/cleanup smoke.
 
 ## Validate
 
 > **Known gate (verified live 2026-06): agent Tasks with an execution workspace
-> are rejected by the current service-backed harness runtime.** The smoke Task
-> below fails immediately with
+> are rejected by the current service-backed harness runtime.** Any Task that
+> sets `spec.execution.workspace` fails immediately with
 > `status.executionWorkspace.reason=WorkspaceValidationFailed` and message
 > `execution workspace is not supported by harness runtime yet` — an
 > unconditional gate in `internal/controller/harness_wrapper.go`
@@ -151,24 +210,90 @@ kubeconfig.
 > run through the long-lived `agent-harness-wrapper` service, and the
 > Task→sandbox-workspace path for agents is not wired through it yet. A **plain**
 > agent Task (no `execution.workspace`) runs fine through the harness + model
-> proxy, so use that to confirm the model path; use the model-free e2e
-> (`scripts/live-agent-sandbox-e2e.sh`) to confirm sandbox plumbing. Treat the
-> Task YAML below as the intended API once the harness wires workspaces.
+> proxy, so use that to confirm the model path. The model-free e2e currently
+> confirms installation/configuration only; it deliberately skips the
+> execution-workspace Task smoke while the harness gate is present. Treat only
+> the execution-workspace YAML in the optional expected-failure check as the
+> intended future API once the harness wires workspaces.
 
-Run the live smoke Task from the concept doc against the kindctl cluster
-(namespace, agent, and template match `install-agent-sandbox.sh`'s defaults):
+Do **not** use an execution-workspace agent Task as the success criterion yet.
+Validate the two currently wired paths separately:
+
+- **Model path through the harness** (requires the optional `AGENTIC=1` step and
+  vekil ready): run a plain agent Task with no `execution.workspace` and wait
+  for it to succeed.
 
 ```bash
-.agents/skills/kindctl/bin/kindctl kubectl apply -f - <<'YAML'
+"$kindctl" kubectl -n demo-magic apply -f - <<'YAML'
+apiVersion: core.orka.ai/v1alpha1
+kind: Agent
+metadata:
+  name: sandbox-codex-agent
+  namespace: demo-magic
+spec:
+  runtime:
+    type: codex
+    defaultMaxTurns: 1
+    defaultAllowBash: true
+  model:
+    name: gpt-5.5
+  secretRef:
+    name: sandbox-model-key
+---
+apiVersion: core.orka.ai/v1alpha1
+kind: Task
+metadata:
+  name: orka-live-model-smoke
+  namespace: demo-magic
+spec:
+  type: agent
+  agentRef:
+    name: sandbox-codex-agent
+  agentRuntime:
+    maxTurns: 1
+  timeout: 10m0s
+  prompt: "Reply exactly: ORKA_LIVE_MODEL_OK"
+YAML
+
+"$kindctl" kubectl -n demo-magic \
+  wait --for=jsonpath='{.status.phase}'=Succeeded task/orka-live-model-smoke --timeout=10m
+```
+
+- **Installation/configuration parity**: run the model-free CI parity script
+  below when you want a self-contained cluster bring-up with fake model
+  credentials. It verifies the install/config path, but it does **not** exercise
+  claim → ready → exec → cleanup while the harness gate is present.
+
+If you need to demonstrate the intended API shape before harness workspace
+support lands, run it only as an **expected-failure** check and wait for the gate
+instead of `Succeeded`:
+
+```bash
+"$kindctl" kubectl apply -f - <<'YAML'
+apiVersion: core.orka.ai/v1alpha1
+kind: Agent
+metadata:
+  name: sandbox-codex-agent
+  namespace: demo-magic
+spec:
+  runtime:
+    type: codex
+    defaultMaxTurns: 1
+    defaultAllowBash: true
+  model:
+    name: gpt-5.5
+  secretRef:
+    name: sandbox-model-key
+---
 apiVersion: core.orka.ai/v1alpha1
 kind: Task
 metadata:
   name: orka-live-sandbox-smoke
-  namespace: orka-system
+  namespace: demo-magic
 spec:
   type: agent
   agentRef:
-    name: claude-agent
+    name: sandbox-codex-agent
   agentRuntime:
     maxTurns: 1
   timeout: 10m0s
@@ -182,21 +307,26 @@ spec:
   prompt: "Reply exactly: ORKA_LIVE_SANDBOX_OK"
 YAML
 
-.agents/skills/kindctl/bin/kindctl kubectl -n orka-system \
-  wait --for=jsonpath='{.status.phase}'=Succeeded task/orka-live-sandbox-smoke --timeout=10m
+"$kindctl" kubectl -n demo-magic \
+  wait --for=jsonpath='{.status.executionWorkspace.reason}'=WorkspaceValidationFailed \
+  task/orka-live-sandbox-smoke --timeout=2m
 ```
 
-A successful sandbox wrapper log includes the claimed workspace name, e.g.
-`completed in sandbox workspace sandbox-claim-...`. Orka Task status does **not**
-expose sandbox claim/exec/cleanup state — read worker logs and upstream
-agent-sandbox resources for lifecycle detail.
+Once the harness wires agent Tasks to execution workspaces, the expected-failure
+check can become the live success smoke. At that point, a successful sandbox
+wrapper log should include the claimed workspace name, e.g. `completed in
+sandbox workspace sandbox-claim-...`. Orka Task status does **not** expose
+sandbox claim/exec/cleanup state — read worker logs and upstream agent-sandbox
+resources for lifecycle detail.
 
 ### Model-free CI parity
 
 `scripts/live-agent-sandbox-e2e.sh` (run by the `Live Agent Sandbox E2E`
-workflow) stands up the whole path with a deterministic fake `claude` CLI and
-**no model access**. Use it to validate Orka's sandbox plumbing independently of
-provider availability:
+workflow) stands up a clean kind cluster with fake model credentials and **no
+model access**. Because the current harness-wrapper runtime is service-backed,
+the script logs `Skipping agent-sandbox Task smoke...` and does not create a
+SandboxClaim or exercise the router exec data path. Use it for installation and
+controller-flag CI parity, not as proof of workspace execution:
 
 ```bash
 bash scripts/live-agent-sandbox-e2e.sh

--- a/.codex/skills/agent-sandbox-deploy/agents/openai.yaml
+++ b/.codex/skills/agent-sandbox-deploy/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Agent Sandbox Deploy"
-  short_description: "Stand up agent-sandbox workspaces on kind for Orka"
-  default_prompt: "Use $agent-sandbox-deploy to stand up the kubernetes-sigs agent-sandbox workspace provider on a local kind cluster and run an Orka agent Task through a sandbox-backed workspace."
+  short_description: "Stand up agent-sandbox install/config parity on kind for Orka"
+  default_prompt: "Use $agent-sandbox-deploy to stand up the kubernetes-sigs agent-sandbox workspace provider on a local kind cluster, validate the currently supported install/config and plain-agent paths, and treat workspace-backed agent Tasks as an expected-failure/future API check until harness support lands."

--- a/.codex/skills/agent-sandbox-deploy/agents/openai.yaml
+++ b/.codex/skills/agent-sandbox-deploy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Agent Sandbox Deploy"
+  short_description: "Stand up agent-sandbox workspaces on kind for Orka"
+  default_prompt: "Use $agent-sandbox-deploy to stand up the kubernetes-sigs agent-sandbox workspace provider on a local kind cluster and run an Orka agent Task through a sandbox-backed workspace."

--- a/.codex/skills/agent-substrate-deploy/SKILL.md
+++ b/.codex/skills/agent-substrate-deploy/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: agent-substrate-deploy
+description: Stand up Agent Substrate (warm, suspendable, gVisor-isolated Actors) on a dedicated local kind cluster wired to Orka, then run an Orka agent Task through a Substrate-backed execution workspace. Use when the user asks to install, enable, deploy, configure, validate, demo, or troubleshoot the Orka substrate execution-workspace provider, SubstrateActorPool, ActorTemplate, or Substrate-backed MCP Tools.
+---
+
+# Agent Substrate Deploy
+
+Stand up [Agent Substrate](https://github.com/agent-substrate/substrate) and an
+Orka-compatible `WorkerPool` + `ActorTemplate` on a local kind cluster, wire Orka
+with `--substrate-*` flags, then validate by running a `type: agent` Task whose
+`spec.execution.workspace` uses `provider: substrate`.
+
+This skill is for **local/kind evaluation and validation**, not production. Orka
+does not install or manage Substrate (CRDs, control plane, router, snapshot
+store, WorkerPool capacity) in production. See
+`website/docs/concepts/substrate.md` for the full design, controller flags, and
+ActorTemplate compatibility contract.
+
+## What this skill orchestrates (do not retype)
+
+The repeatable standup already lives in
+`hack/demos/cluster/install-substrate.sh`, a thin `KEEP_CLUSTER=1` wrapper over
+the CI-proven `scripts/agent-substrate-e2e.sh`. **Drive the installer in place;
+do not copy either script into the skill.** They pin the Substrate revision
+(`SUBSTRATE_REF`, default `b80031d260959b1fc5c6f61e3099fe2a6d368af1`) and own the
+heavy lifting: clone Substrate at the pinned ref, create the kind cluster + local
+registry, deploy the `ate-system` control plane, build/push the controller +
+codex-worker + workspace-agent images via `docker` + `ko`, create a `WorkerPool`
++ gVisor `ActorTemplate`, initialize the RustFS snapshot bucket, and deploy Orka
+wired with `--substrate-*`. Re-pin by overriding `SUBSTRATE_REF`, not by editing
+a copy.
+
+The base standup is **secret-free**. The agentic layer (`AGENTIC=1`, default)
+additionally builds a codex-capable Actor image, deploys the vekil model proxy
+(device-code login), and creates the model + git Secrets.
+
+## Why kindctl cannot host this cluster (the honest exception)
+
+Unlike agent-sandbox, **Substrate must own its own kind cluster** and cannot
+bolt onto a `$kindctl`-managed one. Substrate's `hack/create-kind-cluster.sh`
+uses a custom local Docker registry plus gVisor/`runsc` node configuration, and
+its standup does `kind delete` + recreate. A default kindctl cluster has neither
+the registry mirror nor the gVisor runtime, and kindctl only operates on
+clusters it created (`kindctl kubectl` rejects unowned clusters).
+
+So for Substrate:
+
+- **Do not** run `kindctl create` and try to install Substrate into it.
+- **Do** let `install-substrate.sh` create and own the cluster (named by
+  `KIND_CLUSTER`, default `orka-agent-substrate-e2e`; context
+  `kind-<KIND_CLUSTER>`). This cluster is registered in the standard kubeconfig,
+  not in kindctl's scoped store, so use plain
+  `kubectl --context kind-<KIND_CLUSTER>` for it.
+
+If the user explicitly wants kindctl-style isolation, the supported route is to
+commit a repo `.kind/cluster.yaml` (gVisor node image + `containerd` registry
+mirror) and `.kind/setup.sh` and adapt the Substrate install to target it — that
+is a larger task; confirm scope before attempting it.
+
+## Standard workflow
+
+1. **Preflight tools.** The installer needs `kind`, `ko`, `docker`, `go`, `git`,
+   `jq`, `kubectl`, `curl` (and `gh` for the git-token convenience). Put the Go
+   bin dir on PATH so a `go install`ed `ko` is found:
+
+   ```bash
+   PATH="$(go env GOPATH)/bin:$PATH"
+   command -v ko >/dev/null || go install github.com/google/ko@v0.18.1
+   ```
+
+2. **Stand up Substrate + Orka.** First run builds four images and the Substrate
+   control plane — several minutes.
+
+   ```bash
+   # Base standup only (secret-free, no model run):
+   AGENTIC=0 bash hack/demos/cluster/install-substrate.sh
+
+   # Full agentic standup (codex Actor image + vekil + secrets):
+   bash hack/demos/cluster/install-substrate.sh
+   ```
+
+   Re-running on an existing cluster prompts reuse/recreate/cancel. For
+   non-interactive runs set `DEMO_CLUSTER_REUSE=reuse|recreate|cancel` — **note
+   that `recreate` destroys the cluster and any completed vekil login.**
+
+3. **Stand up the model proxy (vekil) — pause for the human.** When `AGENTIC=1`,
+   the installer deploys vekil with `--skip-wait`, starting a GitHub device-code
+   login. **Surface the login URL and code to the user and wait for their
+   confirmation; never complete the login on their behalf** (the
+   `$vekil-reverse-proxy-deploy` guardrail). Find the prompt and check
+   readiness:
+
+   ```bash
+   ctx="kind-${KIND_CLUSTER:-orka-agent-substrate-e2e}"
+   kubectl --context "$ctx" -n vekil-system logs deploy/vekil | grep 'login/device'
+   kubectl --context "$ctx" -n vekil-system exec deploy/vekil -- wget -qO- http://127.0.0.1:1337/readyz
+   ```
+
+   > **Login race (verified live 2026-06): disarm vekil's liveness probe before
+   > surfacing the code.** vekil does not bind its port until the Copilot login
+   > completes, so its `livenessProbe` on `/healthz` fails and restarts the pod
+   > every ~60s — and **each restart mints a NEW device code**, so a human login
+   > against the old code can never land. The pod's `/readyz` readiness gate stays
+   > un-ready until login, which is correct; the liveness probe is the problem.
+   > Before handing the user a code, remove it and collapse to one pod:
+   >
+   > ```bash
+   > kubectl --context "$ctx" -n vekil-system patch deploy vekil --type=json \
+   >   -p '[{"op":"remove","path":"/spec/template/spec/containers/0/livenessProbe"}]'
+   > kubectl --context "$ctx" -n vekil-system delete rs -l app=vekil \
+   >   --field-selector 'status.replicas!=0' 2>/dev/null || true
+   > ```
+   >
+   > Then read the code from the single fresh pod. GitHub device codes expire in
+   > ~15 min, so surface it promptly and, if it expires, bounce the pod
+   > (`kubectl delete pod -l app=vekil`) for a fresh code rather than waiting.
+
+   For a model-free validation, stay on `AGENTIC=0` and rely on the built-in
+   smoke exercises (next section) instead of standing up vekil.
+
+## Validate
+
+> **Known gate (verified live 2026-06): agent Tasks with an execution workspace
+> are rejected by the current service-backed harness runtime.** A
+> `provider: substrate` (or `agent-sandbox`) agent Task fails immediately with
+> `status.executionWorkspace.reason=WorkspaceValidationFailed` and message
+> `execution workspace is not supported by harness runtime yet`. This is an
+> unconditional gate in `internal/controller/harness_wrapper.go`
+> (`runHarnessWrapperTask`), not a misconfiguration — the agent CLI runtimes now
+> run through the long-lived `agent-harness-wrapper` service, and the
+> Task→workspace path for agents is not wired through it yet. The bundled e2e
+> reflects this: it prints `Skipping agent Task execution-workspace checks:
+> harness-wrapper runtime is service-backed`. What IS validated end-to-end today
+> is the **direct** Substrate path (actor create/resume/router/daemon exec/
+> suspend/delete + retained-workspace reuse), exercised by
+> `SUBSTRATE_E2E_EXTENDED=1` during standup. A **plain** agent Task (no
+> `execution.workspace`) runs fine through the harness + model proxy. Treat the
+> Task YAML below as the intended API once the harness wires workspaces; until
+> then, validate via the e2e's direct-actor exercises.
+
+The installer leaves a fully wired cluster; `SUBSTRATE_E2E_EXTENDED=1` (default)
+already smoke-tests direct actor create/resume/exec/suspend/delete and the
+retained-workspace warm-reuse path during standup.
+
+To talk to the cluster, first make sure its context is in your kubeconfig — the
+installer runs the e2e with an isolated kubeconfig and does **not** leave
+`kind-<KIND_CLUSTER>` in your default one:
+
+```bash
+kind export kubeconfig --name "${KIND_CLUSTER:-orka-agent-substrate-e2e}"
+```
+
+To drive an Orka Task yourself (intended shape; currently gated as noted above):
+
+```bash
+ctx="kind-${KIND_CLUSTER:-orka-agent-substrate-e2e}"
+kubectl --context "$ctx" -n default apply -f - <<'YAML'
+apiVersion: core.orka.ai/v1alpha1
+kind: Task
+metadata:
+  name: substrate-smoke
+  namespace: default
+spec:
+  type: agent
+  agentRef:
+    name: codex-agent
+  prompt: "Run make test and summarize the result."
+  sessionRef:
+    name: substrate-demo
+    create: true
+  execution:
+    workspace:
+      enabled: true
+      provider: substrate
+      templateRef:
+        name: orka-codex
+        namespace: ate-demo
+      reusePolicy: session
+      cleanupPolicy: retain
+YAML
+
+kubectl --context "$ctx" -n default get task substrate-smoke -o yaml
+```
+
+Check the provider-neutral workspace lifecycle in
+`status.executionWorkspace` (`phase`, `placement`, `density`, `resumeLatency`).
+Status is intentionally sanitized — it must not expose actor IDs, snapshot URIs,
+worker pod IPs, daemon URLs, or tokens.
+
+### CI parity
+
+`scripts/agent-substrate-e2e.sh` (the `Agent Substrate E2E` workflow) runs the
+same path end-to-end and is secret-free. Run it directly when you want a clean,
+self-contained validation with its own cluster lifecycle:
+
+```bash
+PATH="$(go env GOPATH)/bin:$PATH" SUBSTRATE_E2E_EXTENDED=1 bash scripts/agent-substrate-e2e.sh
+```
+
+Set `KEEP_CLUSTER=1` to inspect the cluster after a failure.
+
+## Guardrails
+
+- **Local/kind eval only.** Do not present this as a production install. Orka
+  does not own Substrate lifecycle, WorkerPool capacity, or runtime-artifact
+  supply chain in production.
+- **Substrate owns its cluster.** Do not try to host it on a kindctl cluster;
+  use the installer-created `kind-<KIND_CLUSTER>` context. Be explicit with the
+  user that this is the one provider where kindctl is not the cluster creator.
+- **Reference, don't fork.** Drive `hack/demos/cluster/install-substrate.sh` and
+  override pins via env (`SUBSTRATE_REF`, `KIND_CLUSTER`, `AGENTIC`,
+  `DEMO_CLUSTER_REUSE`). Copying the script invites drift from the CI-proven
+  flow.
+- **Human-in-the-loop vekil login.** Surface the device-code URL + code and wait
+  for confirmation. Never complete the GitHub login yourself.
+- **Destructive recreate.** `DEMO_CLUSTER_REUSE=recreate` (and a fresh
+  `scripts/agent-substrate-e2e.sh` run) deletes the cluster. Confirm with the
+  user before recreating a cluster that holds a completed vekil login or state.
+- **No secrets in spec/status/logs.** Never put API keys, source-control tokens,
+  or the Substrate bootstrap token directly in an `ActorTemplate`; use Secrets.
+  The bootstrap token is control-plane credential material — keep it in a Secret
+  and never print it.
+
+## Troubleshooting
+
+- `... requires substrate to be enabled`: controller missing
+  `--substrate-enabled=true`.
+- `bootstrap token secret name is required`: set
+  `--substrate-bootstrap-token-secret-name` and create that Secret in the Task
+  namespace **and** the `ActorTemplate` namespace.
+- `ActorTemplate ... missing label/annotation` / `not Orka-compatible`: the
+  template needs `orka.ai/execution-workspace: "true"`,
+  `orka.ai/workspace-provider: substrate`, the daemon-port/protocol/staging-root
+  annotations, and must run `/orka-workspace-agent` from the agent harness
+  wrapper image. See the ActorTemplate contract in the concept doc.
+- `ActorTemplate ... is not Ready`: inspect Substrate `WorkerPool`, snapshot
+  config, image pulls, and `runsc` configuration.
+- Task `Failed` with `WorkspaceCleanupFailed` after `resultRef.available=true`:
+  command + result succeeded but Substrate failed to checkpoint/delete the actor
+  (a known pinned-revision `runsc delete` flake in GitHub-hosted kind). Inspect
+  `atelet` / `ateom-gvisor` logs.
+- Inspect Substrate directly:
+  `kubectl --context "$ctx" -n ate-system get pods`,
+  `kubectl --context "$ctx" -n ate-demo get workerpool,actortemplate`,
+  `kubectl --context "$ctx" -n ate-system logs deployment/atenet-router`.
+- Full troubleshooting matrix: `website/docs/concepts/substrate.md`.

--- a/.codex/skills/agent-substrate-deploy/SKILL.md
+++ b/.codex/skills/agent-substrate-deploy/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: agent-substrate-deploy
-description: Stand up Agent Substrate (warm, suspendable, gVisor-isolated Actors) on a dedicated local kind cluster wired to Orka, then run an Orka agent Task through a Substrate-backed execution workspace. Use when the user asks to install, enable, deploy, configure, validate, demo, or troubleshoot the Orka substrate execution-workspace provider, SubstrateActorPool, ActorTemplate, or Substrate-backed MCP Tools.
+description: Stand up Agent Substrate (warm, suspendable, gVisor-isolated Actors) on a dedicated local kind cluster wired to Orka, validate the direct Substrate/MCP smoke paths, and treat workspace-backed Orka agent Tasks as expected-failure/future API checks until harness support lands. Use when the user asks to install, enable, deploy, configure, validate, demo, or troubleshoot the Orka substrate execution-workspace provider, WorkerPool, ActorTemplate, or Substrate-backed MCP Tools.
 ---
 
 # Agent Substrate Deploy
 
 Stand up [Agent Substrate](https://github.com/agent-substrate/substrate) and an
 Orka-compatible `WorkerPool` + `ActorTemplate` on a local kind cluster, wire Orka
-with `--substrate-*` flags, then validate by running a `type: agent` Task whose
-`spec.execution.workspace` uses `provider: substrate`.
+with `--substrate-*` flags, then validate the direct Substrate actor/router and
+MCP tool paths. Today, `type: agent` Tasks whose `spec.execution.workspace` uses
+`provider: substrate` are expected-failure/future API checks because the
+service-backed harness rejects execution workspaces.
 
 This skill is for **local/kind evaluation and validation**, not production. Orka
 does not install or manage Substrate (CRDs, control plane, router, snapshot
@@ -48,9 +50,9 @@ So for Substrate:
 - **Do not** run `kindctl create` and try to install Substrate into it.
 - **Do** let `install-substrate.sh` create and own the cluster (named by
   `KIND_CLUSTER`, default `orka-agent-substrate-e2e`; context
-  `kind-<KIND_CLUSTER>`). This cluster is registered in the standard kubeconfig,
-  not in kindctl's scoped store, so use plain
-  `kubectl --context kind-<KIND_CLUSTER>` for it.
+  `kind-<KIND_CLUSTER>`). This cluster is not kindctl-owned. After a fresh
+  standup, export its kubeconfig into a scoped kubeconfig file before running
+  plain `kubectl --context kind-<KIND_CLUSTER>` commands.
 
 If the user explicitly wants kindctl-style isolation, the supported route is to
 commit a repo `.kind/cluster.yaml` (gVisor node image + `containerd` registry
@@ -68,32 +70,56 @@ is a larger task; confirm scope before attempting it.
    command -v ko >/dev/null || go install github.com/google/ko@v0.18.1
    ```
 
-2. **Stand up Substrate + Orka.** First run builds four images and the Substrate
+2. **Stand up Substrate + Orka.** For a fresh cluster, start with the base
+   standup (secret-free, no model run). It builds four images and the Substrate
    control plane — several minutes.
 
    ```bash
-   # Base standup only (secret-free, no model run):
    AGENTIC=0 bash hack/demos/cluster/install-substrate.sh
-
-   # Full agentic standup (codex Actor image + vekil + secrets):
-   bash hack/demos/cluster/install-substrate.sh
    ```
 
    Re-running on an existing cluster prompts reuse/recreate/cancel. For
    non-interactive runs set `DEMO_CLUSTER_REUSE=reuse|recreate|cancel` — **note
    that `recreate` destroys the cluster and any completed vekil login.**
 
-3. **Stand up the model proxy (vekil) — pause for the human.** When `AGENTIC=1`,
-   the installer deploys vekil with `--skip-wait`, starting a GitHub device-code
-   login. **Surface the login URL and code to the user and wait for their
-   confirmation; never complete the login on their behalf** (the
-   `$vekil-reverse-proxy-deploy` guardrail). Find the prompt and check
-   readiness:
+3. **Export kubeconfig for follow-up kubectl commands.** The e2e standup uses an
+   isolated kubeconfig internally. Before reading vekil logs, patching probes,
+   or applying Tasks from your shell, make the retained kind cluster visible in a
+   throwaway kubeconfig and set the context variable used below:
 
    ```bash
-   ctx="kind-${KIND_CLUSTER:-orka-agent-substrate-e2e}"
-   kubectl --context "$ctx" -n vekil-system logs deploy/vekil | grep 'login/device'
-   kubectl --context "$ctx" -n vekil-system exec deploy/vekil -- wget -qO- http://127.0.0.1:1337/readyz
+   cluster="${KIND_CLUSTER:-orka-agent-substrate-e2e}"
+   ctx="kind-${cluster}"
+   export KUBECONFIG="$(mktemp -t orka-substrate-kubeconfig.XXXXXX)"
+   kind export kubeconfig --name "${cluster}" --kubeconfig "${KUBECONFIG}"
+   ```
+
+4. **Add the model proxy (vekil) — pause for the human.** For model-backed
+   validation, rerun the installer against the exported/reused cluster with the
+   agentic layer enabled (the default). It builds the codex Actor image, deploys
+   vekil with `--skip-wait`, and creates the model/git Secrets. vekil starts a
+   GitHub device-code login: **surface the login URL and code to the user and
+   wait for their confirmation; never complete the login on their behalf** (the
+   `$vekil-reverse-proxy-deploy` guardrail). Install/readiness flow:
+
+   ```bash
+   cluster="${KIND_CLUSTER:-orka-agent-substrate-e2e}"
+   ctx="kind-${cluster}"
+   export KUBECONFIG="$(mktemp -t orka-substrate-kubeconfig.XXXXXX)"
+   kind export kubeconfig --name "${cluster}" --kubeconfig "${KUBECONFIG}"
+   DEMO_CLUSTER_REUSE=reuse bash hack/demos/cluster/install-substrate.sh
+
+   # The base e2e creates codex-substrate-ci without model env and patches the
+   # service-backed harness wrapper to use a fake Codex CLI. Patch the Agent with
+   # the model Secret from the agentic layer and remove the fake CLI override
+   # before using a plain agent Task as model-validation evidence.
+   kubectl --context "$ctx" -n default patch agent codex-substrate-ci --type=merge \
+     -p "$(jq -cn \
+       --arg ref substrate-model-key \
+       --arg model gpt-5.5 \
+       '{spec:{model:{name:$model},secretRef:{name:$ref}}}')"
+   kubectl --context "$ctx" -n orka-system set env deployment/orka-agent-harness-wrapper CODEX_CLI_PATH-
+   kubectl --context "$ctx" -n orka-system rollout status deployment/orka-agent-harness-wrapper --timeout=5m
    ```
 
    > **Login race (verified live 2026-06): disarm vekil's liveness probe before
@@ -105,15 +131,42 @@ is a larger task; confirm scope before attempting it.
    > Before handing the user a code, remove it and collapse to one pod:
    >
    > ```bash
-   > kubectl --context "$ctx" -n vekil-system patch deploy vekil --type=json \
-   >   -p '[{"op":"remove","path":"/spec/template/spec/containers/0/livenessProbe"}]'
-   > kubectl --context "$ctx" -n vekil-system delete rs -l app=vekil \
-   >   --field-selector 'status.replicas!=0' 2>/dev/null || true
+   > kubectl --context "$ctx" -n vekil-system get deploy vekil >/dev/null
+   > if kubectl --context "$ctx" -n vekil-system get deploy vekil \
+   >   -o jsonpath='{.spec.template.spec.containers[0].livenessProbe.httpGet.path}' | grep -q .; then
+   >   kubectl --context "$ctx" -n vekil-system patch deploy vekil --type=json \
+   >     -p '[{"op":"remove","path":"/spec/template/spec/containers/0/livenessProbe"}]'
+   > fi
+   > kubectl --context "$ctx" -n vekil-system scale deploy/vekil --replicas=0
+   > for _ in $(seq 1 60); do
+   >   [ -z "$(kubectl --context "$ctx" -n vekil-system get pod -l app.kubernetes.io/name=vekil,app.kubernetes.io/instance=vekil -o name 2>/dev/null)" ] && break
+   >   sleep 2
+   > done
+   > test -z "$(kubectl --context "$ctx" -n vekil-system get pod -l app.kubernetes.io/name=vekil,app.kubernetes.io/instance=vekil -o name 2>/dev/null)"
+   > kubectl --context "$ctx" -n vekil-system scale deploy/vekil --replicas=1
+   > for _ in $(seq 1 60); do
+   >   [ "$(kubectl --context "$ctx" -n vekil-system get pod -l app.kubernetes.io/name=vekil,app.kubernetes.io/instance=vekil --no-headers 2>/dev/null | wc -l | tr -d ' ')" = "1" ] && break
+   >   sleep 2
+   > done
+   > test "$(kubectl --context "$ctx" -n vekil-system get pod -l app.kubernetes.io/name=vekil,app.kubernetes.io/instance=vekil --no-headers 2>/dev/null | wc -l | tr -d ' ')" = "1"
    > ```
    >
-   > Then read the code from the single fresh pod. GitHub device codes expire in
+   > Then read the code from the single fresh pod:
+   >
+   > ```bash
+   > kubectl --context "$ctx" -n vekil-system logs deploy/vekil | grep 'login/device'
+   > ```
+   >
+   > GitHub device codes expire in
    > ~15 min, so surface it promptly and, if it expires, bounce the pod
-   > (`kubectl delete pod -l app=vekil`) for a fresh code rather than waiting.
+   > (`kubectl --context "$ctx" -n vekil-system delete pod -l app.kubernetes.io/name=vekil,app.kubernetes.io/instance=vekil`) for a
+   > fresh code rather than waiting.
+
+   After the human completes login, check readiness before model-backed Tasks:
+
+   ```bash
+   kubectl --context "$ctx" -n vekil-system exec deploy/vekil -- wget -qO- http://127.0.0.1:1337/readyz
+   ```
 
    For a model-free validation, stay on `AGENTIC=0` and rely on the built-in
    smoke exercises (next section) instead of standing up vekil.
@@ -132,28 +185,37 @@ is a larger task; confirm scope before attempting it.
 > reflects this: it prints `Skipping agent Task execution-workspace checks:
 > harness-wrapper runtime is service-backed`. What IS validated end-to-end today
 > is the **direct** Substrate path (actor create/resume/router/daemon exec/
-> suspend/delete + retained-workspace reuse), exercised by
-> `SUBSTRATE_E2E_EXTENDED=1` during standup. A **plain** agent Task (no
-> `execution.workspace`) runs fine through the harness + model proxy. Treat the
+> suspend/delete) plus Substrate-backed MCP tool create/reconcile/cleanup,
+> exercised during standup. After clearing the e2e's fake `CODEX_CLI_PATH`
+> override as shown above, a **plain** agent Task (no `execution.workspace`)
+> runs through the harness + model proxy. Treat the
 > Task YAML below as the intended API once the harness wires workspaces; until
 > then, validate via the e2e's direct-actor exercises.
 
-The installer leaves a fully wired cluster; `SUBSTRATE_E2E_EXTENDED=1` (default)
-already smoke-tests direct actor create/resume/exec/suspend/delete and the
-retained-workspace warm-reuse path during standup.
+The installer leaves a fully wired cluster. During standup it smoke-tests direct
+actor create/resume/exec/suspend/delete and Substrate-backed MCP tool lifecycle.
+It does **not** currently smoke-test retained workspace reuse for Orka agent
+Tasks because those execution-workspace checks are skipped by the harness gate.
 
-To talk to the cluster, first make sure its context is in your kubeconfig — the
-installer runs the e2e with an isolated kubeconfig and does **not** leave
-`kind-<KIND_CLUSTER>` in your default one:
+If you skipped the kubeconfig export in the workflow above, do it before any
+manual `kubectl` commands — the e2e standup uses an isolated kubeconfig and does
+**not** leave `kind-<KIND_CLUSTER>` in your default one. Keep using the scoped
+`KUBECONFIG` in that shell:
 
 ```bash
-kind export kubeconfig --name "${KIND_CLUSTER:-orka-agent-substrate-e2e}"
+cluster="${KIND_CLUSTER:-orka-agent-substrate-e2e}"
+ctx="kind-${cluster}"
+export KUBECONFIG="$(mktemp -t orka-substrate-kubeconfig.XXXXXX)"
+kind export kubeconfig --name "${cluster}" --kubeconfig "${KUBECONFIG}"
 ```
 
 To drive an Orka Task yourself (intended shape; currently gated as noted above):
 
 ```bash
-ctx="kind-${KIND_CLUSTER:-orka-agent-substrate-e2e}"
+cluster="${KIND_CLUSTER:-orka-agent-substrate-e2e}"
+ctx="kind-${cluster}"
+export KUBECONFIG="$(mktemp -t orka-substrate-kubeconfig.XXXXXX)"
+kind export kubeconfig --name "${cluster}" --kubeconfig "${KUBECONFIG}"
 kubectl --context "$ctx" -n default apply -f - <<'YAML'
 apiVersion: core.orka.ai/v1alpha1
 kind: Task
@@ -163,7 +225,7 @@ metadata:
 spec:
   type: agent
   agentRef:
-    name: codex-agent
+    name: codex-substrate-ci
   prompt: "Run make test and summarize the result."
   sessionRef:
     name: substrate-demo
@@ -173,7 +235,7 @@ spec:
       enabled: true
       provider: substrate
       templateRef:
-        name: orka-codex
+        name: orka-codex-ci
         namespace: ate-demo
       reusePolicy: session
       cleanupPolicy: retain
@@ -216,10 +278,13 @@ Set `KEEP_CLUSTER=1` to inspect the cluster after a failure.
 - **Destructive recreate.** `DEMO_CLUSTER_REUSE=recreate` (and a fresh
   `scripts/agent-substrate-e2e.sh` run) deletes the cluster. Confirm with the
   user before recreating a cluster that holds a completed vekil login or state.
-- **No secrets in spec/status/logs.** Never put API keys, source-control tokens,
-  or the Substrate bootstrap token directly in an `ActorTemplate`; use Secrets.
-  The bootstrap token is control-plane credential material — keep it in a Secret
-  and never print it.
+- **No secrets in status/logs.** Never print API keys, source-control tokens, or
+  Substrate bootstrap tokens, and never store them in Task specs/status. The
+  bundled local e2e creates bootstrap-token Secrets for controller lookup, but
+  the current pinned workspace `ActorTemplate` still carries
+  `ORKA_WORKSPACE_BOOTSTRAP_TOKEN` as a literal env value; treat that as a
+  local/CI exception to document and audit, not a production pattern. Prefer
+  `valueFrom.secretKeyRef` for any production template.
 
 ## Troubleshooting
 

--- a/.codex/skills/agent-substrate-deploy/agents/openai.yaml
+++ b/.codex/skills/agent-substrate-deploy/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Agent Substrate Deploy"
-  short_description: "Stand up Agent Substrate workspaces on kind for Orka"
-  default_prompt: "Use $agent-substrate-deploy to stand up Agent Substrate on a dedicated local kind cluster wired to Orka and run an Orka agent Task through a Substrate-backed execution workspace."
+  short_description: "Stand up Agent Substrate direct e2e on kind for Orka"
+  default_prompt: "Use $agent-substrate-deploy to stand up Agent Substrate on a dedicated local kind cluster wired to Orka, validate the direct Substrate e2e smoke path, and treat workspace-backed Orka agent Tasks as an expected-failure/future API check until harness support lands."

--- a/.codex/skills/agent-substrate-deploy/agents/openai.yaml
+++ b/.codex/skills/agent-substrate-deploy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Agent Substrate Deploy"
+  short_description: "Stand up Agent Substrate workspaces on kind for Orka"
+  default_prompt: "Use $agent-substrate-deploy to stand up Agent Substrate on a dedicated local kind cluster wired to Orka and run an Orka agent Task through a Substrate-backed execution workspace."

--- a/.copilot/skills/agent-sandbox-deploy
+++ b/.copilot/skills/agent-sandbox-deploy
@@ -1,0 +1,1 @@
+../../.codex/skills/agent-sandbox-deploy

--- a/.copilot/skills/agent-substrate-deploy
+++ b/.copilot/skills/agent-substrate-deploy
@@ -1,0 +1,1 @@
+../../.codex/skills/agent-substrate-deploy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,8 @@ For testing against a local Kubernetes cluster, use the `$kindctl` skill to mana
 
 To stand up a reverse proxy for Anthropic/Gemini/OpenAI-compatible clients, use the `$vekil-reverse-proxy-deploy` skill. When it falls back to GitHub Copilot device-code login, surface the login code and URL to the user and wait for their confirmation before continuing — never complete the login on their behalf.
 
+To stand up an execution-workspace provider on a local kind cluster for evaluation, use the `$agent-sandbox-deploy` skill (kubernetes-sigs agent-sandbox; pairs with `$kindctl` for the cluster and `$orka-kind-deploy` for the controller) or the `$agent-substrate-deploy` skill (Agent Substrate; owns its own gVisor kind cluster, so it is not hosted on a `$kindctl` cluster). Both are local/kind eval only — Orka does not install or manage these providers in production — and both surface the `$vekil-reverse-proxy-deploy` device-code login to the user for confirmation rather than completing it.
+
 ## Verification
 
 Run after every change:


### PR DESCRIPTION
## Summary

Adds two local/kind **evaluation** skills for Orka's execution-workspace providers, mirroring the existing `orka-kind-deploy` and `vekil-reverse-proxy-deploy` skills:

- **`agent-sandbox-deploy`** — stand up the kubernetes-sigs agent-sandbox provider on a `kindctl` cluster, pairing with `orka-kind-deploy` (controller) and vekil (model proxy), then run a sandbox-backed agent Task.
- **`agent-substrate-deploy`** — stand up Agent Substrate on its **own** gVisor kind cluster (it cannot share a `kindctl` cluster: custom registry + `runsc` node config, and its installer does `kind delete`+recreate) wired to Orka.

Design choices:
- **Reference, don't vendor.** Both skills drive the canonical `hack/demos/cluster/install-{agent-sandbox,substrate}.sh` scripts in place and re-pin via env (`ORKA_AGENT_SANDBOX_VERSION`, `SUBSTRATE_REF`, `AGENTIC`, ...) so they can't drift from the CI-proven flow.
- **Human-in-the-loop vekil login.** Both surface the GitHub Copilot device-code URL + code and wait for the user, per the `$vekil-reverse-proxy-deploy` guardrail.
- Packaged as `.codex/skills/<name>/{SKILL.md,agents/openai.yaml}` and symlinked across `.agents` / `.claude` / `.copilot`, matching the existing convention. `AGENTS.md` gains a callout.

## Live-verified caveats (folded into both skills)

Validated end-to-end on a fresh kind cluster (both providers co-resident; real-model round-trip confirmed via vekil). Findings now documented in the skills:

- **Harness gate:** the service-backed `agent-harness-wrapper` runtime currently rejects workspace-backed agent Tasks — `WorkspaceValidationFailed: execution workspace is not supported by harness runtime yet` (`internal/controller/harness_wrapper.go`). Both providers' plumbing is validated at the **direct** actor/sandbox level by the bundled e2e; the Task→workspace path for agents is not wired yet. Skills treat the Task YAML as the intended API and point at the model-free e2e / direct exercises for validation today.
- **Kubeconfig:** the substrate installer runs with an isolated kubeconfig and does not leave `kind-<cluster>` in the default one — `kind export kubeconfig --name <cluster>` is required.
- **vekil login race:** vekil's `livenessProbe` restarts the pre-login pod every ~60s and each restart mints a new device code, so a human login can't land — disarm the probe before surfacing the code.

## Test plan

- [x] Both skills register and resolve across all three harnesses (symlinks → `SKILL.md`)
- [x] Fresh kind cluster: Substrate control plane + Orka + agent-sandbox stack stood up; bundled `Agent Substrate E2E` passed
- [x] Both `--substrate-enabled` and `--agent-sandbox-enabled` live on one controller
- [x] Plain agent Task returned a real model result via vekil
- [x] Workspace-backed Task gate confirmed and documented (not a regression in this PR)
- [ ] Reviewer sanity-check of the runbooks against their own kind environment