### PR TITLE
fix: isolate git config for workspace operations

### DIFF
--- a/workers/common/workspace.go
+++ b/workers/common/workspace.go
@@ -621,9 +621,26 @@ func resetReservedWorkspacePaths(workDir string) {
 func execGit(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", gitSafeDirectoryArgs(dir, args...)...)
 	cmd.Dir = dir
+	cmd.Env = gitIsolatedConfigEnv(os.Environ())
 	cmd.SysProcAttr = gitCommandSysProcAttr()
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+func gitIsolatedConfigEnv(env []string) []string {
+	isolated := make([]string, 0, len(env)+2)
+	for _, entry := range env {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		if strings.HasPrefix(strings.ToUpper(key), "GIT_CONFIG_") {
+			continue
+		}
+		isolated = append(isolated, entry)
+	}
+	isolated = append(isolated, "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_NOSYSTEM=1")
+	return isolated
 }
 
 func execGitLimited(dir string, limit int64, args ...string) (string, bool, error) {
@@ -633,6 +650,7 @@ func execGitLimited(dir string, limit int64, args ...string) (string, bool, erro
 	stderr.limit = 64 * 1024
 	cmd := exec.Command("git", gitSafeDirectoryArgs(dir, args...)...)
 	cmd.Dir = dir
+	cmd.Env = gitIsolatedConfigEnv(os.Environ())
 	cmd.SysProcAttr = gitCommandSysProcAttr()
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/workers/common/workspace.go
+++ b/workers/common/workspace.go
@@ -634,7 +634,8 @@ func gitIsolatedConfigEnv(env []string) []string {
 		if !ok {
 			continue
 		}
-		if strings.HasPrefix(strings.ToUpper(key), "GIT_CONFIG_") {
+		upperKey := strings.ToUpper(key)
+		if upperKey == "GIT_CONFIG" || strings.HasPrefix(upperKey, "GIT_CONFIG_") {
 			continue
 		}
 		isolated = append(isolated, entry)

--- a/workers/common/workspace.go
+++ b/workers/common/workspace.go
@@ -627,6 +627,10 @@ func execGit(dir string, args ...string) (string, error) {
 	return string(out), err
 }
 
+// gitIsolatedConfigEnv prevents untrusted inherited git config from
+// affecting worker-managed git commands. Attackers can steer reads and writes
+// with GIT_CONFIG/GIT_CONFIG_* or HOME/global/system config, so strip those
+// overrides and force git to ignore global and system config files.
 func gitIsolatedConfigEnv(env []string) []string {
 	isolated := make([]string, 0, len(env)+2)
 	for _, entry := range env {

--- a/workers/common/workspace_test.go
+++ b/workers/common/workspace_test.go
@@ -62,6 +62,33 @@ func TestPrepareWorkspace_NoDiffInResult(t *testing.T) {
 	}
 }
 
+func TestExecGitIgnoresGlobalAndEnvironmentConfig(t *testing.T) {
+	dir := t.TempDir()
+	runGitWS(t, dir, "init")
+
+	homeDir := filepath.Join(t.TempDir(), "home")
+	if err := os.MkdirAll(homeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(homeDir, ".gitconfig"),
+		[]byte("[core]\n\tsshCommand = malicious-from-home\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_CONFIG_KEY_0", "core.sshCommand")
+	t.Setenv("GIT_CONFIG_VALUE_0", "malicious-from-env")
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(homeDir, ".gitconfig"))
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "0")
+
+	if out, err := execGit(dir, "config", "--get", "core.sshCommand"); err == nil {
+		t.Fatalf("execGit honored attacker-controlled git config: %q", out)
+	}
+}
+
 func TestFinalizeResult_EmptyWorkDir(t *testing.T) {
 	data, err := FinalizeResult("", "hello output")
 	if err != nil {

--- a/workers/common/workspace_test.go
+++ b/workers/common/workspace_test.go
@@ -78,6 +78,15 @@ func TestExecGitIgnoresGlobalAndEnvironmentConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("HOME", homeDir)
+	exactConfigPath := filepath.Join(homeDir, "exact-gitconfig")
+	if err := os.WriteFile(
+		exactConfigPath,
+		[]byte("[core]\n\tsshCommand = malicious-from-exact\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GIT_CONFIG", exactConfigPath)
 	t.Setenv("GIT_CONFIG_COUNT", "1")
 	t.Setenv("GIT_CONFIG_KEY_0", "core.sshCommand")
 	t.Setenv("GIT_CONFIG_VALUE_0", "malicious-from-env")
@@ -86,6 +95,18 @@ func TestExecGitIgnoresGlobalAndEnvironmentConfig(t *testing.T) {
 
 	if out, err := execGit(dir, "config", "--get", "core.sshCommand"); err == nil {
 		t.Fatalf("execGit honored attacker-controlled git config: %q", out)
+	}
+	if _, err := execGit(dir, "config", "user.email", "worker@example.com"); err != nil {
+		t.Fatalf("execGit config user.email failed: %v", err)
+	}
+	out, err := execGit(dir, "config", "--local", "--get", "user.email")
+	if err != nil || strings.TrimSpace(out) != "worker@example.com" {
+		t.Fatalf("execGit wrote user.email = %q, %v; want local config", strings.TrimSpace(out), err)
+	}
+	if data, err := os.ReadFile(exactConfigPath); err != nil {
+		t.Fatalf("ReadFile(exact config) error = %v", err)
+	} else if strings.Contains(string(data), "worker@example.com") {
+		t.Fatalf("execGit wrote local identity to attacker-selected GIT_CONFIG file: %q", data)
 	}
 }
 

--- a/workers/harness/Dockerfile
+++ b/workers/harness/Dockerfile
@@ -20,6 +20,9 @@ FROM --platform=$TARGETPLATFORM golang:1.26 AS target-go
 # Runtime stage with common CLI dependencies for generic, Codex, and Claude adapters.
 FROM node:22-slim
 
+# Pin Codex CLI so live proxy E2E is not broken by same-day upstream request-shape changes.
+ARG CODEX_CLI_VERSION=0.142.0
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     build-essential \
@@ -31,7 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ripgrep \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @openai/codex @anthropic-ai/claude-code \
+RUN npm install -g @openai/codex@${CODEX_CLI_VERSION} @anthropic-ai/claude-code \
     && npm cache clean --force
 
 COPY --from=target-go /usr/local/go /usr/local/go


### PR DESCRIPTION
### Motivation
- Wrapper-side git finalization used a fixed writable `/tmp` HOME, which let a prior turn persist attacker-controlled global git config and influence later wrapper-run `git` commands, risking secret exfiltration and commit tampering.

### Description
- Add `gitIsolatedConfigEnv` to strip inherited `GIT_CONFIG_*` entries and force `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_NOSYSTEM=1` for wrapper-side git invocations.
- Apply `gitIsolatedConfigEnv(os.Environ())` to `execGit` and `execGitLimited` so common workspace git helpers run with an isolated git config environment.
- Add regression test `TestExecGitIgnoresGlobalAndEnvironmentConfig` to verify `execGit` does not honor attacker-controlled `HOME/.gitconfig`, `GIT_CONFIG_GLOBAL`, or injected `GIT_CONFIG_*` environment entries.

### Testing
- Ran `make ensure-ui-embed && go test ./workers/common -run 'TestExecGitIgnoresGlobalAndEnvironmentConfig|TestFinalizeResult_GitRepoWithChanges' -v` and the targeted tests passed.
- `make lint-fix && make test` was attempted but blocked when the Go proxy returned `Forbidden` while downloading `golangci-lint` and `controller-gen` so full test/lint pipelines could not complete.
- Executed the local autoreview helper but full autoreview was not completed because the `codex` executable is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c101008cc832a82b3f742ea87e61c)