### PR TITLE
fix(controller): enforce MCP templateRef namespace isolation

### DIFF
--- a/internal/controller/tool_controller.go
+++ b/internal/controller/tool_controller.go
@@ -230,6 +230,14 @@ func (r *ToolReconciler) validateSubstrateMCPTool(ctx context.Context, tool *cor
 		return fmt.Errorf("mcp.substrateActor.poolRef.name is required")
 	}
 	templateRequest := r.substrateMCPTemplateRequest(tool)
+	if r.EnforceNamespaceIsolation && templateRequest.TemplateNamespace != tool.Namespace {
+		return fmt.Errorf(
+			"cross-namespace MCP substrate actor templateRef not allowed when namespace isolation is enforced: template %q in namespace %q, tool in %q",
+			templateRequest.TemplateName,
+			templateRequest.TemplateNamespace,
+			tool.Namespace,
+		)
+	}
 	if err := validateSubstrateMCPActorTemplateResource(ctx, r.Client, templateRequest); err != nil {
 		return err
 	}

--- a/internal/controller/tool_controller_unit_test.go
+++ b/internal/controller/tool_controller_unit_test.go
@@ -1971,6 +1971,38 @@ func TestToolReconcilerFinalizesMCPActorWhenToolBecomesHTTP(t *testing.T) {
 	}
 }
 
+func TestToolReconcilerMCPSubstrateActorRejectsCrossNamespaceTemplateWhenIsolationEnforced(t *testing.T) {
+	scheme := newToolScheme()
+	template := approvedMCPActorTemplateForTest()
+	tool := &corev1alpha1.Tool{
+		ObjectMeta: metav1.ObjectMeta{Name: "mcp-tool", Namespace: "default"},
+		Spec: corev1alpha1.ToolSpec{
+			Description: "MCP tool",
+			MCP: &corev1alpha1.MCPToolServer{
+				Path: "/mcp",
+				SubstrateActor: &corev1alpha1.SubstrateMCPActor{
+					TemplateRef: corev1alpha1.WorkspaceTemplateReference{Name: "mcp-template", Namespace: "ate-demo"},
+					PoolRef:     &corev1alpha1.SubstrateActorPoolReference{Name: testMCPPoolName},
+				},
+			},
+		},
+	}
+	r := &ToolReconciler{
+		Client:                    fake.NewClientBuilder().WithScheme(scheme).WithObjects(tool, template).Build(),
+		Scheme:                    scheme,
+		SubstrateEnabled:          true,
+		EnforceNamespaceIsolation: true,
+	}
+
+	err := r.validateTool(context.Background(), tool)
+	if err == nil {
+		t.Fatal("validateTool() error = nil, want cross-namespace templateRef rejection")
+	}
+	if !contains(err.Error(), "cross-namespace MCP substrate actor templateRef not allowed") {
+		t.Fatalf("validateTool() error = %q, want cross-namespace templateRef rejection", err.Error())
+	}
+}
+
 func TestToolReconcilerMCPSubstrateActorRejectsUnapprovedTemplate(t *testing.T) {
 	scheme := newToolScheme()
 	template := approvedMCPActorTemplateForTest()


### PR DESCRIPTION
### Motivation
- Prevent a tenant from causing the controller to claim/create a Substrate ActorTemplate in another namespace by supplying a cross-namespace `templateRef` when namespace isolation is enabled.

### Description
- Add a namespace check in `validateSubstrateMCPTool` to reject `templateRef` values that resolve to a different namespace than the Tool when `EnforceNamespaceIsolation` is true (file: `internal/controller/tool_controller.go`).
- Add a regression unit test `TestToolReconcilerMCPSubstrateActorRejectsCrossNamespaceTemplateWhenIsolationEnforced` to cover cross-namespace `templateRef` rejection (file: `internal/controller/tool_controller_unit_test.go`).

### Testing
- Ran `go test ./internal/controller -run TestToolReconcilerMCPSubstrateActorRejectsCrossNamespaceTemplateWhenIsolationEnforced -count=1 -v` and the new test passed.
- `make lint-fix` and `make test` could not complete because required tooling downloads from `proxy.golang.org` failed with HTTP 403 in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c0d18bb80832ab5dcd95b4300422e)