### PR TITLE
fix(ci): protect Helm artifacts and stabilize live e2e

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -153,6 +153,7 @@ jobs:
           # Do not let generated website content overwrite preserved Helm
           # repository artifacts at the Pages root.
           rsync -a \
+            --exclude='/charts' \
             --exclude='/charts/***' \
             --exclude='/index.yaml' \
             --exclude='/*.tgz' \

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -154,7 +154,6 @@ jobs:
           # repository artifacts at the Pages root.
           rsync -a \
             --exclude='/charts' \
-            --exclude='/charts/***' \
             --exclude='/index.yaml' \
             --exclude='/*.tgz' \
             --exclude='/*.prov' \

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -150,7 +150,14 @@ jobs:
             ! -name '*.prov' \
             -exec rm -rf {} +
 
-          rsync -a ../website/build/ ./
+          # Do not let generated website content overwrite preserved Helm
+          # repository artifacts at the Pages root.
+          rsync -a \
+            --exclude='/charts/***' \
+            --exclude='/index.yaml' \
+            --exclude='/*.tgz' \
+            --exclude='/*.prov' \
+            ../website/build/ ./
           touch .nojekyll
 
           git add -A

--- a/workers/harness/Dockerfile
+++ b/workers/harness/Dockerfile
@@ -20,6 +20,10 @@ FROM --platform=$TARGETPLATFORM golang:1.26 AS target-go
 # Runtime stage with common CLI dependencies for generic, Codex, and Claude adapters.
 FROM node:22-slim
 
+# Keep the Codex CLI pinned until copilot-proxy accepts the internal
+# metadata passthrough fields emitted by newer 0.142.x clients.
+ARG CODEX_CLI_VERSION=0.141.0
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     build-essential \
@@ -31,7 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ripgrep \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @openai/codex @anthropic-ai/claude-code \
+RUN npm install -g @openai/codex@${CODEX_CLI_VERSION} @anthropic-ai/claude-code \
     && npm cache clean --force
 
 COPY --from=target-go /usr/local/go /usr/local/go


### PR DESCRIPTION
### Motivation
- Fix a supply-chain vulnerability where the website publish step could copy generated `website/build` content into the `gh-pages` root and overwrite preserved Helm repository artifacts (for example `charts/`, `index.yaml`, `*.tgz`, `*.prov`).
- Stabilize the live Copilot proxy E2E path after CI exposed that newer Codex CLI 0.142.x clients send an internal Responses metadata field that the current `copilot-proxy` rejects.

### Description
- Update `/.github/workflows/website.yml` publish step to add anchored `rsync` exclude rules that prevent generated website content from copying over the preserved Helm repository paths at the Pages root.
- Add an explanatory comment above the security-sensitive `rsync` exclude block so future maintainers know why those paths must remain protected.
- Pin the harness-wrapper Codex CLI install in `workers/harness/Dockerfile` to `@openai/codex@0.141.0`, behind a `CODEX_CLI_VERSION` build arg, until `copilot-proxy` supports the internal metadata passthrough emitted by 0.142.x clients.

### Testing
- Pass: `git diff --check`.
- Pass: `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/website.yml`.
- Pass: `go test ./workers/harness/cliwrapper`.
- Pass: `npm view @openai/codex@0.141.0 version`.
- Pass: `rsync -ain --exclude='/charts'` dry run with `website/build/charts` represented as a symlink; verified the protected path is not transferred.
- Pass: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` reported `autoreview clean: no accepted/actionable findings reported` after the latest changes.
- Warning: local Docker image build could not be run because the Docker daemon is unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c0b4858e8832aadf40b145ee1101e)
