### PR TITLE
fix: restrict Vekil proxy ingress by default

### DIFF
--- a/.codex/skills/vekil-reverse-proxy-deploy/SKILL.md
+++ b/.codex/skills/vekil-reverse-proxy-deploy/SKILL.md
@@ -16,7 +16,7 @@ Deploy Vekil as the single reverse-proxy endpoint for Claude/Anthropic, Gemini, 
 2. Deploy the default zero-config Copilot-backed proxy:
    - `scripts/deploy_vekil_reverse_proxy.sh --context <kubectl-context>`
    - Default namespace: `vekil-system`; default service: `ClusterIP`; default image: `ghcr.io/sozercan/vekil:latest`; default port: `1337`.
-   - The script renders a restrictive `NetworkPolicy` by default. In-cluster clients must run in the same namespace with label `vekil.sozercan.io/access=true`, and the cluster CNI must enforce NetworkPolicy.
+   - The script renders a restrictive `NetworkPolicy` by default. In-cluster clients must either run in the Vekil namespace with pod label `vekil.sozercan.io/access=true` or run in a namespace labeled `vekil.sozercan.io/access=true`, and the cluster CNI must enforce NetworkPolicy.
 3. If explicit provider routing is required, write or locate a JSON/YAML providers file that uses secret env references, then pass it with existing Kubernetes secrets:
    ```bash
    scripts/deploy_vekil_reverse_proxy.sh \
@@ -45,7 +45,8 @@ Deploy Vekil as the single reverse-proxy endpoint for Claude/Anthropic, Gemini, 
 
 ## Provider and Auth Notes
 
-- Vekil's provider/Copilot credentials are upstream credentials for the proxy, not client authentication. A `ClusterIP` Service is still reachable by other pods in a default Kubernetes network unless NetworkPolicy or equivalent controls block it. Keep the default NetworkPolicy enabled for shared clusters, label only trusted client pods with `vekil.sozercan.io/access=true`, and do not use `--no-network-policy` unless an equivalent authentication or network boundary is already in place.
+- Vekil's provider/Copilot credentials are upstream credentials for the proxy, not client authentication. A `ClusterIP` Service is still reachable by other pods in a default Kubernetes network unless NetworkPolicy or equivalent controls block it. Keep the default NetworkPolicy enabled for shared clusters, label only trusted same-namespace client pods or trusted client namespaces with `vekil.sozercan.io/access=true`, and do not use `--no-network-policy` unless an equivalent authentication or network boundary is already in place. Re-running the script with `--no-network-policy` deletes the managed `<name>-ingress` NetworkPolicy when applying to a cluster.
+- `NodePort` and `LoadBalancer` Services are still subject to the default NetworkPolicy. External callers and kubelet health probes can be blocked on CNIs that enforce host-sourced traffic, so add explicit ingress exceptions for the intended source ranges/probes or choose `--no-network-policy` only when another boundary protects the proxy.
 - Zero-config mode uses Vekil's built-in GitHub Copilot upstream. In Kubernetes, device-code login can work from pod logs; use `--skip-wait`, watch `kubectl -n <namespace> logs deploy/<name>`, complete the login, then verify `/readyz`. `COPILOT_GITHUB_TOKEN` via `--env-secret` or `--create-copilot-token-secret` is better for non-interactive deployments; `--create-copilot-token-secret` requires local `COPILOT_GITHUB_TOKEN` and does not fall back to GitHub CLI OAuth tokens. If the script-created Secret changes, the script restarts the Deployment so the Secret-backed env var is reloaded.
 - Explicit provider configs should use `api_key_env`, not inline `api_key`, because the bundled script stores the config as a ConfigMap and refuses inline API keys by default. When the script creates or updates the providers ConfigMap, it restarts the Deployment so Vekil reloads provider routing read at startup.
 - OpenAI Codex providers need `auth.json` from `codex login`. If needed, mount an existing secret with `--codex-auth-secret <secret>[:auth.json]` and verify whether the deployment needs a writable token source for refresh behavior.
@@ -72,6 +73,12 @@ Deploy to a custom namespace and expose inside the cluster:
 ```bash
 scripts/deploy_vekil_reverse_proxy.sh --namespace ai-proxy --name vekil
 kubectl -n ai-proxy label pod <trusted-client-pod> vekil.sozercan.io/access=true
+```
+
+Allow all pods in a trusted client namespace to reach Vekil:
+
+```bash
+kubectl label namespace <trusted-client-namespace> vekil.sozercan.io/access=true
 ```
 
 Expose for a local kind/minikube workflow with an explicit context:
@@ -116,6 +123,7 @@ env GEMINI_API_KEY=dummy \
 ## Troubleshooting
 
 - If rollout fails: `kubectl -n <namespace> describe deploy/<name>` and `kubectl -n <namespace> logs deploy/<name>`.
+- If readiness/liveness probes fail on a strict NetworkPolicy CNI, add an ingress exception for kubelet or node-originated health checks, or temporarily disable the default policy only behind an equivalent network boundary.
 - If an existing Secret used with `--env-secret` changes outside this script, restart the Deployment so env vars reload: `kubectl -n <namespace> rollout restart deploy/<name>`.
 - If `/healthz` works but `/readyz` fails, focus on provider auth, provider config model ownership, upstream reachability, or missing secret env vars.
 - If clients cannot connect, verify the base URL path: Anthropic/Gemini use `http://host:1337`; OpenAI/Codex use `http://host:1337/v1`.

--- a/.codex/skills/vekil-reverse-proxy-deploy/SKILL.md
+++ b/.codex/skills/vekil-reverse-proxy-deploy/SKILL.md
@@ -16,6 +16,7 @@ Deploy Vekil as the single reverse-proxy endpoint for Claude/Anthropic, Gemini, 
 2. Deploy the default zero-config Copilot-backed proxy:
    - `scripts/deploy_vekil_reverse_proxy.sh --context <kubectl-context>`
    - Default namespace: `vekil-system`; default service: `ClusterIP`; default image: `ghcr.io/sozercan/vekil:latest`; default port: `1337`.
+   - The script renders a restrictive `NetworkPolicy` by default. In-cluster clients must run in the same namespace with label `vekil.sozercan.io/access=true`, and the cluster CNI must enforce NetworkPolicy.
 3. If explicit provider routing is required, write or locate a JSON/YAML providers file that uses secret env references, then pass it with existing Kubernetes secrets:
    ```bash
    scripts/deploy_vekil_reverse_proxy.sh \
@@ -44,6 +45,7 @@ Deploy Vekil as the single reverse-proxy endpoint for Claude/Anthropic, Gemini, 
 
 ## Provider and Auth Notes
 
+- Vekil's provider/Copilot credentials are upstream credentials for the proxy, not client authentication. A `ClusterIP` Service is still reachable by other pods in a default Kubernetes network unless NetworkPolicy or equivalent controls block it. Keep the default NetworkPolicy enabled for shared clusters, label only trusted client pods with `vekil.sozercan.io/access=true`, and do not use `--no-network-policy` unless an equivalent authentication or network boundary is already in place.
 - Zero-config mode uses Vekil's built-in GitHub Copilot upstream. In Kubernetes, device-code login can work from pod logs; use `--skip-wait`, watch `kubectl -n <namespace> logs deploy/<name>`, complete the login, then verify `/readyz`. `COPILOT_GITHUB_TOKEN` via `--env-secret` or `--create-copilot-token-secret` is better for non-interactive deployments; `--create-copilot-token-secret` requires local `COPILOT_GITHUB_TOKEN` and does not fall back to GitHub CLI OAuth tokens. If the script-created Secret changes, the script restarts the Deployment so the Secret-backed env var is reloaded.
 - Explicit provider configs should use `api_key_env`, not inline `api_key`, because the bundled script stores the config as a ConfigMap and refuses inline API keys by default. When the script creates or updates the providers ConfigMap, it restarts the Deployment so Vekil reloads provider routing read at startup.
 - OpenAI Codex providers need `auth.json` from `codex login`. If needed, mount an existing secret with `--codex-auth-secret <secret>[:auth.json]` and verify whether the deployment needs a writable token source for refresh behavior.
@@ -69,6 +71,7 @@ Deploy to a custom namespace and expose inside the cluster:
 
 ```bash
 scripts/deploy_vekil_reverse_proxy.sh --namespace ai-proxy --name vekil
+kubectl -n ai-proxy label pod <trusted-client-pod> vekil.sozercan.io/access=true
 ```
 
 Expose for a local kind/minikube workflow with an explicit context:

--- a/.codex/skills/vekil-reverse-proxy-deploy/scripts/deploy_vekil_reverse_proxy.sh
+++ b/.codex/skills/vekil-reverse-proxy-deploy/scripts/deploy_vekil_reverse_proxy.sh
@@ -17,6 +17,7 @@ Options:
   --port N                          listen and service port (default: 1337)
   --service-type TYPE               ClusterIP, NodePort, or LoadBalancer (default: ClusterIP)
   --no-network-policy               do not render the default restrictive NetworkPolicy
+                                    and delete the managed policy if it exists
   --providers-config PATH           JSON/YAML provider config to mount as a ConfigMap
   --providers-configmap NAME        ConfigMap name for providers config (default: <name>-providers)
   --env-secret ENV=SECRET:KEY       add env var from an existing Secret (repeatable)
@@ -265,6 +266,9 @@ is_positive_int "$port" || error "Invalid port: $port"
 ((10#$port <= 65535)) || error "Invalid port: $port"
 case "$service_type" in ClusterIP|NodePort|LoadBalancer) ;; *) error "Invalid service type: $service_type" ;; esac
 case "$log_level" in debug|info|error) ;; *) error "Invalid log level: $log_level" ;; esac
+if [[ "$network_policy" == "true" && "$service_type" != "ClusterIP" ]]; then
+  echo "Warning: --service-type $service_type exposes Vekil externally, but the default NetworkPolicy only permits labeled in-cluster sources. Use --no-network-policy or extend the policy for the intended external source ranges." >&2
+fi
 if [[ -n "$providers_configmap" ]]; then
   is_dns_subdomain "$providers_configmap" || error "Invalid ConfigMap name: $providers_configmap"
 else
@@ -547,6 +551,9 @@ spec:
         - podSelector:
             matchLabels:
               vekil.sozercan.io/access: "true"
+        - namespaceSelector:
+            matchLabels:
+              vekil.sozercan.io/access: "true"
       ports:
         - protocol: TCP
           port: $port
@@ -581,6 +588,10 @@ fi
 
 render_workload | k apply -f -
 
+if [[ "$network_policy" == "false" ]]; then
+  k -n "$namespace" delete networkpolicy "${name}-ingress" --ignore-not-found
+fi
+
 if [[ "$copilot_token_secret_changed" == "true" || "$providers_configmap_changed" == "true" ]]; then
   k -n "$namespace" rollout restart "deployment/$name"
 fi
@@ -596,8 +607,22 @@ Vekil service URL inside the cluster:
   http://$name.$namespace.svc.cluster.local:$port
 
 Access control:
-  The default NetworkPolicy allows in-cluster traffic only from pods in namespace '$namespace'
-  labeled 'vekil.sozercan.io/access=true'. NetworkPolicy enforcement depends on the cluster CNI.
+EOF_DONE
+if [[ "$network_policy" == "true" ]]; then
+  cat <<EOF_DONE
+  The default NetworkPolicy allows TCP/$port only from labeled in-cluster sources:
+    - pods in namespace '$namespace' labeled 'vekil.sozercan.io/access=true'
+    - pods in namespaces labeled 'vekil.sozercan.io/access=true'
+  NodePort/LoadBalancer traffic and kubelet probes may need additional ingress exceptions.
+  NetworkPolicy enforcement depends on the cluster CNI.
+EOF_DONE
+else
+  cat <<EOF_DONE
+  No NetworkPolicy is rendered. The managed policy '${name}-ingress' was deleted if it existed.
+  Ensure another authentication or network boundary protects this proxy before sharing it.
+EOF_DONE
+fi
+cat <<EOF_DONE
 
 Local verification:
   kubectl${context_name:+ --context $context_name} -n $namespace port-forward svc/$name $port:$port

--- a/.codex/skills/vekil-reverse-proxy-deploy/scripts/deploy_vekil_reverse_proxy.sh
+++ b/.codex/skills/vekil-reverse-proxy-deploy/scripts/deploy_vekil_reverse_proxy.sh
@@ -16,6 +16,7 @@ Options:
   --replicas N                      deployment replicas (default: 1)
   --port N                          listen and service port (default: 1337)
   --service-type TYPE               ClusterIP, NodePort, or LoadBalancer (default: ClusterIP)
+  --no-network-policy               do not render the default restrictive NetworkPolicy
   --providers-config PATH           JSON/YAML provider config to mount as a ConfigMap
   --providers-configmap NAME        ConfigMap name for providers config (default: <name>-providers)
   --env-secret ENV=SECRET:KEY       add env var from an existing Secret (repeatable)
@@ -97,6 +98,7 @@ timeout="180s"
 create_namespace="true"
 wait_rollout="true"
 print_only="false"
+network_policy="true"
 token_pvc=""
 copilot_token_secret=""
 copilot_token_key="token"
@@ -171,6 +173,10 @@ while [[ $# -gt 0 ]]; do
     --service-type)
       service_type="${2:?missing value for --service-type}"
       shift 2
+      ;;
+    --no-network-policy)
+      network_policy="false"
+      shift
       ;;
     --providers-config)
       providers_config="${2:?missing value for --providers-config}"
@@ -516,6 +522,36 @@ spec:
       port: $port
       targetPort: http
 EOF_SERVICE
+
+  if [[ "$network_policy" == "true" ]]; then
+    cat <<EOF_NETWORK_POLICY
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ${name}-ingress
+  namespace: $namespace
+  labels:
+    app.kubernetes.io/name: vekil
+    app.kubernetes.io/instance: $name
+    app.kubernetes.io/managed-by: vekil-reverse-proxy-deploy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: vekil
+      app.kubernetes.io/instance: $name
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              vekil.sozercan.io/access: "true"
+      ports:
+        - protocol: TCP
+          port: $port
+EOF_NETWORK_POLICY
+  fi
 }
 
 if [[ "$print_only" == "true" ]]; then
@@ -558,6 +594,10 @@ cat <<EOF_DONE
 
 Vekil service URL inside the cluster:
   http://$name.$namespace.svc.cluster.local:$port
+
+Access control:
+  The default NetworkPolicy allows in-cluster traffic only from pods in namespace '$namespace'
+  labeled 'vekil.sozercan.io/access=true'. NetworkPolicy enforcement depends on the cluster CNI.
 
 Local verification:
   kubectl${context_name:+ --context $context_name} -n $namespace port-forward svc/$name $port:$port

--- a/hack/demos/cluster/install-agent-sandbox.sh
+++ b/hack/demos/cluster/install-agent-sandbox.sh
@@ -167,14 +167,36 @@ if [[ "${AGENTIC}" == "1" ]]; then
   fi
 
   # ---- vekil model proxy (one-time GitHub device-code login) ------------
-  vekil_script="${repo_root}/.claude/skills/vekil-reverse-proxy-deploy/scripts/deploy_vekil_reverse_proxy.sh"
+  vekil_script=""
+  for candidate in \
+    "${repo_root}/.codex/skills/vekil-reverse-proxy-deploy/scripts/deploy_vekil_reverse_proxy.sh" \
+    "${repo_root}/.claude/skills/vekil-reverse-proxy-deploy/scripts/deploy_vekil_reverse_proxy.sh"; do
+    if [[ -x "${candidate}" ]]; then
+      vekil_script="${candidate}"
+      break
+    fi
+  done
+  vekil_exists=0
   if kubectl -n "${VEKIL_NS}" get deploy vekil >/dev/null 2>&1; then
-    log "vekil already deployed in ${VEKIL_NS} — reusing it"
-  elif [[ -x "${vekil_script}" ]]; then
-    log "Deploying vekil model proxy to ${VEKIL_NS} (device-code login)"
-    bash "${vekil_script}" --context "$(kubectl config current-context)" --namespace "${VEKIL_NS}" --skip-wait || true
-    log "ACTION REQUIRED: complete the GitHub device-code login in vekil's logs:"
-    log "  kubectl -n ${VEKIL_NS} logs deploy/vekil | grep 'login/device'"
+    vekil_exists=1
+  fi
+  if [[ -x "${vekil_script}" ]]; then
+    if [[ "${vekil_exists}" == 1 ]]; then
+      log "vekil already deployed in ${VEKIL_NS} — reconciling workload and NetworkPolicy"
+    else
+      log "Deploying vekil model proxy to ${VEKIL_NS} (device-code login)"
+    fi
+    bash "${vekil_script}" --context "$(kubectl config current-context)" --namespace "${VEKIL_NS}" --skip-wait
+    kubectl -n "${VEKIL_NS}" get networkpolicy vekil-ingress >/dev/null \
+      || die "vekil NetworkPolicy ${VEKIL_NS}/vekil-ingress was not reconciled"
+    if [[ "${vekil_exists}" == 0 ]]; then
+      log "ACTION REQUIRED: complete the GitHub device-code login in vekil's logs:"
+      log "  kubectl -n ${VEKIL_NS} logs deploy/vekil | grep 'login/device'"
+    fi
+  elif [[ "${vekil_exists}" == 1 ]]; then
+    kubectl -n "${VEKIL_NS}" get networkpolicy vekil-ingress >/dev/null \
+      || die "vekil already exists in ${VEKIL_NS}, but deploy script was not found and NetworkPolicy ${VEKIL_NS}/vekil-ingress is missing"
+    log "vekil already deployed in ${VEKIL_NS} with NetworkPolicy — reusing it"
   else
     log "vekil deploy script not found; provide an OpenAI-compatible proxy and set ${sandbox_model_secret}."
   fi

--- a/hack/demos/cluster/install-agent-sandbox.sh
+++ b/hack/demos/cluster/install-agent-sandbox.sh
@@ -97,6 +97,8 @@ kubectl apply -f "https://github.com/kubernetes-sigs/agent-sandbox/releases/down
 
 log "Ensuring namespace ${demo_namespace}"
 kubectl create namespace "${demo_namespace}" --dry-run=client -o yaml | kubectl apply -f -
+log "Allowing namespace ${demo_namespace} to reach the vekil NetworkPolicy"
+kubectl label namespace "${demo_namespace}" vekil.sozercan.io/access=true --overwrite >/dev/null
 
 log "Applying orka-live SandboxTemplate (runtime image: ${runtime_image})"
 sed "s|REPLACE_RUNTIME_IMAGE|${runtime_image}|g; s|namespace: demo-magic|namespace: ${demo_namespace}|" \

--- a/hack/demos/cluster/install-agent-sandbox.sh
+++ b/hack/demos/cluster/install-agent-sandbox.sh
@@ -79,6 +79,49 @@ else
   log "kind cluster ${cluster_name} not found; using current context $(kubectl config current-context)"
 fi
 
+reconcile_vekil_network_policy() {
+  local ns="$1"
+  local port
+  local selector_yaml
+
+  kubectl -n "${ns}" get service vekil >/dev/null \
+    || die "vekil Service ${ns}/vekil is missing; cannot reconcile NetworkPolicy for clients"
+  port="$(kubectl -n "${ns}" get service vekil -o jsonpath='{.spec.ports[?(@.name=="http")].port}' 2>/dev/null || true)"
+  port="${port:-1337}"
+  selector_yaml="$(kubectl -n "${ns}" get deployment vekil -o json \
+    | jq -r '.spec.selector.matchLabels // {} | to_entries[] | "      \(.key): \(.value | @json)"')"
+  [[ -n "${selector_yaml}" ]] || die "vekil Deployment ${ns}/vekil has no selector labels for NetworkPolicy"
+
+  kubectl -n "${ns}" apply -f - <<YAML
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: vekil-ingress
+  namespace: ${ns}
+  labels:
+    app.kubernetes.io/name: vekil
+    app.kubernetes.io/instance: vekil
+    app.kubernetes.io/managed-by: vekil-reverse-proxy-deploy
+spec:
+  podSelector:
+    matchLabels:
+${selector_yaml}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              vekil.sozercan.io/access: "true"
+        - namespaceSelector:
+            matchLabels:
+              vekil.sozercan.io/access: "true"
+      ports:
+        - protocol: TCP
+          port: ${port}
+YAML
+}
+
 # Agentic layer: build + push the runtime + router images to the kind registry
 # (normal pods pull via localhost:<port>). Done BEFORE the template is applied
 # so the SandboxTemplate references an image that exists.
@@ -180,23 +223,18 @@ if [[ "${AGENTIC}" == "1" ]]; then
   if kubectl -n "${VEKIL_NS}" get deploy vekil >/dev/null 2>&1; then
     vekil_exists=1
   fi
-  if [[ -x "${vekil_script}" ]]; then
-    if [[ "${vekil_exists}" == 1 ]]; then
-      log "vekil already deployed in ${VEKIL_NS} — reconciling workload and NetworkPolicy"
-    else
-      log "Deploying vekil model proxy to ${VEKIL_NS} (device-code login)"
-    fi
+  if [[ "${vekil_exists}" == 1 ]]; then
+    log "vekil already deployed in ${VEKIL_NS} — reconciling only the managed NetworkPolicy"
+    reconcile_vekil_network_policy "${VEKIL_NS}"
+    kubectl -n "${VEKIL_NS}" get networkpolicy vekil-ingress >/dev/null \
+      || die "vekil NetworkPolicy ${VEKIL_NS}/vekil-ingress was not reconciled"
+  elif [[ -x "${vekil_script}" ]]; then
+    log "Deploying vekil model proxy to ${VEKIL_NS} (device-code login)"
     bash "${vekil_script}" --context "$(kubectl config current-context)" --namespace "${VEKIL_NS}" --skip-wait
     kubectl -n "${VEKIL_NS}" get networkpolicy vekil-ingress >/dev/null \
       || die "vekil NetworkPolicy ${VEKIL_NS}/vekil-ingress was not reconciled"
-    if [[ "${vekil_exists}" == 0 ]]; then
-      log "ACTION REQUIRED: complete the GitHub device-code login in vekil's logs:"
-      log "  kubectl -n ${VEKIL_NS} logs deploy/vekil | grep 'login/device'"
-    fi
-  elif [[ "${vekil_exists}" == 1 ]]; then
-    kubectl -n "${VEKIL_NS}" get networkpolicy vekil-ingress >/dev/null \
-      || die "vekil already exists in ${VEKIL_NS}, but deploy script was not found and NetworkPolicy ${VEKIL_NS}/vekil-ingress is missing"
-    log "vekil already deployed in ${VEKIL_NS} with NetworkPolicy — reusing it"
+    log "ACTION REQUIRED: complete the GitHub device-code login in vekil's logs:"
+    log "  kubectl -n ${VEKIL_NS} logs deploy/vekil | grep 'login/device'"
   else
     log "vekil deploy script not found; provide an OpenAI-compatible proxy and set ${sandbox_model_secret}."
   fi

--- a/hack/demos/cluster/install-demo-model.sh
+++ b/hack/demos/cluster/install-demo-model.sh
@@ -88,6 +88,8 @@ log "Ensuring namespace ${demo_namespace}"
 kubectl create namespace "${demo_namespace}" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
 log "Allowing namespace ${demo_namespace} to reach the vekil NetworkPolicy"
 kubectl label namespace "${demo_namespace}" vekil.sozercan.io/access=true --overwrite >/dev/null
+log "Allowing Orka namespace ${orka_namespace} to reach the vekil NetworkPolicy"
+kubectl label namespace "${orka_namespace}" vekil.sozercan.io/access=true --overwrite >/dev/null
 
 # --- Provider api-key Secret (placeholder; vekil holds the real session) ----
 log "Creating provider api-key Secret ${demo_namespace}/${provider_secret}"

--- a/hack/demos/cluster/install-demo-model.sh
+++ b/hack/demos/cluster/install-demo-model.sh
@@ -86,6 +86,8 @@ vekil_url="http://vekil.${vekil_ns}.svc.cluster.local:1337/v1"
 
 log "Ensuring namespace ${demo_namespace}"
 kubectl create namespace "${demo_namespace}" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+log "Allowing namespace ${demo_namespace} to reach the vekil NetworkPolicy"
+kubectl label namespace "${demo_namespace}" vekil.sozercan.io/access=true --overwrite >/dev/null
 
 # --- Provider api-key Secret (placeholder; vekil holds the real session) ----
 log "Creating provider api-key Secret ${demo_namespace}/${provider_secret}"

--- a/hack/demos/cluster/install-substrate.sh
+++ b/hack/demos/cluster/install-substrate.sh
@@ -114,6 +114,50 @@ cluster_health() {
   [[ "${healthy}" == 1 ]]
 }
 
+reconcile_vekil_network_policy() {
+  local ctx="$1"
+  local ns="$2"
+  local port
+  local selector_yaml
+
+  kubectl --context "${ctx}" -n "${ns}" get service vekil >/dev/null \
+    || die "vekil Service ${ns}/vekil is missing; cannot reconcile NetworkPolicy for clients"
+  port="$(kubectl --context "${ctx}" -n "${ns}" get service vekil -o jsonpath='{.spec.ports[?(@.name=="http")].port}' 2>/dev/null || true)"
+  port="${port:-1337}"
+  selector_yaml="$(kubectl --context "${ctx}" -n "${ns}" get deployment vekil -o json \
+    | jq -r '.spec.selector.matchLabels // {} | to_entries[] | "      \(.key): \(.value | @json)"')"
+  [[ -n "${selector_yaml}" ]] || die "vekil Deployment ${ns}/vekil has no selector labels for NetworkPolicy"
+
+  kubectl --context "${ctx}" -n "${ns}" apply -f - <<YAML
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: vekil-ingress
+  namespace: ${ns}
+  labels:
+    app.kubernetes.io/name: vekil
+    app.kubernetes.io/instance: vekil
+    app.kubernetes.io/managed-by: vekil-reverse-proxy-deploy
+spec:
+  podSelector:
+    matchLabels:
+${selector_yaml}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              vekil.sozercan.io/access: "true"
+        - namespaceSelector:
+            matchLabels:
+              vekil.sozercan.io/access: "true"
+      ports:
+        - protocol: TCP
+          port: ${port}
+YAML
+}
+
 # prompt_cluster_action: resolves reuse|recreate|cancel for an existing cluster.
 # Honors DEMO_CLUSTER_REUSE when set; otherwise prompts on /dev/tty (so it works
 # even when the script's stdin is redirected, e.g. via make). With no tty and no
@@ -255,24 +299,19 @@ if [[ "${AGENTIC}" == "1" ]]; then
   if kubectl --context "${ctx}" -n "${VEKIL_NS}" get deploy vekil >/dev/null 2>&1; then
     vekil_exists=1
   fi
-  if [[ -x "${vekil_script}" ]]; then
-    if [[ "${vekil_exists}" == 1 ]]; then
-      log "vekil already deployed in ${VEKIL_NS} — reconciling workload and NetworkPolicy"
-    else
-      log "Deploying vekil model proxy to ${VEKIL_NS} (device-code login)"
-    fi
+  if [[ "${vekil_exists}" == 1 ]]; then
+    log "vekil already deployed in ${VEKIL_NS} — reconciling only the managed NetworkPolicy"
+    reconcile_vekil_network_policy "${ctx}" "${VEKIL_NS}"
+    kubectl --context "${ctx}" -n "${VEKIL_NS}" get networkpolicy vekil-ingress >/dev/null \
+      || die "vekil NetworkPolicy ${VEKIL_NS}/vekil-ingress was not reconciled"
+  elif [[ -x "${vekil_script}" ]]; then
+    log "Deploying vekil model proxy to ${VEKIL_NS} (device-code login)"
     bash "${vekil_script}" --context "${ctx}" --namespace "${VEKIL_NS}" --skip-wait
     kubectl --context "${ctx}" -n "${VEKIL_NS}" get networkpolicy vekil-ingress >/dev/null \
       || die "vekil NetworkPolicy ${VEKIL_NS}/vekil-ingress was not reconciled"
-    if [[ "${vekil_exists}" == 0 ]]; then
-      log "ACTION REQUIRED: complete the GitHub device-code login printed in vekil's logs:"
-      log "  kubectl --context ${ctx} -n ${VEKIL_NS} logs deploy/vekil | grep 'login/device'"
-      log "  (visit the URL, enter the code; then /readyz returns 200)"
-    fi
-  elif [[ "${vekil_exists}" == 1 ]]; then
-    kubectl --context "${ctx}" -n "${VEKIL_NS}" get networkpolicy vekil-ingress >/dev/null \
-      || die "vekil already exists in ${VEKIL_NS}, but deploy script was not found and NetworkPolicy ${VEKIL_NS}/vekil-ingress is missing"
-    log "vekil already deployed in ${VEKIL_NS} with NetworkPolicy — reusing it"
+    log "ACTION REQUIRED: complete the GitHub device-code login printed in vekil's logs:"
+    log "  kubectl --context ${ctx} -n ${VEKIL_NS} logs deploy/vekil | grep 'login/device'"
+    log "  (visit the URL, enter the code; then /readyz returns 200)"
   else
     die "vekil deploy script not found under .codex/skills or .claude/skills; install the skill or deploy an in-cluster OpenAI-compatible proxy before Demo 70"
   fi

--- a/hack/demos/cluster/install-substrate.sh
+++ b/hack/demos/cluster/install-substrate.sh
@@ -197,6 +197,9 @@ if [[ "${AGENTIC}" == "1" ]]; then
   log "Ensuring substrate demo namespace ${SUBSTRATE_NS}"
   kubectl --context "${ctx}" create namespace "${SUBSTRATE_NS}" --dry-run=client -o yaml \
     | kubectl --context "${ctx}" apply -f -
+  log "Allowing namespace ${SUBSTRATE_NS} to reach the vekil NetworkPolicy"
+  kubectl --context "${ctx}" label namespace "${SUBSTRATE_NS}" \
+    vekil.sozercan.io/access=true --overwrite >/dev/null
 
   # ---- 1. Codex-capable Actor image -------------------------------------
   # The agentic run executes a real codex CLI INSIDE the gVisor Actor, so the

--- a/hack/demos/cluster/install-substrate.sh
+++ b/hack/demos/cluster/install-substrate.sh
@@ -197,8 +197,13 @@ if [[ "${AGENTIC}" == "1" ]]; then
   log "Ensuring substrate demo namespace ${SUBSTRATE_NS}"
   kubectl --context "${ctx}" create namespace "${SUBSTRATE_NS}" --dry-run=client -o yaml \
     | kubectl --context "${ctx}" apply -f -
-  log "Allowing namespace ${SUBSTRATE_NS} to reach the vekil NetworkPolicy"
+  log "Ensuring substrate template namespace ${SUBSTRATE_TEMPLATE_NS}"
+  kubectl --context "${ctx}" create namespace "${SUBSTRATE_TEMPLATE_NS}" --dry-run=client -o yaml \
+    | kubectl --context "${ctx}" apply -f -
+  log "Allowing namespaces ${SUBSTRATE_NS} and ${SUBSTRATE_TEMPLATE_NS} to reach the vekil NetworkPolicy"
   kubectl --context "${ctx}" label namespace "${SUBSTRATE_NS}" \
+    vekil.sozercan.io/access=true --overwrite >/dev/null
+  kubectl --context "${ctx}" label namespace "${SUBSTRATE_TEMPLATE_NS}" \
     vekil.sozercan.io/access=true --overwrite >/dev/null
 
   # ---- 1. Codex-capable Actor image -------------------------------------
@@ -246,14 +251,28 @@ if [[ "${AGENTIC}" == "1" ]]; then
       break
     fi
   done
+  vekil_exists=0
   if kubectl --context "${ctx}" -n "${VEKIL_NS}" get deploy vekil >/dev/null 2>&1; then
-    log "vekil already deployed in ${VEKIL_NS} — leaving it (re-run device-code login if /readyz is down)"
-  elif [[ -x "${vekil_script}" ]]; then
-    log "Deploying vekil model proxy to ${VEKIL_NS} (device-code login)"
+    vekil_exists=1
+  fi
+  if [[ -x "${vekil_script}" ]]; then
+    if [[ "${vekil_exists}" == 1 ]]; then
+      log "vekil already deployed in ${VEKIL_NS} — reconciling workload and NetworkPolicy"
+    else
+      log "Deploying vekil model proxy to ${VEKIL_NS} (device-code login)"
+    fi
     bash "${vekil_script}" --context "${ctx}" --namespace "${VEKIL_NS}" --skip-wait
-    log "ACTION REQUIRED: complete the GitHub device-code login printed in vekil's logs:"
-    log "  kubectl --context ${ctx} -n ${VEKIL_NS} logs deploy/vekil | grep 'login/device'"
-    log "  (visit the URL, enter the code; then /readyz returns 200)"
+    kubectl --context "${ctx}" -n "${VEKIL_NS}" get networkpolicy vekil-ingress >/dev/null \
+      || die "vekil NetworkPolicy ${VEKIL_NS}/vekil-ingress was not reconciled"
+    if [[ "${vekil_exists}" == 0 ]]; then
+      log "ACTION REQUIRED: complete the GitHub device-code login printed in vekil's logs:"
+      log "  kubectl --context ${ctx} -n ${VEKIL_NS} logs deploy/vekil | grep 'login/device'"
+      log "  (visit the URL, enter the code; then /readyz returns 200)"
+    fi
+  elif [[ "${vekil_exists}" == 1 ]]; then
+    kubectl --context "${ctx}" -n "${VEKIL_NS}" get networkpolicy vekil-ingress >/dev/null \
+      || die "vekil already exists in ${VEKIL_NS}, but deploy script was not found and NetworkPolicy ${VEKIL_NS}/vekil-ingress is missing"
+    log "vekil already deployed in ${VEKIL_NS} with NetworkPolicy — reusing it"
   else
     die "vekil deploy script not found under .codex/skills or .claude/skills; install the skill or deploy an in-cluster OpenAI-compatible proxy before Demo 70"
   fi

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -200,6 +200,7 @@ var _ = AfterSuite(func() {
 
 	By("removing manager namespace")
 	runCleanupCommand(2*time.Minute, "kubectl", "delete", "ns", namespace, "--ignore-not-found", "--wait=false")
+	runCleanupCommand(2*time.Minute, "kubectl", "wait", "--for=delete", "namespace/"+namespace, "--timeout=120s")
 
 })
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -11,6 +11,7 @@ package e2e
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -192,18 +193,30 @@ var _ = AfterSuite(func() {
 	}
 
 	By("undeploying the controller-manager")
-	cmd = exec.Command("make", "undeploy")
-	_, _ = utils.Run(cmd)
+	runCleanupCommand(2*time.Minute, "kubectl", "delete", "--ignore-not-found=true", "--wait=false", "-k", "config/default")
 
 	By("uninstalling CRDs")
-	cmd = exec.Command("make", "uninstall")
-	_, _ = utils.Run(cmd)
+	runCleanupCommand(2*time.Minute, "kubectl", "delete", "--ignore-not-found=true", "--wait=false", "-k", "config/crd")
 
 	By("removing manager namespace")
-	cmd = exec.Command("kubectl", "delete", "ns", namespace, "--ignore-not-found")
-	_, _ = utils.Run(cmd)
+	runCleanupCommand(2*time.Minute, "kubectl", "delete", "ns", namespace, "--ignore-not-found", "--wait=false")
 
 })
+
+func runCleanupCommand(timeout time.Duration, name string, args ...string) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	output, err := utils.Run(cmd)
+	if ctx.Err() == context.DeadlineExceeded {
+		_, _ = fmt.Fprintf(GinkgoWriter, "cleanup command %q timed out after %s; continuing because the kind cluster teardown handles remaining resources\n", strings.Join(cmd.Args, " "), timeout)
+		return
+	}
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "cleanup command %q failed: %v\n%s\n", strings.Join(cmd.Args, " "), err, output)
+	}
+}
 
 // loadEnvFile reads a .env file and sets environment variables that are not already set.
 func loadEnvFile(path string) {

--- a/workers/harness/Dockerfile
+++ b/workers/harness/Dockerfile
@@ -20,6 +20,9 @@ FROM --platform=$TARGETPLATFORM golang:1.26 AS target-go
 # Runtime stage with common CLI dependencies for generic, Codex, and Claude adapters.
 FROM node:22-slim
 
+# Keep this explicit so live Copilot-proxy compatibility moves deliberately.
+ARG CODEX_CLI_VERSION=0.141.0
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     build-essential \
@@ -31,7 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ripgrep \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @openai/codex @anthropic-ai/claude-code \
+RUN npm install -g @openai/codex@${CODEX_CLI_VERSION} @anthropic-ai/claude-code \
     && npm cache clean --force
 
 COPY --from=target-go /usr/local/go /usr/local/go


### PR DESCRIPTION
### Motivation
- The Vekil deploy script previously rendered a Deployment that mounts upstream provider credentials and exposes an unauthenticated `ClusterIP` service reachable by any pod in the cluster, creating a high-severity in-cluster access risk.
- The change aims to reduce the attack surface by enforcing a conservative network boundary by default while providing an explicit opt-out for environments that manage access differently.

### Description
- Render a restrictive `NetworkPolicy` by default that selects the Vekil pods and permits ingress on the Vekil service port from:
  - pods labeled `vekil.sozercan.io/access=true` in the Vekil namespace; or
  - pods in namespaces labeled `vekil.sozercan.io/access=true`.
- Document that namespace-level allowance is intentionally broader than individual pod labeling: only label namespaces whose pods are trusted to reach the unauthenticated proxy.
- Add a `--no-network-policy` opt-out flag to the deploy script and explicitly delete the managed `<name>-ingress` policy when opting out.
- Warn when `NodePort`/`LoadBalancer` is combined with the default policy, and document kubelet probe behavior on CNIs that enforce host-sourced traffic.
- Update the demo installers to label the namespaces that need Vekil access and to reconcile or verify the managed policy for existing Vekil deployments without overwriting existing provider/PVC/service configuration.
- Pin the harness image Codex CLI through `CODEX_CLI_VERSION=0.141.0` because the required live Copilot Proxy CI rejected the newer Codex request shape; the build arg keeps this easy to bump when compatibility catches up.
- Bound e2e suite teardown so CI does not fail solely because ignored cleanup commands hang after the tests have completed; cleanup now waits for namespace deletion with a timeout for cluster-reuse workflows.

### Testing
- `bash -n .codex/skills/vekil-reverse-proxy-deploy/scripts/deploy_vekil_reverse_proxy.sh hack/demos/cluster/install-substrate.sh hack/demos/cluster/install-demo-model.sh hack/demos/cluster/install-agent-sandbox.sh scripts/*.sh`
- Rendered the Vekil manifest with `--print` and verified the NetworkPolicy, trusted-client selectors, and `--no-network-policy` behavior.
- `npm view @openai/codex@0.141.0 version --json`
- Verified the `@openai/codex@0.141.0` Linux binary does not contain the Copilot-rejected `internal_chat_message_metadata_passthrough` field.
- `go test -tags=e2e ./test/e2e -run TestDoesNotExist`
- `make test`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean on the latest code patches that were accepted; namespace-wide trusted access was intentionally kept and documented as the chosen boundary)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c1007619c832a803e79d33325d4cf)
