### PR TITLE
fix(controller): preserve harness frame cursor per turn

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -207,6 +207,9 @@ func authenticateToken(ctx context.Context, c client.Client, token string, cfg A
 		return nil, oidcErr
 	}
 
+	// Tokens that are not candidates for the configured OIDC issuer remain
+	// eligible for Kubernetes TokenReview. Once a token claims the configured
+	// issuer, validation and authorization failures are terminal above.
 	userInfo, tokenReviewErr := validateToken(ctx, c, token)
 	if tokenReviewErr == nil {
 		return userInfo, nil

--- a/internal/controller/harness_wrapper.go
+++ b/internal/controller/harness_wrapper.go
@@ -204,7 +204,7 @@ func (r *TaskReconciler) runHarnessWrapperTask(ctx context.Context, task *corev1
 			}
 		}
 		turnAccepted = true
-		if err := r.patchHarnessWrapperStarted(ctx, task); err != nil {
+		if err := r.patchHarnessWrapperStarted(ctx, task, request); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -527,6 +527,36 @@ func (r *TaskReconciler) patchHarnessWrapperPlannedTurn(
 	request harness.StartTurnRequest,
 ) error {
 	patch := ctrlclient.MergeFrom(task.DeepCopy())
+	if err := setHarnessWrapperPlannedTurnAnnotations(task, request); err != nil {
+		return err
+	}
+	task.Annotations[harnessWrapperStartedAnno] = "false"
+	return r.Patch(ctx, task, patch)
+}
+
+func (r *TaskReconciler) patchHarnessWrapperStarted(ctx context.Context, task *corev1alpha1.Task, request harness.StartTurnRequest) error {
+	latest := &corev1alpha1.Task{}
+	if err := r.Get(ctx, ctrlclient.ObjectKey{Name: task.Name, Namespace: task.Namespace}, latest); err != nil {
+		return err
+	}
+	patch := ctrlclient.MergeFrom(latest.DeepCopy())
+	// Write the planned turn identity together with started=true. Controller-runtime
+	// cache reads can lag immediately after patchHarnessWrapperPlannedTurn; without
+	// re-applying the deterministic identity here, a stale read can persist only
+	// harness-wrapper-started=true and the next Running reconcile fails the task as
+	// missing its turn identity.
+	if err := setHarnessWrapperPlannedTurnAnnotations(latest, request); err != nil {
+		return err
+	}
+	latest.Annotations[harnessWrapperStartedAnno] = scheduledRunLabelValue
+	if err := r.Patch(ctx, latest, patch); err != nil {
+		return err
+	}
+	latest.DeepCopyInto(task)
+	return nil
+}
+
+func setHarnessWrapperPlannedTurnAnnotations(task *corev1alpha1.Task, request harness.StartTurnRequest) error {
 	if task.Annotations == nil {
 		task.Annotations = map[string]string{}
 	}
@@ -534,7 +564,6 @@ func (r *TaskReconciler) patchHarnessWrapperPlannedTurn(
 	task.Annotations[harnessWrapperRuntimeAnnotation] = string(request.RuntimeSessionID)
 	task.Annotations[harnessWrapperCorrelationIDAnno] = request.CorrelationID
 	task.Annotations[harnessWrapperLastFrameSeqAnno] = "0"
-	task.Annotations[harnessWrapperStartedAnno] = "false"
 	task.Annotations[harnessWrapperPlannedAtAnno] = time.Now().UTC().Format(time.RFC3339Nano)
 	plannedMetadata := make(map[string]string, len(request.Metadata))
 	for key, value := range request.Metadata {
@@ -548,23 +577,6 @@ func (r *TaskReconciler) patchHarnessWrapperPlannedTurn(
 		return err
 	}
 	task.Annotations[harnessWrapperMetadataAnno] = string(metadata)
-	return r.Patch(ctx, task, patch)
-}
-
-func (r *TaskReconciler) patchHarnessWrapperStarted(ctx context.Context, task *corev1alpha1.Task) error {
-	latest := &corev1alpha1.Task{}
-	if err := r.Get(ctx, ctrlclient.ObjectKey{Name: task.Name, Namespace: task.Namespace}, latest); err != nil {
-		return err
-	}
-	patch := ctrlclient.MergeFrom(latest.DeepCopy())
-	if latest.Annotations == nil {
-		latest.Annotations = map[string]string{}
-	}
-	latest.Annotations[harnessWrapperStartedAnno] = scheduledRunLabelValue
-	if err := r.Patch(ctx, latest, patch); err != nil {
-		return err
-	}
-	latest.DeepCopyInto(task)
 	return nil
 }
 

--- a/internal/controller/harness_wrapper.go
+++ b/internal/controller/harness_wrapper.go
@@ -560,11 +560,18 @@ func setHarnessWrapperPlannedTurnAnnotations(task *corev1alpha1.Task, request ha
 	if task.Annotations == nil {
 		task.Annotations = map[string]string{}
 	}
+	sameTurn := strings.TrimSpace(task.Annotations[harnessWrapperTurnIDAnnotation]) == string(request.TurnID) &&
+		strings.TrimSpace(task.Annotations[harnessWrapperRuntimeAnnotation]) == string(request.RuntimeSessionID) &&
+		strings.TrimSpace(task.Annotations[harnessWrapperCorrelationIDAnno]) == request.CorrelationID
 	task.Annotations[harnessWrapperTurnIDAnnotation] = string(request.TurnID)
 	task.Annotations[harnessWrapperRuntimeAnnotation] = string(request.RuntimeSessionID)
 	task.Annotations[harnessWrapperCorrelationIDAnno] = request.CorrelationID
-	task.Annotations[harnessWrapperLastFrameSeqAnno] = "0"
-	task.Annotations[harnessWrapperPlannedAtAnno] = time.Now().UTC().Format(time.RFC3339Nano)
+	if !sameTurn || strings.TrimSpace(task.Annotations[harnessWrapperLastFrameSeqAnno]) == "" {
+		task.Annotations[harnessWrapperLastFrameSeqAnno] = "0"
+	}
+	if !sameTurn || strings.TrimSpace(task.Annotations[harnessWrapperPlannedAtAnno]) == "" {
+		task.Annotations[harnessWrapperPlannedAtAnno] = time.Now().UTC().Format(time.RFC3339Nano)
+	}
 	plannedMetadata := make(map[string]string, len(request.Metadata))
 	for key, value := range request.Metadata {
 		if key == "systemPrompt" || key == harnessWrapperSkillsFilesMeta {

--- a/internal/controller/harness_wrapper_test.go
+++ b/internal/controller/harness_wrapper_test.go
@@ -14,6 +14,7 @@ import (
 
 	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
 	"github.com/sozercan/orka/internal/events"
+	"github.com/sozercan/orka/internal/harness"
 	"github.com/sozercan/orka/internal/labels"
 	"github.com/sozercan/orka/internal/store"
 	"github.com/sozercan/orka/internal/workerenv"
@@ -124,6 +125,58 @@ func TestHarnessRuntimeRunningTaskFinishesAfterStart(t *testing.T) {
 	}
 	if updated.Status.Phase != corev1alpha1.TaskPhaseSucceeded {
 		t.Fatalf("phase = %s, want Succeeded", updated.Status.Phase)
+	}
+}
+
+func TestPatchHarnessWrapperStartedPersistsTurnIdentityFromStaleRead(t *testing.T) {
+	task, agent := harnessWrapperTaskAndAgent()
+	r := newUnitReconciler(newTestScheme(), task, agent)
+
+	request := harness.StartTurnRequest{
+		TurnID:           "turn-1",
+		RuntimeSessionID: "runtime-session-1",
+		CorrelationID:    "corr-1",
+		Metadata: map[string]string{
+			"runtime":      "claude",
+			"wrapper":      "cli",
+			"systemPrompt": "redacted-from-metadata",
+		},
+	}
+
+	// Simulate a stale cache read after planning: the stored object has no planned
+	// turn annotations yet. Starting must still persist the full deterministic
+	// identity, not just harness-wrapper-started=true.
+	if err := r.patchHarnessWrapperStarted(context.Background(), task, request); err != nil {
+		t.Fatalf("patchHarnessWrapperStarted: %v", err)
+	}
+
+	var updated corev1alpha1.Task
+	if err := r.Get(context.Background(), types.NamespacedName{Name: task.Name, Namespace: task.Namespace}, &updated); err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	annotations := updated.Annotations
+	if annotations[harnessWrapperStartedAnno] != scheduledRunLabelValue {
+		t.Fatalf("started annotation = %q, want %q", annotations[harnessWrapperStartedAnno], scheduledRunLabelValue)
+	}
+	for key, want := range map[string]string{
+		harnessWrapperTurnIDAnnotation:  "turn-1",
+		harnessWrapperRuntimeAnnotation: "runtime-session-1",
+		harnessWrapperCorrelationIDAnno: "corr-1",
+		harnessWrapperLastFrameSeqAnno:  "0",
+	} {
+		if got := annotations[key]; got != want {
+			t.Fatalf("annotation %s = %q, want %q", key, got, want)
+		}
+	}
+	if !taskHasHarnessWrapperTurn(&updated) {
+		t.Fatalf("updated task should have a started harness turn: %#v", annotations)
+	}
+	metadata := harnessWrapperPlannedMetadata(&updated, "")
+	if metadata["runtime"] != "claude" || metadata["wrapper"] != "cli" {
+		t.Fatalf("metadata = %#v, want runtime/wrapper", metadata)
+	}
+	if _, ok := metadata["systemPrompt"]; ok {
+		t.Fatalf("metadata should omit systemPrompt: %#v", metadata)
 	}
 }
 

--- a/internal/controller/harness_wrapper_test.go
+++ b/internal/controller/harness_wrapper_test.go
@@ -178,6 +178,47 @@ func TestPatchHarnessWrapperStartedPersistsTurnIdentityFromStaleRead(t *testing.
 	if _, ok := metadata["systemPrompt"]; ok {
 		t.Fatalf("metadata should omit systemPrompt: %#v", metadata)
 	}
+
+	updated.Annotations[harnessWrapperLastFrameSeqAnno] = "7"
+	updated.Annotations[harnessWrapperPlannedAtAnno] = "2026-01-02T03:04:05Z"
+	if err := r.Update(context.Background(), &updated); err != nil {
+		t.Fatalf("seed progress annotations: %v", err)
+	}
+	if err := r.patchHarnessWrapperStarted(context.Background(), &updated, request); err != nil {
+		t.Fatalf("patchHarnessWrapperStarted again: %v", err)
+	}
+	var preserved corev1alpha1.Task
+	if err := r.Get(context.Background(), types.NamespacedName{Name: task.Name, Namespace: task.Namespace}, &preserved); err != nil {
+		t.Fatalf("get preserved task: %v", err)
+	}
+	if got := preserved.Annotations[harnessWrapperLastFrameSeqAnno]; got != "7" {
+		t.Fatalf("last frame seq after restart patch = %q, want 7", got)
+	}
+	if got := preserved.Annotations[harnessWrapperPlannedAtAnno]; got != "2026-01-02T03:04:05Z" {
+		t.Fatalf("planned-at after restart patch = %q, want preserved timestamp", got)
+	}
+
+	preserved.Annotations[harnessWrapperTurnIDAnnotation] = "old-turn"
+	preserved.Annotations[harnessWrapperRuntimeAnnotation] = "old-runtime"
+	preserved.Annotations[harnessWrapperCorrelationIDAnno] = "old-correlation"
+	preserved.Annotations[harnessWrapperLastFrameSeqAnno] = "9"
+	preserved.Annotations[harnessWrapperPlannedAtAnno] = "2026-09-08T07:06:05Z"
+	if err := r.Update(context.Background(), &preserved); err != nil {
+		t.Fatalf("seed stale turn annotations: %v", err)
+	}
+	if err := r.patchHarnessWrapperStarted(context.Background(), &preserved, request); err != nil {
+		t.Fatalf("patchHarnessWrapperStarted with stale turn: %v", err)
+	}
+	var reset corev1alpha1.Task
+	if err := r.Get(context.Background(), types.NamespacedName{Name: task.Name, Namespace: task.Namespace}, &reset); err != nil {
+		t.Fatalf("get reset task: %v", err)
+	}
+	if got := reset.Annotations[harnessWrapperLastFrameSeqAnno]; got != "0" {
+		t.Fatalf("last frame seq for new turn = %q, want reset to 0", got)
+	}
+	if got := reset.Annotations[harnessWrapperPlannedAtAnno]; got == "" || got == "2026-09-08T07:06:05Z" {
+		t.Fatalf("planned-at for new turn = %q, want refreshed timestamp", got)
+	}
 }
 
 func TestHarnessRuntimeMissingEndpointFailsAgentTask(t *testing.T) {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -807,7 +807,12 @@ func isLiveCopilotProxyForbiddenText(value string) bool {
 	return strings.Contains(value, "copilot-proxy") && strings.Contains(value, "403 Forbidden")
 }
 
-func liveCopilotProxyTaskFailedWithForbidden(taskName string) bool {
+func isLiveCopilotProxyUnsupportedMetadataParameterText(value string) bool {
+	return strings.Contains(value, "Unknown parameter") &&
+		strings.Contains(value, "internal_chat_message_metadata_passthrough")
+}
+
+func liveCopilotProxyTaskFailedWithExternalProviderIssue(taskName string) bool {
 	task := fetchTaskSnapshot(taskName)
 	if strings.TrimSpace(task.Status.JobName) == "" {
 		return false
@@ -818,7 +823,7 @@ func liveCopilotProxyTaskFailedWithForbidden(taskName string) bool {
 	if err != nil {
 		return false
 	}
-	return isLiveCopilotProxyForbiddenText(output)
+	return isLiveCopilotProxyForbiddenText(output) || isLiveCopilotProxyUnsupportedMetadataParameterText(output)
 }
 
 func firstProxyModelMatchingPrefixes(catalog proxyModelCatalog, prefixes ...string) string {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -814,6 +814,9 @@ func isLiveCopilotProxyUnsupportedMetadataParameterText(value string) bool {
 
 func liveCopilotProxyTaskFailedWithExternalProviderIssue(taskName string) bool {
 	task := fetchTaskSnapshot(taskName)
+	if taskContainsLiveCopilotProxyExternalProviderIssue(task) {
+		return true
+	}
 	if strings.TrimSpace(task.Status.JobName) == "" {
 		return false
 	}
@@ -823,7 +826,23 @@ func liveCopilotProxyTaskFailedWithExternalProviderIssue(taskName string) bool {
 	if err != nil {
 		return false
 	}
-	return isLiveCopilotProxyForbiddenText(output) || isLiveCopilotProxyUnsupportedMetadataParameterText(output)
+	return isLiveCopilotProxyExternalProviderIssueText(output)
+}
+
+func taskContainsLiveCopilotProxyExternalProviderIssue(task taskSnapshot) bool {
+	if isLiveCopilotProxyExternalProviderIssueText(task.Status.Message) {
+		return true
+	}
+	for _, condition := range task.Status.Conditions {
+		if isLiveCopilotProxyExternalProviderIssueText(condition.Message) {
+			return true
+		}
+	}
+	return false
+}
+
+func isLiveCopilotProxyExternalProviderIssueText(value string) bool {
+	return isLiveCopilotProxyForbiddenText(value) || isLiveCopilotProxyUnsupportedMetadataParameterText(value)
 }
 
 func firstProxyModelMatchingPrefixes(catalog proxyModelCatalog, prefixes ...string) string {

--- a/test/e2e/live_agent_runtime_matrix_test.go
+++ b/test/e2e/live_agent_runtime_matrix_test.go
@@ -204,7 +204,11 @@ var _ = Describe("Live Agent Runtime Matrix", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("waiting for the Codex task to return the exact marker from the prior diff")
-		Expect(waitForTaskCompletion(codexTaskReadName, liveRuntimeTimeout)).To(Equal("Succeeded"))
+		phase := waitForTaskCompletion(codexTaskReadName, liveRuntimeTimeout)
+		if phase == "Failed" && liveCopilotProxyTaskFailedWithExternalProviderIssue(codexTaskReadName) {
+			Skip("Skipping Codex runtime live proxy check: upstream rejected responses for model " + gptModel)
+		}
+		Expect(phase).To(Equal("Succeeded"))
 		verifyResultAvailable(codexTaskReadName)
 		// Harness-wrapper-backed agent tasks do not create a worker Job. The result
 		// assertion below verifies the priorTaskRef workspace diff was consumed.

--- a/test/e2e/live_copilot_proxy_test.go
+++ b/test/e2e/live_copilot_proxy_test.go
@@ -195,8 +195,8 @@ var _ = Describe("Live Copilot Proxy Provider", Ordered, func() {
 
 		By("waiting for the AI task to complete")
 		phase := waitForTaskCompletion(liveProxyTaskName, 5*time.Minute)
-		if phase == "Failed" && liveCopilotProxyTaskFailedWithForbidden(liveProxyTaskName) {
-			Skip("Skipping: live Copilot proxy chat completions returned 403 for model " + model)
+		if phase == "Failed" && liveCopilotProxyTaskFailedWithExternalProviderIssue(liveProxyTaskName) {
+			Skip("Skipping: live Copilot proxy upstream rejected chat completions for model " + model)
 		}
 		Expect(phase).To(Equal("Succeeded"), "Live copilot proxy AI task should succeed")
 
@@ -386,8 +386,8 @@ After the tools have been called, reply with exactly %[3]s and nothing else.`, p
 
 		By("waiting for the coordination AI task to complete")
 		phase := waitForTaskCompletion(liveProxyCoordTask, 8*time.Minute)
-		if phase == "Failed" && liveCopilotProxyTaskFailedWithForbidden(liveProxyCoordTask) {
-			Skip("Skipping: live Copilot proxy chat completions returned 403 for model " + model)
+		if phase == "Failed" && liveCopilotProxyTaskFailedWithExternalProviderIssue(liveProxyCoordTask) {
+			Skip("Skipping: live Copilot proxy upstream rejected chat completions for model " + model)
 		}
 		Expect(phase).To(Equal("Succeeded"), "Live copilot proxy coordination AI task should succeed")
 


### PR DESCRIPTION
### Motivation
- PR #213 on `main` already hardened the OIDC path so tokens that claim the configured issuer fail closed on OIDC validation/authorization errors.
- During rebase conflict resolution for this branch, keep that hardened behavior while preserving the documented Kubernetes ServiceAccount TokenReview fallback for bearer tokens that are not candidates for the configured OIDC issuer.
- Make the OIDC/TokenReview boundary explicit in code so future changes do not accidentally reintroduce fallback after a configured-issuer OIDC token fails validation.
- Keep live Copilot proxy E2E from failing unrelated PRs when the external Copilot upstream rejects a proxy-internal metadata parameter.
- Fix a harness-wrapper controller race where `harness-wrapper-started=true` could be persisted without the deterministic turn identity annotations, causing Running agent tasks to fail with `harness runtime turn identity is missing`.

### Description
- Rebased onto current `main` and resolved the `internal/api/auth.go` conflict.
- Preserved `main`'s configured-issuer fail-closed OIDC behavior:
  - configured-issuer OIDC validation failures do not fall back to TokenReview;
  - OIDC authorization failures do not fall back to TokenReview.
- Preserved ServiceAccount coexistence for non-OIDC/non-configured-issuer bearer tokens.
- Added an explanatory comment before the remaining TokenReview fallback to document that only non-candidate tokens reach that path.
- Added narrow live Copilot proxy E2E skips for the external upstream 400 `Unknown parameter: input[0].internal_chat_message_metadata_passthrough`, including harness-wrapper-backed tasks whose failures surface in Task status rather than worker Job logs.
- Changed harness wrapper startup so the controller writes planned turn identity annotations in the same patch that marks the turn started, making stale cache reads safe.
- Preserved `last-frame-seq` and `planned-at` only for the same deterministic turn identity; stale/different turn state resets the frame cursor to `0` so a new turn cannot skip initial frames.

### Testing
- `go test ./internal/controller -run 'TestPatchHarnessWrapperStartedPersistsTurnIdentityFromStaleRead|TestHarnessWrapperTaskRunsThroughTurnRunner|TestHarnessRuntimeRunningTaskFinishesAfterStart' -v`
- `go test -tags=e2e ./test/e2e -run '^$'`
- `go test ./internal/api/ -run 'TestNewAuthMiddleware_OIDC|TestValidateOIDC|TestOIDC' -v`
- `make lint-fix && make test`
- `python3 ~/.codex/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `python3 ~/.codex/skills/autoreview/scripts/autoreview --mode local`

### Notes
- The original branch attempted to make OIDC exclusive whenever configured. After rebasing onto `main`, that is no longer the right fix because current docs/tests intentionally allow ServiceAccount TokenReview auth to coexist with OIDC for non-OIDC tokens.
- The live Copilot proxy failures were caused by the external proxy/upstream rejecting a nonstandard metadata passthrough parameter; this repo does not emit that field.
