### PR TITLE
fix: harden default Codex sandbox mode

### DIFF
--- a/config/harness-wrapper/deployment.yaml
+++ b/config/harness-wrapper/deployment.yaml
@@ -51,8 +51,6 @@ spec:
           value: "1000"
         - name: ORKA_HARNESS_WRAPPER_CHILD_GID
           value: "1000"
-        - name: ORKA_CODEX_SANDBOX_MODE
-          value: danger-full-access
         - name: ORKA_SA_TOKEN_PATH
           value: /var/run/orka/upload-token/token
         volumeMounts:

--- a/workers/harness/Dockerfile
+++ b/workers/harness/Dockerfile
@@ -31,7 +31,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ripgrep \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @openai/codex @anthropic-ai/claude-code \
+# Pin Codex CLI so live proxy E2E is not broken by upstream request-shape changes.
+ARG CODEX_CLI_VERSION=0.142.1
+RUN npm install -g @openai/codex@${CODEX_CLI_VERSION} @anthropic-ai/claude-code \
     && npm cache clean --force
 
 COPY --from=target-go /usr/local/go /usr/local/go


### PR DESCRIPTION
### Motivation
- The default harness-wrapper kustomize deployment set `ORKA_CODEX_SANDBOX_MODE=danger-full-access`, which weakens the Codex worker sandbox and can allow model-driven processes to access mounted secrets or the service account token.
- Removing that unsafe deployment default lets the Codex adapter fall back to its safer built-in `workspace-write` sandbox unless an operator explicitly overrides it.

### Description
- Remove the explicit `ORKA_CODEX_SANDBOX_MODE: danger-full-access` environment variable from `config/harness-wrapper/deployment.yaml`.
- Pin the Codex CLI version in `workers/harness/Dockerfile` to `@openai/codex@0.142.1` via `CODEX_CLI_VERSION` so the harness-wrapper image remains reproducible and avoids the current `0.142.2` request-shape regression seen in live copilot-proxy E2E while this sandbox hardening rolls out.

### Testing
- `make lint-fix`
- `make test`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` → clean
- `git diff --check`
- `npm view @openai/codex@0.142.1 version`
- Local request-shape probe with `npx @openai/codex@0.142.1` confirmed it does not emit `input[0].internal_chat_message_metadata_passthrough`; the same probe against `0.142.2` reproduced the field that caused live copilot-proxy E2E to fail.
- Docker image build was not run locally because Docker is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c1b2e40e0832aa9046275b61a62fe)
