### PR TITLE
Secure live copilot-proxy E2E workflow by removing pull_request trigger

### DIFF
--- a/.github/workflows/live-copilot-proxy-e2e.yml
+++ b/.github/workflows/live-copilot-proxy-e2e.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Decide whether live e2e can run
         id: gate
         run: |
+          # Defensive guard: this workflow is intentionally not triggered by pull_request,
+          # but keep pull-request events secretless if that trigger is ever re-added.
           if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
             echo "run=false" >> "$GITHUB_OUTPUT"
             echo "reason=Skipping live copilot-proxy e2e for pull requests because it requires repository secrets." >> "$GITHUB_OUTPUT"
@@ -81,7 +83,7 @@ jobs:
       - name: Install kind
         if: steps.gate.outputs.run == 'true'
         run: |
-          curl -fsSL -o ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-$(go env GOARCH)
+          curl -fsSL -o ./kind "https://kind.sigs.k8s.io/dl/latest/kind-linux-$(go env GOARCH)"
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
 

--- a/.github/workflows/live-copilot-proxy-e2e.yml
+++ b/.github/workflows/live-copilot-proxy-e2e.yml
@@ -3,10 +3,8 @@ name: Live Copilot Proxy E2E
 on:
   workflow_dispatch:
   push:
-    paths-ignore:
-      - ".codex/**"
-      - ".claude/**"
-  pull_request:
+    branches:
+      - main
     paths-ignore:
       - ".codex/**"
       - ".claude/**"
@@ -30,19 +28,10 @@ jobs:
     steps:
       - name: Decide whether live e2e can run
         id: gate
-        env:
-          IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
-          ACTOR: ${{ github.actor }}
         run: |
-          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] && [ "${IS_FORK}" = "true" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "reason=Skipping live copilot-proxy e2e for fork pull requests because repository secrets are not exposed." >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ "${ACTOR}" = "dependabot[bot]" ] && [ -z "${COPILOT_GITHUB_TOKEN}" ]; then
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "reason=Skipping live copilot-proxy e2e for Dependabot pull requests because repository secrets are not exposed." >> "$GITHUB_OUTPUT"
+            echo "reason=Skipping live copilot-proxy e2e for pull requests because it requires repository secrets." >> "$GITHUB_OUTPUT"
             exit 0
           fi
 

--- a/internal/controller/harness_wrapper.go
+++ b/internal/controller/harness_wrapper.go
@@ -568,9 +568,6 @@ func (r *TaskReconciler) patchHarnessWrapperStarted(ctx context.Context, task *c
 		harnessWrapperPlannedAtAnno,
 		harnessWrapperMetadataAnno,
 	} {
-		if task.Annotations == nil {
-			break
-		}
 		if value, ok := task.Annotations[key]; ok && strings.TrimSpace(value) != "" {
 			latest.Annotations[key] = value
 		}

--- a/internal/controller/harness_wrapper.go
+++ b/internal/controller/harness_wrapper.go
@@ -560,6 +560,21 @@ func (r *TaskReconciler) patchHarnessWrapperStarted(ctx context.Context, task *c
 	if latest.Annotations == nil {
 		latest.Annotations = map[string]string{}
 	}
+	for _, key := range []string{
+		harnessWrapperTurnIDAnnotation,
+		harnessWrapperRuntimeAnnotation,
+		harnessWrapperCorrelationIDAnno,
+		harnessWrapperLastFrameSeqAnno,
+		harnessWrapperPlannedAtAnno,
+		harnessWrapperMetadataAnno,
+	} {
+		if task.Annotations == nil {
+			break
+		}
+		if value, ok := task.Annotations[key]; ok && strings.TrimSpace(value) != "" {
+			latest.Annotations[key] = value
+		}
+	}
 	latest.Annotations[harnessWrapperStartedAnno] = scheduledRunLabelValue
 	if err := r.Patch(ctx, latest, patch); err != nil {
 		return err

--- a/internal/controller/harness_wrapper_test.go
+++ b/internal/controller/harness_wrapper_test.go
@@ -127,6 +127,45 @@ func TestHarnessRuntimeRunningTaskFinishesAfterStart(t *testing.T) {
 	}
 }
 
+func TestPatchHarnessWrapperStartedCarriesPlannedIdentityFromLocalTask(t *testing.T) {
+	task, agent := harnessWrapperTaskAndAgent()
+	localTask := task.DeepCopy()
+	r := newUnitReconciler(newTestScheme(), task.DeepCopy(), agent)
+
+	request, err := r.harnessWrapperStartTurnRequest(context.Background(), localTask, agent, time.Now(), 1)
+	if err != nil {
+		t.Fatalf("harnessWrapperStartTurnRequest: %v", err)
+	}
+	localTask.Annotations = map[string]string{
+		harnessWrapperTurnIDAnnotation:  string(request.TurnID),
+		harnessWrapperRuntimeAnnotation: string(request.RuntimeSessionID),
+		harnessWrapperCorrelationIDAnno: request.CorrelationID,
+		harnessWrapperLastFrameSeqAnno:  "0",
+		harnessWrapperPlannedAtAnno:     time.Now().UTC().Format(time.RFC3339Nano),
+		harnessWrapperMetadataAnno:      `{"runtime":"codex","wrapper":"cli"}`,
+	}
+
+	if err := r.patchHarnessWrapperStarted(context.Background(), localTask); err != nil {
+		t.Fatalf("patchHarnessWrapperStarted: %v", err)
+	}
+
+	var updated corev1alpha1.Task
+	if err := r.Get(context.Background(), types.NamespacedName{Name: task.Name, Namespace: task.Namespace}, &updated); err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	for key, want := range localTask.Annotations {
+		if got := updated.Annotations[key]; got != want {
+			t.Fatalf("annotation %s = %q, want %q", key, got, want)
+		}
+	}
+	if got := updated.Annotations[harnessWrapperStartedAnno]; got != scheduledRunLabelValue {
+		t.Fatalf("%s = %q, want %q", harnessWrapperStartedAnno, got, scheduledRunLabelValue)
+	}
+	if !taskHasHarnessWrapperTurn(&updated) {
+		t.Fatal("updated task should have a complete started harness-wrapper turn identity")
+	}
+}
+
 func TestHarnessRuntimeMissingEndpointFailsAgentTask(t *testing.T) {
 	task, agent := harnessWrapperTaskAndAgent()
 	secret := attachHarnessWrapperRuntimeSecret(task, agent)


### PR DESCRIPTION
### Motivation
- Prevent repository secret exposure by ensuring `COPILOT_GITHUB_TOKEN` is never provided to PR-controlled code or scripts run from a checked-out PR.
- Keep the live e2e job runnable by trusted maintainers via `workflow_dispatch` while restricting automatic runs to the main branch.
- Maintain a defensive runtime gate so the job will skip if invoked by a pull request in the future.
- Fix the harness-wrapper turn-start race that surfaced in CI after this branch's checks reran: a locally planned turn identity could be lost when the controller refetched the Task before marking it started, causing harness-backed e2e tasks to fail with `harness runtime turn identity is missing`.

### Description
- Removed the `pull_request` trigger from `.github/workflows/live-copilot-proxy-e2e.yml` and restricted automatic `push` runs to the `main` branch while keeping `workflow_dispatch` for manual runs.
- Added an inline comment documenting that the `pull_request` runtime gate is intentional defensive code in case that trigger is ever re-added.
- Quoted the kind download URL in the live copilot-proxy workflow to satisfy actionlint/shellcheck.
- Preserved planned harness-wrapper turn identity annotations when marking a turn as started, with unit coverage for copying the planned identity into the freshly fetched Task.

### Testing
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/live-copilot-proxy-e2e.yml`
- `go test ./internal/controller -run TestPatchHarnessWrapperStartedCarriesPlannedIdentityFromLocalTask -v`
- `go test ./internal/controller -run 'TestHarnessWrapper|TestHarnessRuntime|TestPatchHarnessWrapperStarted'`
- `make lint-fix`
- `make test`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean after each code-change cycle)
- GitHub Actions on PR #224 after commit `cab3b3e9`: all 19 checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c19cb55ac832a8232d8070a8f697f)

