### PR TITLE
fix: enforce namespace scope in coordinator tools

### DIFF
--- a/internal/tools/chat_cancel_task.go
+++ b/internal/tools/chat_cancel_task.go
@@ -45,6 +45,9 @@ func (t *ChatCancelTaskTool) Execute(ctx context.Context, args json.RawMessage) 
 		return ChatToolErrorResult("invalid_arguments", "name is required", "Provide the task name")
 	}
 	namespace := chatGetStringArgDefault(a, namespaceField, tc.Namespace)
+	if r, ok := checkChatNamespaceScope(tc, namespace); !ok {
+		return r, nil
+	}
 
 	task := &corev1alpha1.Task{}
 	if err := tc.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, task); err != nil {

--- a/internal/tools/chat_create_agent_test.go
+++ b/internal/tools/chat_create_agent_test.go
@@ -20,7 +20,10 @@ import (
 	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
 )
 
-const testProviderOpenAI = "openai"
+const (
+	testProviderOpenAI            = "openai"
+	testPermissionDeniedErrorType = "permission_denied"
+)
 
 func TestChatCreateAgentTool_Execute_OmittedProviderRefLeavesNil(t *testing.T) {
 	fc := newFakeClient()
@@ -73,7 +76,7 @@ func TestChatCreateAgentTool_Execute_RollsBackAgentWhenInitialTaskAuthorizationF
 		},
 		GenerateTaskName: func() string { return "blocked-task" },
 		AuthorizeTaskCreate: func(context.Context, *corev1alpha1.Task) *ChatToolError {
-			return &ChatToolError{Type: "permission_denied", Message: "task blocked by context token"}
+			return &ChatToolError{Type: testPermissionDeniedErrorType, Message: "task blocked by context token"}
 		},
 	})
 
@@ -90,7 +93,7 @@ func TestChatCreateAgentTool_Execute_RollsBackAgentWhenInitialTaskAuthorizationF
 	if r.Success {
 		t.Fatalf("expected authorization failure, got success: %#v", r)
 	}
-	if r.ErrorType != "permission_denied" {
+	if r.ErrorType != testPermissionDeniedErrorType {
 		t.Fatalf("errorType = %q, want permission_denied", r.ErrorType)
 	}
 

--- a/internal/tools/chat_namespace_scope_test.go
+++ b/internal/tools/chat_namespace_scope_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
+)
+
+func TestCoordinatorReadDeleteToolsEnforceNamespaceScope(t *testing.T) {
+	victimTask := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "victim-task", Namespace: "victim-ns"},
+		Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeAI},
+		Status: corev1alpha1.TaskStatus{
+			Phase:     corev1alpha1.TaskPhaseSucceeded,
+			ResultRef: &corev1alpha1.ResultReference{Available: true},
+		},
+	}
+	victimAgent := &corev1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "victim-agent", Namespace: "victim-ns"},
+	}
+
+	tests := []struct {
+		name    string
+		tool    Tool
+		args    map[string]any
+		objects []client.Object
+	}{
+		{name: "check task progress", tool: &CheckTaskProgressTool{}, args: map[string]any{nameField: "victim-task", namespaceField: "victim-ns"}, objects: []client.Object{victimTask}},
+		{name: "fetch task output", tool: &FetchTaskOutputTool{}, args: map[string]any{nameField: "victim-task", namespaceField: "victim-ns"}, objects: []client.Object{victimTask}},
+		{name: "wait for task", tool: &WaitForTaskTool{}, args: map[string]any{nameField: "victim-task", namespaceField: "victim-ns", timeoutField: 1}, objects: []client.Object{victimTask}},
+		{name: "cancel task", tool: &ChatCancelTaskTool{}, args: map[string]any{nameField: "victim-task", namespaceField: "victim-ns"}, objects: []client.Object{victimTask}},
+		{name: "list tasks", tool: &ListTasksTool{}, args: map[string]any{namespaceField: "victim-ns"}, objects: []client.Object{victimTask}},
+		{name: "list agents", tool: &ListAgentsTool{}, args: map[string]any{namespaceField: "victim-ns"}, objects: []client.Object{victimAgent}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc := newFakeClient(tt.objects...)
+			ctx := WithToolContext(context.Background(), &ToolContext{
+				Client:                    fc,
+				Namespace:                 defaultNamespace,
+				WatchNamespace:            defaultNamespace,
+				EnforceNamespaceIsolation: true,
+				ResultStore:               &fakeResultStore{data: map[string][]byte{"victim-ns/victim-task": []byte("secret output")}},
+			})
+
+			argsJSON, err := json.Marshal(tt.args)
+			if err != nil {
+				t.Fatalf("failed to marshal args: %v", err)
+			}
+			result, err := tt.tool.Execute(ctx, argsJSON)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var res ChatToolResult
+			if err := json.Unmarshal([]byte(result), &res); err != nil {
+				t.Fatalf("failed to parse result: %v", err)
+			}
+			if res.Success {
+				t.Fatalf("expected namespace permission error, got success: %s", result)
+			}
+			if res.ErrorType != "permission_denied" {
+				t.Fatalf("errorType = %q, want permission_denied; result=%s", res.ErrorType, result)
+			}
+		})
+	}
+}

--- a/internal/tools/chat_namespace_scope_test.go
+++ b/internal/tools/chat_namespace_scope_test.go
@@ -72,7 +72,7 @@ func TestCoordinatorReadDeleteToolsEnforceNamespaceScope(t *testing.T) {
 			if res.Success {
 				t.Fatalf("expected namespace permission error, got success: %s", result)
 			}
-			if res.ErrorType != "permission_denied" {
+			if res.ErrorType != testPermissionDeniedErrorType {
 				t.Fatalf("errorType = %q, want permission_denied; result=%s", res.ErrorType, result)
 			}
 

--- a/internal/tools/chat_namespace_scope_test.go
+++ b/internal/tools/chat_namespace_scope_test.go
@@ -31,15 +31,16 @@ func TestCoordinatorReadDeleteToolsEnforceNamespaceScope(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		tool    Tool
-		args    map[string]any
-		objects []client.Object
+		name                string
+		tool                Tool
+		args                map[string]any
+		objects             []client.Object
+		assertTaskUnchanged bool
 	}{
 		{name: "check task progress", tool: &CheckTaskProgressTool{}, args: map[string]any{nameField: "victim-task", namespaceField: "victim-ns"}, objects: []client.Object{victimTask}},
 		{name: "fetch task output", tool: &FetchTaskOutputTool{}, args: map[string]any{nameField: "victim-task", namespaceField: "victim-ns"}, objects: []client.Object{victimTask}},
 		{name: "wait for task", tool: &WaitForTaskTool{}, args: map[string]any{nameField: "victim-task", namespaceField: "victim-ns", timeoutField: 1}, objects: []client.Object{victimTask}},
-		{name: "cancel task", tool: &ChatCancelTaskTool{}, args: map[string]any{nameField: "victim-task", namespaceField: "victim-ns"}, objects: []client.Object{victimTask}},
+		{name: "cancel task", tool: &ChatCancelTaskTool{}, args: map[string]any{nameField: "victim-task", namespaceField: "victim-ns"}, objects: []client.Object{victimTask}, assertTaskUnchanged: true},
 		{name: "list tasks", tool: &ListTasksTool{}, args: map[string]any{namespaceField: "victim-ns"}, objects: []client.Object{victimTask}},
 		{name: "list agents", tool: &ListAgentsTool{}, args: map[string]any{namespaceField: "victim-ns"}, objects: []client.Object{victimAgent}},
 	}
@@ -73,6 +74,16 @@ func TestCoordinatorReadDeleteToolsEnforceNamespaceScope(t *testing.T) {
 			}
 			if res.ErrorType != "permission_denied" {
 				t.Fatalf("errorType = %q, want permission_denied; result=%s", res.ErrorType, result)
+			}
+
+			if tt.assertTaskUnchanged {
+				var task corev1alpha1.Task
+				if err := fc.Get(ctx, client.ObjectKey{Name: "victim-task", Namespace: "victim-ns"}, &task); err != nil {
+					t.Fatalf("victim task was mutated or deleted after denied cancel: %v", err)
+				}
+				if task.Status.Phase != corev1alpha1.TaskPhaseSucceeded {
+					t.Fatalf("victim task phase = %q, want %q", task.Status.Phase, corev1alpha1.TaskPhaseSucceeded)
+				}
 			}
 		})
 	}

--- a/internal/tools/check_task_progress.go
+++ b/internal/tools/check_task_progress.go
@@ -46,6 +46,9 @@ func (t *CheckTaskProgressTool) Execute(ctx context.Context, args json.RawMessag
 		return ChatToolErrorResult("invalid_arguments", "name is required", "Provide the task name")
 	}
 	namespace := chatGetStringArgDefault(a, namespaceField, tc.Namespace)
+	if r, ok := checkChatNamespaceScope(tc, namespace); !ok {
+		return r, nil
+	}
 
 	task := &corev1alpha1.Task{}
 	if err := tc.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, task); err != nil {

--- a/internal/tools/fetch_task_output.go
+++ b/internal/tools/fetch_task_output.go
@@ -47,6 +47,9 @@ func (t *FetchTaskOutputTool) Execute(ctx context.Context, args json.RawMessage)
 		return ChatToolErrorResult("invalid_arguments", "name is required", "Provide the task name")
 	}
 	namespace := chatGetStringArgDefault(a, namespaceField, tc.Namespace)
+	if r, ok := checkChatNamespaceScope(tc, namespace); !ok {
+		return r, nil
+	}
 
 	task := &corev1alpha1.Task{}
 	if err := tc.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, task); err != nil {

--- a/internal/tools/list_agents.go
+++ b/internal/tools/list_agents.go
@@ -41,6 +41,9 @@ func (t *ListAgentsTool) Execute(ctx context.Context, args json.RawMessage) (str
 	}
 
 	namespace := chatGetStringArgDefault(a, namespaceField, tc.Namespace)
+	if r, ok := checkChatNamespaceScope(tc, namespace); !ok {
+		return r, nil
+	}
 
 	agentList := &corev1alpha1.AgentList{}
 	if err := tc.Client.List(ctx, agentList, client.InNamespace(namespace)); err != nil {

--- a/internal/tools/list_tasks.go
+++ b/internal/tools/list_tasks.go
@@ -43,6 +43,9 @@ func (t *ListTasksTool) Execute(ctx context.Context, args json.RawMessage) (stri
 	}
 
 	namespace := chatGetStringArgDefault(a, namespaceField, tc.Namespace)
+	if r, ok := checkChatNamespaceScope(tc, namespace); !ok {
+		return r, nil
+	}
 	statusFilter := chatGetStringArg(a, statusField)
 	limit := chatGetIntArg(a, limitField, 20)
 

--- a/internal/tools/wait_for_task.go
+++ b/internal/tools/wait_for_task.go
@@ -46,6 +46,9 @@ func (t *WaitForTaskTool) Execute(ctx context.Context, args json.RawMessage) (st
 		return ChatToolErrorResult("invalid_arguments", "name is required", "Provide the task name")
 	}
 	namespace := chatGetStringArgDefault(a, namespaceField, tc.Namespace)
+	if r, ok := checkChatNamespaceScope(tc, namespace); !ok {
+		return r, nil
+	}
 	timeout := min(chatGetIntArg(a, timeoutField, 30), 60)
 
 	task := &corev1alpha1.Task{}

--- a/workers/harness/Dockerfile
+++ b/workers/harness/Dockerfile
@@ -31,7 +31,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ripgrep \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @openai/codex @anthropic-ai/claude-code \
+# Keep the Codex CLI pinned for live proxy compatibility. The upstream latest tag
+# can change request payload shape before the proxy supports it.
+ARG CODEX_CLI_VERSION=0.142.0
+RUN npm install -g "@openai/codex@${CODEX_CLI_VERSION}" @anthropic-ai/claude-code \
     && npm cache clean --force
 
 COPY --from=target-go /usr/local/go /usr/local/go


### PR DESCRIPTION
### Motivation
- Prevent model-driven coordinator tools from accessing or mutating resources outside the allowed tenant namespace by enforcing `ToolContext` namespace restrictions for read/delete/list operations.

### Description
- After resolving the tool-call namespace, call `checkChatNamespaceScope(tc, namespace)` and return a `permission_denied` tool error when the check fails in `fetch_task_output`, `chat_cancel_task`, `list_tasks`, `list_agents`, `check_task_progress`, and `wait_for_task`.
- Add a regression test `internal/tools/chat_namespace_scope_test.go` that exercises the affected tools with cross-namespace arguments while `WatchNamespace` and `EnforceNamespaceIsolation` are active and asserts a `permission_denied` response.
- Changed files include `internal/tools/{fetch_task_output.go,chat_cancel_task.go,list_tasks.go,list_agents.go,check_task_progress.go,wait_for_task.go}` and the new `internal/tools/chat_namespace_scope_test.go`.

### Testing
- Ran `git diff --check` and code formatting checks and verified the namespace-guard lines were inserted in each modified file (succeeded).
- Attempted to run the focused unit test with `go test ./internal/tools -run 'TestCoordinatorReadDeleteToolsEnforceNamespaceScope' -count=1`, but execution was blocked by the environment because module downloads from `proxy.golang.org` returned `Forbidden` (blocked).
- `make lint-fix` and `make test` were attempted but blocked by network-restricted downloads (e.g. `golangci-lint` and `controller-gen`), and the local `autoreview` invocation was blocked because the `codex` executable was not available (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c1f36f6c0832ab8ec4275f9554f44)