### PR TITLE
fix: make compat tool execution opt-in

### DIFF
--- a/internal/api/anthropic_compat.go
+++ b/internal/api/anthropic_compat.go
@@ -390,7 +390,7 @@ func (h *AnthropicCompatHandler) HandleMessages(c fiber.Ctx) error {
 	} else {
 		// Transparent proxy: single LLM call, preserving the streaming fallback
 		// used by tool-loop requests for upstreams that require streaming.
-		resp, err = completeWithStreamingFallback(ctx, provider, compReq)
+		resp, err = completeWithStreamingFallback(ctx, anthropicLog, provider, compReq)
 		if err != nil {
 			anthropicLog.Error(err, "completion failed")
 			return anthropicError(c, 500, "api_error", "completion failed: "+err.Error())

--- a/internal/api/anthropic_compat.go
+++ b/internal/api/anthropic_compat.go
@@ -291,11 +291,11 @@ func (h *AnthropicCompatHandler) HandleMessages(c fiber.Ctx) error {
 		compReq.Temperature = *req.Temperature
 	}
 
-	// Inject Orka tools and run the server-side agentic loop by default.
-	// Set X-Orka-Tools: disabled to use as a transparent proxy instead.
-	orkaToolsDisabled := c.Get("X-Orka-Tools") == "disabled"
+	// Use a transparent proxy by default. Server-side Orka tool execution is
+	// available only when explicitly requested with X-Orka-Tools: enabled.
+	orkaToolsEnabled := compatOrkaToolsEnabled(c.Get("X-Orka-Tools"))
 
-	if !orkaToolsDisabled {
+	if orkaToolsEnabled {
 		// Replace client-provided tools with Orka's tools — the server-side tool loop
 		// executes tools itself, so client tools (e.g. Claude Code's Bash, Task) must
 		// not be visible to the LLM or it will call them and get "tool not found" errors.
@@ -316,7 +316,7 @@ func (h *AnthropicCompatHandler) HandleMessages(c fiber.Ctx) error {
 
 	// Build ToolContext for coordinator tools (create_agent_task, wait_for_task, etc.)
 	var proxyToolCtx *tools.ToolContext
-	if !orkaToolsDisabled {
+	if orkaToolsEnabled {
 		tasksCreated := 0
 		proxyToolCtx = &tools.ToolContext{
 			Client:                    h.client,
@@ -372,14 +372,14 @@ func (h *AnthropicCompatHandler) HandleMessages(c fiber.Ctx) error {
 	}
 
 	if req.Stream {
-		if !orkaToolsDisabled {
+		if orkaToolsEnabled {
 			return h.handleStreamingMessages(c, provider, compReq, model, 0, proxyToolCtx)
 		}
 		return h.handleStreamingProxy(c, provider, compReq, model)
 	}
 
 	var resp *llm.CompletionResponse
-	if !orkaToolsDisabled {
+	if orkaToolsEnabled {
 		// Run the agentic tool loop (executes tools server-side until final text response)
 		resp, err = runNonStreamingToolLoop(ctx, provider, compReq, model, h.config, proxyToolCtx)
 		if err != nil {

--- a/internal/api/anthropic_compat.go
+++ b/internal/api/anthropic_compat.go
@@ -388,8 +388,9 @@ func (h *AnthropicCompatHandler) HandleMessages(c fiber.Ctx) error {
 		}
 		resp = stripGoalStateSentinelFromResponse(resp)
 	} else {
-		// Transparent proxy: single LLM call, return response directly
-		resp, err = provider.Complete(ctx, compReq)
+		// Transparent proxy: single LLM call, preserving the streaming fallback
+		// used by tool-loop requests for upstreams that require streaming.
+		resp, err = completeWithStreamingFallback(ctx, provider, compReq)
 		if err != nil {
 			anthropicLog.Error(err, "completion failed")
 			return anthropicError(c, 500, "api_error", "completion failed: "+err.Error())

--- a/internal/api/anthropic_compat_test.go
+++ b/internal/api/anthropic_compat_test.go
@@ -1016,10 +1016,12 @@ func TestAnthropicCompat_ContextTokenAuthorizationFiltersListModels(t *testing.T
 // --- Mock provider for tool loop tests ---
 
 type mockAnthropicProvider struct {
-	responses []*llm.CompletionResponse
-	errors    []error
-	requests  []*llm.CompletionRequest
-	callIdx   int
+	responses    []*llm.CompletionResponse
+	errors       []error
+	streamChunks []llm.StreamChunk
+	streamErr    error
+	requests     []*llm.CompletionRequest
+	callIdx      int
 }
 
 func (m *mockAnthropicProvider) Complete(_ context.Context, req *llm.CompletionRequest) (*llm.CompletionResponse, error) {
@@ -1041,7 +1043,18 @@ func (m *mockAnthropicProvider) Complete(_ context.Context, req *llm.CompletionR
 }
 
 func (m *mockAnthropicProvider) Stream(_ context.Context, _ *llm.CompletionRequest) (<-chan llm.StreamChunk, error) {
-	return nil, fmt.Errorf("streaming not supported by mock")
+	if m.streamErr != nil {
+		return nil, m.streamErr
+	}
+	if m.streamChunks == nil {
+		return nil, fmt.Errorf("streaming not supported by mock")
+	}
+	ch := make(chan llm.StreamChunk, len(m.streamChunks))
+	for _, chunk := range m.streamChunks {
+		ch <- chunk
+	}
+	close(ch)
+	return ch, nil
 }
 
 func (m *mockAnthropicProvider) Name() string {
@@ -1119,6 +1132,35 @@ func TestHandleStreamingMessages_StripsSentinelAndStreamsSafeToolProgress(t *tes
 	}
 	if mock.callIdx != 2 {
 		t.Fatalf("expected 2 LLM calls, got %d", mock.callIdx)
+	}
+}
+
+func TestHandleStreamingProxy_EstimatesOutputTokens(t *testing.T) {
+	mock := &mockAnthropicProvider{
+		streamChunks: []llm.StreamChunk{
+			{Content: "hello "},
+			{Content: "from stream"},
+			{Done: true, StopReason: oaiStopReasonEndTurn},
+		},
+	}
+
+	handler, app := setupTestAnthropicHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingProxy(c, mock, &llm.CompletionRequest{Model: "claude-sonnet-4-20250514"}, "claude-sonnet-4-20250514")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, "hello ") || !strings.Contains(bodyStr, "from stream") {
+		t.Fatalf("expected streamed text in body, got: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, `"output_tokens":4`) {
+		t.Fatalf("expected estimated output_tokens in message_delta, got: %s", bodyStr)
 	}
 }
 

--- a/internal/api/anthropic_streaming.go
+++ b/internal/api/anthropic_streaming.go
@@ -358,6 +358,7 @@ func (h *AnthropicCompatHandler) handleStreamingProxy(
 		blockIndex := 0
 		inTextBlock := false
 		hasToolCalls := false
+		streamedTextBytes := 0
 
 		for chunk := range streamCh {
 			if chunk.Error != nil {
@@ -366,6 +367,7 @@ func (h *AnthropicCompatHandler) handleStreamingProxy(
 			}
 
 			if chunk.Content != "" {
+				streamedTextBytes += len(chunk.Content)
 				if !inTextBlock {
 					if err := writeContentBlockStart(w, blockIndex, AnthropicContentBlock{
 						Type: "text", Text: "",
@@ -419,14 +421,25 @@ func (h *AnthropicCompatHandler) handleStreamingProxy(
 		if hasToolCalls {
 			stopReason = oaiStopReasonToolUse
 		}
-		_ = writeMessageDelta(w, stopReason, 0)
+		_ = writeMessageDelta(w, stopReason, estimateTokensFromBytes(streamedTextBytes))
 		_ = writeMessageStop(w)
 	})
 }
 
 // estimateTokens provides a rough token count estimate from text length.
 func estimateTokens(text string) int {
-	return len(text) / 4
+	return estimateTokensFromBytes(len(text))
+}
+
+func estimateTokensFromBytes(byteCount int) int {
+	if byteCount == 0 {
+		return 0
+	}
+	estimate := byteCount / 4
+	if estimate == 0 {
+		return 1
+	}
+	return estimate
 }
 
 // handleStreamingFallback uses provider.Complete() and emits the result as a complete SSE sequence.

--- a/internal/api/anthropic_tool_loop.go
+++ b/internal/api/anthropic_tool_loop.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
+
 	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
 	"github.com/sozercan/orka/internal/llm"
 	"github.com/sozercan/orka/internal/tools"
@@ -34,14 +36,14 @@ func compatOrkaToolsEnabled(headerValue string) bool {
 	return strings.EqualFold(strings.TrimSpace(headerValue), "enabled")
 }
 
-func completeWithStreamingFallback(ctx context.Context, provider llm.Provider, req *llm.CompletionRequest) (*llm.CompletionResponse, error) {
+func completeWithStreamingFallback(ctx context.Context, logger logr.Logger, provider llm.Provider, req *llm.CompletionRequest) (*llm.CompletionResponse, error) {
 	resp, err := provider.Complete(ctx, req)
 	if err != nil && isStreamingRequiredErr(err) {
 		// Upstream (Copilot/Anthropic) refuses non-streaming for requests
 		// that may exceed its timeout. Re-issue via Stream and aggregate
 		// chunks into a synthesized CompletionResponse so callers keep
 		// non-streaming semantics even when the upstream requires streaming.
-		anthropicLog.Info("upstream refused non-streaming, retrying via Stream and aggregating")
+		logger.Info("upstream refused non-streaming, retrying via Stream and aggregating")
 		resp, err = completeViaStream(ctx, provider, req)
 	}
 	return resp, err
@@ -687,7 +689,7 @@ func runToolLoopWithObserver(
 			Temperature:  req.Temperature,
 		}
 
-		resp, err := completeWithStreamingFallback(ctx, provider, compReq)
+		resp, err := completeWithStreamingFallback(ctx, anthropicLog, provider, compReq)
 		if err != nil && llm.IsContextTooLongErr(err) {
 			tokenEstimate := 0
 			for _, m := range messages {
@@ -695,7 +697,7 @@ func runToolLoopWithObserver(
 			}
 			messages = llm.TruncateMessages(messages, tokenEstimate/2)
 			compReq.Messages = messages
-			resp, err = completeWithStreamingFallback(ctx, provider, compReq)
+			resp, err = completeWithStreamingFallback(ctx, anthropicLog, provider, compReq)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("LLM completion failed: %w", err)

--- a/internal/api/anthropic_tool_loop.go
+++ b/internal/api/anthropic_tool_loop.go
@@ -28,6 +28,10 @@ import (
 // and skips validation/review/PR.
 const goalStateSentinel = "<ORKA_GOAL_STATE_REACHED>"
 
+func compatOrkaToolsEnabled(headerValue string) bool {
+	return strings.EqualFold(strings.TrimSpace(headerValue), "enabled")
+}
+
 // truncateForLog returns s clipped to max runes, appending "…" if clipped.
 // Used so log lines stay scannable when the model dumps a long progress
 // summary as the body of a premature-end response.

--- a/internal/api/anthropic_tool_loop.go
+++ b/internal/api/anthropic_tool_loop.go
@@ -28,8 +28,23 @@ import (
 // and skips validation/review/PR.
 const goalStateSentinel = "<ORKA_GOAL_STATE_REACHED>"
 
+// compatOrkaToolsEnabled reports whether the compat endpoint caller explicitly
+// opted in to Orka-managed server-side tool execution.
 func compatOrkaToolsEnabled(headerValue string) bool {
 	return strings.EqualFold(strings.TrimSpace(headerValue), "enabled")
+}
+
+func completeWithStreamingFallback(ctx context.Context, provider llm.Provider, req *llm.CompletionRequest) (*llm.CompletionResponse, error) {
+	resp, err := provider.Complete(ctx, req)
+	if err != nil && isStreamingRequiredErr(err) {
+		// Upstream (Copilot/Anthropic) refuses non-streaming for requests
+		// that may exceed its timeout. Re-issue via Stream and aggregate
+		// chunks into a synthesized CompletionResponse so callers keep
+		// non-streaming semantics even when the upstream requires streaming.
+		anthropicLog.Info("upstream refused non-streaming, retrying via Stream and aggregating")
+		resp, err = completeViaStream(ctx, provider, req)
+	}
+	return resp, err
 }
 
 // truncateForLog returns s clipped to max runes, appending "…" if clipped.
@@ -672,15 +687,7 @@ func runToolLoopWithObserver(
 			Temperature:  req.Temperature,
 		}
 
-		resp, err := provider.Complete(ctx, compReq)
-		if err != nil && isStreamingRequiredErr(err) {
-			// Upstream (Copilot/Anthropic) refuses non-streaming for requests
-			// that may exceed its 10-minute timeout. Re-issue via Stream and
-			// aggregate the chunks into a synthesized CompletionResponse so
-			// our tool loop can continue as if Complete had worked.
-			anthropicLog.Info("upstream refused non-streaming, retrying via Stream and aggregating")
-			resp, err = completeViaStream(ctx, provider, compReq)
-		}
+		resp, err := completeWithStreamingFallback(ctx, provider, compReq)
 		if err != nil && llm.IsContextTooLongErr(err) {
 			tokenEstimate := 0
 			for _, m := range messages {
@@ -688,10 +695,7 @@ func runToolLoopWithObserver(
 			}
 			messages = llm.TruncateMessages(messages, tokenEstimate/2)
 			compReq.Messages = messages
-			resp, err = provider.Complete(ctx, compReq)
-			if err != nil && isStreamingRequiredErr(err) {
-				resp, err = completeViaStream(ctx, provider, compReq)
-			}
+			resp, err = completeWithStreamingFallback(ctx, provider, compReq)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("LLM completion failed: %w", err)

--- a/internal/api/anthropic_tool_loop_test.go
+++ b/internal/api/anthropic_tool_loop_test.go
@@ -7,9 +7,13 @@ MIT License - see LICENSE file for details.
 package api
 
 import (
+	"context"
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/sozercan/orka/internal/llm"
 )
 
 func TestCoordinatorSystemPrompt_PRReviewCIRepairLoop(t *testing.T) {
@@ -411,6 +415,55 @@ func TestCoordinatorSystemPrompt_Demo10ContainerCacheAndReviewerTypeGuardrails(t
 		if strings.Contains(prompt, banned) {
 			t.Fatalf("coordinator prompt still contains old vague guidance:\n%s", banned)
 		}
+	}
+}
+
+type streamingFallbackProvider struct {
+	completeErr   error
+	streamChunks  []llm.StreamChunk
+	completeCalls int
+	streamCalls   int
+}
+
+func (p *streamingFallbackProvider) Complete(_ context.Context, _ *llm.CompletionRequest) (*llm.CompletionResponse, error) {
+	p.completeCalls++
+	return nil, p.completeErr
+}
+
+func (p *streamingFallbackProvider) Stream(_ context.Context, _ *llm.CompletionRequest) (<-chan llm.StreamChunk, error) {
+	p.streamCalls++
+	ch := make(chan llm.StreamChunk, len(p.streamChunks))
+	for _, chunk := range p.streamChunks {
+		ch <- chunk
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (p *streamingFallbackProvider) Name() string { return "streaming-fallback" }
+
+func TestCompleteWithStreamingFallback(t *testing.T) {
+	provider := &streamingFallbackProvider{
+		completeErr: fmt.Errorf("streaming is required for operations that may take longer than 10 minutes"),
+		streamChunks: []llm.StreamChunk{
+			{Content: "fallback "},
+			{Content: "content"},
+			{Done: true, StopReason: "end_turn"},
+		},
+	}
+
+	resp, err := completeWithStreamingFallback(context.Background(), provider, &llm.CompletionRequest{Model: "test-model"})
+	if err != nil {
+		t.Fatalf("completeWithStreamingFallback returned error: %v", err)
+	}
+	if resp.Content != "fallback content" {
+		t.Fatalf("content = %q, want fallback content", resp.Content)
+	}
+	if resp.StopReason != "end_turn" {
+		t.Fatalf("stop_reason = %q, want end_turn", resp.StopReason)
+	}
+	if provider.completeCalls != 1 || provider.streamCalls != 1 {
+		t.Fatalf("calls complete=%d stream=%d, want 1/1", provider.completeCalls, provider.streamCalls)
 	}
 }
 

--- a/internal/api/anthropic_tool_loop_test.go
+++ b/internal/api/anthropic_tool_loop_test.go
@@ -452,7 +452,7 @@ func TestCompleteWithStreamingFallback(t *testing.T) {
 		},
 	}
 
-	resp, err := completeWithStreamingFallback(context.Background(), provider, &llm.CompletionRequest{Model: "test-model"})
+	resp, err := completeWithStreamingFallback(context.Background(), anthropicLog, provider, &llm.CompletionRequest{Model: "test-model"})
 	if err != nil {
 		t.Fatalf("completeWithStreamingFallback returned error: %v", err)
 	}

--- a/internal/api/anthropic_tool_loop_test.go
+++ b/internal/api/anthropic_tool_loop_test.go
@@ -413,3 +413,25 @@ func TestCoordinatorSystemPrompt_Demo10ContainerCacheAndReviewerTypeGuardrails(t
 		}
 	}
 }
+
+func TestCompatOrkaToolsEnabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		headerValue string
+		want        bool
+	}{
+		{name: "default transparent", want: false},
+		{name: "legacy disabled remains transparent", headerValue: "disabled", want: false},
+		{name: "explicit enabled", headerValue: "enabled", want: true},
+		{name: "enabled trims whitespace", headerValue: " enabled ", want: true},
+		{name: "enabled case insensitive", headerValue: "ENABLED", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compatOrkaToolsEnabled(tt.headerValue); got != tt.want {
+				t.Fatalf("compatOrkaToolsEnabled(%q) = %v, want %v", tt.headerValue, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/api/context_token_compat_tools_test.go
+++ b/internal/api/context_token_compat_tools_test.go
@@ -127,6 +127,7 @@ func TestOpenAICompat_ContextTokenAllowedToolsFiltersInjectedProxyTools(t *testi
 	body := []byte(`{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"hello"}],"max_tokens":100}`)
 	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", bytes.NewReader(body))
 	req.Header.Set(KontxtHeaderName, token)
+	req.Header.Set("X-Orka-Tools", "enabled")
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiber.TestConfig{Timeout: 10 * time.Second})
@@ -204,6 +205,7 @@ func TestAnthropicCompat_ContextTokenAllowedToolsFiltersInjectedProxyTools(t *te
 	body := []byte(`{"model":"anthropic/claude-sonnet-4-20250514","messages":[{"role":"user","content":"hello"}],"max_tokens":100}`)
 	req := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", bytes.NewReader(body))
 	req.Header.Set(KontxtHeaderName, token)
+	req.Header.Set("X-Orka-Tools", "enabled")
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiber.TestConfig{Timeout: 10 * time.Second})

--- a/internal/api/openai_compat.go
+++ b/internal/api/openai_compat.go
@@ -269,11 +269,11 @@ func (h *OpenAICompatHandler) HandleChatCompletions(c fiber.Ctx) error {
 	completionID := fmt.Sprintf("chatcmpl-%s", generateChatID())
 	now := time.Now().Unix()
 
-	// Inject Orka tools and run the server-side agentic loop by default.
-	// Set X-Orka-Tools: disabled to use as a transparent proxy instead.
-	orkaToolsDisabled := c.Get("X-Orka-Tools") == "disabled"
+	// Use a transparent proxy by default. Server-side Orka tool execution is
+	// available only when explicitly requested with X-Orka-Tools: enabled.
+	orkaToolsEnabled := compatOrkaToolsEnabled(c.Get("X-Orka-Tools"))
 
-	if !orkaToolsDisabled {
+	if orkaToolsEnabled {
 		// Replace client tools with Orka's tools (builtin + coordinator)
 		compReq.Tools = nil
 		injectOrkaTools(ctx, h.client, compReq, namespace)
@@ -291,7 +291,7 @@ func (h *OpenAICompatHandler) HandleChatCompletions(c fiber.Ctx) error {
 
 	// Build ToolContext for coordinator tools
 	var proxyToolCtx *tools.ToolContext
-	if !orkaToolsDisabled {
+	if orkaToolsEnabled {
 		tasksCreated := 0
 		proxyToolCtx = &tools.ToolContext{
 			Client:                    h.client,
@@ -357,13 +357,13 @@ func (h *OpenAICompatHandler) HandleChatCompletions(c fiber.Ctx) error {
 	}
 
 	if req.Stream {
-		if !orkaToolsDisabled {
+		if orkaToolsEnabled {
 			return h.handleStreamingToolLoop(c, ctx, provider, compReq, completionID, model, now, req.StreamOptions, proxyToolCtx)
 		}
 		return h.handleStreamingCompletion(c, ctx, provider, compReq, completionID, model, now, req.StreamOptions)
 	}
 
-	if !orkaToolsDisabled {
+	if orkaToolsEnabled {
 		return h.handleNonStreamingToolLoop(c, ctx, provider, compReq, completionID, model, now, proxyToolCtx)
 	}
 	return h.handleNonStreamingCompletion(c, ctx, provider, compReq, completionID, model, now)

--- a/internal/api/openai_compat.go
+++ b/internal/api/openai_compat.go
@@ -438,7 +438,7 @@ func (h *OpenAICompatHandler) handleNonStreamingCompletion(
 	completionID, model string,
 	created int64,
 ) error {
-	resp, err := completeWithStreamingFallback(ctx, provider, req)
+	resp, err := completeWithStreamingFallback(ctx, oaiLog, provider, req)
 	if err != nil {
 		oaiLog.Error(err, "completion failed")
 		return c.Status(500).JSON(OAIError{Error: OAIErrorDetail{

--- a/internal/api/openai_compat.go
+++ b/internal/api/openai_compat.go
@@ -438,7 +438,7 @@ func (h *OpenAICompatHandler) handleNonStreamingCompletion(
 	completionID, model string,
 	created int64,
 ) error {
-	resp, err := provider.Complete(ctx, req)
+	resp, err := completeWithStreamingFallback(ctx, provider, req)
 	if err != nil {
 		oaiLog.Error(err, "completion failed")
 		return c.Status(500).JSON(OAIError{Error: OAIErrorDetail{

--- a/internal/api/openai_compat_test.go
+++ b/internal/api/openai_compat_test.go
@@ -606,6 +606,46 @@ func TestHandleNonStreamingCompletion_WithToolCalls(t *testing.T) {
 	}
 }
 
+func TestHandleNonStreamingCompletion_StreamingRequiredFallback(t *testing.T) {
+	ch := make(chan llm.StreamChunk, 3)
+	ch <- llm.StreamChunk{Content: "Hello"}
+	ch <- llm.StreamChunk{Content: " from stream"}
+	ch <- llm.StreamChunk{Done: true, StopReason: "end_turn"}
+	close(ch)
+
+	mock := &oaiMockProvider{
+		err:      fmt.Errorf("streaming is required for operations that may take longer than 10 minutes"),
+		streamCh: ch,
+	}
+
+	handler, app := setupTestOpenAIHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleNonStreamingCompletion(
+			c, context.Background(), mock,
+			&llm.CompletionRequest{Model: "gpt-4", Messages: []llm.Message{{Role: "user", Content: "hi"}}},
+			"chatcmpl-fallback", "gpt-4", 1234567890,
+		)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var oaiResp OAIResponse
+	json.NewDecoder(resp.Body).Decode(&oaiResp) //nolint:errcheck
+	if got := extractContent(oaiResp.Choices[0].Message.Content); got != "Hello from stream" {
+		t.Fatalf("content = %q, want streaming fallback content", got)
+	}
+	if len(mock.requests) != 1 {
+		t.Fatalf("Complete calls = %d, want 1", len(mock.requests))
+	}
+}
+
 func TestHandleNonStreamingCompletion_Error(t *testing.T) {
 	mock := &oaiMockProvider{
 		err: fmt.Errorf("API rate limited"),

--- a/test/e2e/live_anthropic_compat_test.go
+++ b/test/e2e/live_anthropic_compat_test.go
@@ -123,6 +123,19 @@ var _ = Describe("Live Anthropic Compat API", Ordered, func() {
 		Expect(flattenAnthropicText(resp.Content)).To(ContainSubstring(liveAnthropicExpectedText))
 	})
 
+	It("should run the opt-in Orka tool loop for non-streaming anthropic messages", func() {
+		resp := postLiveAnthropicJSONWithOrkaTools(apiBaseURL, token, liveAnthropicProviderName, liveClaudeModel, liveAnthropicExpectedText, true)
+
+		Expect(resp.Type).To(Equal("message"))
+		Expect(resp.Role).To(Equal("assistant"))
+		Expect(resp.Model).To(Equal(liveClaudeModel))
+		Expect(resp.StopReason).NotTo(BeNil())
+		Expect(*resp.StopReason).To(Equal("end_turn"))
+		text := flattenAnthropicText(resp.Content)
+		Expect(text).To(ContainSubstring(liveAnthropicExpectedText))
+		Expect(text).NotTo(ContainSubstring(liveAnthropicGoalStateSentinel))
+	})
+
 	It("should stream anthropic messages via SSE", func() {
 		stream := postLiveAnthropicSSE(apiBaseURL, token, liveAnthropicProviderName, liveClaudeModel, liveAnthropicExpectedText)
 
@@ -222,6 +235,10 @@ func fetchLiveAnthropicModels(apiBaseURL, token string) liveAnthropicModelList {
 }
 
 func postLiveAnthropicJSON(apiBaseURL, token, providerName, model, expectedText string) liveAnthropicResponse {
+	return postLiveAnthropicJSONWithOrkaTools(apiBaseURL, token, providerName, model, expectedText, false)
+}
+
+func postLiveAnthropicJSONWithOrkaTools(apiBaseURL, token, providerName, model, expectedText string, orkaToolsEnabled bool) liveAnthropicResponse {
 	body := fmt.Sprintf(`{
 		"model": "%s/%s",
 		"max_tokens": 32,
@@ -236,6 +253,9 @@ func postLiveAnthropicJSON(apiBaseURL, token, providerName, model, expectedText 
 	req.Header.Set("x-api-key", token)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("anthropic-version", "2023-06-01")
+	if orkaToolsEnabled {
+		req.Header.Set("X-Orka-Tools", "enabled")
+	}
 
 	client := &http.Client{Timeout: 3 * time.Minute}
 	resp, err := client.Do(req)

--- a/website/docs/development/testing.md
+++ b/website/docs/development/testing.md
@@ -78,7 +78,7 @@ End-to-end tests run against a dedicated Kind cluster:
 | `test/e2e/provider_advanced_test.go` | Provider rate-limit config coverage |
 | `test/e2e/live_copilot_proxy_test.go` | Live Orka Provider + `type: ai` path using copilot-proxy as the backend harness, including durable memory recall, proposal governance, and transcript search tool execution |
 | `test/e2e/live_chat_api_test.go` | Live chat SSE and JSON transport/session coverage using a proxy-backed Provider |
-| `test/e2e/live_anthropic_compat_test.go` | Live Anthropic-compatible `/anthropic/v1/models` and `/anthropic/v1/messages` coverage with default tools-enabled behavior |
+| `test/e2e/live_anthropic_compat_test.go` | Live Anthropic-compatible `/anthropic/v1/models` and `/anthropic/v1/messages` coverage for transparent default JSON/SSE flows plus an explicit `X-Orka-Tools: enabled` non-streaming tool-loop smoke |
 | `test/e2e/live_agent_runtime_matrix_test.go` | Live Orka runtime matrix: Codex+GPT, Claude Code+Claude, Copilot+Gemini |
 | `.github/workflows/live-agent-sandbox-e2e.yml` / `scripts/live-agent-sandbox-e2e.sh` | Live upstream `agent-sandbox` Kind validation for Orka agent workspace claim, sandbox execution, delete cleanup, retained-session reuse, and token scrubbing using a fake model-free Claude runtime |
 | `.github/workflows/live-github-label-trigger-e2e.yml` / `scripts/live-github-label-trigger-e2e.sh` | Manual model-free GitHub label trigger validation for HMAC rejection, signed webhook Task creation, scoped workspace settings, and duplicate delivery idempotency |
@@ -114,7 +114,7 @@ The live copilot-proxy E2E path runs in a separate workflow and executes the foc
 
 - provider-backed `type: ai` tasks, including durable memory/tool execution coverage
 - chat SSE/JSON flows via `/api/v1/chat`
-- Anthropic-compatible `/anthropic/v1/models` and `/anthropic/v1/messages` flows, including explicit `X-Orka-Tools: enabled` coverage for the Orka tool loop
+- Anthropic-compatible `/anthropic/v1/models` and `/anthropic/v1/messages` flows, including transparent default JSON/SSE coverage and explicit `X-Orka-Tools: enabled` non-streaming coverage for the Orka tool loop
 - external agent runtimes across `codex` + GPT, `claude` + Claude, and `copilot` + Gemini
 
 This is an **Orka** live integration suite, not a deep `copilot-proxy` feature suite. The proxy is test harness infrastructure that gives non-Copilot runtimes access to live GPT, Claude, and Gemini models in CI. The only proxy-specific assertions are smoke checks that the harness is alive and usable:

--- a/website/docs/development/testing.md
+++ b/website/docs/development/testing.md
@@ -114,7 +114,7 @@ The live copilot-proxy E2E path runs in a separate workflow and executes the foc
 
 - provider-backed `type: ai` tasks, including durable memory/tool execution coverage
 - chat SSE/JSON flows via `/api/v1/chat`
-- Anthropic-compatible `/anthropic/v1/models` and `/anthropic/v1/messages` flows with the default Orka tool loop enabled
+- Anthropic-compatible `/anthropic/v1/models` and `/anthropic/v1/messages` flows, including explicit `X-Orka-Tools: enabled` coverage for the Orka tool loop
 - external agent runtimes across `codex` + GPT, `claude` + Claude, and `copilot` + Gemini
 
 This is an **Orka** live integration suite, not a deep `copilot-proxy` feature suite. The proxy is test harness infrastructure that gives non-Copilot runtimes access to live GPT, Claude, and Gemini models in CI. The only proxy-specific assertions are smoke checks that the harness is alive and usable:

--- a/website/docs/reference/anthropic-compat.md
+++ b/website/docs/reference/anthropic-compat.md
@@ -15,7 +15,7 @@ Orka acts as a **proxy** to whichever LLM provider is configured in your cluster
 | `POST` | `/anthropic/v1/messages` | Create a message (streaming & non-streaming) |
 | `GET` | `/anthropic/v1/models` | List available models from configured providers |
 
-PR-blocking live CI exercises this API directly against a live Claude-family backend by checking `/anthropic/v1/models` and both non-streaming and streaming `/anthropic/v1/messages` requests. Those live checks keep the default Orka tool-loop behavior enabled unless a client explicitly sets `X-Orka-Tools: disabled`.
+PR-blocking live CI exercises this API directly against a live Claude-family backend by checking `/anthropic/v1/models` and both non-streaming and streaming `/anthropic/v1/messages` requests. Those live checks keep the transparent-proxy default; server-side Orka tool-loop behavior is exercised only when the client explicitly sets `X-Orka-Tools: enabled`.
 
 ## Authentication
 
@@ -145,19 +145,19 @@ curl https://orka.example.com/anthropic/v1/models \
 
 ## Server-Side Tool Execution
 
-By default, the Anthropic endpoint enables **server-side tool execution** — it injects Orka's built-in tools into the request and runs an autonomous tool loop. When the LLM returns `tool_use` content blocks, the proxy intercepts them, executes the tools, feeds results back to the LLM, and repeats until a final text response is produced. Clients never need to execute tools locally.
+By default, the Anthropic endpoint is a **transparent proxy**: requests are forwarded to the LLM and responses are returned without intercepting tool calls. The client manages its own tool execution loop.
 
-To disable this and use the endpoint as a **transparent proxy**, set the `X-Orka-Tools: disabled` header:
+To opt in to **server-side tool execution**, set the `X-Orka-Tools: enabled` header:
 
 ```
-X-Orka-Tools: disabled
+X-Orka-Tools: enabled
 ```
 
-When this header is set, requests are forwarded to the LLM and responses are returned without intercepting tool calls. The client manages its own tool execution loop.
+When this header is set, Orka injects its built-in tools into the request and runs an autonomous tool loop. When the LLM returns `tool_use` content blocks, the proxy intercepts them, executes the tools, feeds results back to the LLM, and repeats until a final text response is produced.
 
 ### Available Tools
 
-By default (without the `X-Orka-Tools: disabled` header), the proxy automatically injects these built-in tools into the request:
+When `X-Orka-Tools: enabled` is set, the proxy automatically injects these built-in tools into the request:
 
 | Tool | Description |
 |------|-------------|
@@ -233,7 +233,7 @@ curl -X POST https://orka.example.com/anthropic/v1/messages \
   }'
 ```
 
-To use as a transparent proxy instead (client manages tools), add `X-Orka-Tools: disabled`.
+By default, the endpoint is a transparent proxy where the client manages tools. Add `X-Orka-Tools: enabled` only when you want Orka to manage server-side tools.
 
 ## Architecture
 
@@ -250,4 +250,4 @@ To use as a transparent proxy instead (client manages tools), add `X-Orka-Tools:
                     └──────────────────────────────┘
 ```
 
-Orka injects built-in tools and runs server-side tool execution by default. Set `X-Orka-Tools: disabled` to use as a transparent proxy where the client manages its own tool execution loop — see [Server-Side Tool Execution](#server-side-tool-execution) above.
+Orka uses transparent proxy mode by default. Set `X-Orka-Tools: enabled` to inject built-in tools and run server-side tool execution — see [Server-Side Tool Execution](#server-side-tool-execution) above.

--- a/website/docs/reference/api-reference.md
+++ b/website/docs/reference/api-reference.md
@@ -453,7 +453,7 @@ See [OpenAI Compatibility](openai-compat.md) for details.
 | `/anthropic/v1/messages` | POST | Create a message (streaming & non-streaming) |
 | `/anthropic/v1/models` | GET | List available models |
 
-The `/anthropic/v1/messages` endpoint injects built-in tools and runs server-side tool execution by default. Set `X-Orka-Tools: disabled` header to use as a transparent proxy instead. See [Anthropic Compatibility](anthropic-compat.md) for details.
+The `/anthropic/v1/messages` endpoint is a transparent proxy by default. Set the `X-Orka-Tools: enabled` header to opt in to Orka-managed server-side tool execution. See [Anthropic Compatibility](anthropic-compat.md) for details.
 
 ## Internal API (Worker Communication)
 

--- a/website/docs/reference/openai-compat.md
+++ b/website/docs/reference/openai-compat.md
@@ -177,4 +177,4 @@ curl https://orka.example.com/openai/v1/models \
 
 Orka transparently proxies requests to the backend LLM provider. The client manages its own tool execution loop — Orka simply forwards the messages and tool definitions to the LLM and returns the response.
 
-> **Note:** Both the OpenAI and Anthropic endpoints inject Orka's built-in tools (web_search, code_exec, etc.) and run server-side tool execution by default. Set `X-Orka-Tools: disabled` header to use as a transparent proxy instead.
+> **Note:** Both the OpenAI and Anthropic endpoints are transparent proxies by default. Set the `X-Orka-Tools: enabled` header to opt in to Orka-managed server-side tool execution.


### PR DESCRIPTION
### Motivation
- The compatibility endpoints previously injected and executed Orka-managed tools by default, including powerful server-side capabilities such as `code_exec`, for any authenticated compatibility-client request.
- The safer default for `/openai/v1/chat/completions` and `/anthropic/v1/messages` is transparent proxy behavior: forward client messages/tools to the configured provider and let the client manage its own tool loop unless it explicitly asks Orka to manage tools.

### Description
- Make OpenAI and Anthropic compatibility handlers transparent proxies by default.
- Add `compatOrkaToolsEnabled(headerValue string) bool`, which enables Orka-managed server-side tool injection/execution only when `X-Orka-Tools: enabled` is present, trimmed and case-insensitive.
- Gate Orka tool injection, coordinator prompt injection, ToolContext construction, and streaming/non-streaming server-side tool-loop dispatch behind that explicit opt-in.
- Preserve existing non-streaming behavior for upstreams that require streaming by extracting `completeWithStreamingFallback` and using it from both transparent compat paths and the Orka tool-loop path. The helper now accepts the caller logger so OpenAI fallback logs are attributed to `openai-compat` and Anthropic fallback logs to `anthropic-compat`.
- Preserve Anthropic streaming proxy usage reporting by estimating `output_tokens` from streamed text when the upstream stream does not provide usage.
- Update context-token injected-tool tests to opt in with `X-Orka-Tools: enabled` so the Orka tool-injection path remains covered.
- Add live Anthropic compat E2E coverage for both transparent default JSON/SSE flows and an explicit `X-Orka-Tools: enabled` non-streaming tool-loop smoke.
- Update compatibility docs and developer testing notes to document transparent-by-default behavior and the explicit opt-in.

### Testing
- `go test ./internal/api -run 'TestHandleStreamingProxy_EstimatesOutputTokens|TestCompleteWithStreamingFallback|TestHandleNonStreamingCompletion_StreamingRequiredFallback' -v`
- `go test ./internal/api -run 'TestCompleteWithStreamingFallback|TestCompatOrkaToolsEnabled|TestHandleNonStreamingCompletion_StreamingRequiredFallback|Test(OpenAICompat|AnthropicCompat)_ContextTokenAllowedToolsFiltersInjectedProxyTools|TestContextTokenAllowedToolsFiltersInjectedProxyTools' -v`
- `go test -tags=e2e ./test/e2e -run '^$'`
- `make lint-fix && make test`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt "Final review for PR #229 after addressing unresolved review comments. Check transparent compat default, explicit X-Orka-Tools opt-in tool execution/tests/live coverage, and streaming-required fallback preservation for OpenAI and Anthropic compatibility endpoints."`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review PR #229 latest fixes: pass the correct logger into completeWithStreamingFallback from OpenAI/Anthropic call sites and preserve Anthropic streaming proxy output token estimates for live SSE CI."`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c224bcc90832abf5e0569da9a49b4)
