### PR TITLE
fix: authorize API task creation with Kubernetes RBAC

### DIFF
--- a/charts/orka/templates/rbac.yaml
+++ b/charts/orka/templates/rbac.yaml
@@ -112,9 +112,12 @@ rules:
     resources: ["clusterrolebindings"]
     verbs: ["get", "list", "watch", "create", "update", "delete"]
 
-  # TokenReview for authentication
+  # TokenReview authenticates caller tokens; SubjectAccessReview authorizes Kubernetes callers
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
     verbs: ["create"]
 
   # Leader election

--- a/internal/api/anthropic_compat.go
+++ b/internal/api/anthropic_compat.go
@@ -331,7 +331,7 @@ func (h *AnthropicCompatHandler) HandleMessages(c fiber.Ctx) error {
 			GenerateTaskName:          func() string { return fmt.Sprintf("proxy-%s", uuid.New().String()[:8]) },
 			TaskLabels:                func() map[string]string { return map[string]string{"orka.ai/source": "anthropic-proxy"} },
 			AuthorizeTaskCreate: func(ctx context.Context, task *corev1alpha1.Task) *tools.ChatToolError {
-				if err := authorizeAndStampToolTaskCreate(ctx, h.client, contextToken, h.contextTokenAuthorization, "anthropicToolCreateTask", userInfo, task); err != nil {
+				if err := authorizeAndStampToolTaskCreate(ctx, h.client, h.kubeClient, contextToken, h.contextTokenAuthorization, "anthropicToolCreateTask", userInfo, task); err != nil {
 					return &tools.ChatToolError{
 						Type:       "authorization_failed",
 						Message:    err.Error(),

--- a/internal/api/chat.go
+++ b/internal/api/chat.go
@@ -298,7 +298,7 @@ func (ch *ChatHandler) HandleChat(c fiber.Ctx) error {
 	executor.provider = providerInfo.Name
 	executor.providerType = providerInfo.Type
 	executor.SetTaskCreateAuthorizer(func(ctx context.Context, task *corev1alpha1.Task) error {
-		return authorizeAndStampToolTaskCreate(ctx, ch.client, contextToken, ch.contextTokenAuthorization, "chatToolCreateTask", userInfo, task)
+		return authorizeAndStampToolTaskCreate(ctx, ch.client, ch.kubeClient, contextToken, ch.contextTokenAuthorization, "chatToolCreateTask", userInfo, task)
 	})
 	executor.SetTaskDeleteAuthorizer(func(ctx context.Context, task *corev1alpha1.Task) error {
 		return authorizeContextTokenTaskDeleteObject(ctx, ch.client, contextToken, ch.contextTokenAuthorization, "chatToolDeleteTask", task)

--- a/internal/api/context_token_authorization.go
+++ b/internal/api/context_token_authorization.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sozercan/orka/internal/workerenv"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -306,16 +307,22 @@ func authorizeContextTokenTaskCreateObject(ctx context.Context, k8sClient client
 	return handleContextTokenAuthorizationFailures(cfg, token, action, failures)
 }
 
-func authorizeAndStampToolTaskCreate(ctx context.Context, k8sClient client.Client, token *ContextToken, cfg ContextTokenAuthorizationConfig, action string, ui *UserInfo, task *corev1alpha1.Task) error {
+func authorizeAndStampToolTaskCreate(ctx context.Context, k8sClient client.Client, kubeClient kubernetes.Interface, token *ContextToken, cfg ContextTokenAuthorizationConfig, action string, ui *UserInfo, task *corev1alpha1.Task) error {
 	if err := authorizeContextTokenTaskCreateObject(ctx, k8sClient, token, cfg, action, task); err != nil {
+		return err
+	}
+	if err := authorizeKubernetesTaskCreate(ctx, kubeClient, ui, task); err != nil {
 		return err
 	}
 	stampTaskRequesterFromUserInfo(task, ui)
 	return nil
 }
 
-func authorizeAndStampTaskContext(ctx context.Context, k8sClient client.Client, token *ContextToken, cfg ContextTokenAuthorizationConfig, action string, ui *UserInfo, task *corev1alpha1.Task) error {
+func authorizeAndStampTaskContext(ctx context.Context, k8sClient client.Client, kubeClient kubernetes.Interface, token *ContextToken, cfg ContextTokenAuthorizationConfig, action string, ui *UserInfo, task *corev1alpha1.Task) error {
 	if err := authorizeContextTokenTaskContextObject(ctx, k8sClient, token, cfg, action, task); err != nil {
+		return err
+	}
+	if err := authorizeKubernetesTaskCreate(ctx, kubeClient, ui, task); err != nil {
 		return err
 	}
 	stampTaskRequesterFromUserInfo(task, ui)

--- a/internal/api/context_token_authorization_test.go
+++ b/internal/api/context_token_authorization_test.go
@@ -516,7 +516,7 @@ func TestAuthorizeAndStampToolTaskCreateStampsContextTokenProvenance(t *testing.
 		},
 	}
 
-	err := authorizeAndStampToolTaskCreate(context.Background(), nil, token, cfg, "chatToolCreateTask", ui, task)
+	err := authorizeAndStampToolTaskCreate(context.Background(), nil, nil, token, cfg, "chatToolCreateTask", ui, task)
 	require.NoError(t, err)
 	require.NotNil(t, task.Spec.RequestedBy)
 	require.Equal(t, testContextTokenSubject, task.Spec.RequestedBy.Subject)

--- a/internal/api/fork_handlers.go
+++ b/internal/api/fork_handlers.go
@@ -153,6 +153,9 @@ func (h *Handlers) ForkTask(c fiber.Ctx) error {
 	if err := h.authorizeContextTokenTaskCreate(c, createTaskRequestFromTask(forked), namespace); err != nil {
 		return err
 	}
+	if err := h.authorizeTaskCreate(c.Context(), c, forked); err != nil {
+		return err
+	}
 
 	sourceSessionName, forkedSessionName, err := h.resolveForkSessionNames(c.Context(), namespace, source, forked)
 	if err != nil {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -482,6 +482,10 @@ func (h *Handlers) CreateTask(c fiber.Ctx) error {
 	}
 
 	ctx := c.Context()
+	if err := h.authorizeTaskCreate(ctx, c, task); err != nil {
+		return err
+	}
+
 	if err := h.client.Create(ctx, task); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			return fiber.NewError(fiber.StatusConflict, "task already exists")
@@ -490,6 +494,10 @@ func (h *Handlers) CreateTask(c fiber.Ctx) error {
 	}
 
 	return c.Status(fiber.StatusCreated).JSON(task)
+}
+
+func (h *Handlers) authorizeTaskCreate(ctx context.Context, c fiber.Ctx, task *corev1alpha1.Task) error {
+	return authorizeKubernetesTaskCreate(ctx, h.clientset, GetUserInfo(c), task)
 }
 
 // ListTasks lists tasks

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -38,6 +40,84 @@ import (
 )
 
 const testWatchNamespace = "prod"
+
+func TestHandlers_CreateTaskRequiresKubernetesRBACForTokenReviewUser(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	kubeClient := kubefake.NewSimpleClientset()
+	kubeClient.PrependReactor("create", "subjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction := action.(k8stesting.CreateAction)
+		review := createAction.GetObject().(*authorizationv1.SubjectAccessReview)
+		require.Equal(t, "system:serviceaccount:default:limited", review.Spec.User)
+		require.Equal(t, []string{"system:serviceaccounts", "system:serviceaccounts:default"}, review.Spec.Groups)
+		require.NotNil(t, review.Spec.ResourceAttributes)
+		require.Equal(t, "default", review.Spec.ResourceAttributes.Namespace)
+		require.Equal(t, "create", review.Spec.ResourceAttributes.Verb)
+		require.Equal(t, corev1alpha1.GroupVersion.Group, review.Spec.ResourceAttributes.Group)
+		require.Equal(t, "tasks", review.Spec.ResourceAttributes.Resource)
+		review.Status.Allowed = false
+		return true, review, nil
+	})
+
+	handlers := NewHandlers(HandlersConfig{Client: fakeClient, KubeClient: kubeClient})
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.Locals(UserInfoContextKey, &UserInfo{
+			Username: "system:serviceaccount:default:limited",
+			Groups:   []string{"system:serviceaccounts", "system:serviceaccounts:default"},
+			AuthType: AuthTypeTokenReview,
+		})
+		return c.Next()
+	})
+	app.Post("/tasks", handlers.CreateTask)
+
+	resp := testJSONRequest(t, app, http.MethodPost, "/tasks", map[string]any{
+		"name":  "denied-task",
+		"type":  "container",
+		"image": "alpine:3.20",
+	})
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	var created corev1alpha1.Task
+	err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "denied-task", Namespace: "default"}, &created)
+	require.True(t, apierrors.IsNotFound(err), "denied task should not be created")
+}
+
+func TestHandlers_CreateTaskAllowsKubernetesRBACAuthorizedTokenReviewUser(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	kubeClient := kubefake.NewSimpleClientset()
+	kubeClient.PrependReactor("create", "subjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction := action.(k8stesting.CreateAction)
+		review := createAction.GetObject().(*authorizationv1.SubjectAccessReview)
+		review.Status.Allowed = true
+		return true, review, nil
+	})
+
+	handlers := NewHandlers(HandlersConfig{Client: fakeClient, KubeClient: kubeClient})
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.Locals(UserInfoContextKey, &UserInfo{
+			Username: "system:serviceaccount:default:editor",
+			AuthType: AuthTypeTokenReview,
+		})
+		return c.Next()
+	})
+	app.Post("/tasks", handlers.CreateTask)
+
+	resp := testJSONRequest(t, app, http.MethodPost, "/tasks", map[string]any{
+		"name":  "allowed-task",
+		"type":  "container",
+		"image": "alpine:3.20",
+	})
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+}
 
 func setupTestHandlers() (*Handlers, *fiber.App) {
 	scheme := runtime.NewScheme()

--- a/internal/api/kubernetes_task_authorization.go
+++ b/internal/api/kubernetes_task_authorization.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/gofiber/fiber/v3"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
+)
+
+func authorizeKubernetesTaskCreate(ctx context.Context, clientset kubernetes.Interface, userInfo *UserInfo, task *corev1alpha1.Task) error {
+	if userInfo == nil || userInfo.AuthType != AuthTypeTokenReview || task == nil {
+		return nil
+	}
+	if kubernetesClientsetIsNil(clientset) {
+		log.Info("task create authorization unavailable: missing Kubernetes clientset",
+			"username", userInfo.Username,
+			"namespace", task.Namespace,
+			"task", task.Name,
+		)
+		return fiber.NewError(fiber.StatusForbidden, "not authorized to create tasks")
+	}
+
+	extra := make(map[string]authorizationv1.ExtraValue, len(userInfo.Extra))
+	for key, values := range userInfo.Extra {
+		extra[key] = authorizationv1.ExtraValue(values)
+	}
+
+	review, err := clientset.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			User:   userInfo.Username,
+			Groups: userInfo.Groups,
+			Extra:  extra,
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: task.Namespace,
+				Verb:      "create",
+				Group:     corev1alpha1.GroupVersion.Group,
+				Resource:  "tasks",
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		log.Error(err, "task create authorization check failed",
+			"username", userInfo.Username,
+			"namespace", task.Namespace,
+			"task", task.Name,
+		)
+		return fiber.NewError(fiber.StatusForbidden, "not authorized to create tasks")
+	}
+	if !review.Status.Allowed {
+		log.Info("task create authorization denied",
+			"username", userInfo.Username,
+			"namespace", task.Namespace,
+			"task", task.Name,
+			"reason", review.Status.Reason,
+		)
+		return fiber.NewError(fiber.StatusForbidden, "not authorized to create tasks")
+	}
+
+	return nil
+}
+
+func kubernetesClientsetIsNil(clientset kubernetes.Interface) bool {
+	if clientset == nil {
+		return true
+	}
+	value := reflect.ValueOf(clientset)
+	return value.Kind() == reflect.Ptr && value.IsNil()
+}

--- a/internal/api/kubernetes_task_authorization_test.go
+++ b/internal/api/kubernetes_task_authorization_test.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
+	"github.com/sozercan/orka/internal/events"
+	"github.com/sozercan/orka/internal/store"
+	"github.com/sozercan/orka/internal/store/sqlite"
+)
+
+func TestHandlers_CreateTaskKubernetesRBACFailsClosed(t *testing.T) {
+	tests := []struct {
+		name       string
+		kubeClient *kubefake.Clientset
+	}{
+		{name: "missing clientset"},
+		{name: "subject access review error", kubeClient: denyingSubjectAccessReviewClient(t, errors.New("sar unavailable"), nil)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, corev1alpha1.AddToScheme(scheme))
+			require.NoError(t, corev1.AddToScheme(scheme))
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			handlers := NewHandlers(HandlersConfig{Client: fakeClient, KubeClient: tt.kubeClient})
+			app := fiber.New()
+			app.Use(tokenReviewUserMiddleware(limitedTokenReviewUser("default")))
+			app.Post("/tasks", handlers.CreateTask)
+
+			resp := testJSONRequest(t, app, http.MethodPost, "/tasks", map[string]any{
+				"name":  "fail-closed-task",
+				"type":  "container",
+				"image": "alpine:3.20",
+			})
+			require.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+			created := &corev1alpha1.Task{}
+			err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "fail-closed-task", Namespace: "default"}, created)
+			require.True(t, apierrors.IsNotFound(err), "failed authorization must not create a task")
+		})
+	}
+}
+
+func TestForkTaskRequiresKubernetesRBACForTokenReviewUser(t *testing.T) {
+	eventStore := store.NewFakeExecutionEventStore()
+	appendTestTaskEvent(t, eventStore, "source-task", events.ExecutionEventTypeTaskStarted)
+	source := testTask("default", "source-task")
+	source.Spec.Type = corev1alpha1.TaskTypeAgent
+	h, app := setupTaskEventHandlers(t, eventStore, source)
+	h.clientset = denyingSubjectAccessReviewClient(t, nil, func(review *authorizationv1.SubjectAccessReview) {
+		require.Equal(t, "system:serviceaccount:default:limited", review.Spec.User)
+		require.NotNil(t, review.Spec.ResourceAttributes)
+		require.Equal(t, "default", review.Spec.ResourceAttributes.Namespace)
+		require.Equal(t, "create", review.Spec.ResourceAttributes.Verb)
+		require.Equal(t, corev1alpha1.GroupVersion.Group, review.Spec.ResourceAttributes.Group)
+		require.Equal(t, "tasks", review.Spec.ResourceAttributes.Resource)
+	})
+	app.Use(tokenReviewUserMiddleware(limitedTokenReviewUser("default")))
+	app.Post("/api/v1/tasks/:id/fork", h.ForkTask)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks/source-task/fork?namespace=default", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	tasks := &corev1alpha1.TaskList{}
+	require.NoError(t, h.client.List(context.Background(), tasks, client.InNamespace("default")))
+	require.Len(t, tasks.Items, 1, "denied fork should leave only the source task")
+	require.Equal(t, "source-task", tasks.Items[0].Name)
+}
+
+func TestAuthorizeAndStampToolTaskCreateRequiresKubernetesRBACForTokenReviewUser(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1alpha1.AddToScheme(scheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "tool-task", Namespace: "default"},
+		Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeAgent},
+	}
+
+	err := authorizeAndStampToolTaskCreate(
+		context.Background(),
+		fakeClient,
+		denyingSubjectAccessReviewClient(t, nil, nil),
+		nil,
+		ContextTokenAuthorizationConfig{},
+		"chatToolCreateTask",
+		limitedTokenReviewUser("default"),
+		task,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not authorized to create tasks")
+}
+
+func TestCreateManualSecurityScanRequiresKubernetesRBACForTaskCreate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	scan := &corev1alpha1.RepositoryScan{
+		ObjectMeta: metav1.ObjectMeta{Name: "scan-1", Namespace: "demo"},
+		Spec: corev1alpha1.RepositoryScanSpec{
+			RepoURL:          securityTestRepoURL,
+			Branch:           "main",
+			AnalysisAgentRef: corev1alpha1.AgentReference{Name: "analysis"},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&corev1alpha1.RepositoryScan{}).
+		WithRuntimeObjects(scan).
+		Build()
+	db, err := sqlite.NewDB(":memory:")
+	require.NoError(t, err)
+	securityStore := sqlite.NewStore(db, ":memory:")
+	handlers := NewHandlers(HandlersConfig{
+		Client:        fakeClient,
+		SecurityStore: securityStore,
+		KubeClient:    denyingSubjectAccessReviewClient(t, nil, nil),
+	})
+	app := fiber.New()
+	app.Use(tokenReviewUserMiddleware(limitedTokenReviewUser("demo")))
+	app.Post("/security/repositories/:name/scans", handlers.CreateManualSecurityScan)
+
+	req := httptest.NewRequest(http.MethodPost, "/security/repositories/scan-1/scans?namespace=demo", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	tasks := &corev1alpha1.TaskList{}
+	require.NoError(t, fakeClient.List(context.Background(), tasks, client.InNamespace("demo")))
+	require.Empty(t, tasks.Items, "denied security scan should not create a task")
+
+	runs, _, err := securityStore.ListScanRuns(context.Background(), "demo", "scan-1", 10, "")
+	require.NoError(t, err)
+	require.Empty(t, runs, "denied security scan should not create a scan run")
+}
+
+func denyingSubjectAccessReviewClient(t *testing.T, reviewErr error, assertReview func(*authorizationv1.SubjectAccessReview)) *kubefake.Clientset {
+	t.Helper()
+	kubeClient := kubefake.NewSimpleClientset()
+	kubeClient.PrependReactor("create", "subjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction := action.(k8stesting.CreateAction)
+		review := createAction.GetObject().(*authorizationv1.SubjectAccessReview)
+		if assertReview != nil {
+			assertReview(review)
+		}
+		if reviewErr != nil {
+			return true, nil, reviewErr
+		}
+		review.Status.Allowed = false
+		return true, review, nil
+	})
+	return kubeClient
+}
+
+func limitedTokenReviewUser(namespace string) *UserInfo {
+	return &UserInfo{
+		Username:  "system:serviceaccount:" + namespace + ":limited",
+		Groups:    []string{"system:serviceaccounts", "system:serviceaccounts:" + namespace},
+		Namespace: namespace,
+		AuthType:  AuthTypeTokenReview,
+	}
+}
+
+func tokenReviewUserMiddleware(userInfo *UserInfo) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		c.Locals(UserInfoContextKey, userInfo)
+		return c.Next()
+	}
+}

--- a/internal/api/openai_compat.go
+++ b/internal/api/openai_compat.go
@@ -307,7 +307,7 @@ func (h *OpenAICompatHandler) HandleChatCompletions(c fiber.Ctx) error {
 			TaskLabels:                func() map[string]string { return map[string]string{"orka.ai/source": "openai-proxy"} },
 			AuthorizeTaskCreate: func(ctx context.Context, task *corev1alpha1.Task) *tools.ChatToolError {
 				authorize := func(ctx context.Context, task *corev1alpha1.Task) error {
-					return authorizeAndStampToolTaskCreate(ctx, h.client, contextToken, h.contextTokenAuthorization, "openAIToolCreateTask", userInfo, task)
+					return authorizeAndStampToolTaskCreate(ctx, h.client, h.kubeClient, contextToken, h.contextTokenAuthorization, "openAIToolCreateTask", userInfo, task)
 				}
 				return chatToolAuthorizationError(authorize, ctx, task, "Use a task configuration authorized by the context token")
 			},

--- a/internal/api/security_handlers.go
+++ b/internal/api/security_handlers.go
@@ -185,7 +185,7 @@ func (h *Handlers) createSecurityScanRun(ctx context.Context, ui *UserInfo, scan
 			return nil, err
 		}
 	}
-	if err := authorizeAndStampTaskContext(ctx, h.client, contextTokenFromUserInfo(ui), h.contextTokenAuthorization, "createSecurityScanTask", ui, task); err != nil {
+	if err := authorizeAndStampTaskContext(ctx, h.client, h.clientset, contextTokenFromUserInfo(ui), h.contextTokenAuthorization, "createSecurityScanTask", ui, task); err != nil {
 		return nil, err
 	}
 	if err := h.client.Create(ctx, task); err != nil {
@@ -262,7 +262,7 @@ func (h *Handlers) createSecurityValidationTask(ctx context.Context, ui *UserInf
 			return err
 		}
 	}
-	if err := authorizeAndStampTaskContext(ctx, h.client, contextTokenFromUserInfo(ui), h.contextTokenAuthorization, "createSecurityValidationTask", ui, task); err != nil {
+	if err := authorizeAndStampTaskContext(ctx, h.client, h.clientset, contextTokenFromUserInfo(ui), h.contextTokenAuthorization, "createSecurityValidationTask", ui, task); err != nil {
 		return err
 	}
 	if err := h.client.Create(ctx, task); err != nil {
@@ -344,7 +344,7 @@ func (h *Handlers) createSecurityPatchTask(ctx context.Context, ui *UserInfo, sc
 			return nil, err
 		}
 	}
-	if err := authorizeAndStampTaskContext(ctx, h.client, contextTokenFromUserInfo(ui), h.contextTokenAuthorization, "createSecurityPatchTask", ui, task); err != nil {
+	if err := authorizeAndStampTaskContext(ctx, h.client, h.clientset, contextTokenFromUserInfo(ui), h.contextTokenAuthorization, "createSecurityPatchTask", ui, task); err != nil {
 		return nil, err
 	}
 	if err := h.client.Create(ctx, task); err != nil {


### PR DESCRIPTION
### Motivation
- The API previously accepted any valid Kubernetes bearer token (via `TokenReview`) but did not verify that the authenticated principal was allowed to create Orka `Task` resources, which lets an in-cluster caller escalate by creating jobs that run as the privileged worker ServiceAccount.
- The change enforces Kubernetes RBAC checks before the controller client is used to create a `Task`, failing closed when the authorization check cannot be performed.

### Description
- Add `authorizeTaskCreate(ctx, c, task)` which performs a Kubernetes `SubjectAccessReview` for `create` on `core.orka.io/tasks` in the resolved namespace using the server `clientset`, and returns `403` when denied or when the check cannot be completed.
- Call `authorizeTaskCreate` from `CreateTask` before creating the `Task` with the controller client so TokenReview-authenticated identities are subject to RBAC checks.
- Fail closed when the server does not have a usable `clientset` for performing the `SubjectAccessReview` to avoid silently allowing requests.
- Add unit tests that mock `SubjectAccessReview` responses to verify denied and allowed RBAC outcomes for TokenReview-authenticated ServiceAccount users.

### Testing
- Ran `go test ./internal/api -run 'TestHandlers_CreateTaskRequiresKubernetesRBACForTokenReviewUser|TestHandlers_CreateTaskAllowsKubernetesRBACAuthorizedTokenReviewUser' -v` and both tests passed.
- Ran `go test ./internal/api` and the package tests passed locally after adding the UI embed stub with `make ensure-ui-embed`.
- Attempted broader verification (`make lint-fix && make test`, `make test`, and `go test ./...`) but these were blocked or produced unrelated environment/test-dependency failures: tooling downloads were blocked by `proxy.golang.org` 403 responses and controller envtest required local kubebuilder binaries (pre-existing environment constraints), and some unrelated package tests reported existing failures; these issues prevented a full repo-wide green run in this environment.
- Running the repository `autoreview` helper was attempted but blocked by the local `codex` executable not being available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c29418e70832aa2172524ef0a316d)