### PR TITLE
fix: harden Helm namespace isolation defaults

### DIFF
--- a/charts/orka/templates/_helpers.tpl
+++ b/charts/orka/templates/_helpers.tpl
@@ -62,6 +62,22 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+
+{{/*
+Create the namespace for the chart-managed client ServiceAccount.
+When namespace isolation is enforced and the controller watches one namespace,
+place the default client in that namespace so its token remains usable.
+*/}}
+{{- define "orka.clientNamespace" -}}
+{{- if .Values.client.namespace }}
+{{- .Values.client.namespace }}
+{{- else if and .Values.controller.enforceNamespaceIsolation .Values.controller.watchNamespace }}
+{{- .Values.controller.watchNamespace }}
+{{- else }}
+{{- .Release.Namespace }}
+{{- end }}
+{{- end }}
+
 {{/*
 Create release-scoped worker ClusterRole names.
 */}}

--- a/charts/orka/templates/rbac.yaml
+++ b/charts/orka/templates/rbac.yaml
@@ -44,7 +44,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["serviceaccounts"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "create", "update"]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "watch"]

--- a/charts/orka/templates/rbac.yaml
+++ b/charts/orka/templates/rbac.yaml
@@ -44,7 +44,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["serviceaccounts"]
-    verbs: ["get", "list", "watch", "create", "update", "delete"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "watch"]

--- a/charts/orka/templates/rbac.yaml
+++ b/charts/orka/templates/rbac.yaml
@@ -109,8 +109,18 @@ rules:
     resources: ["clusterroles", "roles", "rolebindings"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["rolebindings"]
+    verbs: ["create", "update", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["clusterrolebindings"]
     verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    resourceNames:
+      - {{ include "orka.aiWorkerClusterRoleName" . }}
+      - {{ include "orka.vendorWorkerClusterRoleName" . }}
+      - {{ include "orka.containerWorkerClusterRoleName" . }}
+    verbs: ["bind"]
 
   # TokenReview for authentication
   - apiGroups: ["authentication.k8s.io"]
@@ -184,11 +194,20 @@ rules:
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.controller.enforceNamespaceIsolation }}
+kind: RoleBinding
+metadata:
+  name: {{ include "orka.fullname" . }}-client
+  namespace: {{ include "orka.clientNamespace" . }}
+  labels:
+    {{- include "orka.labels" . | nindent 4 }}
+{{- else }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "orka.fullname" . }}-client
   labels:
     {{- include "orka.labels" . | nindent 4 }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -196,7 +215,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.client.name }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "orka.clientNamespace" . }}
 {{- end }}
 ---
 # AI Worker Role (trusted worker with Kubernetes tool and code_exec permissions)
@@ -282,11 +301,20 @@ rules:
     verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.controller.enforceNamespaceIsolation }}
+kind: RoleBinding
+metadata:
+  name: {{ include "orka.aiWorkerClusterRoleBindingName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "orka.labels" . | nindent 4 }}
+{{- else }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "orka.aiWorkerClusterRoleBindingName" . }}
   labels:
     {{- include "orka.labels" . | nindent 4 }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -367,11 +395,20 @@ rules:
     verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.controller.enforceNamespaceIsolation }}
+kind: RoleBinding
+metadata:
+  name: {{ include "orka.vendorWorkerClusterRoleBindingName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "orka.labels" . | nindent 4 }}
+{{- else }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "orka.vendorWorkerClusterRoleBindingName" . }}
   labels:
     {{- include "orka.labels" . | nindent 4 }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -398,11 +435,20 @@ rules:
     verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.controller.enforceNamespaceIsolation }}
+kind: RoleBinding
+metadata:
+  name: {{ include "orka.containerWorkerClusterRoleBindingName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "orka.labels" . | nindent 4 }}
+{{- else }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "orka.containerWorkerClusterRoleBindingName" . }}
   labels:
     {{- include "orka.labels" . | nindent 4 }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/orka/templates/serviceaccount.yaml
+++ b/charts/orka/templates/serviceaccount.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.client.name }}
+  namespace: {{ include "orka.clientNamespace" . }}
   labels:
     {{- include "orka.labels" . | nindent 4 }}
     orka.ai/client: "true"

--- a/charts/orka/values.yaml
+++ b/charts/orka/values.yaml
@@ -266,3 +266,6 @@ client:
   create: true
   # Name of the client service account
   name: orka-client
+  # Namespace for the client service account. Empty defaults to controller.watchNamespace
+  # when namespace isolation is enforced and watchNamespace is set, otherwise the release namespace.
+  namespace: ""

--- a/charts/orka/values.yaml
+++ b/charts/orka/values.yaml
@@ -39,7 +39,7 @@ controller:
   logLevel: info
 
   # Enforce namespace isolation (restrict users to their SA namespace)
-  enforceNamespaceIsolation: false
+  enforceNamespaceIsolation: true
 
   # Max active tasks per namespace (0 = unlimited)
   maxTasksPerNamespace: 0

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -14,6 +14,9 @@ namePrefix: orka-
 #  pairs:
 #    someName: someValue
 
+configurations:
+- kustomizeconfig.yaml
+
 resources:
 - ../crd
 - ../rbac

--- a/config/default/kustomizeconfig.yaml
+++ b/config/default/kustomizeconfig.yaml
@@ -1,0 +1,9 @@
+nameReference:
+- kind: ClusterRole
+  group: rbac.authorization.k8s.io
+  version: v1
+  fieldSpecs:
+  - kind: ClusterRole
+    group: rbac.authorization.k8s.io
+    version: v1
+    path: rules/resourceNames

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -263,6 +263,7 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
+  - rolebindings
   verbs:
   - create
   - delete
@@ -272,9 +273,18 @@ rules:
   - watch
 - apiGroups:
   - rbac.authorization.k8s.io
+  resourceNames:
+  - ai-worker-role
+  - container-worker-role
+  - vendor-worker-role
   resources:
   - clusterroles
-  - rolebindings
+  verbs:
+  - bind
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
   - roles
   verbs:
   - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -58,10 +58,19 @@ rules:
   - ""
   resources:
   - secrets
-  - serviceaccounts
   verbs:
   - create
   - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
   - get
   - list
   - update

--- a/internal/api/context_token.go
+++ b/internal/api/context_token.go
@@ -355,12 +355,15 @@ func contextTokenToUserInfo(token *ContextToken) *UserInfo {
 		username = token.RequestingWorkload
 	}
 
+	namespace, _ := contextString(token.TransactionContext, "namespace")
+
 	return &UserInfo{
 		Username:     username,
 		AuthType:     AuthTypeContextToken,
 		Subject:      token.Subject,
 		Issuer:       token.Issuer,
 		Roles:        append([]string{}, token.Scopes...),
+		Namespace:    namespace,
 		ContextToken: token,
 	}
 }

--- a/internal/api/context_token_test.go
+++ b/internal/api/context_token_test.go
@@ -187,6 +187,39 @@ func TestContextToken_KontxtValidViaTxnTokenHeader(t *testing.T) {
 	}
 }
 
+func TestContextToken_UserInfoNamespaceFromTransactionContext(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+	cfg := testContextTokenConfig(t, provider, "")
+	token := issueTestContextToken(t, provider, nil, map[string]any{
+		"tctx": map[string]any{
+			"namespace": "team-a",
+		},
+	})
+
+	app := fiber.New()
+	app.Use(NewAuthMiddleware(nil, AuthConfig{ContextTokens: cfg}))
+	app.Get("/test", func(ctx fiber.Ctx) error {
+		userInfo := GetUserInfo(ctx)
+		if userInfo == nil || userInfo.AuthType != AuthTypeContextToken {
+			return fiber.NewError(fiber.StatusInternalServerError, "missing context token user info")
+		}
+		if userInfo.Namespace != "team-a" {
+			return fiber.NewError(fiber.StatusInternalServerError, "context token namespace was not mapped")
+		}
+		return ctx.SendString("OK")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set(KontxtHeaderName, token)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
 func TestContextToken_KontxtValidViaAuthorizationBearerWhenConfigured(t *testing.T) {
 	provider := newTestOIDCProvider(t)
 	cfg := testContextTokenConfig(t, provider, "Txn-Token,Authorization:Bearer")

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -177,10 +177,20 @@ func (h *Handlers) resolveNamespace(c fiber.Ctx, explicit string) (string, error
 		ns = GetEffectiveNamespace(c, "")
 	}
 
-	// Enforce namespace isolation: user can only access their SA namespace
+	// Enforce namespace isolation: authenticated callers must carry a namespace
+	// and can only access that namespace.
 	if h.enforceNamespaceIsolation {
 		ui := GetUserInfo(c)
-		if ui != nil && ui.Namespace != "" && ns != ui.Namespace {
+		if ui != nil && ui.Namespace == "" {
+			log.Info("namespace access denied: namespace-less identity",
+				"username", ui.Username,
+				"authType", ui.AuthType,
+				"requestedNamespace", ns,
+				"ip", c.IP(),
+			)
+			return "", fiber.NewError(fiber.StatusForbidden, "namespace-bound identity required")
+		}
+		if ui != nil && ns != ui.Namespace {
 			log.Info("namespace access denied: isolation violation",
 				"username", ui.Username,
 				"userNamespace", ui.Namespace,

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -3095,6 +3095,32 @@ func TestResolveNamespace_IsolationEnforced(t *testing.T) {
 	require.Equal(t, http.StatusForbidden, resp.StatusCode)
 }
 
+func TestResolveNamespace_IsolationRejectsNamespaceLessAuthenticatedUser(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	db, _ := sqlite.NewDB(":memory:")
+	ss := sqlite.NewStore(db, ":memory:")
+	handlers := NewHandlers(HandlersConfig{Client: fakeClient, EnforceNamespaceIsolation: true, SessionStore: ss, ResultStore: ss})
+
+	app := fiber.New()
+	app.Get("/test", func(c fiber.Ctx) error {
+		c.Locals(UserInfoContextKey, &UserInfo{Username: "oidc-user", AuthType: AuthTypeOIDC})
+		ns, err := handlers.resolveNamespace(c, "team-a")
+		if err != nil {
+			return err
+		}
+		return c.SendString(ns)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
 func TestResolveNamespace_IsolationAllowsSameNamespace(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1alpha1.AddToScheme(scheme)

--- a/internal/api/namespace.go
+++ b/internal/api/namespace.go
@@ -36,10 +36,19 @@ func ResolveNamespace(c fiber.Ctx, explicit string, watchNamespace string, enfor
 		ns = GetEffectiveNamespace(c, "")
 	}
 
-	// Enforce namespace isolation: user can only access their SA namespace
+	// Enforce namespace isolation: authenticated callers must carry a namespace
+	// and can only access that namespace.
 	if enforceIsolation {
 		ui := GetUserInfo(c)
-		if ui != nil && ui.Namespace != "" && ns != ui.Namespace {
+		if ui != nil && ui.Namespace == "" {
+			log.Info("namespace access denied: namespace-less identity",
+				"authType", ui.AuthType,
+				"requestedNamespace", ns,
+				"ip", c.IP(),
+			)
+			return "", fiber.NewError(fiber.StatusForbidden, "namespace-bound identity required")
+		}
+		if ui != nil && ns != ui.Namespace {
 			log.Info("namespace access denied: isolation violation",
 				"userNamespace", ui.Namespace,
 				"requestedNamespace", ns,

--- a/internal/api/namespace_test.go
+++ b/internal/api/namespace_test.go
@@ -100,6 +100,16 @@ func TestResolveNamespace(t *testing.T) {
 			wantStatus: http.StatusForbidden,
 		},
 		{
+			name:             "enforceIsolation rejects namespace-less authenticated identity",
+			explicit:         "any-ns",
+			enforceIsolation: true,
+			userInfo: &UserInfo{
+				Username: "oidc-user",
+				AuthType: AuthTypeOIDC,
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
 			name:             "enforceIsolation with no userInfo allows any namespace",
 			explicit:         "any-ns",
 			enforceIsolation: true,

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -44,6 +44,7 @@ type oidcClaims struct {
 	Email       string          `json:"email,omitempty"`
 	Username    string          `json:"preferred_username,omitempty"`
 	Name        string          `json:"name,omitempty"`
+	Namespace   string          `json:"namespace,omitempty"`
 	Groups      stringList      `json:"groups,omitempty"`
 	Roles       stringList      `json:"roles,omitempty"`
 	RealmAccess oidcRealmAccess `json:"realm_access,omitempty"`
@@ -134,13 +135,14 @@ func userInfoFromOIDCClaims(claims oidcClaims) *UserInfo {
 	roles = append(roles, claims.RealmAccess.Roles...)
 
 	return &UserInfo{
-		Username: username,
-		Groups:   append([]string{}, claims.Groups...),
-		AuthType: AuthTypeOIDC,
-		Subject:  claims.Subject,
-		Email:    claims.Email,
-		Issuer:   claims.Issuer,
-		Roles:    roles,
+		Username:  username,
+		Groups:    append([]string{}, claims.Groups...),
+		AuthType:  AuthTypeOIDC,
+		Subject:   claims.Subject,
+		Email:     claims.Email,
+		Issuer:    claims.Issuer,
+		Roles:     roles,
+		Namespace: claims.Namespace,
 	}
 }
 

--- a/internal/api/oidc_test.go
+++ b/internal/api/oidc_test.go
@@ -46,6 +46,7 @@ type testOIDCTokenOptions struct {
 	Username   string
 	Email      string
 	Name       string
+	Namespace  string
 	Groups     []string
 	Roles      []string
 	RealmRoles []string
@@ -151,6 +152,9 @@ func (p *testOIDCProvider) issueToken(t *testing.T, opts testOIDCTokenOptions) s
 	if opts.Name != "" {
 		claims["name"] = opts.Name
 	}
+	if opts.Namespace != "" {
+		claims["namespace"] = opts.Namespace
+	}
 	if opts.Groups != nil {
 		claims["groups"] = opts.Groups
 	}
@@ -229,6 +233,7 @@ func TestValidateOIDCToken_Valid(t *testing.T) {
 		Groups:     []string{"devs", "admins"},
 		Roles:      []string{"submitter"},
 		RealmRoles: []string{"reviewer"},
+		Namespace:  "team-a",
 	})
 
 	userInfo, err := validateOIDCToken(context.Background(), token, cfg)
@@ -256,6 +261,9 @@ func TestValidateOIDCToken_Valid(t *testing.T) {
 	}
 	if strings.Join(userInfo.Roles, ",") != "submitter,reviewer" {
 		t.Fatalf("Roles = %#v, want [submitter reviewer]", userInfo.Roles)
+	}
+	if userInfo.Namespace != "team-a" {
+		t.Fatalf("Namespace = %q, want %q", userInfo.Namespace, "team-a")
 	}
 }
 

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -122,7 +122,7 @@ type TaskReconciler struct {
 // +kubebuilder:rbac:groups="",resources=pods/log,verbs=get
 // +kubebuilder:rbac:groups="",resources=pods/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;patch
-// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -138,7 +138,9 @@ type TaskReconciler struct {
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;roles;rolebindings,verbs=get;list;watch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create;update;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,resourceNames=ai-worker-role;vendor-worker-role;container-worker-role,verbs=bind
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=get;list
 // +kubebuilder:rbac:groups=ate.dev,resources=actortemplates,verbs=get;list;watch
@@ -2839,13 +2841,23 @@ func workerClusterRoleBindingName(prefix, tier, namespace string) string {
 	return fmt.Sprintf("%s-%s", name[:prefixLength], suffix)
 }
 
-// ensureWorkerRBAC ensures each worker ServiceAccount and ClusterRoleBinding
+// ensureWorkerRBAC ensures each worker ServiceAccount and worker role binding
 // exists in the given namespace so that task jobs have trust-tiered permissions.
 func (r *TaskReconciler) ensureWorkerRBAC(ctx context.Context, namespace string) error {
 	for _, spec := range r.workerRBACSpecs(namespace) {
 		if err := r.ensureWorkerServiceAccount(ctx, namespace, spec.serviceAccountName); err != nil {
 			return err
 		}
+		if r.EnforceNamespaceIsolation {
+			if err := r.ensureWorkerRoleBinding(ctx, namespace, spec); err != nil {
+				return err
+			}
+			if err := r.deleteLegacyWorkerClusterRoleBinding(ctx, namespace, spec); err != nil {
+				return err
+			}
+			continue
+		}
+
 		if err := r.ensureWorkerClusterRoleBinding(ctx, namespace, spec); err != nil {
 			return err
 		}
@@ -2895,6 +2907,135 @@ func (r *TaskReconciler) ensureWorkerServiceAccount(ctx context.Context, namespa
 		log.Info("Updated worker ServiceAccount", "namespace", namespace, "serviceAccount", name)
 	}
 
+	return nil
+}
+
+func (r *TaskReconciler) ensureWorkerRoleBinding(ctx context.Context, namespace string, spec workerRBACSpec) error {
+	log := logf.FromContext(ctx)
+	desired := workerRoleBinding(namespace, spec)
+
+	rb := &rbacv1.RoleBinding{}
+	err := r.Get(ctx, types.NamespacedName{Name: spec.clusterRoleBindingName, Namespace: namespace}, rb)
+	if apierrors.IsNotFound(err) {
+		if err := r.Create(ctx, desired); err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				return fmt.Errorf("creating worker RoleBinding %s/%s: %w", namespace, spec.clusterRoleBindingName, err)
+			}
+			if err := r.Get(ctx, types.NamespacedName{Name: spec.clusterRoleBindingName, Namespace: namespace}, rb); err != nil {
+				return fmt.Errorf("getting worker RoleBinding %s/%s after create conflict: %w", namespace, spec.clusterRoleBindingName, err)
+			}
+		} else {
+			log.Info("Created worker RoleBinding", "namespace", namespace, "binding", spec.clusterRoleBindingName, "serviceAccount", spec.serviceAccountName, "clusterRole", spec.clusterRoleName)
+			return nil
+		}
+	} else if err != nil {
+		return fmt.Errorf("getting worker RoleBinding %s/%s: %w", namespace, spec.clusterRoleBindingName, err)
+	}
+
+	if rb.RoleRef != desired.RoleRef {
+		recreated, err := r.recreateWorkerRoleBinding(ctx, namespace, spec, rb, desired)
+		if err != nil {
+			return err
+		}
+		rb = recreated
+	}
+
+	changed := false
+	if rb.Labels == nil {
+		rb.Labels = map[string]string{}
+	}
+	if rb.Labels[managedByLabelKey] != managedByLabelValue {
+		rb.Labels[managedByLabelKey] = managedByLabelValue
+		changed = true
+	}
+	if !subjectsEqual(rb.Subjects, desired.Subjects) {
+		rb.Subjects = desired.Subjects
+		changed = true
+	}
+
+	if changed {
+		if err := r.Update(ctx, rb); err != nil {
+			return fmt.Errorf("updating worker RoleBinding %s/%s: %w", namespace, spec.clusterRoleBindingName, err)
+		}
+		log.Info("Updated worker RoleBinding", "namespace", namespace, "binding", spec.clusterRoleBindingName, "serviceAccount", spec.serviceAccountName, "clusterRole", spec.clusterRoleName)
+	}
+
+	return nil
+}
+
+func (r *TaskReconciler) recreateWorkerRoleBinding(ctx context.Context, namespace string, spec workerRBACSpec, current, desired *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+	log := logf.FromContext(ctx)
+	log.Info("Recreating worker RoleBinding with stale RoleRef", "namespace", namespace, "binding", spec.clusterRoleBindingName, "currentKind", current.RoleRef.Kind, "currentName", current.RoleRef.Name, "desiredKind", desired.RoleRef.Kind, "desiredName", desired.RoleRef.Name)
+
+	if err := r.Delete(ctx, current); err != nil && !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("deleting worker RoleBinding %s/%s with stale RoleRef %s/%s: %w", namespace, spec.clusterRoleBindingName, current.RoleRef.Kind, current.RoleRef.Name, err)
+	}
+
+	var recreated *rbacv1.RoleBinding
+	err := wait.PollUntilContextTimeout(ctx, workerClusterRoleBindingRecreateInterval, workerClusterRoleBindingRecreateTimeout, true, func(ctx context.Context) (bool, error) {
+		latest := &rbacv1.RoleBinding{}
+		err := r.Get(ctx, types.NamespacedName{Name: spec.clusterRoleBindingName, Namespace: namespace}, latest)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("getting worker RoleBinding %s/%s while waiting for stale RoleRef deletion: %w", namespace, spec.clusterRoleBindingName, err)
+		}
+
+		if err == nil {
+			if latest.RoleRef == desired.RoleRef {
+				recreated = latest
+				return true, nil
+			}
+
+			// The API server may still be serving the stale object while deletion is
+			// propagating, or another actor may have recreated it with the stale
+			// immutable RoleRef. Keep deleting/retrying until the name is available.
+			if err := r.Delete(ctx, latest); err != nil && !apierrors.IsNotFound(err) {
+				return false, fmt.Errorf("deleting worker RoleBinding %s/%s with stale RoleRef %s/%s during retry: %w", namespace, spec.clusterRoleBindingName, latest.RoleRef.Kind, latest.RoleRef.Name, err)
+			}
+			return false, nil
+		}
+
+		create := desired.DeepCopy()
+		if err := r.Create(ctx, create); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("recreating worker RoleBinding %s/%s with RoleRef %s/%s: %w", namespace, spec.clusterRoleBindingName, desired.RoleRef.Kind, desired.RoleRef.Name, err)
+		}
+
+		recreated = create
+		return true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("recreating worker RoleBinding %s/%s after stale RoleRef %s/%s: %w", namespace, spec.clusterRoleBindingName, current.RoleRef.Kind, current.RoleRef.Name, err)
+	}
+
+	log.Info("Recreated worker RoleBinding", "namespace", namespace, "binding", spec.clusterRoleBindingName, "serviceAccount", spec.serviceAccountName, "clusterRole", spec.clusterRoleName)
+	return recreated, nil
+}
+
+func (r *TaskReconciler) deleteLegacyWorkerClusterRoleBinding(ctx context.Context, namespace string, spec workerRBACSpec) error {
+	log := logf.FromContext(ctx)
+	legacy := &rbacv1.ClusterRoleBinding{}
+	err := r.Get(ctx, types.NamespacedName{Name: spec.clusterRoleBindingName}, legacy)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("getting legacy worker ClusterRoleBinding %s: %w", spec.clusterRoleBindingName, err)
+	}
+
+	desiredLegacy := workerClusterRoleBinding(namespace, spec)
+	managed := legacy.Labels[managedByLabelKey] == managedByLabelValue
+	bindsWorkerServiceAccount := len(desiredLegacy.Subjects) == 1 && subjectsContain(legacy.Subjects, desiredLegacy.Subjects[0])
+	if !managed && !bindsWorkerServiceAccount {
+		log.Info("Skipping unmanaged legacy worker ClusterRoleBinding", "namespace", namespace, "binding", spec.clusterRoleBindingName)
+		return nil
+	}
+
+	if err := r.Delete(ctx, legacy); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("deleting legacy worker ClusterRoleBinding %s: %w", spec.clusterRoleBindingName, err)
+	}
+	log.Info("Deleted legacy worker ClusterRoleBinding", "namespace", namespace, "binding", spec.clusterRoleBindingName, "serviceAccount", spec.serviceAccountName, "clusterRole", spec.clusterRoleName)
 	return nil
 }
 
@@ -3001,6 +3142,30 @@ func (r *TaskReconciler) recreateWorkerClusterRoleBinding(ctx context.Context, n
 	return recreated, nil
 }
 
+func workerRoleBinding(namespace string, spec workerRBACSpec) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      spec.clusterRoleBindingName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				managedByLabelKey: managedByLabelValue,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     spec.clusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      spec.serviceAccountName,
+				Namespace: namespace,
+			},
+		},
+	}
+}
+
 func workerClusterRoleBinding(namespace string, spec workerRBACSpec) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -3022,6 +3187,10 @@ func workerClusterRoleBinding(namespace string, spec workerRBACSpec) *rbacv1.Clu
 			},
 		},
 	}
+}
+
+func subjectsContain(subjects []rbacv1.Subject, want rbacv1.Subject) bool {
+	return slices.Contains(subjects, want)
 }
 
 // subjectsEqual is intentionally order-sensitive; desired worker bindings

--- a/internal/controller/task_controller_unit_test.go
+++ b/internal/controller/task_controller_unit_test.go
@@ -1958,6 +1958,76 @@ func TestEnsureWorkerRBAC_CreatesResources(t *testing.T) {
 	}
 }
 
+func TestEnsureWorkerRBAC_UsesNamespacedRoleBindingsWhenIsolationEnforced(t *testing.T) {
+	scheme := newTestScheme()
+	r := newUnitReconciler(scheme)
+	r.EnforceNamespaceIsolation = true
+
+	if err := r.ensureWorkerRBAC(context.Background(), testNS); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []struct {
+		serviceAccount string
+		binding        string
+		clusterRole    string
+	}{
+		{AIWorkerServiceAccount, "orka-ai-worker-test-ns", DefaultAIWorkerClusterRoleName},
+		{VendorWorkerServiceAccount, "orka-vendor-worker-test-ns", DefaultVendorWorkerClusterRoleName},
+		{ContainerWorkerServiceAccount, "orka-container-worker-test-ns", DefaultContainerWorkerClusterRoleName},
+	}
+
+	for _, tt := range expected {
+		t.Run(tt.serviceAccount, func(t *testing.T) {
+			rb := &rbacv1.RoleBinding{}
+			if err := r.Get(context.Background(), types.NamespacedName{Name: tt.binding, Namespace: testNS}, rb); err != nil {
+				t.Fatalf("expected RoleBinding %s/%s to exist: %v", testNS, tt.binding, err)
+			}
+			if rb.RoleRef.Kind != "ClusterRole" || rb.RoleRef.Name != tt.clusterRole {
+				t.Fatalf("unexpected roleRef: %#v", rb.RoleRef)
+			}
+			if len(rb.Subjects) != 1 {
+				t.Fatalf("expected 1 subject, got %d", len(rb.Subjects))
+			}
+			subject := rb.Subjects[0]
+			if subject.Kind != rbacv1.ServiceAccountKind || subject.Name != tt.serviceAccount || subject.Namespace != testNS {
+				t.Fatalf("unexpected subject: %#v", subject)
+			}
+
+			crb := &rbacv1.ClusterRoleBinding{}
+			if err := r.Get(context.Background(), types.NamespacedName{Name: tt.binding}, crb); !apierrors.IsNotFound(err) {
+				t.Fatalf("expected no ClusterRoleBinding %s, got err %v and object %#v", tt.binding, err, crb)
+			}
+		})
+	}
+}
+
+func TestEnsureWorkerRBAC_IsolationDeletesManagedLegacyClusterRoleBindings(t *testing.T) {
+	scheme := newTestScheme()
+	legacy := workerClusterRoleBinding(testNS, workerRBACSpec{
+		serviceAccountName:     AIWorkerServiceAccount,
+		clusterRoleName:        "old-ai-worker-role",
+		clusterRoleBindingName: "orka-ai-worker-test-ns",
+	})
+	legacy.Subjects = append(legacy.Subjects, rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "extra-worker", Namespace: testNS})
+	r := newUnitReconciler(scheme, legacy)
+	r.EnforceNamespaceIsolation = true
+
+	if err := r.ensureWorkerRBAC(context.Background(), testNS); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	crb := &rbacv1.ClusterRoleBinding{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "orka-ai-worker-test-ns"}, crb); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected managed legacy ClusterRoleBinding to be deleted, got err %v", err)
+	}
+
+	rb := &rbacv1.RoleBinding{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "orka-ai-worker-test-ns", Namespace: testNS}, rb); err != nil {
+		t.Fatalf("expected replacement RoleBinding to exist: %v", err)
+	}
+}
+
 func TestEnsureWorkerRBAC_UsesClusterRoleBindingPrefix(t *testing.T) {
 	scheme := newTestScheme()
 	r := newUnitReconciler(scheme)

--- a/website/docs/concepts/configuration.md
+++ b/website/docs/concepts/configuration.md
@@ -666,6 +666,7 @@ Key configuration values for the Helm chart:
 | `controller.replicas` | `1` | Controller replicas |
 | `controller.image.repository` | `ghcr.io/sozercan/orka` | Controller image |
 | `controller.watchNamespace` | `""` | Namespace scope (empty = cluster-wide) |
+| `controller.enforceNamespaceIsolation` | `true` | Restrict namespace-bound API callers and default Helm RBAC to their namespace |
 | `controller.apiPort` | `8080` | REST API port |
 | `controller.metricsPort` | `8081` | Metrics endpoint port |
 | `controller.healthPort` | `8082` | Health probe port |
@@ -686,6 +687,7 @@ Key configuration values for the Helm chart:
 | `monitoring.enabled` | `false` | Enable Prometheus ServiceMonitor |
 | `client.create` | `true` | Create client ServiceAccount for API access |
 | `client.name` | `orka-client` | Client ServiceAccount name |
+| `client.namespace` | `""` | Client ServiceAccount namespace override. Empty defaults to `controller.watchNamespace` when namespace isolation is enforced and `watchNamespace` is set, otherwise the release namespace. |
 
 Context-token flags can also be configured through Helm under
 `controller.contextToken`. For example:


### PR DESCRIPTION
### Motivation
- Make the Helm default meaningfully namespace-isolated for chart-managed API clients and task worker tokens.
- Reduce unnecessary controller RBAC by removing the unused `delete` verb on `serviceaccounts` without breaking worker ServiceAccount reconciliation.
- Preserve existing cluster-wide behavior for operators who explicitly opt out with `controller.enforceNamespaceIsolation=false`.

### Description
- Default `controller.enforceNamespaceIsolation` to `true` in `charts/orka/values.yaml`.
- Keep controller `serviceaccounts` `create`/`update` because `TaskReconciler.ensureWorkerRBAC` creates and labels worker ServiceAccounts in task namespaces; remove only the unused `delete` verb.
- Add restricted `bind` permission for the configured worker ClusterRoles so the controller can still create worker bindings without holding every worker permission itself.
- Render chart-managed client and worker bindings as namespace-scoped `RoleBinding`s when namespace isolation is enforced; keep the previous `ClusterRoleBinding` behavior when isolation is disabled.
- Default the chart-managed client ServiceAccount namespace to `controller.watchNamespace` for watched-namespace isolated installs, otherwise the Helm release namespace; `client.namespace` can override this.
- In the controller, create per-task-namespace worker `RoleBinding`s when namespace isolation is enabled and remove managed legacy worker `ClusterRoleBinding`s that would otherwise keep cluster-wide permissions.
- Reject authenticated namespace-less API identities while namespace isolation is enabled; context tokens map `tctx.namespace` and OIDC tokens can map a `namespace` claim.

### Testing
- `make lint-fix`
- `make test`
- `helm lint charts/orka`
- `helm template` validation for default isolated, watched-namespace isolated, and explicitly unisolated chart renders
- `kubectl kustomize config/default` validation for transformed worker ClusterRole `bind` resource names
- `$autoreview` clean after addressing the accepted finding about stale managed worker ClusterRoleBinding cleanup

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c2f0e5258832a87340821603ccdac)
