### PR TITLE
Authorize Kubernetes API task access

### DIFF
--- a/charts/orka/templates/rbac.yaml
+++ b/charts/orka/templates/rbac.yaml
@@ -117,6 +117,11 @@ rules:
     resources: ["tokenreviews"]
     verbs: ["create"]
 
+  # SubjectAccessReview for API request authorization
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
+
   # Leader election
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -469,6 +469,9 @@ func (h *Handlers) CreateTask(c fiber.Ctx) error {
 	if err := h.authorizeContextTokenTaskCreate(c, authReq, namespace); err != nil {
 		return err
 	}
+	if err := h.authorizeKubernetesTaskAccess(c, "create", namespace, name); err != nil {
+		return err
+	}
 
 	stampTaskRequesterFromUserInfo(task, GetUserInfo(c))
 
@@ -507,6 +510,9 @@ func (h *Handlers) ListTasks(c fiber.Ctx) error {
 	}
 	opts.Namespace = namespace
 	if err := h.authorizeContextTokenAction(c, "listTasks", h.contextTokenAuthorization.TaskListScopes); err != nil {
+		return err
+	}
+	if err := h.authorizeKubernetesTaskAccess(c, "list", namespace, ""); err != nil {
 		return err
 	}
 
@@ -571,6 +577,9 @@ func (h *Handlers) GetTask(c fiber.Ctx) error {
 	if err := h.authorizeContextTokenTaskRead(c, "getTask", namespace, id); err != nil {
 		return err
 	}
+	if err := h.authorizeKubernetesTaskAccess(c, "get", namespace, id); err != nil {
+		return err
+	}
 
 	task := &corev1alpha1.Task{}
 	ctx := c.Context()
@@ -623,6 +632,9 @@ func (h *Handlers) DeleteTask(c fiber.Ctx) error {
 	if err := h.authorizeContextTokenAction(c, "deleteTask", h.contextTokenAuthorization.TaskDeleteScopes); err != nil {
 		return err
 	}
+	if err := h.authorizeKubernetesTaskAccess(c, "delete", namespace, id); err != nil {
+		return err
+	}
 
 	task := &corev1alpha1.Task{}
 	ctx := c.Context()
@@ -651,6 +663,9 @@ func (h *Handlers) GetTaskLogs(c fiber.Ctx) error {
 		return err
 	}
 	if err := h.authorizeContextTokenTaskRead(c, "getTaskLogs", namespace, id); err != nil {
+		return err
+	}
+	if err := h.authorizeKubernetesTaskAccess(c, "get", namespace, id); err != nil {
 		return err
 	}
 
@@ -765,6 +780,9 @@ func (h *Handlers) GetTaskResult(c fiber.Ctx) error {
 	if err := h.authorizeContextTokenTaskRead(c, "getTaskResult", namespace, id); err != nil {
 		return err
 	}
+	if err := h.authorizeKubernetesTaskAccess(c, "get", namespace, id); err != nil {
+		return err
+	}
 
 	task := &corev1alpha1.Task{}
 	ctx := c.Context()
@@ -803,6 +821,9 @@ func (h *Handlers) GetTaskPlan(c fiber.Ctx) error {
 		return err
 	}
 	if err := h.authorizeContextTokenTaskRead(c, "getTaskPlan", namespace, id); err != nil {
+		return err
+	}
+	if err := h.authorizeKubernetesTaskAccess(c, "get", namespace, id); err != nil {
 		return err
 	}
 
@@ -1552,6 +1573,9 @@ func (h *Handlers) GetTaskChildren(c fiber.Ctx) error {
 	if err := h.authorizeContextTokenTaskRead(c, "getTaskChildren", namespace, taskName); err != nil {
 		return err
 	}
+	if err := h.authorizeKubernetesTaskAccess(c, "get", namespace, taskName); err != nil {
+		return err
+	}
 
 	ctx := c.Context()
 	if h.contextTokenAuthorization.Enabled() {
@@ -1607,6 +1631,9 @@ func (h *Handlers) ListTaskArtifacts(c fiber.Ctx) error {
 	if err := h.authorizeContextTokenTaskRead(c, "listTaskArtifacts", namespace, id); err != nil {
 		return err
 	}
+	if err := h.authorizeKubernetesTaskAccess(c, "get", namespace, id); err != nil {
+		return err
+	}
 
 	task := &corev1alpha1.Task{}
 	ctx := c.Context()
@@ -1645,6 +1672,9 @@ func (h *Handlers) DownloadTaskArtifact(c fiber.Ctx) error {
 		return err
 	}
 	if err := h.authorizeContextTokenTaskRead(c, "downloadTaskArtifact", namespace, id); err != nil {
+		return err
+	}
+	if err := h.authorizeKubernetesTaskAccess(c, "get", namespace, id); err != nil {
 		return err
 	}
 

--- a/internal/api/kubernetes_authorization.go
+++ b/internal/api/kubernetes_authorization.go
@@ -1,0 +1,78 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gofiber/fiber/v3"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const taskResourceGroup = "core.orka.ai"
+
+func (h *Handlers) authorizeKubernetesTaskAccess(c fiber.Ctx, verb, namespace, name string) error {
+	ui := GetUserInfo(c)
+	if ui == nil || h.client == nil {
+		return nil
+	}
+	if ui.AuthType != AuthTypeTokenReview && ui.AuthType != AuthTypeOIDC {
+		return nil
+	}
+
+	allowed, reason, err := h.subjectAccessReview(c.Context(), ui, authorizationv1.ResourceAttributes{
+		Group:     taskResourceGroup,
+		Resource:  "tasks",
+		Verb:      verb,
+		Namespace: namespace,
+		Name:      name,
+	})
+	if err != nil {
+		log.Error(err, "kubernetes authorization check failed", "username", ui.Username, "verb", verb, "namespace", namespace, "task", name)
+		return fiber.NewError(fiber.StatusForbidden, "task access denied")
+	}
+	if !allowed {
+		log.Info("kubernetes authorization denied task access", "username", ui.Username, "verb", verb, "namespace", namespace, "task", name, "reason", reason)
+		return fiber.NewError(fiber.StatusForbidden, "task access denied")
+	}
+
+	return nil
+}
+
+func (h *Handlers) subjectAccessReview(ctx context.Context, ui *UserInfo, attrs authorizationv1.ResourceAttributes) (bool, string, error) {
+	sar := &authorizationv1.SubjectAccessReview{
+		ObjectMeta: metav1.ObjectMeta{Name: "orka-api-authorization"},
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			User:               ui.Username,
+			Groups:             ui.Groups,
+			Extra:              authorizationExtra(ui.Extra),
+			ResourceAttributes: &attrs,
+		},
+	}
+	if err := h.client.Create(ctx, sar); err != nil {
+		return false, "", fmt.Errorf("create SubjectAccessReview: %w", err)
+	}
+	return sar.Status.Allowed, sar.Status.Reason, nil
+}
+
+func authorizationExtra(extra map[string]authenticationv1.ExtraValue) map[string]authorizationv1.ExtraValue {
+	if len(extra) == 0 {
+		return nil
+	}
+	copied := make(map[string]authorizationv1.ExtraValue, len(extra))
+	for k, v := range extra {
+		values := make(authorizationv1.ExtraValue, len(v))
+		for i, value := range v {
+			values[i] = value
+		}
+		copied[k] = values
+	}
+	return copied
+}

--- a/internal/api/kubernetes_authorization_test.go
+++ b/internal/api/kubernetes_authorization_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package api
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/require"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestAuthorizeKubernetesTaskAccess_SubjectAccessReviewAllowed(t *testing.T) {
+	handlers, app := setupSubjectAccessReviewTestHandlers(t, true)
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Locals(UserInfoContextKey, &UserInfo{
+			Username:  "system:serviceaccount:team-a:caller",
+			Groups:    []string{"system:serviceaccounts", "system:serviceaccounts:team-a"},
+			Extra:     map[string]authenticationv1.ExtraValue{"authentication.kubernetes.io/pod-name": {"caller"}},
+			AuthType:  AuthTypeTokenReview,
+			Namespace: "team-a",
+		})
+		return handlers.authorizeKubernetesTaskAccess(c, "create", "team-a", "task-a")
+	})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+}
+
+func TestAuthorizeKubernetesTaskAccess_SubjectAccessReviewDenied(t *testing.T) {
+	handlers, app := setupSubjectAccessReviewTestHandlers(t, false)
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Locals(UserInfoContextKey, &UserInfo{Username: "system:serviceaccount:team-a:caller", AuthType: AuthTypeTokenReview})
+		return handlers.authorizeKubernetesTaskAccess(c, "create", "team-b", "task-a")
+	})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+}
+
+func setupSubjectAccessReviewTestHandlers(t *testing.T, allowed bool) (*Handlers, *fiber.App) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, authorizationv1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if sar, ok := obj.(*authorizationv1.SubjectAccessReview); ok {
+					require.Equal(t, "system:serviceaccount:team-a:caller", sar.Spec.User)
+					require.NotNil(t, sar.Spec.ResourceAttributes)
+					require.Equal(t, "core.orka.ai", sar.Spec.ResourceAttributes.Group)
+					require.Equal(t, "tasks", sar.Spec.ResourceAttributes.Resource)
+					require.Equal(t, "create", sar.Spec.ResourceAttributes.Verb)
+					sar.Status.Allowed = allowed
+					if !allowed {
+						sar.Status.Reason = "denied by test"
+					}
+					return nil
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		}).Build()
+
+	return NewHandlers(HandlersConfig{Client: fakeClient}), fiber.New()
+}

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -147,6 +147,7 @@ type TaskReconciler struct {
 // +kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxwarmpools,verbs=get;list;watch
 // +kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods/portforward,verbs=create
+// +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 // +kubebuilder:rbac:groups=metrics.k8s.io,resources=pods;nodes,verbs=get;list
 
 // updateStatusWithRetry updates the task status with retry on conflict.


### PR DESCRIPTION
### Motivation
- Fix an authorization bypass where any valid Kubernetes bearer token (validated via `TokenReview`) could be used to perform privileged task operations through the controller client without a per-resource authorization decision.
- Ensure the API enforces Kubernetes RBAC semantics for `core.orka.ai/tasks` so callers can only create/list/get/delete tasks they are allowed to manage.
- Preserve existing context-token-based authorization paths while preventing TokenReview-only or OIDC-authenticated callers from acting as a confused deputy.

### Description
- Add a Kubernetes `SubjectAccessReview` helper in `internal/api/kubernetes_authorization.go` that implements `authorizeKubernetesTaskAccess` and `subjectAccessReview` to check per-resource verbs (`create`, `get`, `list`, `delete`, etc.) against `core.orka.ai/tasks` using the caller identity and extras.
- Wire the authorization check into task handlers in `internal/api/handlers.go` to call `authorizeKubernetesTaskAccess` for `CreateTask`, `ListTasks`, `GetTask`, `DeleteTask`, and task-adjacent read endpoints such as logs, results, plans, children, and artifacts.
- Grant the controller permission to create `SubjectAccessReview` in Helm RBAC (`charts/orka/templates/rbac.yaml`) and add the corresponding kubebuilder RBAC marker in `internal/controller/task_controller.go` so generated manifests include the new permission.
- Add focused unit tests in `internal/api/kubernetes_authorization_test.go` that exercise SAR allow/deny behavior using a fake client interceptor and verify the generated `SubjectAccessReview` resource attributes.

### Testing
- Ran `git diff --check` which succeeded locally.
- Attempted `make manifests generate` but it was blocked because the environment could not download the Go 1.26.2 toolchain from `proxy.golang.org` so controller-gen/type generation could not run.
- Attempted `make lint-fix && make test` and `GOTOOLCHAIN=local go test ./internal/api -run TestAuthorizeKubernetesTaskAccess` but both were blocked due to Go toolchain/version constraints (`go.mod` requires Go 1.26.2 while local/toolchain downloads were unavailable or the local Go is 1.25.1).
- Attempted to run the repo-local `autoreview` check but it could not complete in this environment because the `codex` executable is not installed; therefore the required structured closeout review could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c495724dc832a96638addb91c98d9)