### PR TITLE
fix: block chat access to system namespace

### DIFF
--- a/internal/api/chat.go
+++ b/internal/api/chat.go
@@ -143,8 +143,9 @@ func NewChatHandler(c client.Client, sm *controller.SessionManager, config ChatC
 
 // blockedNamespaces that cannot be targeted by chat requests.
 var blockedNamespaces = map[string]bool{
-	"kube-system": true,
-	"kube-public": true,
+	"kube-system":   true,
+	"kube-public":   true,
+	"mercan-system": true,
 }
 
 // HandleChat handles POST /api/v1/chat.

--- a/internal/api/chat_test.go
+++ b/internal/api/chat_test.go
@@ -1044,21 +1044,25 @@ func TestHandleChat(t *testing.T) {
 	})
 
 	t.Run("blocked namespace returns 403", func(t *testing.T) {
-		objs := providerCRD("default", "default", "test-type", "test-model")
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
-		ss := newTestSessionStore(t)
-		rs := newTestResultStore(t)
-		ch := newTestChatHandler(t, fakeClient, ss, rs, DefaultChatConfig())
+		for _, namespace := range []string{"kube-system", "kube-public", "mercan-system"} {
+			t.Run(namespace, func(t *testing.T) {
+				objs := providerCRD("default", "default", "test-type", "test-model")
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+				ss := newTestSessionStore(t)
+				rs := newTestResultStore(t)
+				ch := newTestChatHandler(t, fakeClient, ss, rs, DefaultChatConfig())
 
-		app := fiber.New()
-		app.Post("/api/v1/chat", ch.HandleChat)
+				app := fiber.New()
+				app.Post("/api/v1/chat", ch.HandleChat)
 
-		body, _ := json.Marshal(ChatRequest{Message: "hello", Namespace: "kube-system"})
-		req := httptest.NewRequest(http.MethodPost, "/api/v1/chat", bytes.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req)
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+				body, _ := json.Marshal(ChatRequest{Message: "hello", Namespace: namespace})
+				req := httptest.NewRequest(http.MethodPost, "/api/v1/chat", bytes.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				resp, err := app.Test(req)
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+			})
+		}
 	})
 
 	t.Run("namespace mismatch with watch namespace returns 403", func(t *testing.T) {


### PR DESCRIPTION
### Motivation
- The chat endpoint could be used to create (including scheduled/recurring) Tasks in Orka's control-plane namespace because `mercan-system` was removed from the chat denylist and the chat path does not perform per-namespace RBAC; this change restores protection for that high-value namespace.

### Description
- Re-added `"mercan-system"` to the `blockedNamespaces` map in `internal/api/chat.go` to prevent chat-created tasks targeting the control namespace.
- Extended the `TestHandleChat` blocked-namespace unit test in `internal/api/chat_test.go` to assert that `kube-system`, `kube-public`, and `mercan-system` each return HTTP 403 for chat requests.
- No other task creation, scheduling, or controller behavior was modified.

### Testing
- `git diff --check` was run and passed.
- `go test ./internal/api/ -run 'TestHandleChat/blocked_namespace_returns_403' -v` was attempted but timed out in this environment and did not complete.
- `make lint-fix` and `make test` could not complete because required tools failed to download from `proxy.golang.org` (Forbidden) in this environment.
- Pre-land `autoreview` was attempted but could not run because the `codex` executable is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c424e3b34832aa7b8d940943afcc8)