### PR TITLE
fix: bind coordination waits to child tasks and tighten worker RBAC

### DIFF
--- a/config/rbac/worker_role.yaml
+++ b/config/rbac/worker_role.yaml
@@ -22,7 +22,9 @@ kind: ClusterRole
 metadata:
   name: ai-worker-role
 rules:
-# ConfigMaps: skills/session lookup and namespace-scoped code_exec result persistence
+# ConfigMaps: skills/session lookup and namespace-scoped code_exec result persistence.
+# Avoid list/watch from worker pods so a compromised worker cannot enumerate
+# namespace result ConfigMaps.
 - apiGroups:
   - ""
   resources:
@@ -31,8 +33,6 @@ rules:
   - create
   - delete
   - get
-  - list
-  - watch
 # Secrets: read existing credentials and create ephemeral code_exec code Secrets
 - apiGroups:
   - ""
@@ -61,15 +61,14 @@ rules:
   - create
   - update
   - delete
-# Orka Task CRDs (for coordination - delegate and wait)
+# Orka Task CRDs (for coordination - delegate and wait). Do not grant
+# list/watch: coordination tools must operate only on explicit child task names.
 - apiGroups:
   - core.orka.ai
   resources:
   - tasks
   verbs:
   - get
-  - list
-  - watch
   - create
   - patch
   - delete
@@ -257,15 +256,14 @@ kind: ClusterRole
 metadata:
   name: vendor-worker-role
 rules:
-# ConfigMaps: read-only (skills, non-secret lookup)
+# ConfigMaps: read-only (skills, non-secret lookup). Avoid list/watch from
+# worker pods so result ConfigMaps cannot be enumerated.
 - apiGroups:
   - ""
   resources:
   - configmaps
   verbs:
   - get
-  - list
-  - watch
 # Orka Tool CRDs
 - apiGroups:
   - core.orka.ai
@@ -284,15 +282,14 @@ rules:
   - create
   - update
   - delete
-# Orka Task CRDs (for coordination - delegate and wait)
+# Orka Task CRDs (for coordination - delegate and wait). Do not grant
+# list/watch: coordination tools must operate only on explicit child task names.
 - apiGroups:
   - core.orka.ai
   resources:
   - tasks
   verbs:
   - get
-  - list
-  - watch
   - create
   - patch
   - delete

--- a/internal/tools/wait_for_tasks.go
+++ b/internal/tools/wait_for_tasks.go
@@ -134,6 +134,11 @@ func (t *WaitForTasksTool) Execute(ctx context.Context, args json.RawMessage) (s
 		return "", fmt.Errorf("%s environment variable is not set", envOrkaTaskNamespace)
 	}
 
+	parentTaskName := os.Getenv(envOrkaTaskName)
+	if parentTaskName == "" {
+		return "", fmt.Errorf("%s environment variable is not set", envOrkaTaskName)
+	}
+
 	deadline := time.Now().Add(timeout)
 	pollInterval := 5 * time.Second
 	ticker := time.NewTicker(pollInterval)
@@ -156,6 +161,12 @@ func (t *WaitForTasksTool) Execute(ctx context.Context, args json.RawMessage) (s
 			if err != nil {
 				results[taskName].Phase = taskPhaseErrorString
 				results[taskName].Result = fmt.Sprintf("error: %v", err)
+				continue
+			}
+
+			if !isWaitForTasksChildOfParent(&task, parentTaskName) {
+				results[taskName].Phase = taskPhaseErrorString
+				results[taskName].Result = "error: task is not a child of the current coordinator"
 				continue
 			}
 
@@ -262,6 +273,24 @@ func (t *WaitForTasksTool) Execute(ctx context.Context, args json.RawMessage) (s
 
 // Ensure WaitForTasksTool implements Tool
 var _ Tool = (*WaitForTasksTool)(nil)
+
+func isWaitForTasksChildOfParent(task *corev1alpha1.Task, parentTaskName string) bool {
+	if task == nil || parentTaskName == "" {
+		return false
+	}
+	if task.Annotations[labels.AnnotationParentTaskName] == parentTaskName {
+		return true
+	}
+	if task.Labels[labels.LabelParentTask] == labels.SelectorValue(parentTaskName) {
+		return true
+	}
+	for _, owner := range task.OwnerReferences {
+		if owner.APIVersion == corev1alpha1.GroupVersion.String() && owner.Kind == taskKindString && owner.Name == parentTaskName {
+			return true
+		}
+	}
+	return false
+}
 
 func truncateWaitTaskSummary(summary string) string {
 	if len(summary) <= maxWaitTaskSummaryChars {

--- a/internal/tools/wait_for_tasks_test.go
+++ b/internal/tools/wait_for_tasks_test.go
@@ -55,6 +55,17 @@ func TestWaitForTasksTool_Parameters(t *testing.T) {
 	}
 }
 
+func markWaitTestTaskAsChild(task *corev1alpha1.Task, parent string) {
+	if task.Labels == nil {
+		task.Labels = map[string]string{}
+	}
+	if task.Annotations == nil {
+		task.Annotations = map[string]string{}
+	}
+	task.Labels[labels.LabelParentTask] = labels.SelectorValue(parent)
+	task.Annotations[labels.AnnotationParentTaskName] = parent
+}
+
 func TestWaitForTasksTool_Execute(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -171,6 +182,7 @@ func TestWaitForTasksTool_Execute(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envOrkaTaskName, parentTaskName)
 			t.Setenv(envOrkaTaskNamespace, testNamespace)
 
 			// Set up HTTP test server for result fetching
@@ -199,6 +211,7 @@ func TestWaitForTasksTool_Execute(t *testing.T) {
 			scheme := newTestScheme()
 			objs := make([]client.Object, 0, len(tt.tasks))
 			for i := range tt.tasks {
+				markWaitTestTaskAsChild(&tt.tasks[i], parentTaskName)
 				objs = append(objs, &tt.tasks[i])
 			}
 
@@ -309,6 +322,7 @@ func TestWaitForTasksTool_Execute_TruncatesLongStructuredSummary(t *testing.T) {
 	defer server.Close()
 
 	t.Setenv(envOrkaTaskNamespace, defaultNamespace)
+	t.Setenv(envOrkaTaskName, parentTaskName)
 	t.Setenv(envOrkaControllerURL, server.URL)
 
 	task := &corev1alpha1.Task{
@@ -318,6 +332,8 @@ func TestWaitForTasksTool_Execute_TruncatesLongStructuredSummary(t *testing.T) {
 			ResultRef: &corev1alpha1.ResultReference{Available: true},
 		},
 	}
+
+	markWaitTestTaskAsChild(task, parentTaskName)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(newTestScheme()).
@@ -381,6 +397,7 @@ func TestWaitForTasksTool_Execute_StructuredResult(t *testing.T) {
 	defer server.Close()
 
 	t.Setenv(envOrkaTaskNamespace, defaultNamespace)
+	t.Setenv(envOrkaTaskName, parentTaskName)
 	t.Setenv(envOrkaControllerURL, server.URL)
 
 	task := &corev1alpha1.Task{
@@ -400,6 +417,8 @@ func TestWaitForTasksTool_Execute_StructuredResult(t *testing.T) {
 			ResultRef: &corev1alpha1.ResultReference{Available: true},
 		},
 	}
+
+	markWaitTestTaskAsChild(task, parentTaskName)
 
 	scheme := newTestScheme()
 	fakeClient := fake.NewClientBuilder().
@@ -461,6 +480,7 @@ func TestWaitForTasksTool_Execute_StructuredResult(t *testing.T) {
 
 func TestWaitForTasksTool_Execute_AutoRetry(t *testing.T) {
 	t.Setenv(envOrkaTaskNamespace, testNamespace)
+	t.Setenv(envOrkaTaskName, parentTaskName)
 
 	// Create a failed task with auto-retry annotations
 	failedTask := &corev1alpha1.Task{
@@ -494,6 +514,8 @@ func TestWaitForTasksTool_Execute_AutoRetry(t *testing.T) {
 	}))
 	defer srv.Close()
 	t.Setenv(envOrkaControllerURL, srv.URL)
+
+	markWaitTestTaskAsChild(failedTask, parentTaskName)
 
 	scheme := newTestScheme()
 	fakeClient := fake.NewClientBuilder().
@@ -560,6 +582,7 @@ func TestWaitForTasksTool_Execute_AutoRetry(t *testing.T) {
 
 func TestWaitForTasksTool_Execute_AutoRetryExhausted(t *testing.T) {
 	t.Setenv(envOrkaTaskNamespace, testNamespace)
+	t.Setenv(envOrkaTaskName, parentTaskName)
 
 	// Task with retries already exhausted
 	failedTask := &corev1alpha1.Task{
@@ -589,6 +612,8 @@ func TestWaitForTasksTool_Execute_AutoRetryExhausted(t *testing.T) {
 	}))
 	defer srv.Close()
 	t.Setenv(envOrkaControllerURL, srv.URL)
+
+	markWaitTestTaskAsChild(failedTask, parentTaskName)
 
 	scheme := newTestScheme()
 	fakeClient := fake.NewClientBuilder().
@@ -647,6 +672,7 @@ func TestWaitForTasksTool_Execute_AutoRetryExhausted(t *testing.T) {
 
 func TestWaitForTasksTool_Execute_NoAutoRetryOnSuccess(t *testing.T) {
 	t.Setenv(envOrkaTaskNamespace, testNamespace)
+	t.Setenv(envOrkaTaskName, parentTaskName)
 
 	// Succeeded task with auto-retry — should NOT trigger retry
 	succeededTask := &corev1alpha1.Task{
@@ -674,6 +700,8 @@ func TestWaitForTasksTool_Execute_NoAutoRetryOnSuccess(t *testing.T) {
 	}))
 	defer srv.Close()
 	t.Setenv(envOrkaControllerURL, srv.URL)
+
+	markWaitTestTaskAsChild(succeededTask, parentTaskName)
 
 	scheme := newTestScheme()
 	fakeClient := fake.NewClientBuilder().
@@ -708,6 +736,7 @@ func TestWaitForTasksTool_Execute_NoAutoRetryOnSuccess(t *testing.T) {
 
 func TestWaitForTasksTool_Execute_FetchResultNon200(t *testing.T) {
 	t.Setenv(envOrkaTaskNamespace, testNamespace)
+	t.Setenv(envOrkaTaskName, parentTaskName)
 
 	// Server returns 500 for result fetch
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -728,6 +757,8 @@ func TestWaitForTasksTool_Execute_FetchResultNon200(t *testing.T) {
 			ResultRef: &corev1alpha1.ResultReference{Available: true},
 		},
 	}
+
+	markWaitTestTaskAsChild(task, parentTaskName)
 
 	scheme := newTestScheme()
 	fakeClient := fake.NewClientBuilder().
@@ -757,6 +788,7 @@ func TestWaitForTasksTool_Execute_FetchResultNon200(t *testing.T) {
 
 func TestWaitForTasksTool_Execute_FetchResultInvalidJSON(t *testing.T) {
 	t.Setenv(envOrkaTaskNamespace, testNamespace)
+	t.Setenv(envOrkaTaskName, parentTaskName)
 
 	// Server returns 200 but invalid JSON
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -777,6 +809,8 @@ func TestWaitForTasksTool_Execute_FetchResultInvalidJSON(t *testing.T) {
 			ResultRef: &corev1alpha1.ResultReference{Available: true},
 		},
 	}
+
+	markWaitTestTaskAsChild(task, parentTaskName)
 
 	scheme := newTestScheme()
 	fakeClient := fake.NewClientBuilder().
@@ -806,6 +840,7 @@ func TestWaitForTasksTool_Execute_FetchResultInvalidJSON(t *testing.T) {
 
 func TestWaitForTasksTool_Execute_FallbackToMessage(t *testing.T) {
 	t.Setenv(envOrkaTaskNamespace, testNamespace)
+	t.Setenv(envOrkaTaskName, parentTaskName)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
@@ -825,6 +860,8 @@ func TestWaitForTasksTool_Execute_FallbackToMessage(t *testing.T) {
 			Message: "completed with warnings",
 		},
 	}
+
+	markWaitTestTaskAsChild(task, parentTaskName)
 
 	scheme := newTestScheme()
 	fakeClient := fake.NewClientBuilder().
@@ -849,5 +886,56 @@ func TestWaitForTasksTool_Execute_FallbackToMessage(t *testing.T) {
 	}
 	if waitResult.Results[0].Result != "completed with warnings" {
 		t.Errorf("expected message fallback, got %q", waitResult.Results[0].Result)
+	}
+}
+
+func TestWaitForTasksTool_ExecuteRejectsNonChildTask(t *testing.T) {
+	t.Setenv(envOrkaTaskName, parentTaskName)
+	t.Setenv(envOrkaTaskNamespace, testNamespace)
+	t.Setenv(envOrkaControllerURL, "http://127.0.0.1:1")
+
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testTaskAName,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				labels.LabelParentTask: labels.SelectorValue("other-parent"),
+			},
+			Annotations: map[string]string{
+				labels.AnnotationParentTaskName: "other-parent",
+			},
+		},
+		Status: corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseSucceeded},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(newTestScheme()).
+		WithObjects(task).
+		WithStatusSubresource(&corev1alpha1.Task{}).
+		Build()
+
+	tool := NewWaitForTasksTool(fakeClient)
+	argsJSON, err := json.Marshal(WaitForTasksArgs{Tasks: []string{testTaskAName}, Timeout: shortPollIntervalString})
+	if err != nil {
+		t.Fatalf("failed to marshal args: %v", err)
+	}
+
+	result, err := tool.Execute(context.Background(), argsJSON)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got WaitForTasksResult
+	if err := json.Unmarshal([]byte(result), &got); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(got.Results))
+	}
+	if got.Results[0].Phase != taskPhaseErrorString {
+		t.Fatalf("phase = %q, want %q", got.Results[0].Phase, taskPhaseErrorString)
+	}
+	if !strings.Contains(got.Results[0].Result, "not a child") {
+		t.Fatalf("result = %q, want child authorization error", got.Results[0].Result)
 	}
 }


### PR DESCRIPTION
### Motivation
- Close an authorization gap that let worker pods enumerate ConfigMaps and Tasks and allowed coordination tools to read or follow arbitrary Tasks in the namespace. 
- Prevent compromised or prompt-injected worker code from bypassing controller-side coordination guardrails and reading/exfiltrating other tasks' results. 
- Ensure `wait_for_tasks` only returns results for tasks that are provably children of the current coordinator task.

### Description
- Remove `list`/`watch` verbs for `configmaps` and `tasks` in worker ClusterRole entries so worker pods cannot enumerate namespace ConfigMaps or Tasks and only keep the explicit per-Task operations needed by tools. (file: `config/rbac/worker_role.yaml`) 
- Require the coordinator task identity in worker env and add a child-ownership check to `wait_for_tasks` so it rejects any requested task that is not bound to the coordinator via the parent annotation, parent label, or ownerReference. (file: `internal/tools/wait_for_tasks.go`) 
- Add a helper `isWaitForTasksChildOfParent` and update `wait_for_tasks` to fail non-child requests with a clear error. (file: `internal/tools/wait_for_tasks.go`) 
- Update unit test fixtures and add a new test to assert non-child tasks are rejected, and adjust existing wait tests to set the coordinator env and mark fixtures as children. (file: `internal/tools/wait_for_tasks_test.go`)

### Testing
- `git diff --check` produced no whitespace or diff-check errors. (success) 
- Focused unit tests for the tools package were attempted with `go test ./internal/tools -run 'TestWaitForTasksTool'` but could not complete because the environment Go version is older than the `go.mod` requirement (local Go 1.25.1 vs required >= 1.26.2). (blocked)
- The repository-local `autoreview` helper was invoked but could not finish because the `codex` review executable is not available in this environment. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c415d3678832aa0dd33a61dc15ef8)