### PR TITLE
feat(telemetry): add task trace topology

### DIFF
--- a/cmd/orka-agent-harness-wrapper/main.go
+++ b/cmd/orka-agent-harness-wrapper/main.go
@@ -9,7 +9,10 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
+	"github.com/sozercan/orka/internal/tracing"
+	"github.com/sozercan/orka/internal/workerenv"
 	"github.com/sozercan/orka/workers/harness/cliwrapper"
 )
 
@@ -91,6 +94,19 @@ func run(args []string) error {
 		cfg.Claude.WorkDir = cfg.WorkDir
 		cfg.Copilot.WorkDir = cfg.WorkDir
 	}
+	telemetryEnabled := workerenv.IsTrue(os.Getenv(workerenv.EnableTelemetry))
+	tracingShutdown, err := tracing.Init("orka-agent-harness-wrapper", telemetryEnabled)
+	if err != nil {
+		return fmt.Errorf("failed to initialize telemetry: %w", err)
+	}
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if shutdownErr := tracingShutdown(shutdownCtx); shutdownErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to shutdown telemetry: %v\n", shutdownErr)
+		}
+	}()
+
 	adapter, err := cliwrapper.NewRuntimeAdapter(cfg)
 	if err != nil {
 		return err

--- a/internal/api/chat.go
+++ b/internal/api/chat.go
@@ -439,7 +439,11 @@ func (ch *ChatHandler) runToolLoop(
 	for iteration := 0; ; iteration++ {
 		iterTracer := tracing.Tracer("orka.chat")
 		iterCtx, iterSpan := iterTracer.Start(ctx, "chat.tool_loop.iteration",
-			trace.WithAttributes(attribute.Int("chat.iteration", iteration)),
+			trace.WithAttributes(
+				attribute.Int("chat.iteration", iteration),
+				attribute.String(tracing.AttrTenant, namespace),
+				attribute.String(genai.AttrRequestModel, model),
+			),
 		)
 
 		select {
@@ -476,6 +480,7 @@ func (ch *ChatHandler) runToolLoop(
 			iterSpan.End()
 			return "", usage, allToolCalls, fmt.Errorf("LLM completion failed: %w", err)
 		}
+		iterSpan.SetAttributes(attribute.Int("chat.tool_call_count", len(resp.ToolCalls)))
 		usage.LLMCalls++
 		usage.InputTokens += resp.InputTokens
 		usage.OutputTokens += resp.OutputTokens

--- a/internal/controller/harness_wrapper.go
+++ b/internal/controller/harness_wrapper.go
@@ -852,7 +852,16 @@ func (r *TaskReconciler) harnessWrapperTurnMetadata(
 		"wrapper":  "cli",
 		"maxTurns": "50",
 	}
+	if task != nil && task.Annotations != nil {
+		if traceparent := strings.TrimSpace(task.Annotations[labels.AnnotationTraceParent]); traceparent != "" {
+			metadata["traceparent"] = traceparent
+		}
+		if tracestate := strings.TrimSpace(task.Annotations[labels.AnnotationTraceState]); tracestate != "" {
+			metadata["tracestate"] = tracestate
+		}
+	}
 	if agent != nil {
+		metadata["agentName"] = agent.Name
 		if agent.Spec.Model != nil && strings.TrimSpace(agent.Spec.Model.Name) != "" {
 			metadata["model"] = strings.TrimSpace(agent.Spec.Model.Name)
 		}
@@ -1136,6 +1145,11 @@ func (r *TaskReconciler) harnessWrapperBaseTurnEnv(ctx context.Context, task *co
 			priorNS = task.Namespace
 		}
 		env = append(env, harness.TurnEnvVar{Name: workerenv.PriorTaskNamespace, Value: priorNS})
+	}
+	if task.Annotations != nil {
+		if traceparent := strings.TrimSpace(task.Annotations[labels.AnnotationTraceParent]); traceparent != "" {
+			env = setHarnessTurnEnv(env, workerenv.TraceParent, traceparent)
+		}
 	}
 	if parentTask := labels.ParentTaskName(task.Labels, task.Annotations); parentTask != "" {
 		env = append(env, harness.TurnEnvVar{Name: workerenv.ParentTask, Value: parentTask})

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -570,13 +570,17 @@ func (b *JobBuilder) buildEnvVars(ctx context.Context, task *corev1alpha1.Task, 
 
 // buildEnvVarsWithOptions builds the environment variables for the container using additional options.
 func (b *JobBuilder) buildEnvVarsWithOptions(ctx context.Context, task *corev1alpha1.Task, agent *corev1alpha1.Agent, provider *corev1alpha1.Provider, opts JobBuildOptions) []corev1.EnvVar {
-	envVars := workerenv.BaseEnv{
+	baseEnv := workerenv.BaseEnv{
 		TaskName:       task.Name,
 		TaskNamespace:  task.Namespace,
 		TaskUID:        string(task.UID),
 		ResultEndpoint: fmt.Sprintf("%s/internal/v1/results/%s/%s", b.ControllerURL, task.Namespace, task.Name),
 		ControllerURL:  b.ControllerURL,
-	}.EnvVars()
+	}
+	if agent != nil {
+		baseEnv.AgentName = agent.Name
+	}
+	envVars := baseEnv.EnvVars()
 	if taskRequestsReadOnlyAgent(task) {
 		envVars = setControllerEnv(envVars, workerenv.ResultStdout, scheduledRunLabelValue)
 	}
@@ -591,6 +595,9 @@ func (b *JobBuilder) buildEnvVarsWithOptions(ctx context.Context, task *corev1al
 	envVars = setControllerEnv(envVars, workerenv.TaskName, task.Name)
 	envVars = setControllerEnv(envVars, workerenv.TaskNamespace, task.Namespace)
 	envVars = setControllerEnv(envVars, workerenv.TaskUID, string(task.UID))
+	if agent != nil {
+		envVars = setControllerEnv(envVars, workerenv.AgentName, agent.Name)
+	}
 	envVars = setControllerEnv(envVars, workerenv.ResultEndpoint, fmt.Sprintf("%s/internal/v1/results/%s/%s", b.ControllerURL, task.Namespace, task.Name))
 	envVars = setControllerEnv(envVars, workerenv.ControllerURL, b.ControllerURL)
 	envVars = setControllerEnvValue(envVars, workerenv.AITools, "")
@@ -811,7 +818,7 @@ func appendTaskEnvVars(envVars []corev1.EnvVar, task *corev1alpha1.Task) []corev
 		return envVars
 	}
 	for _, envVar := range task.Spec.Env {
-		if task.Spec.Type == corev1alpha1.TaskTypeAI && isReservedAIWorkerTelemetryEnv(envVar.Name) {
+		if isReservedTaskTelemetryEnv(task, envVar.Name) {
 			continue
 		}
 		envVars = append(envVars, envVar)
@@ -819,12 +826,38 @@ func appendTaskEnvVars(envVars []corev1.EnvVar, task *corev1alpha1.Task) []corev
 	return envVars
 }
 
+func isReservedTaskTelemetryEnv(task *corev1alpha1.Task, name string) bool {
+	if task == nil {
+		return false
+	}
+	switch task.Spec.Type {
+	case corev1alpha1.TaskTypeAI:
+		return isReservedAIWorkerTelemetryEnv(name)
+	case corev1alpha1.TaskTypeAgent:
+		return isReservedTraceContextEnv(name)
+	default:
+		return false
+	}
+}
+
 func isReservedAIWorkerTelemetryEnv(name string) bool {
+	if isReservedTraceContextEnv(name) {
+		return true
+	}
 	switch name {
-	case workerenv.EnableTelemetry, workerenv.TraceParent, workerenv.TraceState, workerenv.TraceBaggage, "OTEL_RESOURCE_ATTRIBUTES":
+	case workerenv.EnableTelemetry, "OTEL_RESOURCE_ATTRIBUTES":
 		return true
 	default:
 		return strings.HasPrefix(name, "OTEL_EXPORTER_OTLP")
+	}
+}
+
+func isReservedTraceContextEnv(name string) bool {
+	switch name {
+	case workerenv.TraceParent, workerenv.TraceState, workerenv.TraceBaggage:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -1293,8 +1326,11 @@ func (b *JobBuilder) addSecretVolumes(ctx context.Context, job *batchv1.Job, tas
 				},
 			},
 		)
-		if task.Spec.Type == corev1alpha1.TaskTypeAI {
+		switch task.Spec.Type {
+		case corev1alpha1.TaskTypeAI:
 			job.Spec.Template.Spec.Containers[0].Env = reserveAIWorkerTelemetryEnvFromKeys(job.Spec.Template.Spec.Containers[0].Env)
+		case corev1alpha1.TaskTypeAgent:
+			job.Spec.Template.Spec.Containers[0].Env = reserveTraceContextEnvFromKeys(job.Spec.Template.Spec.Containers[0].Env)
 		}
 		// Also mount as files for tools that read from filesystem
 		job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, corev1.Volume{
@@ -1316,6 +1352,15 @@ func (b *JobBuilder) addSecretVolumes(ctx context.Context, job *batchv1.Job, tas
 	}
 
 	return nil
+}
+
+func reserveTraceContextEnvFromKeys(envVars []corev1.EnvVar) []corev1.EnvVar {
+	for _, name := range []string{workerenv.TraceParent, workerenv.TraceState, workerenv.TraceBaggage} {
+		if !envVarExists(envVars, name) {
+			envVars = append(envVars, corev1.EnvVar{Name: name})
+		}
+	}
+	return envVars
 }
 
 func reserveAIWorkerTelemetryEnvFromKeys(envVars []corev1.EnvVar) []corev1.EnvVar {

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -1824,6 +1824,34 @@ func TestAddSecretVolumes_AgentSecret(t *testing.T) {
 	}
 }
 
+func TestAddSecretVolumes_AgentEnvFromReservesTraceContextEnv(t *testing.T) {
+	jb := setupJobBuilder()
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: testTask, Namespace: defaultNS, UID: "uid-1234-5678"},
+		Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeAgent},
+	}
+	agent := &corev1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-agent", Namespace: defaultNS},
+		Spec: corev1alpha1.AgentSpec{
+			SecretRef: &corev1.LocalObjectReference{Name: testAgentSecretName},
+		},
+	}
+	job, _ := jb.Build(context.Background(), task, nil, nil)
+	if err := jb.addSecretVolumes(context.Background(), job, task, agent, nil); err != nil {
+		t.Fatalf("addSecretVolumes() error = %v", err)
+	}
+
+	for _, name := range []string{workerenv.TraceParent, workerenv.TraceState, workerenv.TraceBaggage} {
+		got, ok := findEnvVar(job.Spec.Template.Spec.Containers[0].Env, name)
+		if !ok || got.Value != "" || got.ValueFrom != nil {
+			t.Fatalf("reserved trace env %s = %#v, found=%v", name, got, ok)
+		}
+	}
+	if _, ok := findEnvVar(job.Spec.Template.Spec.Containers[0].Env, workerenv.EnableTelemetry); ok {
+		t.Fatalf("%s should not be blank-reserved for agent envFrom", workerenv.EnableTelemetry)
+	}
+}
+
 func TestAddSecretVolumes_AIAgentEnvFromReservesTelemetryEnv(t *testing.T) {
 	jb := setupJobBuilder()
 	task := &corev1alpha1.Task{
@@ -2575,6 +2603,7 @@ func TestJobBuilder_buildEnvVars_TaskEnvCannotSpoofApprovalState(t *testing.T) {
 			Prompt: "Coordinate incident",
 			Env: []corev1.EnvVar{
 				{Name: workerenv.TaskUID, Value: "spoofed-uid"},
+				{Name: workerenv.AgentName, Value: "spoofed-agent"},
 				{Name: workerenv.AITools, Value: "request_approval"},
 				{Name: workerenv.CoordinationEnabled, Value: scheduledRunLabelValue},
 				{Name: workerenv.AutonomousMode, Value: scheduledRunLabelValue},
@@ -2583,10 +2612,16 @@ func TestJobBuilder_buildEnvVars_TaskEnvCannotSpoofApprovalState(t *testing.T) {
 			},
 		},
 	}
-	agent := &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{Model: &corev1alpha1.ModelConfig{Provider: "openai", Name: "gpt-4"}}}
+	agent := &corev1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "real-agent", Namespace: defaultNS},
+		Spec:       corev1alpha1.AgentSpec{Model: &corev1alpha1.ModelConfig{Provider: "openai", Name: "gpt-4"}},
+	}
 	envVars := builder.buildEnvVarsWithOptions(context.Background(), task, agent, nil, JobBuildOptions{})
 	if env, ok := findEnvVar(envVars, workerenv.TaskUID); !ok || env.Value != "real-uid" {
 		t.Fatalf("%s = %#v, found=%t; want real-uid", workerenv.TaskUID, env, ok)
+	}
+	if env, ok := findEnvVar(envVars, workerenv.AgentName); !ok || env.Value != "real-agent" {
+		t.Fatalf("%s = %#v, found=%t; want real-agent", workerenv.AgentName, env, ok)
 	}
 	for _, name := range []string{
 		workerenv.AITools,
@@ -2756,6 +2791,64 @@ func TestJobBuilder_buildEnvVars_IgnoresTaskSuppliedAITelemetryEnv(t *testing.T)
 	}
 	if got, ok := findEnvVar(envVars, "CUSTOM_ENV"); !ok || got.Value != "kept" {
 		t.Fatalf("CUSTOM_ENV = %#v, found=%v", got, ok)
+	}
+}
+
+func TestJobBuilder_buildEnvVars_IgnoresTaskSuppliedAgentTelemetryEnv(t *testing.T) {
+	builder := setupJobBuilder()
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: testTask, Namespace: defaultNS},
+		Spec: corev1alpha1.TaskSpec{
+			Type:   corev1alpha1.TaskTypeAgent,
+			Prompt: "p",
+			Env: []corev1.EnvVar{
+				{Name: workerenv.EnableTelemetry, Value: "true"},
+				{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: "otel-collector:4317"},
+				{Name: workerenv.TraceParent, Value: "00-" + strings.Repeat("1", 32) + "-" + strings.Repeat("2", 16) + "-01"},
+				{Name: workerenv.TraceState, Value: "vendor=value"},
+				{Name: "CUSTOM_ENV", Value: "kept"},
+			},
+		},
+	}
+
+	envVars := builder.buildEnvVars(context.Background(), task, nil, nil)
+	for _, name := range []string{workerenv.TraceParent, workerenv.TraceState} {
+		if _, ok := findEnvVar(envVars, name); ok {
+			t.Fatalf("task-supplied %s should be ignored for agent workers", name)
+		}
+	}
+	if got, ok := findEnvVar(envVars, workerenv.EnableTelemetry); !ok || got.Value != "true" {
+		t.Fatalf("%s = %#v, found=%v", workerenv.EnableTelemetry, got, ok)
+	}
+	if got, ok := findEnvVar(envVars, "OTEL_EXPORTER_OTLP_ENDPOINT"); !ok || got.Value != "otel-collector:4317" {
+		t.Fatalf("OTEL_EXPORTER_OTLP_ENDPOINT = %#v, found=%v", got, ok)
+	}
+	if got, ok := findEnvVar(envVars, "CUSTOM_ENV"); !ok || got.Value != "kept" {
+		t.Fatalf("CUSTOM_ENV = %#v, found=%v", got, ok)
+	}
+}
+
+func TestJobBuilder_buildEnvVars_PreservesContainerTelemetryEnv(t *testing.T) {
+	builder := setupJobBuilder()
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: testTask, Namespace: defaultNS},
+		Spec: corev1alpha1.TaskSpec{
+			Type:    corev1alpha1.TaskTypeContainer,
+			Image:   "busybox",
+			Command: []string{"true"},
+			Env: []corev1.EnvVar{
+				{Name: workerenv.EnableTelemetry, Value: "true"},
+				{Name: "OTEL_RESOURCE_ATTRIBUTES", Value: "service.name=user-container"},
+			},
+		},
+	}
+
+	envVars := builder.buildEnvVars(context.Background(), task, nil, nil)
+	if got, ok := findEnvVar(envVars, workerenv.EnableTelemetry); !ok || got.Value != "true" {
+		t.Fatalf("%s = %#v, found=%v", workerenv.EnableTelemetry, got, ok)
+	}
+	if got, ok := findEnvVar(envVars, "OTEL_RESOURCE_ATTRIBUTES"); !ok || got.Value != "service.name=user-container" {
+		t.Fatalf("OTEL_RESOURCE_ATTRIBUTES = %#v, found=%v", got, ok)
 	}
 }
 

--- a/internal/llm/tracing_benchmark_test.go
+++ b/internal/llm/tracing_benchmark_test.go
@@ -1,0 +1,25 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package llm
+
+import (
+	"context"
+	"testing"
+)
+
+func BenchmarkTracingProviderCompleteTelemetryDisabled(b *testing.B) {
+	provider := NewTracingProvider(&mockProvider{name: "bench"})
+	req := &CompletionRequest{Model: "bench-model", Messages: []Message{{Role: "user", Content: "hello"}}}
+	ctx := context.Background()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		if _, err := provider.Complete(ctx, req); err != nil {
+			b.Fatalf("Complete() error = %v", err)
+		}
+	}
+}

--- a/internal/tools/chat_create_agent.go
+++ b/internal/tools/chat_create_agent.go
@@ -20,6 +20,7 @@ import (
 
 	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
 	"github.com/sozercan/orka/internal/labels"
+	"github.com/sozercan/orka/internal/tracing"
 )
 
 // ChatCreateAgentTool creates an Agent CRD from the chat context.
@@ -197,6 +198,7 @@ func (t *ChatCreateAgentTool) handleInitialPrompt(ctx context.Context, tc *ToolC
 		}
 		return result, nil
 	}
+	tracing.StampTaskTraceContext(ctx, task)
 	if err := tc.Client.Create(ctx, task); err != nil {
 		return ChatToolSuccess(map[string]any{
 			"agentName":      agent.Name,

--- a/internal/tools/create_agent_task.go
+++ b/internal/tools/create_agent_task.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
+	"github.com/sozercan/orka/internal/tracing"
 )
 
 // CreateAgentTaskTool creates an agent-runtime Task CR.
@@ -142,6 +143,7 @@ func (t *CreateAgentTaskTool) Execute(ctx context.Context, args json.RawMessage)
 	if result, ok := authorizeTaskCreate(ctx, tc, task); !ok {
 		return result, nil
 	}
+	tracing.StampTaskTraceContext(ctx, task)
 	if err := tc.Client.Create(ctx, task); err != nil {
 		return classifyChatK8sErr(err)
 	}

--- a/internal/tools/create_ai_task.go
+++ b/internal/tools/create_ai_task.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
+	"github.com/sozercan/orka/internal/tracing"
 )
 
 // CreateAITaskTool creates an AI-type Task CR.
@@ -104,6 +105,7 @@ func (t *CreateAITaskTool) Execute(ctx context.Context, args json.RawMessage) (s
 	if result, ok := authorizeTaskCreate(ctx, tc, task); !ok {
 		return result, nil
 	}
+	tracing.StampTaskTraceContext(ctx, task)
 	if err := tc.Client.Create(ctx, task); err != nil {
 		return classifyChatK8sErr(err)
 	}

--- a/internal/tools/create_container_task.go
+++ b/internal/tools/create_container_task.go
@@ -21,7 +21,7 @@ import (
 
 	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
 	"github.com/sozercan/orka/internal/labels"
-	orkatracing "github.com/sozercan/orka/internal/tracing"
+	"github.com/sozercan/orka/internal/tracing"
 )
 
 // CreateContainerTaskTool creates a container-type Task CR.
@@ -111,6 +111,7 @@ func (t *CreateContainerTaskTool) Execute(ctx context.Context, args json.RawMess
 	if result, ok := authorizeTaskCreate(ctx, tc, task); !ok {
 		return result, nil
 	}
+	tracing.StampTaskTraceContext(ctx, task)
 	if err := tc.Client.Create(ctx, task); err != nil {
 		return classifyChatK8sErr(err)
 	}
@@ -192,7 +193,7 @@ func (t *CreateContainerTaskTool) executeCoordination(ctx context.Context, args 
 	if err := validateChildTaskAgainstParentTransaction(ctx, t.k8sClient, parentTask, task, ""); err != nil {
 		return "", err
 	}
-	orkatracing.StampTaskTraceContext(ctx, task)
+	tracing.StampTaskTraceContext(ctx, task)
 
 	childTokenExchangeEnabled, err := shouldPrepareChildTransactionToken(parentTask)
 	if err != nil {

--- a/internal/tools/create_pr_monitor.go
+++ b/internal/tools/create_pr_monitor.go
@@ -21,6 +21,7 @@ import (
 	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
 	"github.com/sozercan/orka/internal/labels"
 	"github.com/sozercan/orka/internal/security"
+	"github.com/sozercan/orka/internal/tracing"
 	"github.com/sozercan/orka/internal/workerenv"
 )
 
@@ -189,6 +190,7 @@ func (t *CreatePRMonitorTool) Execute(ctx context.Context, argsJSON json.RawMess
 		task.Spec.AI.ProviderRef = &corev1alpha1.ProviderReference{Name: providerName}
 	}
 
+	tracing.StampTaskTraceContext(ctx, task)
 	if result, ok := authorizeTaskCreate(ctx, tc, task); !ok {
 		return result, nil
 	}

--- a/internal/tools/create_pr_monitor_test.go
+++ b/internal/tools/create_pr_monitor_test.go
@@ -20,6 +20,8 @@ import (
 
 	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
 	"github.com/sozercan/orka/internal/labels"
+	"github.com/sozercan/orka/internal/tracing"
+	"github.com/sozercan/orka/internal/tracing/testutil"
 	"github.com/sozercan/orka/internal/workerenv"
 )
 
@@ -182,6 +184,46 @@ func TestCreatePRMonitorTool_ExecuteCreatesScheduledAITask(t *testing.T) {
 	}
 	if !strings.Contains(task.Spec.Prompt, "Focus on regressions.") {
 		t.Errorf("prompt missing extra instructions: %s", task.Spec.Prompt)
+	}
+}
+
+func TestCreatePRMonitorTool_ExecuteStampsTraceContext(t *testing.T) {
+	if _, err := tracing.Init("test", false); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	_ = testutil.NewSpanHarness(t)
+	_, gitSecret := githubRepoTaskWithSecret("https://github.com/sozercan/orka")
+	fc := newFakeClient(
+		&corev1alpha1.Agent{
+			ObjectMeta: metav1.ObjectMeta{Name: "reviewer", Namespace: defaultNamespace},
+			Spec: corev1alpha1.AgentSpec{
+				Coordination: &corev1alpha1.CoordinationConfig{Enabled: true},
+			},
+		},
+		gitSecret,
+	)
+	baseCtx := newCreatePRMonitorToolContext(fc)
+	parentCtx, parentSpan := tracing.Tracer("test").Start(context.Background(), "chat-tool")
+	defer parentSpan.End()
+	ctx := WithToolContext(parentCtx, GetToolContext(baseCtx))
+
+	_, err := (&CreatePRMonitorTool{}).Execute(ctx, mustJSON(t, map[string]any{
+		nameField:      "trace-pr-monitor",
+		repoURLField:   "https://github.com/sozercan/orka",
+		scheduleField:  "*/15 * * * *",
+		agentRefField:  "reviewer",
+		"gitSecretRef": gitSecret.Name,
+	}))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var task corev1alpha1.Task
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: "pr-monitor-task", Namespace: defaultNamespace}, &task); err != nil {
+		t.Fatalf("failed to get created task: %v", err)
+	}
+	if task.Annotations[labels.AnnotationTraceParent] == "" {
+		t.Fatalf("missing %s annotation", labels.AnnotationTraceParent)
 	}
 }
 

--- a/internal/tools/delegate_task.go
+++ b/internal/tools/delegate_task.go
@@ -22,6 +22,7 @@ import (
 	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
 	"github.com/sozercan/orka/internal/labels"
 	orkatracing "github.com/sozercan/orka/internal/tracing"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // DelegateTaskTool implements multi-agent task delegation
@@ -451,10 +452,12 @@ func (t *DelegateTaskTool) Execute(ctx context.Context, args json.RawMessage) (s
 	if err != nil {
 		return "", err
 	}
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(orkatracing.DelegateAttributes(dc.parentName, "")...)
+	orkatracing.StampTaskTraceContext(ctx, childTask)
 	if err := validateChildTaskAgainstParentTransaction(ctx, t.k8sClient, dc.parentTask, childTask, dc.args.Agent); err != nil {
 		return "", err
 	}
-	orkatracing.StampTaskTraceContext(ctx, childTask)
 
 	childTokenExchangeEnabled, err := shouldPrepareChildTransactionToken(dc.parentTask)
 	if err != nil {
@@ -473,6 +476,7 @@ func (t *DelegateTaskTool) Execute(ctx context.Context, args json.RawMessage) (s
 		}
 		return "", fmt.Errorf("failed to create child task: %w", err)
 	}
+	span.SetAttributes(orkatracing.DelegateAttributes("", childTask.Name)...)
 
 	if childTokenExchangeEnabled {
 		if err := adoptChildTransactionTokenSecret(ctx, t.k8sClient, childTask); err != nil {

--- a/internal/tools/delegate_task_test.go
+++ b/internal/tools/delegate_task_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/sozercan/orka/internal/contexttoken"
 	"github.com/sozercan/orka/internal/labels"
 	orkatracing "github.com/sozercan/orka/internal/tracing"
+	"github.com/sozercan/orka/internal/tracing/genai"
 	"github.com/sozercan/orka/internal/tracing/testutil"
 	"github.com/sozercan/orka/internal/workerenv"
 )
@@ -1366,5 +1367,87 @@ func TestDelegateTaskTool_Execute_NoAutoRetry(t *testing.T) {
 	// When auto_retry is not set, no retry annotations should be present
 	if _, ok := childTask.Annotations[labels.AnnotationAutoRetry]; ok {
 		t.Error("expected no auto-retry annotation when auto_retry is false")
+	}
+}
+
+func TestDelegateTaskToolExecuteStampsTraceContextAndSpanAttributes(t *testing.T) {
+	if _, err := orkatracing.Init("test", false); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	spans := testutil.NewSpanHarness(t)
+	t.Setenv(envOrkaTaskName, parentTaskName)
+	t.Setenv(envOrkaTaskNamespace, defaultNamespace)
+	t.Setenv(envOrkaCoordinationDepth, "0")
+	t.Setenv(envOrkaCoordinationAllowedAgents, testResearcherAgentName)
+	t.Setenv(envOrkaCoordinationMaxDepth, "3")
+
+	k8sClient := newFakeClient(parentTask(), researcherAgent())
+	registry := NewRegistry()
+	registry.Register(NewDelegateTaskTool(k8sClient))
+
+	rootCtx, rootSpan := orkatracing.Tracer("test").Start(context.Background(), "task.run")
+	stepCtx, stepSpan := orkatracing.Tracer("test").Start(rootCtx, "agent.step")
+	toolCtx := WithToolContext(stepCtx, &ToolContext{TaskID: parentTaskName, Namespace: defaultNamespace, Tenant: defaultNamespace})
+	result, err := registry.Execute(toolCtx, delegateTaskToolName, json.RawMessage(`{"agent":"researcher","prompt":"Research"}`))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	stepSpan.End()
+	rootSpan.End()
+
+	var delegateResult DelegateTaskResult
+	if err := json.Unmarshal([]byte(result), &delegateResult); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	childTask := &corev1alpha1.Task{}
+	if err := k8sClient.Get(context.Background(), apitypes.NamespacedName{Name: delegateResult.TaskName, Namespace: defaultNamespace}, childTask); err != nil {
+		t.Fatalf("get child task: %v", err)
+	}
+	if childTask.Annotations[labels.AnnotationTraceParent] == "" {
+		t.Fatalf("missing %s annotation", labels.AnnotationTraceParent)
+	}
+
+	delegateSpan := testutil.SpanNamed(spans.Recorder.Ended(), "execute_tool delegate_task")
+	if delegateSpan == nil {
+		t.Fatal("missing delegate tool span")
+	}
+	attrs := testutil.AttributeMap(delegateSpan)
+	if got := attrs[orkatracing.AttrToolKind].AsString(); got != orkatracing.ToolKindDelegate {
+		t.Fatalf("%s = %q", orkatracing.AttrToolKind, got)
+	}
+	if got := attrs[orkatracing.AttrParentTaskID].AsString(); got != parentTaskName {
+		t.Fatalf("%s = %q", orkatracing.AttrParentTaskID, got)
+	}
+	if got := attrs[orkatracing.AttrChildTaskID].AsString(); got != delegateResult.TaskName {
+		t.Fatalf("%s = %q", orkatracing.AttrChildTaskID, got)
+	}
+
+	childCtx := orkatracing.ExtractTaskTraceContext(context.Background(), childTask)
+	childTaskCtx, childRunSpan := orkatracing.Tracer("test").Start(childCtx, "child task.run")
+	childStepCtx, childStepSpan := orkatracing.Tracer("test").Start(childTaskCtx, "child agent.step")
+	_, childModelSpan := orkatracing.GenAITracer(genai.InstrumentationName).Start(childStepCtx, "chat test-model")
+	childModelSpan.End()
+	childStepSpan.End()
+	childRunSpan.End()
+	childRun := testutil.SpanNamed(spans.Recorder.Ended(), "child task.run")
+	if childRun == nil {
+		t.Fatal("missing child task.run span")
+	}
+	if got, want := childRun.SpanContext().TraceID(), delegateSpan.SpanContext().TraceID(); got != want {
+		t.Fatalf("child trace id = %s, want %s", got, want)
+	}
+	if got, want := childRun.Parent().SpanID(), delegateSpan.SpanContext().SpanID(); got != want {
+		t.Fatalf("child parent span id = %s, want delegate span %s", got, want)
+	}
+	childStep := testutil.SpanNamed(spans.Recorder.Ended(), "child agent.step")
+	childModel := testutil.SpanNamed(spans.Recorder.Ended(), "chat test-model")
+	if childStep == nil || childModel == nil {
+		t.Fatalf("missing child step/model spans: step=%v model=%v", childStep != nil, childModel != nil)
+	}
+	if got, want := childModel.SpanContext().TraceID(), delegateSpan.SpanContext().TraceID(); got != want {
+		t.Fatalf("child model trace id = %s, want %s", got, want)
+	}
+	if got, want := childModel.Parent().SpanID(), childStep.SpanContext().SpanID(); got != want {
+		t.Fatalf("child model parent = %s, want child step %s", got, want)
 	}
 }

--- a/internal/tools/list_tasks_test.go
+++ b/internal/tools/list_tasks_test.go
@@ -175,8 +175,8 @@ func TestListTasksTool_Execute_InvalidJSON(t *testing.T) {
 	if res.Success {
 		t.Error("expected failure for invalid JSON")
 	}
-	if res.ErrorType != "invalid_arguments" {
-		t.Errorf("expected errorType 'invalid_arguments', got %q", res.ErrorType)
+	if res.ErrorType != errTypeInvalidArgs {
+		t.Errorf("expected errorType invalid_arguments, got %q", res.ErrorType)
 	}
 }
 

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -211,13 +211,22 @@ func (r *Registry) Execute(ctx context.Context, name string, args json.RawMessag
 		toolTelemetryName = unknownToolTelemetryName
 	}
 	toolTypeValue := toolType(ctx, tool)
+	toolKind := registryToolKind(name)
 	attrs := []attribute.KeyValue{
 		attribute.String(genai.AttrOperationName, genai.OperationExecuteTool),
 		attribute.String(genai.AttrToolName, toolTelemetryName),
 		attribute.String(genai.AttrToolType, toolTypeValue),
 	}
-	if tc := GetToolContext(ctx); tc != nil && tc.ToolCallID != "" {
-		attrs = append(attrs, attribute.String(genai.AttrToolCallID, tc.ToolCallID))
+	attrs = append(attrs, tracing.ToolAttributes(toolTelemetryName, toolKind, -1, "")...)
+	if tc := GetToolContext(ctx); tc != nil {
+		tenant := tc.Tenant
+		if tenant == "" {
+			tenant = tc.Namespace
+		}
+		attrs = append(attrs, tracing.TaskAttributes(tc.TaskID, tc.Namespace, tenant, "", "")...)
+		if tc.ToolCallID != "" {
+			attrs = append(attrs, attribute.String(genai.AttrToolCallID, tc.ToolCallID))
+		}
 	}
 	if ok {
 		if description := tool.Description(); description != "" {
@@ -228,6 +237,7 @@ func (r *Registry) Execute(ctx context.Context, name string, args json.RawMessag
 	ctx, span := tracer.Start(ctx, genai.OperationExecuteTool+" "+toolTelemetryName, trace.WithSpanKind(trace.SpanKindInternal), trace.WithAttributes(attrs...))
 	defer span.End()
 
+	// Keep histogram labels low-cardinality and separate from span-only task/result attributes.
 	metricAttrs := []attribute.KeyValue{
 		attribute.String(genai.AttrOperationName, genai.OperationExecuteTool),
 		attribute.String(genai.AttrToolName, toolTelemetryName),
@@ -245,6 +255,7 @@ func (r *Registry) Execute(ctx context.Context, name string, args json.RawMessag
 
 	result, err := tool.Execute(ctx, args)
 	duration := time.Since(start).Seconds()
+	span.SetAttributes(tracing.ToolAttributes("", "", len(result), "")...)
 	if err != nil {
 		errType := fmt.Sprintf("%T", err)
 		span.RecordError(err)
@@ -329,6 +340,13 @@ func toolType(ctx context.Context, _ Tool) string {
 	// Registry tools are in-process functions. External Tool CRD/MCP execution is
 	// handled by worker.ToolExecutor and can be modeled as extension later.
 	return genai.ToolTypeFunction
+}
+
+func registryToolKind(name string) string {
+	if name == delegateTaskToolName {
+		return tracing.ToolKindDelegate
+	}
+	return tracing.ToolKindBuiltin
 }
 
 func recordToolDuration(ctx context.Context, seconds float64, attrs ...attribute.KeyValue) {

--- a/internal/tools/registry_benchmark_test.go
+++ b/internal/tools/registry_benchmark_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func BenchmarkRegistryExecuteTelemetryDisabled(b *testing.B) {
+	registry := NewRegistry()
+	registry.Register(tracingTestTool{})
+	ctx := WithToolContext(context.Background(), &ToolContext{TaskID: "task-a", Namespace: "default", Tenant: "default", ToolCallID: "call-a"})
+	args := json.RawMessage(`{}`)
+	b.ReportAllocs()
+
+	for b.Loop() {
+		if _, err := registry.Execute(ctx, tracingToolName, args); err != nil {
+			b.Fatalf("Execute() error = %v", err)
+		}
+	}
+}

--- a/internal/tools/registry_tracing_test.go
+++ b/internal/tools/registry_tracing_test.go
@@ -15,13 +15,16 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
+	"github.com/sozercan/orka/internal/tracing"
 	"github.com/sozercan/orka/internal/tracing/genai"
 	"github.com/sozercan/orka/internal/tracing/testutil"
 )
 
+const tracingToolName = "tracing_test_tool"
+
 type tracingTestTool struct{}
 
-func (tracingTestTool) Name() string                { return "test_tool" }
+func (tracingTestTool) Name() string                { return tracingToolName }
 func (tracingTestTool) Description() string         { return "test description" }
 func (tracingTestTool) Parameters() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
 func (tracingTestTool) Execute(context.Context, json.RawMessage) (string, error) {
@@ -34,7 +37,7 @@ func TestRegistryExecuteEmitsGenAIToolSpanAndMetric(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(tracingTestTool{})
 	ctx := WithToolContext(context.Background(), &ToolContext{ToolCallID: "call-1"})
-	if _, err := registry.Execute(ctx, "test_tool", json.RawMessage(`{}`)); err != nil {
+	if _, err := registry.Execute(ctx, tracingToolName, json.RawMessage(`{}`)); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
 
@@ -49,11 +52,20 @@ func TestRegistryExecuteEmitsGenAIToolSpanAndMetric(t *testing.T) {
 	if got := attrs[genai.AttrOperationName].AsString(); got != genai.OperationExecuteTool {
 		t.Fatalf("operation attr = %q", got)
 	}
-	if got := attrs[genai.AttrToolName].AsString(); got != "test_tool" {
+	if got := attrs[genai.AttrToolName].AsString(); got != tracingToolName {
 		t.Fatalf("tool name attr = %q", got)
 	}
 	if got := attrs[genai.AttrToolCallID].AsString(); got != "call-1" {
 		t.Fatalf("tool call id attr = %q", got)
+	}
+	if got := attrs[tracing.AttrToolName].AsString(); got != tracingToolName {
+		t.Fatalf("orka tool name attr = %q", got)
+	}
+	if got := attrs[tracing.AttrToolKind].AsString(); got != tracing.ToolKindBuiltin {
+		t.Fatalf("orka tool kind attr = %q", got)
+	}
+	if got := attrs[tracing.AttrToolResultSizeBytes].AsInt64(); got != int64(len(`{"success":true}`)) {
+		t.Fatalf("result size attr = %d", got)
 	}
 
 	rm := metrics.Collect(t)
@@ -63,7 +75,7 @@ func TestRegistryExecuteEmitsGenAIToolSpanAndMetric(t *testing.T) {
 }
 
 func findToolSpan(spans []sdktrace.ReadOnlySpan) sdktrace.ReadOnlySpan {
-	return findSpanByName(spans, "execute_tool test_tool")
+	return findSpanByName(spans, "execute_tool "+tracingToolName)
 }
 
 func findSpanByName(spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
@@ -104,6 +116,9 @@ func TestRegistryExecuteMarksStructuredToolFailure(t *testing.T) {
 			}
 			if got := attrs[genai.AttrErrorType].AsString(); got != errTypeInvalidArgs {
 				t.Fatalf("error type attr = %q, want invalid_arguments", got)
+			}
+			if got := attrs[tracing.AttrToolResultSizeBytes].AsInt64(); got == 0 {
+				t.Fatal("missing structured failure result size")
 			}
 			return
 		}

--- a/internal/tracing/attrs.go
+++ b/internal/tracing/attrs.go
@@ -1,0 +1,85 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package tracing
+
+import "go.opentelemetry.io/otel/attribute"
+
+const (
+	AttrTaskID              = "orka.task.id"
+	AttrTaskNamespace       = "orka.task.namespace"
+	AttrAgentName           = "orka.agent.name"
+	AttrTenant              = "orka.tenant"
+	AttrUserSub             = "orka.user.sub"
+	AttrParentTaskID        = "orka.parent_task.id"
+	AttrChildTaskID         = "orka.child_task.id"
+	AttrToolName            = "orka.tool.name"
+	AttrToolKind            = "orka.tool.kind"
+	AttrToolResultSizeBytes = "orka.tool.result.size_bytes"
+)
+
+const (
+	ToolKindBuiltin  = "builtin"
+	ToolKindHTTP     = "http"
+	ToolKindDelegate = "delegate"
+)
+
+// TaskAttributes returns safe Orka-native task attributes for spans.
+// Empty optional values are omitted. The values must be stable metadata only;
+// callers must never pass prompts, completions, tokens, credentials, or result bodies.
+func TaskAttributes(taskName, namespace, tenant, agentName, userSub string) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 5)
+	if taskName != "" {
+		attrs = append(attrs, attribute.String(AttrTaskID, taskName))
+	}
+	if namespace != "" {
+		attrs = append(attrs, attribute.String(AttrTaskNamespace, namespace))
+	}
+	if tenant == "" {
+		tenant = namespace
+	}
+	if tenant != "" {
+		attrs = append(attrs, attribute.String(AttrTenant, tenant))
+	}
+	if agentName != "" {
+		attrs = append(attrs, attribute.String(AttrAgentName, agentName))
+	}
+	if userSub != "" {
+		attrs = append(attrs, attribute.String(AttrUserSub, userSub))
+	}
+	return attrs
+}
+
+// ToolAttributes returns safe Orka-native tool attributes. resultSize is emitted
+// only when it is non-negative, allowing callers to omit it before execution.
+func ToolAttributes(name, kind string, resultSize int, errType string) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 4)
+	if name != "" {
+		attrs = append(attrs, attribute.String(AttrToolName, name))
+	}
+	if kind != "" {
+		attrs = append(attrs, attribute.String(AttrToolKind, kind))
+	}
+	if resultSize >= 0 {
+		attrs = append(attrs, attribute.Int(AttrToolResultSizeBytes, resultSize))
+	}
+	if errType != "" {
+		attrs = append(attrs, attribute.String("error.type", errType))
+	}
+	return attrs
+}
+
+// DelegateAttributes returns safe parent/child task relationship attributes.
+func DelegateAttributes(parentTaskID, childTaskID string) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 2)
+	if parentTaskID != "" {
+		attrs = append(attrs, attribute.String(AttrParentTaskID, parentTaskID))
+	}
+	if childTaskID != "" {
+		attrs = append(attrs, attribute.String(AttrChildTaskID, childTaskID))
+	}
+	return attrs
+}

--- a/internal/tracing/attrs_test.go
+++ b/internal/tracing/attrs_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package tracing
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestTaskAttributesOmitEmptyFieldsAndUseTenantFallback(t *testing.T) {
+	attrs := TaskAttributes("task-a", "team-a", "", "agent-a", "")
+	got := attrMap(attrs)
+
+	if got[AttrTaskID].AsString() != "task-a" {
+		t.Fatalf("%s = %q", AttrTaskID, got[AttrTaskID].AsString())
+	}
+	if got[AttrTaskNamespace].AsString() != "team-a" {
+		t.Fatalf("%s = %q", AttrTaskNamespace, got[AttrTaskNamespace].AsString())
+	}
+	if got[AttrTenant].AsString() != "team-a" {
+		t.Fatalf("%s = %q, want namespace fallback", AttrTenant, got[AttrTenant].AsString())
+	}
+	if got[AttrAgentName].AsString() != "agent-a" {
+		t.Fatalf("%s = %q", AttrAgentName, got[AttrAgentName].AsString())
+	}
+	if _, ok := got[AttrUserSub]; ok {
+		t.Fatalf("%s was emitted for empty user subject", AttrUserSub)
+	}
+}
+
+func TestToolAttributesIncludeExactSafeKeys(t *testing.T) {
+	attrs := ToolAttributes("delegate_task", ToolKindDelegate, 123, "invalid_arguments")
+	got := attrMap(attrs)
+
+	if got[AttrToolName].AsString() != "delegate_task" {
+		t.Fatalf("%s = %q", AttrToolName, got[AttrToolName].AsString())
+	}
+	if got[AttrToolKind].AsString() != ToolKindDelegate {
+		t.Fatalf("%s = %q", AttrToolKind, got[AttrToolKind].AsString())
+	}
+	if got[AttrToolResultSizeBytes].AsInt64() != 123 {
+		t.Fatalf("%s = %d", AttrToolResultSizeBytes, got[AttrToolResultSizeBytes].AsInt64())
+	}
+	if got["error.type"].AsString() != "invalid_arguments" {
+		t.Fatalf("error.type = %q", got["error.type"].AsString())
+	}
+}
+
+func TestToolAttributesOmitUnknownResultSizeAndEmptyError(t *testing.T) {
+	attrs := ToolAttributes("web_search", ToolKindBuiltin, -1, "")
+	got := attrMap(attrs)
+	if _, ok := got[AttrToolResultSizeBytes]; ok {
+		t.Fatalf("%s was emitted for unknown result size", AttrToolResultSizeBytes)
+	}
+	if _, ok := got["error.type"]; ok {
+		t.Fatal("error.type was emitted for empty error type")
+	}
+}
+
+func TestDelegateAttributesOmitEmptyValues(t *testing.T) {
+	attrs := DelegateAttributes("parent-a", "")
+	got := attrMap(attrs)
+	if got[AttrParentTaskID].AsString() != "parent-a" {
+		t.Fatalf("%s = %q", AttrParentTaskID, got[AttrParentTaskID].AsString())
+	}
+	if _, ok := got[AttrChildTaskID]; ok {
+		t.Fatalf("%s was emitted for empty child id", AttrChildTaskID)
+	}
+}
+
+func attrMap(attrs []attribute.KeyValue) map[string]attribute.Value {
+	out := make(map[string]attribute.Value, len(attrs))
+	for _, kv := range attrs {
+		out[string(kv.Key)] = kv.Value
+	}
+	return out
+}

--- a/internal/tracing/testutil/testutil.go
+++ b/internal/tracing/testutil/testutil.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -62,4 +63,37 @@ func (h *MetricHarness) Collect(t *testing.T) metricdata.ResourceMetrics {
 		t.Fatalf("Collect() error = %v", err)
 	}
 	return rm
+}
+
+// AttributeMap converts span attributes to a key/value map for assertions.
+func AttributeMap(span sdktrace.ReadOnlySpan) map[string]attribute.Value {
+	attrs := map[string]attribute.Value{}
+	if span == nil {
+		return attrs
+	}
+	for _, kv := range span.Attributes() {
+		attrs[string(kv.Key)] = kv.Value
+	}
+	return attrs
+}
+
+// SpanNamed returns the first span with the given name.
+func SpanNamed(spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
+	for _, span := range spans {
+		if span.Name() == name {
+			return span
+		}
+	}
+	return nil
+}
+
+// SpansNamed returns all spans with the given name in recorder order.
+func SpansNamed(spans []sdktrace.ReadOnlySpan, name string) []sdktrace.ReadOnlySpan {
+	out := []sdktrace.ReadOnlySpan{}
+	for _, span := range spans {
+		if span.Name() == name {
+			out = append(out, span)
+		}
+	}
+	return out
 }

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -11,7 +11,11 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestInit(t *testing.T) {
@@ -19,14 +23,8 @@ func TestInit(t *testing.T) {
 		name    string
 		enabled bool
 	}{
-		{
-			name:    "disabled returns noop shutdown",
-			enabled: false,
-		},
-		{
-			name:    "enabled creates provider",
-			enabled: true,
-		},
+		{name: "disabled returns noop shutdown", enabled: false},
+		{name: "enabled creates provider", enabled: true},
 	}
 
 	for _, tt := range tests {
@@ -128,4 +126,57 @@ func TestOTLPProtocolSelectsHTTPExporter(t *testing.T) {
 		t.Fatalf("newMetricExporter() error = %v", err)
 	}
 	defer func() { _ = metricExporter.Shutdown(context.Background()) }()
+}
+
+func TestInitDisabledLeavesTracerProviderUnchanged(t *testing.T) {
+	previous := otel.GetTracerProvider()
+	shutdown, err := Init("test-service", false)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if shutdown == nil {
+		t.Fatal("Init() returned nil shutdown")
+	}
+	if got := otel.GetTracerProvider(); got != previous {
+		t.Fatalf("tracer provider changed in disabled mode: got %#v want %#v", got, previous)
+	}
+}
+
+func TestSDKSamplerEnvironmentAlwaysOffDropsSpans(t *testing.T) {
+	t.Setenv("OTEL_TRACES_SAMPLER", "always_off")
+	recorder := tracetest.NewSpanRecorder()
+	// Intentionally omit WithSampler: the Go SDK provider reads OTEL_TRACES_SAMPLER
+	// from the environment when no explicit sampler option is supplied.
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	defer provider.Shutdown(context.Background()) //nolint:errcheck
+	_, span := provider.Tracer("test").Start(context.Background(), "dropped")
+	span.End()
+	if got := recorder.Ended(); len(got) != 0 {
+		t.Fatalf("ended spans = %d, want 0", len(got))
+	}
+}
+
+func TestSDKSamplerEnvironmentParentBasedPreservesSampledRemoteParent(t *testing.T) {
+	t.Setenv("OTEL_TRACES_SAMPLER", "parentbased_always_off")
+	recorder := tracetest.NewSpanRecorder()
+	// Intentionally omit WithSampler so this covers SDK environment sampler wiring.
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	defer provider.Shutdown(context.Background()) //nolint:errcheck
+	traceID, err := trace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("trace id: %v", err)
+	}
+	spanID, err := trace.SpanIDFromHex("0123456789abcdef")
+	if err != nil {
+		t.Fatalf("span id: %v", err)
+	}
+	parent := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: traceID, SpanID: spanID, TraceFlags: trace.FlagsSampled, Remote: true,
+	})
+	ctx := trace.ContextWithRemoteSpanContext(context.Background(), parent)
+	_, span := provider.Tracer("test").Start(ctx, "child")
+	span.End()
+	if got := recorder.Ended(); len(got) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(got))
+	}
 }

--- a/internal/worker/tool_executor.go
+++ b/internal/worker/tool_executor.go
@@ -28,7 +28,14 @@ import (
 
 	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
 	"github.com/sozercan/orka/internal/contexttoken"
+	"github.com/sozercan/orka/internal/tracing"
+	"github.com/sozercan/orka/internal/tracing/genai"
 	"github.com/sozercan/orka/internal/workerenv"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -44,6 +51,21 @@ const (
 	mcpInitializedNotificationMethod = "notifications/initialized"
 	toolIdempotencyKeyHeader         = "Idempotency-Key"
 )
+
+type toolCallIDContextKey struct{}
+
+// WithToolCallID records the model provider's tool-call id for Tool CRD span metadata.
+func WithToolCallID(ctx context.Context, toolCallID string) context.Context {
+	if strings.TrimSpace(toolCallID) == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, toolCallIDContextKey{}, toolCallID)
+}
+
+func toolCallIDFromContext(ctx context.Context) string {
+	toolCallID, _ := ctx.Value(toolCallIDContextKey{}).(string)
+	return strings.TrimSpace(toolCallID)
+}
 
 // ToolExecutor handles execution of custom Tool CRDs via HTTP or MCP-over-HTTP.
 type ToolExecutor struct {
@@ -81,10 +103,45 @@ func NewToolExecutor() *ToolExecutor {
 }
 
 // Execute executes a Tool CRD by making an HTTP request.
-func (e *ToolExecutor) Execute(ctx context.Context, tool *corev1alpha1.Tool, args json.RawMessage) (string, error) {
+func (e *ToolExecutor) Execute(ctx context.Context, tool *corev1alpha1.Tool, args json.RawMessage) (result string, err error) {
+	start := time.Now()
+	toolName := toolTelemetryName(tool)
+	attrs := []attribute.KeyValue{
+		attribute.String(genai.AttrOperationName, genai.OperationExecuteTool),
+		attribute.String(genai.AttrToolName, toolName),
+		attribute.String(genai.AttrToolType, genai.ToolTypeExtension),
+	}
+	attrs = append(attrs, tracing.ToolAttributes(toolName, tracing.ToolKindHTTP, -1, "")...)
+	attrs = append(attrs, tracing.TaskAttributes(os.Getenv(workerenv.TaskName), e.namespace, e.namespace, "", "")...)
+	if toolCallID := toolCallIDFromContext(ctx); toolCallID != "" {
+		attrs = append(attrs, attribute.String(genai.AttrToolCallID, toolCallID))
+	}
+	ctx, span := tracing.GenAITracer(genai.InstrumentationName).Start(ctx, genai.OperationExecuteTool+" "+toolName, trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attrs...))
+	defer func() {
+		resultSize := len(result)
+		span.SetAttributes(tracing.ToolAttributes("", "", resultSize, "")...)
+		metricAttrs := []attribute.KeyValue{
+			attribute.String(genai.AttrOperationName, genai.OperationExecuteTool),
+			attribute.String(genai.AttrToolName, toolName),
+			attribute.String(genai.AttrToolType, genai.ToolTypeExtension),
+		}
+		if err != nil {
+			errType := toolExecutionErrorType(err)
+			span.SetStatus(codes.Error, errType)
+			span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+			metricAttrs = append(metricAttrs, attribute.String(genai.AttrErrorType, errType))
+		}
+		recordExternalToolDuration(ctx, time.Since(start).Seconds(), metricAttrs...)
+		span.End()
+	}()
+
 	prepared, err := e.prepareRequest(ctx, tool, args)
 	if err != nil {
 		return "", err
+	}
+	if prepared.request != nil {
+		span.SetAttributes(httpToolRequestAttributes(prepared.request)...)
+		injectTraceHeaders(ctx, prepared.request.Header)
 	}
 
 	// Configure timeout
@@ -118,6 +175,74 @@ func (e ToolRequestAttemptedError) Unwrap() error { return e.Err }
 func ToolRequestWasAttempted(err error) bool {
 	var attempted ToolRequestAttemptedError
 	return errors.As(err, &attempted)
+}
+
+func recordExternalToolDuration(ctx context.Context, seconds float64, attrs ...attribute.KeyValue) {
+	meter := tracing.GenAIMeter(genai.InstrumentationName)
+	histogram, err := meter.Float64Histogram(
+		genai.MetricExecuteToolDuration,
+		metric.WithUnit(genai.UnitSeconds),
+		metric.WithExplicitBucketBoundaries(genai.ToolDurationBuckets...),
+	)
+	if err != nil {
+		return
+	}
+	histogram.Record(ctx, seconds, metric.WithAttributes(attrs...))
+}
+
+func toolExecutionErrorType(err error) string {
+	if err == nil {
+		return ""
+	}
+	message := err.Error()
+	const httpPrefix = "tool returned HTTP "
+	if idx := strings.Index(message, httpPrefix); idx >= 0 {
+		statusText := message[idx+len(httpPrefix):]
+		code := ""
+		for _, r := range statusText {
+			if r < '0' || r > '9' {
+				break
+			}
+			code += string(r)
+		}
+		if code != "" {
+			return "http_status_" + code
+		}
+	}
+	return fmt.Sprintf("%T", err)
+}
+
+func toolTelemetryName(tool *corev1alpha1.Tool) string {
+	if tool != nil && strings.TrimSpace(tool.Name) != "" {
+		return strings.TrimSpace(tool.Name)
+	}
+	return "http_tool"
+}
+
+func httpToolRequestAttributes(req *http.Request) []attribute.KeyValue {
+	if req == nil {
+		return nil
+	}
+	attrs := []attribute.KeyValue{}
+	if req.Method != "" {
+		attrs = append(attrs, attribute.String("http.request.method", req.Method))
+	}
+	if req.URL != nil {
+		if host := req.URL.Hostname(); host != "" {
+			attrs = append(attrs, attribute.String("server.address", host))
+		}
+		if req.URL.Scheme != "" {
+			attrs = append(attrs, attribute.String("url.scheme", req.URL.Scheme))
+		}
+	}
+	return attrs
+}
+
+func injectTraceHeaders(ctx context.Context, header http.Header) {
+	if header == nil {
+		return
+	}
+	propagation.TraceContext{}.Inject(ctx, propagation.HeaderCarrier(header))
 }
 
 func executeToolHTTPRequest(httpClient *http.Client, req *http.Request, secrets ...string) ([]byte, error) {
@@ -520,6 +645,7 @@ func (e *ToolExecutor) terminateMCPSession(ctx context.Context, httpClient *http
 	req.Header.Del("Content-Type")
 	req.Header.Set(mcpSessionIDHeader, sessionID)
 	req.Header.Set(mcpProtocolVersionHeader, mcpProtocolHeaderValue(protocolVersion))
+	injectTraceHeaders(cleanupCtx, req.Header)
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -554,6 +680,7 @@ func newMCPRequest(ctx context.Context, prepared preparedToolRequest, body []byt
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json, text/event-stream")
 	req.Header.Set(mcpProtocolVersionHeader, mcpProtocolHeaderValue(protocolVersion))
+	injectTraceHeaders(ctx, req.Header)
 	return req, nil
 }
 

--- a/internal/worker/tool_executor_benchmark_test.go
+++ b/internal/worker/tool_executor_benchmark_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
+)
+
+func BenchmarkToolExecutorTelemetryDisabled(b *testing.B) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+	executor := &ToolExecutor{client: server.Client(), namespace: "default", secretPath: "/secrets/tools"}
+	tool := &corev1alpha1.Tool{
+		ObjectMeta: metav1.ObjectMeta{Name: "bench_http"},
+		Spec:       corev1alpha1.ToolSpec{HTTP: &corev1alpha1.HTTPExecution{URL: server.URL}},
+	}
+	args := json.RawMessage(`{"x":1}`)
+	ctx := context.Background()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		if _, err := executor.Execute(ctx, tool, args); err != nil {
+			b.Fatalf("Execute() error = %v", err)
+		}
+	}
+}

--- a/internal/worker/tool_executor_test.go
+++ b/internal/worker/tool_executor_test.go
@@ -28,7 +28,12 @@ import (
 
 	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
 	"github.com/sozercan/orka/internal/contexttoken"
+	"github.com/sozercan/orka/internal/tracing"
+	"github.com/sozercan/orka/internal/tracing/genai"
+	"github.com/sozercan/orka/internal/tracing/testutil"
 	"github.com/sozercan/orka/internal/workerenv"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 const (
@@ -2127,4 +2132,216 @@ func TestToolExecutor_Execute_IdempotencyKeyReservedHeaderConflict(t *testing.T)
 	if err == nil || !strings.Contains(err.Error(), "reserved header") {
 		t.Fatalf("Execute() error = %v, want reserved header conflict", err)
 	}
+}
+
+func TestToolExecutor_Execute_InjectsTraceparentAndEmitsHTTPToolSpan(t *testing.T) {
+	if _, err := tracing.Init("test", false); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	spans := testutil.NewSpanHarness(t)
+	metrics := testutil.NewMetricHarness(t)
+	var gotTraceparent string
+	var gotBaggage string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTraceparent = r.Header.Get("traceparent")
+		gotBaggage = r.Header.Get("baggage")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	executor := &ToolExecutor{client: server.Client(), namespace: "team-a", secretPath: "/secrets/tools"}
+	tool := &corev1alpha1.Tool{
+		ObjectMeta: metav1.ObjectMeta{Name: "lookup"},
+		Spec:       corev1alpha1.ToolSpec{HTTP: &corev1alpha1.HTTPExecution{URL: server.URL}},
+	}
+	ctx, parent := tracing.Tracer("test").Start(context.Background(), "agent.step")
+	member, err := baggage.NewMember("tenant", "acme")
+	if err != nil {
+		t.Fatalf("baggage member: %v", err)
+	}
+	bag, err := baggage.New(member)
+	if err != nil {
+		t.Fatalf("baggage: %v", err)
+	}
+	ctx = baggage.ContextWithBaggage(ctx, bag)
+	ctx = WithToolCallID(ctx, "call-http")
+	result, err := executor.Execute(ctx, tool, json.RawMessage(`{"x":1}`))
+	parent.End()
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result != `{"ok":true}` {
+		t.Fatalf("result = %q", result)
+	}
+	if !validTraceparent(gotTraceparent) {
+		t.Fatalf("traceparent = %q, want valid W3C header", gotTraceparent)
+	}
+	if gotBaggage != "" {
+		t.Fatalf("baggage header = %q, want empty", gotBaggage)
+	}
+	span := testutil.SpanNamed(spans.Recorder.Ended(), "execute_tool lookup")
+	if span == nil {
+		t.Fatal("missing HTTP tool span")
+	}
+	attrs := testutil.AttributeMap(span)
+	if got := attrs[tracing.AttrToolKind].AsString(); got != tracing.ToolKindHTTP {
+		t.Fatalf("%s = %q", tracing.AttrToolKind, got)
+	}
+	if got := attrs[tracing.AttrToolResultSizeBytes].AsInt64(); got != int64(len(result)) {
+		t.Fatalf("result size = %d", got)
+	}
+	if got := attrs[genai.AttrToolCallID].AsString(); got != "call-http" {
+		t.Fatalf("tool call id = %q", got)
+	}
+	if countMetricDataPoints(metrics.Collect(t), genai.MetricExecuteToolDuration) != 1 {
+		t.Fatalf("missing %s datapoint", genai.MetricExecuteToolDuration)
+	}
+}
+
+func TestToolExecutor_Execute_MCPSubstrateActorInjectsTraceparent(t *testing.T) {
+	if _, err := tracing.Init("test", false); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	_ = testutil.NewSpanHarness(t)
+	const sessionID = "session-trace"
+	var traceparents []string
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		traceparents = append(traceparents, r.Header.Get("traceparent"))
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusAccepted)
+			calls++
+			return
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request %d: %v", calls, err)
+		}
+		switch calls {
+		case 0:
+			if got := body["method"]; got != mcpInitializeMethod {
+				t.Fatalf("method = %v, want %s", got, mcpInitializeMethod)
+			}
+			w.Header().Set(mcpSessionIDHeader, sessionID)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"initialize","result":{"protocolVersion":"2025-06-18"}}`))
+		case 1:
+			if got := body["method"]; got != mcpInitializedNotificationMethod {
+				t.Fatalf("method = %v, want %s", got, mcpInitializedNotificationMethod)
+			}
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","result":{}}`))
+		case 2:
+			if got := body["method"]; got != mcpToolsCallMethod {
+				t.Fatalf("method = %v, want %s", got, mcpToolsCallMethod)
+			}
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"1","result":{"content":[{"type":"text","text":"ok"}]}}`))
+		default:
+			t.Fatalf("unexpected MCP request %d", calls)
+		}
+		calls++
+	}))
+	defer server.Close()
+
+	executor := &ToolExecutor{client: server.Client(), namespace: "default", secretPath: "/secrets/tools"}
+	tool := &corev1alpha1.Tool{
+		ObjectMeta: metav1.ObjectMeta{Name: "lookup"},
+		Spec: corev1alpha1.ToolSpec{MCP: &corev1alpha1.MCPToolServer{SubstrateActor: &corev1alpha1.SubstrateMCPActor{
+			TemplateRef: corev1alpha1.WorkspaceTemplateReference{Name: "mcp-template"},
+		}}},
+		Status: corev1alpha1.ToolStatus{Endpoint: server.URL + "/mcp", Actor: &corev1alpha1.ToolActorStatus{RouteHost: "actor-1.actors.test"}},
+	}
+	ctx, parent := tracing.Tracer("test").Start(context.Background(), "agent.step")
+	member, err := baggage.NewMember("tenant", "acme")
+	if err != nil {
+		t.Fatalf("baggage member: %v", err)
+	}
+	bag, err := baggage.New(member)
+	if err != nil {
+		t.Fatalf("baggage: %v", err)
+	}
+	ctx = baggage.ContextWithBaggage(ctx, bag)
+	ctx = WithToolCallID(ctx, "call-http")
+	result, err := executor.Execute(ctx, tool, json.RawMessage(`{"x":1}`))
+	parent.End()
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result != "ok" {
+		t.Fatalf("result = %q, want ok", result)
+	}
+	if len(traceparents) != 4 {
+		t.Fatalf("traceparent count = %d, want 4", len(traceparents))
+	}
+	for i, traceparent := range traceparents {
+		if !validTraceparent(traceparent) {
+			t.Fatalf("traceparent[%d] = %q, want valid W3C header", i, traceparent)
+		}
+		if traceparent != traceparents[0] {
+			t.Fatalf("traceparent[%d] = %q, want %q", i, traceparent, traceparents[0])
+		}
+	}
+}
+
+func validTraceparent(value string) bool {
+	parts := strings.Split(value, "-")
+	return len(parts) == 4 && parts[0] == "00" && len(parts[1]) == 32 && len(parts[2]) == 16 && len(parts[3]) == 2
+}
+
+func TestToolExecutor_Execute_HTTPErrorRecordsErrorType(t *testing.T) {
+	if _, err := tracing.Init("test", false); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	spans := testutil.NewSpanHarness(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`bad gateway sensitive-body-marker`))
+	}))
+	defer server.Close()
+	executor := &ToolExecutor{client: server.Client(), namespace: "default", secretPath: "/secrets/tools"}
+	tool := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{Name: "failing_http"}, Spec: corev1alpha1.ToolSpec{HTTP: &corev1alpha1.HTTPExecution{URL: server.URL}}}
+	ctx, parent := tracing.Tracer("test").Start(context.Background(), "agent.step")
+	_, err := executor.Execute(ctx, tool, json.RawMessage(`{}`))
+	parent.End()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want HTTP error")
+	}
+	span := testutil.SpanNamed(spans.Recorder.Ended(), "execute_tool failing_http")
+	if span == nil {
+		t.Fatal("missing HTTP tool span")
+	}
+	attrs := testutil.AttributeMap(span)
+	if got := attrs["error.type"].AsString(); got != "http_status_502" {
+		t.Fatalf("error.type = %q", got)
+	}
+	if strings.Contains(span.Status().Description, "sensitive-body-marker") {
+		t.Fatalf("span status leaked response body: %q", span.Status().Description)
+	}
+	for _, event := range span.Events() {
+		if strings.Contains(event.Name, "sensitive-body-marker") {
+			t.Fatalf("span event leaked response body: %#v", event)
+		}
+		for _, kv := range event.Attributes {
+			if strings.Contains(kv.Value.AsString(), "sensitive-body-marker") {
+				t.Fatalf("span event attribute leaked response body: %#v", event)
+			}
+		}
+	}
+}
+
+func countMetricDataPoints(rm metricdata.ResourceMetrics, name string) int {
+	count := 0
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			switch data := metric.Data.(type) {
+			case metricdata.Histogram[int64]:
+				count += len(data.DataPoints)
+			case metricdata.Histogram[float64]:
+				count += len(data.DataPoints)
+			}
+		}
+	}
+	return count
 }

--- a/internal/workerenv/env.go
+++ b/internal/workerenv/env.go
@@ -319,6 +319,7 @@ type BaseEnv struct {
 	TaskUID            string
 	ResultEndpoint     string
 	ControllerURL      string
+	AgentName          string
 	TransactionID      string
 	TransactionProfile string
 }
@@ -332,6 +333,7 @@ func (e BaseEnv) EnvVars() []corev1.EnvVar {
 		Env(ControllerURL, e.ControllerURL),
 	}
 	envVars = AppendIfSet(envVars, TaskUID, e.TaskUID)
+	envVars = AppendIfSet(envVars, AgentName, e.AgentName)
 	envVars = AppendIfSet(envVars, TransactionID, e.TransactionID)
 	envVars = AppendIfSet(envVars, TransactionProfile, e.TransactionProfile)
 	return envVars
@@ -345,6 +347,7 @@ func ParseBaseEnv(getenv func(string) string) BaseEnv {
 		TaskUID:            getenv(TaskUID),
 		ResultEndpoint:     getenv(ResultEndpoint),
 		ControllerURL:      getenv(ControllerURL),
+		AgentName:          getenv(AgentName),
 		TransactionID:      getenv(TransactionID),
 		TransactionProfile: getenv(TransactionProfile),
 	}

--- a/internal/workerenv/env_test.go
+++ b/internal/workerenv/env_test.go
@@ -21,6 +21,7 @@ func TestAIWorkerEnvRoundTrip(t *testing.T) {
 			TaskNamespace:      "default",
 			ResultEndpoint:     "http://controller/results/default/task-1",
 			ControllerURL:      "http://controller",
+			AgentName:          "agent-a",
 			TransactionID:      "txn-123",
 			TransactionProfile: "kontxt",
 		},

--- a/website/docs/concepts/configuration.md
+++ b/website/docs/concepts/configuration.md
@@ -958,19 +958,25 @@ env:
 
 | Flag / Environment Variable | Default | Description |
 |------------------------------|---------|-------------|
-| `--enable-tracing` | `false` | Enable OpenTelemetry tracing |
+| `--enable-telemetry` / `--enable-tracing` | `false` | Enable OpenTelemetry traces and metrics |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `localhost:4317` | OTLP gRPC collector endpoint |
+| `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG` | SDK default | Standard OpenTelemetry sampler configuration |
 
 ### Instrumented Components
 
 | Tracer | Span | Attributes |
 |--------|------|------------|
-| `orka.api` | `GET /api/v1/tasks` | `http.method`, `http.route`, `http.status_code`, `http.request_id` |
-| `orka.chat` | `chat.request` | `session.id`, `chat.provider`, `chat.model` |
-| `orka.chat` | `chat.tool_loop.iteration` | `chat.iteration` |
-| `orka.llm` | `llm.complete` | `llm.provider`, `llm.model`, `llm.input_tokens`, `llm.output_tokens` |
-| `orka.tools` | `tool.execute` | `tool.name`, `tool.success` |
-| `orka.controller` | `task.reconcile` | `task.name`, `task.namespace`, `task.type` |
+| `orka.api` | HTTP/API middleware spans | HTTP request/route/status metadata |
+| `orka.chat` | `chat.request`, `chat.tool_loop.iteration` | session metadata; `chat.iteration`, `orka.tenant`, requested model, tool-call count |
+| `orka.worker` / `orka.harness` | `task.run` | `orka.task.id`, `orka.task.namespace`, `orka.tenant`, `orka.agent.name` when known |
+| `orka.agent` | `agent.step` | iteration, requested model/provider, tool-call count, Orka task metadata |
+| `orka.gen_ai` | `chat {model}` | `gen_ai.*` provider/model/token metadata and `error.type` |
+| `orka.gen_ai` | `execute_tool {tool.name}` | `gen_ai.tool.*`, `orka.tool.name`, `orka.tool.kind`, `orka.tool.result.size_bytes`, parent/child task fields for delegation |
+| `orka.controller` | `task.reconcile` | task name, namespace, type, and propagated trace context |
+
+Use `orka.task.id` to find a Task trace, `orka.tool.name` to find specific tool
+executions, and `orka.parent_task.id` / `orka.child_task.id` to follow delegated
+children. Tool spans do not include raw arguments or result bodies.
 
 ### Example: Jaeger Setup
 

--- a/website/docs/development/development.md
+++ b/website/docs/development/development.md
@@ -89,16 +89,25 @@ bash scripts/agent-substrate-e2e.sh
 
 Telemetry is enabled with `--enable-telemetry` (or the legacy alias
 `--enable-tracing`) and exported through `OTEL_EXPORTER_OTLP_ENDPOINT`. When the
-controller flag is enabled, AI worker Jobs receive `ORKA_ENABLE_TELEMETRY=true`
-and the non-secret standard OTLP environment. OTLP endpoint variables alone do
-not enable Kubernetes worker telemetry.
+controller flag is enabled and a worker-reachable OTLP endpoint is configured,
+AI worker Jobs receive `ORKA_ENABLE_TELEMETRY=true`, `ORKA_TRACEPARENT`, and the
+non-secret standard OTLP environment. Agent-runtime and harness-wrapper
+telemetry is explicit opt-in on those workloads; OTLP endpoint variables alone
+do not enable Kubernetes worker telemetry. Delegated child Tasks continue the
+active parent trace through Task annotations.
 
 GenAI semantic-convention constants live in `internal/tracing/genai` rather than
 upstream `semconv` because the GenAI conventions are still Development-stage.
 Run focused telemetry tests with:
 
 ```bash
-go test ./internal/tracing/... ./internal/llm/ ./internal/tools/ -run 'Tracing|Telemetry|GenAI|ExecuteTool|TraceContext' -v
+go test ./internal/tracing/... ./internal/llm/ ./internal/tools/ ./internal/worker ./workers/ai ./workers/harness/cliwrapper -run 'Tracing|Telemetry|GenAI|ExecuteTool|TraceContext|Traceparent|TaskRun|DelegateTrace' -v
+```
+
+Run disabled-telemetry hot-path benchmarks with:
+
+```bash
+go test ./internal/llm ./internal/tools ./internal/worker -run '^$' -bench 'Telemetry|Tracing|ExecuteTool|ToolExecutor' -benchmem
 ```
 
 ## UI Development

--- a/website/docs/guides/observability.md
+++ b/website/docs/guides/observability.md
@@ -4,10 +4,13 @@ slug: /observability
 
 # Observability
 
-Orka emits OpenTelemetry traces and metrics for controller, chat, tool, and AI
-worker paths when telemetry is enabled. The GenAI signals are backend
-instrumentation: they are exported over OTLP to your collector/backend and are
-separate from the Orka React UI.
+Orka emits OpenTelemetry traces and metrics for controller, chat, tool, AI
+worker, and harness-backed agent runtime paths when telemetry is enabled. The
+GenAI signals are backend instrumentation: they are exported over OTLP to your
+collector/backend and are separate from the Orka React UI.
+
+Telemetry is disabled by default. Disabled mode keeps the hot path on the global
+OpenTelemetry no-op providers and does not configure OTLP exporters.
 
 ## Enable telemetry
 
@@ -23,19 +26,77 @@ OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector.otel.svc:4317 \
 metrics. Existing Prometheus metrics on `--metrics-bind-address` continue to
 work independently.
 
-When controller telemetry is enabled, worker Jobs receive:
+When controller telemetry is enabled and a worker-reachable OTLP endpoint is configured, AI worker Jobs receive:
 
 - `ORKA_ENABLE_TELEMETRY=true`
-- `OTEL_EXPORTER_OTLP_ENDPOINT` and related standard OTLP environment variables
-- `ORKA_TRACEPARENT` when a Task was created from an already-traced API/chat/tool
-  request
+- `OTEL_EXPORTER_OTLP_ENDPOINT` and related standard non-secret OTLP environment variables
+- `ORKA_TRACEPARENT` when a Task was created from an already-traced API/chat/tool request
+
+Harness-wrapper and agent-runtime worker telemetry is explicit opt-in: set
+`ORKA_ENABLE_TELEMETRY=true` and OTLP exporter configuration on those workloads
+when you want their process-local spans exported.
 
 Credential-bearing OTLP header environment variables are not copied from the
 controller into task workloads. Use an in-cluster collector endpoint or a
 worker-scoped credential mechanism if your collector requires authentication.
 
-AI workers require `ORKA_ENABLE_TELEMETRY=true`; OTLP endpoint variables alone
-do not enable telemetry for Kubernetes task workloads.
+Kubernetes task workloads require `ORKA_ENABLE_TELEMETRY=true`; OTLP endpoint variables alone
+do not enable telemetry. Standard SDK sampling is
+available through `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` (for
+example `always_off`, `always_on`, or `parentbased_traceidratio`).
+
+## Trace topology
+
+A delegated Task should appear as one distributed trace:
+
+```text
+task.run
+  └─ agent.step / chat.tool_loop.iteration
+      ├─ chat {model}
+      ├─ execute_tool {tool.name}
+      └─ execute_tool delegate_task
+          └─ child task.run
+              └─ child agent.step / chat.tool_loop.iteration
+                  ├─ chat {model}
+                  └─ execute_tool {tool.name}
+```
+
+Model client spans measure provider-call latency only. Tool spans are siblings
+of the model client span under the same agent/chat step, not children of the
+model client span.
+
+Task creation stamps the current W3C trace context into Task annotations. The
+controller extracts that context when reconciling the Task and injects
+`ORKA_TRACEPARENT` into worker Jobs or harness-wrapper turn metadata. Delegation
+stamps the active `execute_tool delegate_task` span context onto the child Task,
+so the child `task.run` span is linked to the parent tool call.
+
+Outbound HTTP and MCP Tool CRD requests receive W3C `traceparent` headers. If a
+Tool config supplies its own `traceparent` header, the active Orka trace context
+wins.
+
+## Orka query attributes
+
+Orka emits low-cardinality, content-safe attributes alongside GenAI attributes:
+
+| Attribute | Meaning |
+|---|---|
+| `orka.task.id` | Task name |
+| `orka.task.namespace` | Kubernetes namespace |
+| `orka.tenant` | Tenant; currently the namespace fallback |
+| `orka.agent.name` | Agent name/runtime when known |
+| `orka.parent_task.id` | Parent Task name on delegation spans |
+| `orka.child_task.id` | Child Task name after creation |
+| `orka.tool.name` | Tool name |
+| `orka.tool.kind` | `builtin`, `delegate`, or `http` |
+| `orka.tool.result.size_bytes` | Tool result size only; never the body |
+
+Useful backend queries:
+
+- Find a Task trace: filter spans by `orka.task.id = "<task-name>"`.
+- Find tool calls: filter by `orka.tool.name = "delegate_task"` or another tool name.
+- Locate child work: filter by `orka.parent_task.id` or `orka.child_task.id`.
+- Split built-in vs external tools: group by `orka.tool.kind`.
 
 ## GenAI traces
 
@@ -58,11 +119,10 @@ Key attributes include:
 | `gen_ai.response.model` / `gen_ai.response.finish_reasons` / `gen_ai.response.id` | Response metadata when available |
 | `error.type` | Provider status code or Go error type on failed calls |
 
-Legacy `llm.*` attributes are dual-emitted during the migration window.
-
-Tool calls executed through the built-in registry are emitted as internal spans
-named `execute_tool {tool.name}` with `gen_ai.tool.*` attributes and a duration
-metric.
+Tool calls executed through the built-in registry are emitted as spans named
+`execute_tool {tool.name}` with `gen_ai.tool.*` and `orka.tool.*` attributes and
+a duration metric. External HTTP/MCP tools use the same span name and
+`orka.tool.kind=http`.
 
 ## GenAI metrics
 
@@ -75,32 +135,52 @@ Orka records these OTLP histograms when model/tool calls run:
 | `gen_ai.client.operation.time_to_first_chunk` | `s` | Streaming calls |
 | `gen_ai.execute_tool.duration` | `s` | Built-in registry tool calls |
 
-Dimensions are intentionally low-cardinality: operation, provider, model, token
-type, tool name/type, and error type when applicable.
+Metric dimensions are intentionally low-cardinality: operation, provider, model, token
+type, tool name/type, and error type when applicable. High-cardinality fields such
+as task IDs and result sizes stay on spans, not metric labels.
 
-## Distributed traces across pods
+## Example collector and backend
 
-Task creation stamps the current W3C trace context into Task annotations. The
-controller extracts that context when reconciling the Task and injects the
-`ORKA_TRACEPARENT` environment variable into worker Jobs.
+A development collector can export traces to Jaeger or Tempo. Example collector
+pipeline:
 
-```text
-HTTP/API span
-  └─ chat.request
-      ├─ chat {model}
-      └─ execute_tool create_agent_task
-          └─ Task annotation: orka.ai/traceparent
-              ├─ controller task.reconcile
-              └─ worker chat {model}
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+exporters:
+  otlp/tempo:
+    endpoint: tempo.observability.svc:4317
+    tls:
+      insecure: true
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/tempo]
 ```
 
-This preserves TraceID continuity across the API process, controller reconcile,
-and worker Pod without adding CRD fields.
+For local Jaeger all-in-one, expose its OTLP gRPC endpoint and set:
+
+```bash
+kubectl set env deployment/orka-controller \
+  OTEL_EXPORTER_OTLP_ENDPOINT=jaeger-collector.observability.svc:4317
+```
 
 ## Content capture and privacy
 
 Prompt/completion content capture is fail-closed and defaults to `none`. The
 current rollout emits metadata, token counts, model/provider identity, tool
-names, and durations, but not raw prompt or completion text. Future opt-in
-content capture must pass through Orka redaction and size caps before any span
-attribute or event is emitted.
+names, result sizes, and durations, but not raw prompt or completion text.
+
+Telemetry must not include:
+
+- raw prompts or completion content,
+- raw tool arguments or tool result bodies,
+- API keys, auth headers, TxTokens, context tokens, JWTs, cookies, or credentials,
+- raw transcripts or broad local filesystem paths.
+
+Future opt-in content capture must pass through Orka redaction and size caps
+before any span attribute or event is emitted.

--- a/workers/ai/main.go
+++ b/workers/ai/main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,7 +24,6 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -123,6 +123,17 @@ func run() (err error) {
 			"baggage":     workerEnv.TraceBaggage,
 		})
 	}
+
+	taskAttrs := tracing.TaskAttributes(taskName, taskNamespace, taskNamespace, workerEnv.AgentName, "")
+	ctx, taskSpan := tracing.Tracer("orka.worker").Start(ctx, "task.run", trace.WithAttributes(taskAttrs...))
+	defer func() {
+		if err != nil {
+			errType := aiWorkerErrorType(err)
+			taskSpan.SetStatus(codes.Error, errType)
+			taskSpan.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+		}
+		taskSpan.End()
+	}()
 
 	transactionLogFields := workerenv.TransactionLogFields(
 		workerEnv.TransactionID, workerEnv.TransactionProfile,
@@ -936,6 +947,7 @@ func executeAgentLoopWithEvents(
 	}
 
 	for iteration := range maxIterations {
+		stepCtx, stepSpan := startAgentStepSpan(ctx, iteration, provider, model, llmTools, baseToolCtx)
 		req := &llm.CompletionRequest{
 			Model:        model,
 			Messages:     messages,
@@ -954,7 +966,7 @@ func executeAgentLoopWithEvents(
 			})),
 		)
 
-		resp, err := provider.Complete(ctx, req)
+		resp, err := provider.Complete(stepCtx, req)
 		if err != nil && llm.IsContextTooLongErr(err) {
 			tokenEstimate := 0
 			for _, m := range messages {
@@ -972,9 +984,12 @@ func executeAgentLoopWithEvents(
 					"messageCountAfter":  len(messages),
 				})),
 			)
-			resp, err = provider.Complete(ctx, req)
+			resp, err = provider.Complete(stepCtx, req)
 		}
 		if err != nil {
+			errType := aiWorkerErrorType(err)
+			stepSpan.SetStatus(codes.Error, errType)
+			stepSpan.SetAttributes(attribute.String(genai.AttrErrorType, errType))
 			common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeModelRequestFailed, modelLoopEventTimeout,
 				common.WithEventSeverity(events.ExecutionEventSeverityError),
 				common.WithEventSummary(err.Error()),
@@ -984,8 +999,10 @@ func executeAgentLoopWithEvents(
 					"provider":  llm.ProviderTelemetryName(provider),
 				})),
 			)
+			stepSpan.End()
 			return "", fmt.Errorf("completion failed: %w", err)
 		}
+		stepSpan.SetAttributes(attribute.Int("agent.step.tool_call_count", len(resp.ToolCalls)))
 		common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeModelRequestCompleted, modelLoopEventTimeout,
 			common.WithEventSummary("model request completed"),
 			common.WithEventContent(eventContent(map[string]any{
@@ -1011,6 +1028,7 @@ func executeAgentLoopWithEvents(
 
 		// If no tool calls, we're done
 		if len(resp.ToolCalls) == 0 {
+			stepSpan.End()
 			return resp.Content, nil
 		}
 
@@ -1026,7 +1044,7 @@ func executeAgentLoopWithEvents(
 		var continueLoop bool
 		var approvalErr error
 		messages, approvalResult, done, continueLoop, approvalErr = processApprovalBatch(
-			ctx,
+			stepCtx,
 			messages,
 			resp.ToolCalls,
 			approvalGate,
@@ -1036,12 +1054,18 @@ func executeAgentLoopWithEvents(
 			baseToolCtx,
 		)
 		if approvalErr != nil {
+			stepSpan.RecordError(approvalErr)
+			stepSpan.SetStatus(codes.Error, aiWorkerErrorType(approvalErr))
+			stepSpan.SetAttributes(attribute.String(genai.AttrErrorType, aiWorkerErrorType(approvalErr)))
+			stepSpan.End()
 			return "", approvalErr
 		}
 		if done {
+			stepSpan.End()
 			return approvalResult, nil
 		}
 		if continueLoop {
+			stepSpan.End()
 			continue
 		}
 
@@ -1069,10 +1093,10 @@ func executeAgentLoopWithEvents(
 			customToolForCall := customTools[toolName]
 			if _, ok := allowedToolCalls[toolName]; !ok {
 				execErr = fmt.Errorf("tool %q was not enabled for this task", tc.Name)
-				tools.RecordRejectedToolCall(ctx, toolName, tc.ID, "tool_not_enabled", execErr.Error())
+				tools.RecordRejectedToolCall(stepCtx, toolName, tc.ID, "tool_not_enabled", execErr.Error())
 			} else {
 				execArgs, approvalKey, alreadyFired, execErr = approvalGate.prepareApprovedCall(
-					ctx,
+					stepCtx,
 					toolName,
 					tc.Arguments,
 					customToolForCall,
@@ -1084,14 +1108,11 @@ func executeAgentLoopWithEvents(
 				result = fmt.Sprintf("already executed approved action for idempotency key %s; skipping duplicate", approvalKey)
 			} else if customToolForCall != nil {
 				customTool := customToolForCall
-				execCtx := ctx
+				execCtx := worker.WithToolCallID(stepCtx, tc.ID)
 				if approvalKey != "" {
 					execCtx = worker.WithToolIdempotencyKey(execCtx, approvalKey)
 				}
-				executeCustomTool := func(callCtx context.Context) (string, error) {
-					return toolExecutor.Execute(callCtx, customTool, execArgs)
-				}
-				result, execErr = executeCustomToolWithTelemetry(execCtx, toolName, tc.ID, executeCustomTool)
+				result, execErr = toolExecutor.Execute(execCtx, customTool, execArgs)
 				if execErr == nil || worker.ToolRequestWasAttempted(execErr) {
 					approvalGate.markFired(approvalKey)
 				}
@@ -1100,14 +1121,14 @@ func executeAgentLoopWithEvents(
 				if approvalKey != "" {
 					execArgs, execErr = injectIdempotencyKey(execArgs, approvalKey)
 				}
-				execCtx := ctx
+				execCtx := stepCtx
 				if baseToolCtx != nil {
 					toolCtxCopy := *baseToolCtx
 					toolCtxCopy.ToolCallID = tc.ID
 					if toolCtxCopy.Tenant == "" {
 						toolCtxCopy.Tenant = toolCtxCopy.Namespace
 					}
-					execCtx = tools.WithToolContext(ctx, &toolCtxCopy)
+					execCtx = tools.WithToolContext(stepCtx, &toolCtxCopy)
 				}
 				if execErr == nil {
 					approvalGate.markFired(approvalKey)
@@ -1144,6 +1165,7 @@ func executeAgentLoopWithEvents(
 				Name:       tc.Name,
 			})
 		}
+		stepSpan.End()
 	}
 
 	return "", fmt.Errorf("max iterations reached without completion")
@@ -1157,49 +1179,43 @@ func approvalToolingRequested(coordinationEnv workerenv.CoordinationEnv, allowed
 	return requestApprovalAdvertised
 }
 
-func executeCustomToolWithTelemetry(
+func aiWorkerErrorType(err error) string {
+	if err == nil {
+		return ""
+	}
+	var providerErr *llm.ProviderError
+	if errors.As(err, &providerErr) && providerErr.StatusCode > 0 {
+		return fmt.Sprintf("llm_status_%d", providerErr.StatusCode)
+	}
+	return fmt.Sprintf("%T", err)
+}
+
+func startAgentStepSpan(
 	ctx context.Context,
-	toolName string,
-	toolCallID string,
-	execute func(context.Context) (string, error),
-) (string, error) {
-	start := time.Now()
+	iteration int,
+	provider llm.Provider,
+	model string,
+	llmTools []llm.Tool,
+	baseToolCtx *tools.ToolContext,
+) (context.Context, trace.Span) {
 	attrs := []attribute.KeyValue{
-		attribute.String(genai.AttrOperationName, genai.OperationExecuteTool),
-		attribute.String(genai.AttrToolName, toolName),
-		attribute.String(genai.AttrToolType, genai.ToolTypeExtension),
+		attribute.Int("agent.step.iteration", iteration+1),
+		attribute.Int("agent.step.available_tools", len(llmTools)),
 	}
-	if toolCallID != "" {
-		attrs = append(attrs, attribute.String(genai.AttrToolCallID, toolCallID))
+	if model != "" {
+		attrs = append(attrs, attribute.String(genai.AttrRequestModel, model))
 	}
-	ctx, span := tracing.GenAITracer(genai.InstrumentationName).Start(
-		ctx,
-		genai.OperationExecuteTool+" "+toolName,
-		trace.WithSpanKind(trace.SpanKindInternal),
-		trace.WithAttributes(attrs...),
-	)
-	defer span.End()
-	result, err := execute(ctx)
-	metricAttrs := []attribute.KeyValue{
-		attribute.String(genai.AttrOperationName, genai.OperationExecuteTool),
-		attribute.String(genai.AttrToolName, toolName),
-		attribute.String(genai.AttrToolType, genai.ToolTypeExtension),
+	if providerName := llm.ProviderTelemetryName(provider); providerName != "" {
+		attrs = append(attrs, attribute.String(genai.AttrProviderName, providerName))
 	}
-	if err != nil {
-		errType := fmt.Sprintf("%T", err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
-		metricAttrs = append(metricAttrs, attribute.String(genai.AttrErrorType, errType))
+	if baseToolCtx != nil {
+		tenant := baseToolCtx.Tenant
+		if tenant == "" {
+			tenant = baseToolCtx.Namespace
+		}
+		attrs = append(attrs, tracing.TaskAttributes(baseToolCtx.TaskID, baseToolCtx.Namespace, tenant, "", "")...)
 	}
-	if histogram, histErr := tracing.GenAIMeter(genai.InstrumentationName).Float64Histogram(
-		genai.MetricExecuteToolDuration,
-		metric.WithUnit(genai.UnitSeconds),
-		metric.WithExplicitBucketBoundaries(genai.ToolDurationBuckets...),
-	); histErr == nil {
-		histogram.Record(ctx, time.Since(start).Seconds(), metric.WithAttributes(metricAttrs...))
-	}
-	return result, err
+	return tracing.Tracer("orka.agent").Start(ctx, "agent.step", trace.WithAttributes(attrs...))
 }
 
 func advertisedToolNames(llmTools []llm.Tool) map[string]struct{} {

--- a/workers/ai/main_test.go
+++ b/workers/ai/main_test.go
@@ -24,10 +24,12 @@ import (
 	"github.com/sozercan/orka/internal/llm"
 	"github.com/sozercan/orka/internal/store"
 	toolspkg "github.com/sozercan/orka/internal/tools"
+	"github.com/sozercan/orka/internal/tracing"
 	"github.com/sozercan/orka/internal/tracing/genai"
 	"github.com/sozercan/orka/internal/tracing/testutil"
 	"github.com/sozercan/orka/internal/workerenv"
 	"github.com/sozercan/orka/workers/common"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 const roleUser = "user"
@@ -675,31 +677,6 @@ func TestAIWorkerEventCompletenessSmoke(t *testing.T) {
 	}
 }
 
-func TestExecuteCustomToolWithTelemetryRecordsSpan(t *testing.T) {
-	spans := testutil.NewSpanHarness(t)
-	execute := func(context.Context) (string, error) {
-		return "custom result", nil
-	}
-	result, err := executeCustomToolWithTelemetry(context.Background(), "custom_http_tool", "call-custom", execute)
-	if err != nil || result != "custom result" {
-		t.Fatalf("executeCustomToolWithTelemetry() result=%q err=%v", result, err)
-	}
-	for _, span := range spans.Recorder.Ended() {
-		if span.Name() != "execute_tool custom_http_tool" {
-			continue
-		}
-		attrs := map[string]string{}
-		for _, kv := range span.Attributes() {
-			attrs[string(kv.Key)] = kv.Value.AsString()
-		}
-		if attrs[genai.AttrToolType] != genai.ToolTypeExtension || attrs[genai.AttrToolCallID] != "call-custom" {
-			t.Fatalf("custom tool span attrs = %#v", attrs)
-		}
-		return
-	}
-	t.Fatalf("missing custom tool span, got %#v", spans.Recorder.Ended())
-}
-
 func TestAIWorkerRecordsRejectedToolTelemetry(t *testing.T) {
 	spans := testutil.NewSpanHarness(t)
 	provider := &mockProvider{responses: []*llm.CompletionResponse{
@@ -1086,4 +1063,76 @@ func hasEventTypes(got []string, want []string) bool {
 		}
 	}
 	return true
+}
+
+func TestExecuteAgentLoopTracingStepParentsModelAndToolSiblings(t *testing.T) {
+	if _, err := tracing.Init("test", false); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	spans := testutil.NewSpanHarness(t)
+	restore := replaceDefaultToolRegistryForTest(t)
+	defer restore()
+	toolspkg.DefaultRegistry.Register(staticTestTool{name: customToolName})
+	llmTools := toolspkg.DefaultRegistry.ToLLMTools([]string{customToolName})
+	provider := llm.NewTracingProvider(&mockProvider{responses: []*llm.CompletionResponse{
+		{
+			Content: "calling tool",
+			ToolCalls: []llm.ToolCall{{
+				ID:        "call-1",
+				Name:      customToolName,
+				Arguments: json.RawMessage(`{"path":"README.md"}`),
+			}},
+			StopReason: "tool_use",
+			Model:      "test-model",
+		},
+		{Content: "done", StopReason: "end_turn", Model: "test-model"},
+	}})
+	baseToolCtx := &toolspkg.ToolContext{TaskID: "task-a", Namespace: "team-a", Tenant: "team-a"}
+	result, err := executeAgentLoopWithEvents(
+		context.Background(), provider, []llm.Message{{Role: "user", Content: "use tool"}}, "", "test-model",
+		llmTools, nil, nil, common.NoopEventRecorder{}, baseToolCtx,
+	)
+	if err != nil {
+		t.Fatalf("executeAgentLoopWithEvents() error = %v", err)
+	}
+	if result != "done" {
+		t.Fatalf("result = %q, want done", result)
+	}
+
+	ended := spans.Recorder.Ended()
+	toolSpan := testutil.SpanNamed(ended, "execute_tool "+customToolName)
+	if toolSpan == nil {
+		t.Fatal("missing tool span")
+	}
+	var stepSpan sdktrace.ReadOnlySpan
+	for _, span := range testutil.SpansNamed(ended, "agent.step") {
+		attrs := testutil.AttributeMap(span)
+		if attrs["agent.step.tool_call_count"].AsInt64() == 1 {
+			stepSpan = span
+			break
+		}
+	}
+	if stepSpan == nil {
+		t.Fatal("missing first agent.step span")
+	}
+	var modelSpan sdktrace.ReadOnlySpan
+	for _, span := range testutil.SpansNamed(ended, "chat test-model") {
+		if span.Parent().SpanID() == stepSpan.SpanContext().SpanID() {
+			modelSpan = span
+			break
+		}
+	}
+	if modelSpan == nil {
+		t.Fatal("missing model span under first step")
+	}
+	if got, want := toolSpan.Parent().SpanID(), stepSpan.SpanContext().SpanID(); got != want {
+		t.Fatalf("tool parent = %s, want step %s", got, want)
+	}
+	if toolSpan.Parent().SpanID() == modelSpan.SpanContext().SpanID() {
+		t.Fatalf("tool span is child of model span; want sibling under step")
+	}
+	attrs := testutil.AttributeMap(stepSpan)
+	if got := attrs[tracing.AttrTaskID].AsString(); got != "task-a" {
+		t.Fatalf("step %s = %q", tracing.AttrTaskID, got)
+	}
 }

--- a/workers/common/agent_runtime.go
+++ b/workers/common/agent_runtime.go
@@ -28,8 +28,12 @@ import (
 
 	"github.com/sozercan/orka/internal/events"
 	"github.com/sozercan/orka/internal/redact"
+	"github.com/sozercan/orka/internal/tracing"
 	"github.com/sozercan/orka/internal/workerenv"
 	"github.com/sozercan/orka/internal/workspace"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // AgentConfig holds worker configuration from environment variables.
@@ -472,6 +476,43 @@ func execGitContext(ctx context.Context, dir string, args ...string) error {
 // AgentExecutor is a function that runs the agent and returns its output.
 type AgentExecutor func(ctx context.Context, cfg *AgentConfig) (string, error)
 
+func agentTelemetryEnabled() bool {
+	return workerenv.IsTrue(os.Getenv(workerenv.EnableTelemetry))
+}
+
+func startAgentTaskRunTelemetry(
+	ctx context.Context,
+	runtimeName string,
+	cfg *AgentConfig,
+) (context.Context, trace.Span, func(context.Context) error, error) {
+	tracingShutdown, err := tracing.Init("orka-agent-worker", agentTelemetryEnabled())
+	if err != nil {
+		return ctx, nil, nil, fmt.Errorf("failed to initialize telemetry: %w", err)
+	}
+	if traceParent := os.Getenv(workerenv.TraceParent); traceParent != "" {
+		ctx = tracing.ExtractContext(ctx, tracing.MapCarrier{
+			"traceparent": traceParent,
+			"tracestate":  os.Getenv(workerenv.TraceState),
+			"baggage":     os.Getenv(workerenv.TraceBaggage),
+		})
+	}
+	agentName := strings.TrimSpace(os.Getenv(workerenv.AgentName))
+	if agentName == "" {
+		agentName = runtimeName
+	}
+	ctx, taskSpan := tracing.Tracer("orka.worker").Start(ctx, "task.run", trace.WithAttributes(
+		tracing.TaskAttributes(cfg.TaskName, cfg.TaskNamespace, cfg.TaskNamespace, agentName, "")...,
+	))
+	return ctx, taskSpan, tracingShutdown, nil
+}
+
+func agentRuntimeErrorType(err error) string {
+	if err == nil {
+		return ""
+	}
+	return fmt.Sprintf("%T", err)
+}
+
 const (
 	agentSandboxWorkerUploadPath              = "orka-agent-worker"
 	agentSandboxWorkerExecPath                = "/app/" + agentSandboxWorkerUploadPath
@@ -624,6 +665,9 @@ func RunAgent(name, workspaceDir string, defaultMaxTurns int, executor AgentExec
 	}
 
 	defer func() {
+		// RunAgent has a named error return. Go assigns every return expression
+		// to err before deferred functions run, including returns from shadowed
+		// inner err variables, so this observes the final worker outcome.
 		if err != nil {
 			recordAgentWorkerFailedEvent(eventRecorder, name, taskName, err)
 			return
@@ -640,6 +684,26 @@ func RunAgent(name, workspaceDir string, defaultMaxTurns int, executor AgentExec
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
 	taskName = cfg.TaskName
+
+	ctx, taskSpan, tracingShutdown, err := startAgentTaskRunTelemetry(ctx, name, cfg)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if shutdownErr := tracingShutdown(shutdownCtx); shutdownErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to shutdown telemetry: %v\n", shutdownErr)
+		}
+	}()
+	defer func() {
+		if err != nil {
+			errType := agentRuntimeErrorType(err)
+			taskSpan.SetStatus(codes.Error, errType)
+			taskSpan.SetAttributes(attribute.String("error.type", errType))
+		}
+		taskSpan.End()
+	}()
 
 	fmt.Printf("Worker %s started task=%s/%s%s\n",
 		name, cfg.TaskNamespace, cfg.TaskName, workerenv.TransactionLogFields(cfg.TransactionID, cfg.TransactionProfile))

--- a/workers/common/agent_runtime_test.go
+++ b/workers/common/agent_runtime_test.go
@@ -27,6 +27,8 @@ import (
 
 	corev1alpha1 "github.com/sozercan/orka/api/v1alpha1"
 	"github.com/sozercan/orka/internal/events"
+	"github.com/sozercan/orka/internal/tracing"
+	"github.com/sozercan/orka/internal/tracing/testutil"
 	"github.com/sozercan/orka/internal/workerenv"
 	"github.com/sozercan/orka/internal/workspace"
 )
@@ -863,6 +865,46 @@ func TestRunAgent_ExecutorSuccess(t *testing.T) {
 	err := RunAgent("test-agent", "/tmp/ws", 50, executor)
 	if err != nil {
 		t.Fatalf("RunAgent should succeed, got: %v", err)
+	}
+}
+
+func TestRunAgentEmitsTaskRunSpanFromTraceparent(t *testing.T) {
+	if _, err := tracing.Init("test", false); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	spans := testutil.NewSpanHarness(t)
+	parentCtx, parentSpan := tracing.Tracer("test").Start(context.Background(), "parent")
+	carrier := tracing.InjectContext(parentCtx)
+	t.Setenv(workerenv.TraceParent, carrier.Get("traceparent"))
+	t.Setenv(workerenv.AgentName, "agent-a")
+	setBasicRunAgentEnv(t, "trace-task")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	t.Setenv(workerenv.ResultEndpoint, server.URL)
+	restoreRecorder := setRunAgentEventRecorderForTest(NewFakeEventRecorder())
+	defer restoreRecorder()
+
+	if err := RunAgent("codex", t.TempDir(), 50, func(context.Context, *AgentConfig) (string, error) {
+		return "done", nil
+	}); err != nil {
+		t.Fatalf("RunAgent() error = %v", err)
+	}
+	parentSpan.End()
+	taskRun := testutil.SpanNamed(spans.Recorder.Ended(), "task.run")
+	if taskRun == nil {
+		t.Fatal("missing task.run span")
+	}
+	if got, want := taskRun.Parent().SpanID(), parentSpan.SpanContext().SpanID(); got != want {
+		t.Fatalf("task.run parent = %s, want %s", got, want)
+	}
+	attrs := testutil.AttributeMap(taskRun)
+	if got := attrs[tracing.AttrTaskID].AsString(); got != "trace-task" {
+		t.Fatalf("%s = %q", tracing.AttrTaskID, got)
+	}
+	if got := attrs[tracing.AttrAgentName].AsString(); got != "agent-a" {
+		t.Fatalf("%s = %q", tracing.AttrAgentName, got)
 	}
 }
 

--- a/workers/harness/cliwrapper/server.go
+++ b/workers/harness/cliwrapper/server.go
@@ -19,8 +19,12 @@ import (
 
 	"github.com/sozercan/orka/internal/events"
 	"github.com/sozercan/orka/internal/harness"
+	"github.com/sozercan/orka/internal/tracing"
 	"github.com/sozercan/orka/internal/workerenv"
 	"github.com/sozercan/orka/workers/common"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -418,12 +422,26 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request, turn *turn
 
 func (s *Server) runTurn(turn *turnState) { //nolint:gocyclo
 	defer s.finishTurn(turn)
-	ctx := turn.ctx
+	ctx := extractHarnessTurnTraceContext(turn.ctx, turn.request)
 	if !turn.request.Deadline.IsZero() {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithDeadline(ctx, turn.request.Deadline)
 		defer cancel()
 	}
+	agentName := strings.TrimSpace(turn.request.Metadata["agentName"])
+	if agentName == "" {
+		agentName = s.adapter.Name()
+	}
+	ctx, taskSpan := tracing.Tracer("orka.harness").Start(ctx, "task.run", trace.WithAttributes(
+		tracing.TaskAttributes(turn.request.TaskName, turn.request.Namespace, turn.request.Namespace, agentName, "")...,
+	))
+	defer func() {
+		if failed, errType := turnTerminalFailure(turn); failed {
+			taskSpan.SetStatus(codes.Error, errType)
+			taskSpan.SetAttributes(attribute.String("error.type", errType))
+		}
+		taskSpan.End()
+	}()
 	turnCtx := turnContextFromRequest(s.adapter.Name(), s.config, turn.request)
 	if eventing, ok := s.adapter.(EventingAdapter); ok {
 		_, err := eventing.RunTurn(ctx, turnCtx, func(frame harness.HarnessEventFrame) error {
@@ -656,6 +674,32 @@ func (s *Server) runTurn(turn *turnState) { //nolint:gocyclo
 			return
 		}
 	}
+}
+
+func extractHarnessTurnTraceContext(ctx context.Context, request harness.StartTurnRequest) context.Context {
+	carrier := tracing.MapCarrier{}
+	if request.Metadata != nil {
+		carrier["traceparent"] = request.Metadata["traceparent"]
+		carrier["tracestate"] = request.Metadata["tracestate"]
+	}
+	if carrier["traceparent"] == "" {
+		return ctx
+	}
+	return tracing.ExtractContext(ctx, carrier)
+}
+
+func turnTerminalFailure(turn *turnState) (bool, string) {
+	if turn == nil {
+		return false, ""
+	}
+	turn.mu.Lock()
+	defer turn.mu.Unlock()
+	for i := len(turn.frames) - 1; i >= 0; i-- {
+		if turn.frames[i].Type == harness.FrameTurnFailed {
+			return true, "turn_failed"
+		}
+	}
+	return false, ""
 }
 
 func (s *Server) failedTurnPartialResult(ctx context.Context, turnCtx TurnContext, run CommandResult) (string, bool) {

--- a/workers/harness/cliwrapper/server_test.go
+++ b/workers/harness/cliwrapper/server_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/sozercan/orka/internal/harness"
+	"github.com/sozercan/orka/internal/tracing"
+	"github.com/sozercan/orka/internal/tracing/testutil"
 	"github.com/sozercan/orka/internal/workerenv"
 )
 
@@ -739,5 +741,64 @@ func TestServerStripsGitCredentialsFromReadOnlyCommandEnv(t *testing.T) {
 	}
 	if strings.Contains(last.Completed.Result, "token") {
 		t.Fatalf("read-only command received git credentials: %q", last.Completed.Result)
+	}
+}
+
+func TestServerRunTurnEmitsTaskRunSpanFromTraceparentMetadata(t *testing.T) {
+	if _, err := tracing.Init("test", false); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	spans := testutil.NewSpanHarness(t)
+	cfg := DefaultConfig()
+	cfg.AllowUnauthenticated = true
+	server, err := NewServer(cfg, NewFakeAdapter(FakeBehaviorSuccess))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv := httptest.NewServer(server.Handler())
+	defer srv.Close()
+	client, err := harness.NewClient(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentCtx, parentSpan := tracing.Tracer("test").Start(context.Background(), "controller")
+	carrier := tracing.InjectContext(parentCtx)
+	forgedCtx, forgedSpan := tracing.Tracer("test").Start(context.Background(), "forged")
+	forgedCarrier := tracing.InjectContext(forgedCtx)
+	forgedSpan.End()
+	request := validWrapperStartTurnRequest()
+	request.Metadata = map[string]string{
+		"traceparent": carrier.Get("traceparent"),
+		"agentName":   "agent-a",
+	}
+	request.Input.Env = append(request.Input.Env, harness.TurnEnvVar{
+		Name:  workerenv.TraceParent,
+		Value: forgedCarrier.Get("traceparent"),
+	})
+	if _, err := client.StartTurn(context.Background(), request); err != nil {
+		t.Fatalf("StartTurn: %v", err)
+	}
+	_ = collectWrapperFrames(t, client, request.TurnID, 0)
+	parentSpan.End()
+
+	eventually(t, time.Second, func() bool {
+		return testutil.SpanNamed(spans.Recorder.Ended(), "task.run") != nil
+	})
+	taskRun := testutil.SpanNamed(spans.Recorder.Ended(), "task.run")
+	if taskRun == nil {
+		t.Fatal("missing task.run span")
+	}
+	if got, want := taskRun.Parent().SpanID(), parentSpan.SpanContext().SpanID(); got != want {
+		t.Fatalf("task.run parent = %s, want controller %s", got, want)
+	}
+	if got, forged := taskRun.Parent().SpanID(), forgedSpan.SpanContext().SpanID(); got == forged {
+		t.Fatalf("task.run used task-supplied forged traceparent %s", forged)
+	}
+	attrs := testutil.AttributeMap(taskRun)
+	if got := attrs[tracing.AttrTaskID].AsString(); got != request.TaskName {
+		t.Fatalf("%s = %q", tracing.AttrTaskID, got)
+	}
+	if got := attrs[tracing.AttrAgentName].AsString(); got != "agent-a" {
+		t.Fatalf("%s = %q", tracing.AttrAgentName, got)
 	}
 }


### PR DESCRIPTION
## Summary

- add safe Orka-native telemetry attributes and test helpers for task, tool, and delegation spans
- add `task.run` and `agent.step` coverage across AI workers, harness-backed agent turns, and agent worker runtime paths
- enrich built-in, delegate, HTTP, and MCP tool spans while propagating W3C `traceparent` to delegated Tasks and outbound tool requests
- document the task/model/tool/delegation trace topology, privacy rules, query attributes, sampler behavior, and validation workflow
- add disabled-telemetry benchmarks for LLM tracing, built-in tool execution, and HTTP tool execution

## Safety / privacy

- telemetry remains disabled by default
- span attributes use metadata only; no raw prompts, completions, tool arguments, tool result bodies, tokens, or credentials are emitted
- tool/model/task error telemetry uses stable error types/statuses instead of raw response bodies or provider messages
- high-cardinality task/result-size fields stay on spans and are not used as metric labels

## Validation

- `make lint-fix`
- `make test`
- `go test ./internal/tracing/... ./internal/llm/ ./internal/tools/ ./internal/worker ./workers/ai ./workers/harness/cliwrapper ./workers/common ./cmd/orka-agent-harness-wrapper -run 'Attr|Attribute|Tracing|Telemetry|GenAI|ExecuteTool|TraceContext|Traceparent|TaskRun|DelegateTrace|Sampler|HTTPErrorRecords' -v`
- `go test ./internal/tools -run 'Registry.*Tracing|Delegate.*Trace|DelegateTask' -v`
- `go test ./internal/worker -run 'ToolExecutor.*Trace|Traceparent|MCP.*Trace|HTTPErrorRecords' -v`
- `go test ./internal/api ./workers/ai -run 'Tracing|ToolLoop|Step|Iteration' -v`
- `go test ./internal/llm ./internal/tools ./internal/worker -run '^$' -bench 'Telemetry|Tracing|ExecuteTool|ToolExecutor' -benchmem -count=10`
- `cd website && yarn build`
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings
