### PR TITLE
test(e2e): verify otel delegated task topology

### DIFF
--- a/test/e2e/otel_genai_test.go
+++ b/test/e2e/otel_genai_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os/exec"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -24,13 +25,18 @@ import (
 )
 
 const (
-	otelCollectorName       = "e2e-otel-collector"
-	otelFakeOpenAIName      = "e2e-otel-openai"
-	otelProviderName        = "e2e-otel-provider"
-	otelProviderAuthRefName = "e2e-otel-openai-auth"
-	otelTaskName            = "e2e-otel-genai-task"
-	otelModelName           = "e2e-otel-model"
-	otelFakeOpenAIImage     = "python:3.14-slim"
+	otelCollectorName               = "e2e-otel-collector"
+	otelFakeOpenAIName              = "e2e-otel-openai"
+	otelProviderName                = "e2e-otel-provider"
+	otelProviderAuthRefName         = "e2e-otel-openai-auth"
+	otelTaskName                    = "e2e-otel-genai-task"
+	otelTopologyProviderName        = "e2e-otel-topology-provider"
+	otelTopologyProviderAuthRefName = "e2e-otel-topology-openai-auth"
+	otelTopologyTaskName            = "e2e-otel-topology-task"
+	otelTopologyCoordAgent          = "e2e-otel-topology-coord"
+	otelTopologyWorkerAgent         = "e2e-otel-topology-worker"
+	otelModelName                   = "e2e-otel-model"
+	otelFakeOpenAIImage             = "python:3.14-slim"
 )
 
 func otelCollectorServiceAddr() string {
@@ -58,11 +64,18 @@ var _ = Describe("OpenTelemetry GenAI export", Ordered, Serial, func() {
 
 	AfterAll(func() {
 		By("cleaning up OpenTelemetry GenAI test resources")
+		cmd := exec.Command("kubectl", "delete", "tasks", "-l", fmt.Sprintf("orka.ai/parent-task=%s", otelTopologyTaskName), "-n", namespace, "--ignore-not-found")
+		_, _ = utils.Run(cmd)
 		for _, resource := range []struct {
 			kind string
 			name string
 		}{
 			{kind: "task", name: otelTaskName},
+			{kind: "task", name: otelTopologyTaskName},
+			{kind: "agent", name: otelTopologyCoordAgent},
+			{kind: "agent", name: otelTopologyWorkerAgent},
+			{kind: "provider", name: otelTopologyProviderName},
+			{kind: "secret", name: otelTopologyProviderAuthRefName},
 			{kind: "provider", name: otelProviderName},
 			{kind: "secret", name: otelProviderAuthRefName},
 			{kind: "deployment", name: otelCollectorName},
@@ -82,6 +95,7 @@ var _ = Describe("OpenTelemetry GenAI export", Ordered, Serial, func() {
 
 	AfterEach(func() {
 		dumpDebugInfo(otelTaskName)
+		dumpDebugInfo(otelTopologyTaskName)
 		dumpOTelCollectorLogsForDiagnostics()
 	})
 
@@ -146,7 +160,115 @@ var _ = Describe("OpenTelemetry GenAI export", Ordered, Serial, func() {
 			"gen_ai.execute_tool.duration",
 		}, 3*time.Minute)
 	})
+
+	It("exports one trace for a delegated parent and child task topology", func() {
+		By("cleaning up prior topology resources from earlier runs")
+		cleanupOTelTopologyResources()
+
+		By("creating a Provider CRD that points to the fake OpenAI endpoint")
+		createOTelSecretOrFail(otelTopologyProviderAuthRefName, map[string]string{"token": "placeholder"})
+		createProviderCRD(
+			otelTopologyProviderName,
+			"openai",
+			otelTopologyProviderAuthRefName,
+			"token",
+			fmt.Sprintf("http://%s.%s.svc:8080", otelFakeOpenAIName, namespace),
+			otelModelName,
+		)
+
+		By("creating a worker agent with a child tool and a coordinator agent with delegation enabled")
+		applyOTelManifest(fmt.Sprintf(`{
+			"apiVersion": "core.orka.ai/v1alpha1",
+			"kind": "Agent",
+			"metadata": {
+				"name": "%s",
+				"namespace": "%s"
+			},
+			"spec": {
+				"providerRef": {"name": "%s"},
+				"model": {"name": "%s"},
+				"tools": [{"name": "file_write"}]
+			}
+		}`, otelTopologyWorkerAgent, namespace, otelTopologyProviderName, otelModelName))
+
+		applyOTelManifest(fmt.Sprintf(`{
+			"apiVersion": "core.orka.ai/v1alpha1",
+			"kind": "Agent",
+			"metadata": {
+				"name": "%s",
+				"namespace": "%s"
+			},
+			"spec": {
+				"providerRef": {"name": "%s"},
+				"model": {"name": "%s"},
+				"coordination": {
+					"enabled": true,
+					"maxDepth": 2,
+					"maxConcurrentChildren": 1,
+					"allowedAgents": [{"name": "%s"}]
+				}
+			}
+		}`, otelTopologyCoordAgent, namespace, otelTopologyProviderName, otelModelName, otelTopologyWorkerAgent))
+
+		By("creating a coordinator task that delegates to the worker")
+		taskManifest := fmt.Sprintf(`{
+			"apiVersion": "core.orka.ai/v1alpha1",
+			"kind": "Task",
+			"metadata": {
+				"name": "%s",
+				"namespace": "%s"
+			},
+			"spec": {
+				"type": "ai",
+				"agentRef": {"name": "%s"},
+				"ai": {
+					"prompt": "OTEL_TOPOLOGY_PARENT: delegate exactly one child task, wait for it, then reply otel topology complete.",
+					"model": "%s",
+					"providerRef": {"name": "%s"}
+				}
+			}
+		}`, otelTopologyTaskName, namespace, otelTopologyCoordAgent, otelModelName, otelTopologyProviderName)
+
+		cmd := exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = stringReader(taskManifest)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create OpenTelemetry topology task")
+
+		By("waiting for the delegated child task to be created")
+		childTaskName := waitForOTelTopologyChildTask(otelTopologyTaskName, 5*time.Minute)
+
+		By("waiting for child and parent tasks to complete successfully")
+		Expect(waitForTaskCompletion(childTaskName, 5*time.Minute)).To(Equal("Succeeded"), "delegated child task should succeed")
+		Expect(waitForTaskCompletion(otelTopologyTaskName, 7*time.Minute)).To(Equal("Succeeded"), "topology parent task should succeed")
+		verifyResultAvailable(childTaskName)
+		verifyResultAvailable(otelTopologyTaskName)
+
+		By("asserting parent and child Jobs received telemetry enablement and OTLP settings")
+		verifyOTelTelemetryEnvForTaskJob(otelTopologyTaskName)
+		verifyOTelTelemetryEnvForTaskJob(childTaskName)
+
+		By("asserting the collector received the delegated topology in one trace")
+		assertOTelCollectorHasDelegatedTopology(otelTopologyTaskName, childTaskName, 3*time.Minute)
+	})
 })
+
+func cleanupOTelTopologyResources() {
+	cmd := exec.Command("kubectl", "delete", "tasks", "-l", fmt.Sprintf("orka.ai/parent-task=%s", otelTopologyTaskName), "-n", namespace, "--ignore-not-found")
+	_, _ = utils.Run(cmd)
+	for _, resource := range []struct {
+		kind string
+		name string
+	}{
+		{kind: "task", name: otelTopologyTaskName},
+		{kind: "agent", name: otelTopologyCoordAgent},
+		{kind: "agent", name: otelTopologyWorkerAgent},
+		{kind: "provider", name: otelTopologyProviderName},
+		{kind: "secret", name: otelTopologyProviderAuthRefName},
+	} {
+		cmd = exec.Command("kubectl", "delete", resource.kind, resource.name, "-n", namespace, "--ignore-not-found")
+		_, _ = utils.Run(cmd)
+	}
+}
 
 func applyOTelManifest(manifest string) {
 	cmd := exec.Command("kubectl", "apply", "-f", "-")
@@ -333,6 +455,240 @@ func assertOTelCollectorLogsContain(needles []string, timeout time.Duration) {
 	}, timeout, 2*time.Second).Should(Succeed())
 }
 
+func waitForOTelTopologyChildTask(parentTaskName string, timeout time.Duration) string {
+	var childTaskName string
+	Eventually(func(g Gomega) {
+		cmd := exec.Command("kubectl", "get", "tasks",
+			"-l", fmt.Sprintf("orka.ai/parent-task=%s", parentTaskName),
+			"-o", "jsonpath={.items[0].metadata.name}",
+			"-n", namespace,
+		)
+		output, err := utils.Run(cmd)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(strings.TrimSpace(output)).NotTo(BeEmpty(), "delegated child task should be created")
+		childTaskName = strings.TrimSpace(output)
+	}, timeout, 2*time.Second).Should(Succeed())
+	return childTaskName
+}
+
+type otelDebugSpan struct {
+	Name     string
+	TraceID  string
+	SpanID   string
+	ParentID string
+	Attrs    map[string]string
+}
+
+func assertOTelCollectorHasDelegatedTopology(parentTaskName, childTaskName string, timeout time.Duration) {
+	Eventually(func(g Gomega) {
+		logs := otelCollectorLogs()
+		spans := parseOTelDebugSpans(logs)
+
+		childRun := requireOTelSpan(g, spans, "task.run", "orka.task.id", childTaskName)
+		delegateSpan := requireOTelSpan(g, spans, "execute_tool delegate_task", "orka.child_task.id", childTaskName)
+		g.Expect(delegateSpan.TraceID).To(Equal(childRun.TraceID), "delegate_task span should share current child TraceID")
+
+		traceID := childRun.TraceID
+		parentRun := requireOTelSpanWithTrace(g, spans, "task.run", "orka.task.id", parentTaskName, traceID)
+
+		parentSteps := otelSpansNamedWithAttrAndTrace(spans, "agent.step", "orka.task.id", parentTaskName, traceID)
+		childSteps := otelSpansNamedWithAttrAndTrace(spans, "agent.step", "orka.task.id", childTaskName, traceID)
+		g.Expect(parentSteps).NotTo(BeEmpty(), "parent agent.step should be exported")
+		g.Expect(childSteps).NotTo(BeEmpty(), "child agent.step should be exported")
+		g.Expect(otelAllTraceIDs(parentSteps)).To(ConsistOf(traceID), "parent agent.step spans should share current TraceID")
+		g.Expect(otelAllTraceIDs(childSteps)).To(ConsistOf(traceID), "child agent.step spans should share current TraceID")
+		g.Expect(otelAllParents(parentSteps)).To(ConsistOf(parentRun.SpanID), "parent agent.step spans should be children of parent task.run")
+		g.Expect(otelAllParents(childSteps)).To(ConsistOf(childRun.SpanID), "child agent.step spans should be children of child task.run")
+
+		g.Expect(delegateSpan.Attrs).To(HaveKeyWithValue("orka.parent_task.id", parentTaskName))
+		g.Expect(delegateSpan.Attrs).To(HaveKeyWithValue("orka.tool.name", "delegate_task"))
+		g.Expect(delegateSpan.Attrs).To(HaveKeyWithValue("orka.tool.kind", "delegate"))
+		g.Expect(otelSpanIDs(parentSteps)).To(ContainElement(delegateSpan.ParentID), "delegate_task should be a child of a parent agent.step")
+		g.Expect(childRun.ParentID).To(Equal(delegateSpan.SpanID), "child task.run should be a child of delegate_task")
+
+		childTool := requireOTelSpanWithTrace(g, spans, "execute_tool file_write", "orka.task.id", childTaskName, traceID)
+		g.Expect(childTool.Attrs).To(HaveKeyWithValue("orka.tool.name", "file_write"))
+		g.Expect(otelSpanIDs(childSteps)).To(ContainElement(childTool.ParentID), "child file_write should be a child of a child agent.step")
+
+		chatSpans := otelSpansNamed(spans, "chat "+otelModelName)
+		g.Expect(otelHasSpanWithTraceAndParent(chatSpans, traceID, otelSpanIDs(parentSteps))).To(BeTrue(), "parent chat span should be a child of a parent agent.step")
+		g.Expect(otelHasSpanWithTraceAndParent(chatSpans, traceID, otelSpanIDs(childSteps))).To(BeTrue(), "child chat span should be a child of a child agent.step")
+
+		g.Expect(logs).NotTo(ContainSubstring("OTEL_TOPOLOGY_PARENT"), "collector logs should not include raw parent prompt content")
+		g.Expect(logs).NotTo(ContainSubstring("OTEL_TOPOLOGY_CHILD"), "collector logs should not include raw child prompt content")
+	}, timeout, 2*time.Second).Should(Succeed())
+}
+
+func parseOTelDebugSpans(logs string) []otelDebugSpan {
+	spans := []otelDebugSpan{}
+	var current *otelDebugSpan
+	finish := func() {
+		if current != nil && current.Name != "" && current.TraceID != "" {
+			spans = append(spans, *current)
+		}
+		current = nil
+	}
+
+	for _, line := range strings.Split(logs, "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "Span #"):
+			finish()
+			current = &otelDebugSpan{Attrs: map[string]string{}}
+			continue
+		case strings.HasPrefix(trimmed, "ResourceSpans #"), strings.HasPrefix(trimmed, "ScopeSpans #"), strings.HasPrefix(trimmed, "Metric #"):
+			finish()
+			continue
+		case current == nil:
+			continue
+		}
+
+		if value, ok := otelDebugLineValue(trimmed, "Trace ID"); ok {
+			current.TraceID = value
+			continue
+		}
+		if value, ok := otelDebugLineValue(trimmed, "Parent ID"); ok {
+			current.ParentID = value
+			continue
+		}
+		if value, ok := otelDebugLineValue(trimmed, "Span ID"); ok {
+			current.SpanID = value
+			continue
+		}
+		if value, ok := otelDebugLineValue(trimmed, "ID"); ok {
+			current.SpanID = value
+			continue
+		}
+		if value, ok := otelDebugLineValue(trimmed, "Name"); ok {
+			current.Name = value
+			continue
+		}
+		if strings.HasPrefix(trimmed, "->") {
+			keyValue := strings.TrimSpace(strings.TrimPrefix(trimmed, "->"))
+			key, raw, ok := strings.Cut(keyValue, ":")
+			if ok {
+				current.Attrs[strings.TrimSpace(key)] = otelDebugAttributeValue(raw)
+			}
+		}
+	}
+	finish()
+	return spans
+}
+
+func otelDebugLineValue(line, key string) (string, bool) {
+	left, right, ok := strings.Cut(line, ":")
+	if !ok || strings.TrimSpace(left) != key {
+		return "", false
+	}
+	return strings.TrimSpace(right), true
+}
+
+func otelDebugAttributeValue(raw string) string {
+	value := strings.TrimSpace(raw)
+	open := strings.Index(value, "(")
+	if open >= 0 && strings.HasSuffix(value, ")") {
+		return value[open+1 : len(value)-1]
+	}
+	return value
+}
+
+func requireOTelSpan(g Gomega, spans []otelDebugSpan, name, attrKey, attrValue string) otelDebugSpan {
+	matches := otelSpansNamedWithAttr(spans, name, attrKey, attrValue)
+	g.Expect(matches).NotTo(BeEmpty(), "expected span %q with %s=%s", name, attrKey, attrValue)
+	if len(matches) == 0 {
+		return otelDebugSpan{}
+	}
+	return matches[0]
+}
+
+func requireOTelSpanWithTrace(g Gomega, spans []otelDebugSpan, name, attrKey, attrValue, traceID string) otelDebugSpan {
+	matches := otelSpansNamedWithAttrAndTrace(spans, name, attrKey, attrValue, traceID)
+	g.Expect(matches).NotTo(BeEmpty(), "expected span %q with %s=%s in trace %s", name, attrKey, attrValue, traceID)
+	if len(matches) == 0 {
+		return otelDebugSpan{}
+	}
+	return matches[0]
+}
+
+func otelSpansNamed(spans []otelDebugSpan, name string) []otelDebugSpan {
+	matches := []otelDebugSpan{}
+	for _, span := range spans {
+		if span.Name == name {
+			matches = append(matches, span)
+		}
+	}
+	return matches
+}
+
+func otelSpansNamedWithAttr(spans []otelDebugSpan, name, attrKey, attrValue string) []otelDebugSpan {
+	matches := []otelDebugSpan{}
+	for _, span := range spans {
+		if span.Name == name && span.Attrs[attrKey] == attrValue {
+			matches = append(matches, span)
+		}
+	}
+	return matches
+}
+
+func otelSpansNamedWithAttrAndTrace(spans []otelDebugSpan, name, attrKey, attrValue, traceID string) []otelDebugSpan {
+	matches := []otelDebugSpan{}
+	for _, span := range spans {
+		if span.TraceID == traceID && span.Name == name && span.Attrs[attrKey] == attrValue {
+			matches = append(matches, span)
+		}
+	}
+	return matches
+}
+
+func otelSpanIDs(spans []otelDebugSpan) []string {
+	ids := make([]string, 0, len(spans))
+	for _, span := range spans {
+		if span.SpanID != "" {
+			ids = append(ids, span.SpanID)
+		}
+	}
+	return ids
+}
+
+func otelAllTraceIDs(spans []otelDebugSpan) []string {
+	return sortedUniqueOTelSpanValues(spans, func(span otelDebugSpan) string { return span.TraceID })
+}
+
+func otelAllParents(spans []otelDebugSpan) []string {
+	return sortedUniqueOTelSpanValues(spans, func(span otelDebugSpan) string { return span.ParentID })
+}
+
+func sortedUniqueOTelSpanValues(spans []otelDebugSpan, valueFn func(otelDebugSpan) string) []string {
+	seen := map[string]struct{}{}
+	for _, span := range spans {
+		if value := valueFn(span); value != "" {
+			seen[value] = struct{}{}
+		}
+	}
+	values := make([]string, 0, len(seen))
+	for value := range seen {
+		values = append(values, value)
+	}
+	sort.Strings(values)
+	return values
+}
+
+func otelHasSpanWithTraceAndParent(spans []otelDebugSpan, traceID string, parentIDs []string) bool {
+	parents := map[string]struct{}{}
+	for _, id := range parentIDs {
+		parents[id] = struct{}{}
+	}
+	for _, span := range spans {
+		if span.TraceID != traceID {
+			continue
+		}
+		if _, ok := parents[span.ParentID]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 func otelCollectorLogs() string {
 	cmd := exec.Command("kubectl", "logs", "deployment/"+otelCollectorName, "-n", namespace, "--tail=5000")
 	output, err := utils.Run(cmd)
@@ -465,6 +821,49 @@ data:
         "mode": "write",
         "create_dirs": True,
     })
+    TOPOLOGY_CHILD_TOOL_ARGS = json.dumps({
+        "path": "otel-topology-child.txt",
+        "content": "otel topology child output",
+        "mode": "write",
+        "create_dirs": True,
+    })
+    TOPOLOGY_WORKER_AGENT = "%[5]s"
+
+    def message_content_contains(messages, marker):
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+            content = message.get("content")
+            if isinstance(content, str) and marker in content:
+                return True
+        return False
+
+    def tool_message_contents(messages):
+        return [
+            m.get("content") or ""
+            for m in messages
+            if isinstance(m, dict) and m.get("role") == "tool"
+        ]
+
+    def delegated_task_name(messages):
+        for content in tool_message_contents(messages):
+            try:
+                payload = json.loads(content)
+            except Exception:
+                continue
+            if isinstance(payload, dict) and payload.get("taskName"):
+                return payload["taskName"]
+        return ""
+
+    def has_wait_for_tasks_result(messages):
+        for content in tool_message_contents(messages):
+            try:
+                payload = json.loads(content)
+            except Exception:
+                continue
+            if isinstance(payload, dict) and "completed" in payload and "results" in payload:
+                return True
+        return False
 
     class Handler(BaseHTTPRequestHandler):
         def log_message(self, fmt, *args):
@@ -502,6 +901,111 @@ data:
             if self.path.endswith("/chat/completions"):
                 model = request.get("model") or "%[3]s"
                 messages = request.get("messages") or []
+                is_topology_parent = message_content_contains(messages, "OTEL_TOPOLOGY_PARENT")
+                is_topology_child = message_content_contains(messages, "OTEL_TOPOLOGY_CHILD")
+
+                if is_topology_parent:
+                    child_task = delegated_task_name(messages)
+                    if not child_task:
+                        delegate_args = json.dumps({
+                            "agent": TOPOLOGY_WORKER_AGENT,
+                            "prompt": "OTEL_TOPOLOGY_CHILD: use file_write once, then reply otel topology child complete.",
+                            "timeout": "5m",
+                        })
+                        self._json(200, {
+                            "id": "chatcmpl-otel-topology-delegate",
+                            "object": "chat.completion",
+                            "model": model,
+                            "choices": [{
+                                "index": 0,
+                                "message": {
+                                    "role": "assistant",
+                                    "content": "",
+                                    "tool_calls": [{
+                                        "id": "call_otel_delegate_task",
+                                        "type": "function",
+                                        "function": {"name": "delegate_task", "arguments": delegate_args},
+                                    }],
+                                },
+                                "finish_reason": "tool_calls",
+                            }],
+                            "usage": {"prompt_tokens": 19, "completion_tokens": 13, "total_tokens": 32},
+                        })
+                        return
+
+                    if not has_wait_for_tasks_result(messages):
+                        wait_args = json.dumps({"tasks": [child_task], "timeout": "5m"})
+                        self._json(200, {
+                            "id": "chatcmpl-otel-topology-wait",
+                            "object": "chat.completion",
+                            "model": model,
+                            "choices": [{
+                                "index": 0,
+                                "message": {
+                                    "role": "assistant",
+                                    "content": "",
+                                    "tool_calls": [{
+                                        "id": "call_otel_wait_for_tasks",
+                                        "type": "function",
+                                        "function": {"name": "wait_for_tasks", "arguments": wait_args},
+                                    }],
+                                },
+                                "finish_reason": "tool_calls",
+                            }],
+                            "usage": {"prompt_tokens": 23, "completion_tokens": 9, "total_tokens": 32},
+                        })
+                        return
+
+                    self._json(200, {
+                        "id": "chatcmpl-otel-topology-parent-final",
+                        "object": "chat.completion",
+                        "model": model,
+                        "choices": [{
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "otel topology complete"},
+                            "finish_reason": "stop",
+                        }],
+                        "usage": {"prompt_tokens": 31, "completion_tokens": 4, "total_tokens": 35},
+                    })
+                    return
+
+                if is_topology_child:
+                    saw_child_tool_result = any(tool_message_contents(messages))
+                    if not saw_child_tool_result:
+                        self._json(200, {
+                            "id": "chatcmpl-otel-topology-child-tool-call",
+                            "object": "chat.completion",
+                            "model": model,
+                            "choices": [{
+                                "index": 0,
+                                "message": {
+                                    "role": "assistant",
+                                    "content": "",
+                                    "tool_calls": [{
+                                        "id": "call_otel_topology_child_file_write",
+                                        "type": "function",
+                                        "function": {"name": "file_write", "arguments": TOPOLOGY_CHILD_TOOL_ARGS},
+                                    }],
+                                },
+                                "finish_reason": "tool_calls",
+                            }],
+                            "usage": {"prompt_tokens": 17, "completion_tokens": 8, "total_tokens": 25},
+                        })
+                        return
+
+                    self._json(200, {
+                        "id": "chatcmpl-otel-topology-child-final",
+                        "object": "chat.completion",
+                        "model": model,
+                        "choices": [{
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "otel topology child complete"},
+                            "finish_reason": "stop",
+                        }],
+                        "usage": {"prompt_tokens": 21, "completion_tokens": 4, "total_tokens": 25},
+                    })
+                    return
+
                 saw_tool_result = any(m.get("role") == "tool" for m in messages if isinstance(m, dict))
                 if not saw_tool_result:
                     self._json(200, {
@@ -602,5 +1106,5 @@ spec:
     - name: http
       port: 8080
       targetPort: http
-`, otelFakeOpenAIName, namespace, otelModelName, otelFakeOpenAIImage)
+    `, otelFakeOpenAIName, namespace, otelModelName, otelFakeOpenAIImage, otelTopologyWorkerAgent)
 }


### PR DESCRIPTION
## Summary

- adds deterministic OpenTelemetry E2E coverage for delegated parent/child task topology
- extends the fake OpenAI endpoint to drive parent delegation, child tool execution, and parent wait/finalization without live LLM credentials
- verifies parent/delegate/child spans share one trace, have expected parentage, include safe Orka attributes, and do not export raw prompt markers

## Tests

- `go test -tags=e2e ./test/e2e -run '^$'`
- `make lint-fix`
- `go test -tags=e2e ./test/e2e -timeout 30m -v -ginkgo.v -ginkgo.focus='OpenTelemetry GenAI export.*delegated parent'`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
