### PR TITLE
docs(security): update scanner references

### DIFF
--- a/website/docs/concepts/configuration.md
+++ b/website/docs/concepts/configuration.md
@@ -144,6 +144,15 @@ spec:
   timeZone: "UTC"               # optional IANA time zone
   historyDays: 30                # optional initial history window
   validationMode: light          # off, light, or full
+  validationMaxFindingsPerRun: 8 # optional auto-validation task cap for light mode
+  validationMinSeverity: medium  # optional auto-validation severity threshold
+  validationMinConfidence: medium # optional auto-validation confidence threshold
+  customScanInstructionsRef:     # optional ConfigMap-backed additive scanner instructions
+    name: repo-security-policy
+    key: policy                  # optional; defaults to policy
+  falsePositivePolicyRef:        # optional ConfigMap-backed false-positive policy
+    name: repo-security-policy
+    key: false-positives
   analysisAgentRef:
     name: security-reviewer
   patchAgentRef:                 # optional; defaults to the analysis agent when omitted
@@ -170,10 +179,17 @@ spec:
 | `timeZone` | string | No | IANA time zone used by `schedule`. |
 | `historyDays` | int32 | No | How far back the initial scan should inspect repository history. |
 | `validationMode` | string | No | Validation aggressiveness: `off`, `light`, or `full`. Defaults to `light`. |
+| `validationMaxFindingsPerRun` | int32 | No | Maximum automatic validation tasks to enqueue per scan run in `light` mode. |
+| `validationMinSeverity` | string | No | Minimum severity eligible for automatic validation. Defaults are mode-dependent. |
+| `validationMinConfidence` | string | No | Minimum confidence eligible for automatic validation. Defaults are mode-dependent. |
+| `customScanInstructionsRef` | PolicyConfigMapKeyRef | No | Same-namespace ConfigMap key containing additive scanner instructions. The ConfigMap must opt in with `orka.ai/security-policy: "true"` as a label or annotation. |
+| `falsePositivePolicyRef` | PolicyConfigMapKeyRef | No | Same-namespace ConfigMap key containing additive false-positive policy text. The ConfigMap must opt in with `orka.ai/security-policy: "true"` as a label or annotation. |
 | `analysisAgentRef` | AgentReference | Yes | Agent used for repository scan runs and threat model generation. |
 | `patchAgentRef` | AgentReference | No | Agent used for patch proposal runs. |
-| `maxFindingsPerRun` | int32 | No | Bounds scan output volume. |
+| `maxFindingsPerRun` | int32 | No | Bounds accepted scan findings per run after validation and deterministic dropped-finding filters. |
 | `suspend` | bool | No | Pauses scheduled incremental scans while preserving the scan configuration. |
+
+`PolicyConfigMapKeyRef` uses `name` plus optional `key`; when `key` is omitted, Orka reads the `policy` key. Policy ConfigMap values are capped at 32 KiB and rejected if they look like they contain secrets, tokens, private keys, or credentials. Custom policy text is additive only; it cannot disable Orka's default evidence, no-secret, or finding-quality rules.
 
 **Status fields:**
 

--- a/website/docs/reference/api-reference.md
+++ b/website/docs/reference/api-reference.md
@@ -279,7 +279,8 @@ Common query parameters:
 - `cursor` — store cursor for `GET /api/v1/security/repositories/:name/scans`, `GET /api/v1/security/repositories/:name/slices`, `GET /api/v1/security/repositories/:name/dropped-findings`, and `GET /api/v1/security/repositories/:name/findings`.
 - `severity`, `validationStatus`, `state`, `sliceID`, `category` — filters for `GET /api/v1/security/repositories/:name/findings`.
 - `status` — filter for `GET /api/v1/security/repositories/:name/slices`.
-- `scanRunID`, `sliceID` — filters for `GET /api/v1/security/repositories/:name/dropped-findings`.
+- `scanRunID`, `sliceID`, `layer` — filters for `GET /api/v1/security/repositories/:name/dropped-findings`. `layer` is one of `validation`, `filter`, or `cap`.
+- `reason` — exact dropped-finding reason filter; use `reason=contains=<text>` for substring matching.
 - `recommended=true` — filters findings to recommended remediation candidates.
 
 ### Create Repository Scan
@@ -298,6 +299,11 @@ Common query parameters:
     "ref": "v1.2.3",
     "schedule": "0 2 * * *",
     "validationMode": "light",
+    "validationMaxFindingsPerRun": 8,
+    "validationMinSeverity": "medium",
+    "validationMinConfidence": "medium",
+    "customScanInstructionsRef": {"name": "repo-security-policy", "key": "policy"},
+    "falsePositivePolicyRef": {"name": "repo-security-policy", "key": "false-positives"},
     "analysisAgentRef": {"name": "security-reviewer"}
   }
 }
@@ -306,6 +312,8 @@ Common query parameters:
 **Response (201):** The created `RepositoryScan` resource.
 
 Required fields are `name`, `spec.repoURL`, and `spec.analysisAgentRef.name`. The API defaults or infers provider, owner, repository, branch, and validation mode where possible. Set `spec.ref` to pin scan tasks to a specific tag, branch, or commit SHA; when `ref` is set without `branch`, scan workspaces check out that ref directly instead of forcing the default `main` branch.
+
+The request accepts the same `RepositoryScan` spec fields as the CRD, including automatic validation tuning (`validationMaxFindingsPerRun`, `validationMinSeverity`, `validationMinConfidence`) and ConfigMap-backed scanner policy refs (`customScanInstructionsRef`, `falsePositivePolicyRef`). Policy ConfigMaps must be in the same namespace and opt in with `orka.ai/security-policy: "true"` as a label or annotation.
 
 ### Security Findings Workflow
 
@@ -322,7 +330,7 @@ Review slice and dropped-output inspection:
 
 1. List slices with `GET /api/v1/security/repositories/:name/slices?namespace=default`.
 2. Inspect one slice with `GET /api/v1/security/repositories/:name/slices/:sliceID?namespace=default`.
-3. List rejected v2 model output with `GET /api/v1/security/repositories/:name/dropped-findings?namespace=default&scanRunID=scan_...`.
+3. List rejected v2 model output with `GET /api/v1/security/repositories/:name/dropped-findings?namespace=default&scanRunID=scan_...&layer=filter&reason=contains=rate-limit`.
 
 ## Repository Monitors
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -407,16 +407,23 @@ Usage:
   orka task [command]
 
 Available Commands:
+  approvals   List task approvals
+  approve     Approve a pending task approval
   artifacts   List artifacts for a task
   children    List child tasks
   create      Create a new task
+  decline     Decline a pending task approval
   delete      Delete a task
   download    Download task artifacts
+  events      List task execution events
+  follow      Follow task execution events
+  fork        Fork a task from an execution event checkpoint
   get         Get task details
   list        List tasks
   logs        Get task logs
   plan        Get task autonomous plan state
   result      Get task result
+  trace       Show a task trace summary
   wait        Wait for a task to complete
 
 Flags:
@@ -1420,6 +1427,8 @@ Usage:
 
 Available Commands:
   delete      Delete a session resource
+  events      List session execution events
+  follow      Follow session execution events
   get         Get a session resource
   list        List session resources
 
@@ -2454,11 +2463,15 @@ Usage:
   orka security dropped-findings list <repo> [flags]
 
 Flags:
-      --continue string   Continue token
-      --cursor string     Cursor token
-  -h, --help              help for list
-      --limit int         Maximum number of results (default 50)
-  -o, --output string     Output format: table, json, yaml (default "table")
+      --continue string      Continue token
+      --cursor string        Cursor token
+  -h, --help                 help for list
+      --layer string         Filter by dropped-finding layer (validation, filter, cap)
+      --limit int            Maximum number of results (default 50)
+  -o, --output string        Output format: table, json, yaml (default "table")
+      --reason string        Filter by exact reason or contains=<text>
+      --scan-run-id string   Filter by scan run ID
+      --slice-id string      Filter by review slice ID
 
 Global Flags:
       --kubeconfig string       Path to kubeconfig file

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -194,6 +194,7 @@ orka security scan list my-repo -o json
 orka security finding list my-repo -o json
 orka security slice list my-repo -o json
 orka security dropped-findings list my-repo -o json
+orka security dropped-findings list my-repo --layer filter --reason contains=rate-limit -o json
 orka security repo delete my-repo
 ```
 


### PR DESCRIPTION
## Summary

- Update the `RepositoryScan` configuration reference with validation tuning and ConfigMap-backed scanner policy fields.
- Document dropped-finding API filters for scan run, slice, layer, and reason matching.
- Refresh CLI command reference docs so `orka security dropped-findings list` includes its filter flags.
- Add an example CLI dropped-findings query for filter/reason inspection.

## Why

The security scanning guide and design docs already describe the newer scanner behavior, but the broader reference docs had drifted behind the implemented feature surface. This aligns configuration, API, and CLI references with the current security scanning capabilities.

## Validation

- `make docs-cli-check`
- `cd website && yarn build`
- `git diff --check`
