### PR TITLE
docs: document OpenTelemetry enablement

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ One `helm install`, one LLM secret, and you're chatting with an orchestrator tha
 - 🔌 **REST & OpenAI-Compatible API** — Full CRUD + `/openai/v1/chat/completions` endpoint for Continue, Cursor, and any OpenAI-compatible client
 - 🔐 **Kubernetes, OIDC & Kontxt TxToken Auth** — ServiceAccount tokens by default, with optional OIDC and scoped `kontxt` transaction-token flows
 - 🔮 **Anthropic-Compatible API** — `/anthropic/v1/messages` endpoint for Claude Code and other Anthropic-native clients
-- 📊 **Observability** — Prometheus metrics, structured logging, health probes
+- 📊 **Observability** — Prometheus metrics, structured logging, health probes, and optional OpenTelemetry traces + GenAI OTLP metrics
 - 🔒 **Hardened by Default** — Non-root containers, read-only rootfs, ServiceAccount token auth
 
 ## Quick Start
@@ -115,6 +115,7 @@ The built-in orchestrator creates agents, runs tasks, monitors progress, and ret
 | [Getting Started](website/docs/getting-started.md)                   | Installation, quick start, CLI setup                  |
 | [Architecture](website/docs/concepts/architecture.md)                         | System design, components, and data flow              |
 | [Configuration](website/docs/concepts/configuration.md)                       | CRD reference, Helm values, controller flags, metrics |
+| [Observability](website/docs/guides/observability.md)                        | OpenTelemetry traces, GenAI metrics, and task trace guidance |
 | [Agent Runtimes](website/docs/concepts/agent-runtimes.md)                     | Codex CLI, Claude Code CLI, and Copilot CLI runtimes  |
 | [CLI Harness Wrapper](website/docs/guides/cli-harness-wrapper.md)                  | Harness protocol wrapper for Codex, Claude, and Copilot CLI runtimes |
 | [Agent Sandbox](website/docs/concepts/agent-sandbox.md)                       | Experimental upstream `agent-sandbox` workspace execution for agent runtimes |

--- a/scripts/generate-cli-docs.sh
+++ b/scripts/generate-cli-docs.sh
@@ -37,7 +37,7 @@ commands=(
   "models" "models list"
   "status"
   "audit" "audit trace"
-  "task" "task create" "task list" "task get" "task logs" "task result" "task plan" "task children" "task wait" "task delete" "task artifacts" "task download"
+  "task" "task create" "task list" "task get" "task logs" "task result" "task plan" "task children" "task events" "task follow" "task trace" "task approvals" "task approve" "task decline" "task fork" "task wait" "task delete" "task artifacts" "task download"
   "workspace" "workspace status"
   "provider" "provider list" "provider get" "provider create" "provider update" "provider delete"
   "agent" "agent list" "agent get" "agent create" "agent update" "agent delete"

--- a/website/docs/concepts/architecture.md
+++ b/website/docs/concepts/architecture.md
@@ -112,7 +112,7 @@ Orka uses seven CRDs:
 | **API Authentication** | Kubernetes ServiceAccount tokens plus optional OIDC JWT and generic context-token validation. | Native K8s auth by default; OIDC and `kontxt` TxTokens support external/request-scoped API clients. |
 | **Task Queue** | Priority queuing (0-1000) | Higher priority tasks are scheduled first. |
 | **Secret Management** | Reference K8s Secrets in specs | Controller mounts secrets to worker/harness pods. |
-| **Observability** | Prometheus metrics, structured logs, optional OpenTelemetry tracing. | Standard K8s metrics/logging with opt-in distributed tracing. |
+| **Observability** | Prometheus metrics, structured logs, optional OpenTelemetry traces and GenAI OTLP metrics. | Standard K8s metrics/logging with opt-in distributed tracing and model/tool latency telemetry. |
 | **AI Tools** | Built-in + extensible via CRDs | Ship with categorized built-in tools and can be extended via Tool CRDs. |
 | **Failure Policy** | Configurable retry with backoff | `spec.retryPolicy` with max retries and exponential backoff. |
 | **Session Execution** | Serial per session | Tasks sharing a session run one-at-a-time to prevent race conditions. |

--- a/website/docs/concepts/configuration.md
+++ b/website/docs/concepts/configuration.md
@@ -814,7 +814,7 @@ See [charts/orka/values.yaml](https://github.com/sozercan/orka/blob/main/charts/
 | `--health-probe-bind-address` | `:8081` | Health probe address |
 | `--metrics-secure` | `true` | Serve metrics via HTTPS |
 | `--enable-http2` | `false` | Enable HTTP/2 for metrics and webhook servers |
-| `--enable-tracing` | `false` | Enable OpenTelemetry distributed tracing (requires `OTEL_EXPORTER_OTLP_ENDPOINT`) |
+| `--enable-telemetry` / `--enable-tracing` | `false` | Enable OpenTelemetry traces and metrics (requires worker-reachable OTLP endpoint for worker telemetry) |
 
 ### Agent Sandbox Controller Settings
 
@@ -940,27 +940,49 @@ monitoring:
 
 Context-token metrics are described in more detail in [Kontxt TxToken integration](kontxt.md#observability). All context-token labels use low-cardinality values only.
 
-## OpenTelemetry Tracing
+## OpenTelemetry telemetry
 
-Orka supports opt-in OpenTelemetry distributed tracing for debugging and performance analysis. Tracing is disabled by default (zero overhead).
+Orka supports opt-in OpenTelemetry traces and GenAI metrics for debugging,
+performance analysis, and backend cost/latency dashboards. Telemetry is
+disabled by default and uses OpenTelemetry no-op providers until enabled.
 
-### Enabling Tracing
+### Enabling telemetry
 
-Add the `--enable-tracing` flag to the controller:
+Add the `--enable-telemetry` flag to the controller and configure an OTLP
+collector endpoint. The legacy `--enable-tracing` alias enables the same traces
+and metrics:
 
 ```yaml
 args:
-  - --enable-tracing
+  - --enable-telemetry
 env:
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: "jaeger-collector.observability.svc:4317"
+  - name: OTEL_EXPORTER_OTLP_INSECURE
+    value: "true"
 ```
 
 | Flag / Environment Variable | Default | Description |
 |------------------------------|---------|-------------|
 | `--enable-telemetry` / `--enable-tracing` | `false` | Enable OpenTelemetry traces and metrics |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `localhost:4317` | OTLP gRPC collector endpoint |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | SDK default `localhost:4317` | OTLP collector endpoint for traces and metrics |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | unset | Trace-specific OTLP endpoint |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | unset | Metrics-specific OTLP endpoint |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | SDK default gRPC | Set to `http/protobuf` for OTLP/HTTP collectors |
+| `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` / `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` | unset | Signal-specific exporter protocol overrides |
+| `OTEL_EXPORTER_OTLP_INSECURE` and signal-specific insecure vars | SDK default | Disable TLS for in-cluster/dev collectors that require it |
 | `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG` | SDK default | Standard OpenTelemetry sampler configuration |
+
+Controller-local defaults such as `localhost:4317` are valid only for the
+controller process. AI worker Jobs receive telemetry enablement only when the
+controller has a non-loopback, worker-reachable OTLP endpoint. The controller
+copies non-secret OTLP endpoint/protocol/insecure/timeout/compression settings
+to AI worker Pods and intentionally does not copy OTLP headers, certificate or
+client-key env vars, `OTEL_RESOURCE_ATTRIBUTES`, or baggage.
+
+Harness-wrapper and agent-runtime worker telemetry is explicit opt-in. Set
+`ORKA_ENABLE_TELEMETRY=true` and OTLP exporter env on those workloads when you
+want their process-local `task.run` spans exported.
 
 ### Instrumented Components
 

--- a/website/docs/development/development.md
+++ b/website/docs/development/development.md
@@ -104,6 +104,11 @@ Run focused telemetry tests with:
 go test ./internal/tracing/... ./internal/llm/ ./internal/tools/ ./internal/worker ./workers/ai ./workers/harness/cliwrapper -run 'Tracing|Telemetry|GenAI|ExecuteTool|TraceContext|Traceparent|TaskRun|DelegateTrace' -v
 ```
 
+The live Kind e2e coverage for collector export lives in
+`test/e2e/otel_genai_test.go`. It patches the controller with
+`--enable-telemetry`, points it at an in-cluster OpenTelemetry Collector, and
+asserts that AI worker Jobs export GenAI model/tool spans and metrics.
+
 Run disabled-telemetry hot-path benchmarks with:
 
 ```bash

--- a/website/docs/guides/observability.md
+++ b/website/docs/guides/observability.md
@@ -14,8 +14,8 @@ OpenTelemetry no-op providers and does not configure OTLP exporters.
 
 ## Enable telemetry
 
-Start the controller with telemetry enabled and point it at an OTLP gRPC
-endpoint:
+Start the controller with telemetry enabled and point it at an OTLP endpoint.
+gRPC is the default exporter protocol:
 
 ```bash
 OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector.otel.svc:4317 \
@@ -26,15 +26,70 @@ OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector.otel.svc:4317 \
 metrics. Existing Prometheus metrics on `--metrics-bind-address` continue to
 work independently.
 
+For an existing Kubernetes Deployment, set both the controller flag and the
+collector environment. Setting `OTEL_EXPORTER_OTLP_ENDPOINT` alone does not
+enable telemetry:
+
+```bash
+kubectl patch deployment orka-controller -n orka-system --type=json -p='[
+  {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--enable-telemetry"},
+  {"op":"add","path":"/spec/template/spec/containers/0/env/-","value":{"name":"OTEL_EXPORTER_OTLP_ENDPOINT","value":"otel-collector.otel.svc:4317"}},
+  {"op":"add","path":"/spec/template/spec/containers/0/env/-","value":{"name":"OTEL_EXPORTER_OTLP_INSECURE","value":"true"}}
+]'
+```
+
+Use `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` (or signal-specific
+`OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` / `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`)
+for HTTP/protobuf collectors. Signal-specific endpoints are also supported:
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and
+`OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`.
+
 When controller telemetry is enabled and a worker-reachable OTLP endpoint is configured, AI worker Jobs receive:
 
 - `ORKA_ENABLE_TELEMETRY=true`
 - `OTEL_EXPORTER_OTLP_ENDPOINT` and related standard non-secret OTLP environment variables
 - `ORKA_TRACEPARENT` when a Task was created from an already-traced API/chat/tool request
 
+The controller copies only worker-safe OTLP settings into AI worker Pods:
+
+| Copied when set | Not copied |
+|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `OTEL_EXPORTER_OTLP_HEADERS` |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | `OTEL_EXPORTER_OTLP_TRACES_HEADERS` / `OTEL_EXPORTER_OTLP_METRICS_HEADERS` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` and signal-specific protocol vars | OTLP certificate and client-key env vars |
+| `OTEL_EXPORTER_OTLP_INSECURE` and signal-specific insecure vars | `OTEL_RESOURCE_ATTRIBUTES` |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` and signal-specific timeout vars | `ORKA_BAGGAGE` |
+| `OTEL_EXPORTER_OTLP_COMPRESSION` and signal-specific compression vars | |
+
+Worker endpoint values must be reachable from the worker Pod. Empty,
+loopback, and unspecified hosts such as `localhost`, `127.0.0.1`, `::1`, and
+`::` are not copied into worker Jobs. If a signal-specific endpoint is
+unreachable, its signal-specific overrides are dropped instead of sending a
+broken per-signal configuration to the worker.
+
+Telemetry environment for AI workers is controller-owned: task-supplied
+`ORKA_ENABLE_TELEMETRY`, `ORKA_TRACEPARENT`, `ORKA_TRACESTATE`, and
+`OTEL_EXPORTER_OTLP*` values in `spec.env` are ignored. Generic container Tasks
+preserve user-supplied telemetry env, because Orka does not instrument arbitrary
+container processes.
+
 Harness-wrapper and agent-runtime worker telemetry is explicit opt-in: set
 `ORKA_ENABLE_TELEMETRY=true` and OTLP exporter configuration on those workloads
 when you want their process-local spans exported.
+
+For the singleton CLI harness wrapper Deployment, opt in explicitly:
+
+```bash
+kubectl set env deployment/orka-agent-harness-wrapper -n orka-system \
+  ORKA_ENABLE_TELEMETRY=true \
+  OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector.otel.svc:4317 \
+  OTEL_EXPORTER_OTLP_INSECURE=true
+```
+
+For per-Task agent runtime Jobs, set telemetry env in the Task `spec.env` where
+you intentionally want that runtime process to export spans. Orka reserves and
+overwrites trace-context env (`ORKA_TRACEPARENT`, `ORKA_TRACESTATE`,
+`ORKA_BAGGAGE`) so user-supplied values cannot forge parentage.
 
 Credential-bearing OTLP header environment variables are not copied from the
 controller into task workloads. Use an in-cluster collector endpoint or a
@@ -74,6 +129,14 @@ so the child `task.run` span is linked to the parent tool call.
 Outbound HTTP and MCP Tool CRD requests receive W3C `traceparent` headers. If a
 Tool config supplies its own `traceparent` header, the active Orka trace context
 wins.
+
+### OpenTelemetry traces vs Task trace read model
+
+OpenTelemetry traces are exported to your collector/backend and are queried in
+that backend. Orka's Task trace API (`GET /api/v1/tasks/:id/trace`) and CLI
+(`orka task trace`) are different: they build an execution read model from
+stored Orka events for UI/CLI troubleshooting. The two systems share task and
+tool terminology, but the Task trace API does not read from the OTel backend.
 
 ## Orka query attributes
 
@@ -122,7 +185,8 @@ Key attributes include:
 Tool calls executed through the built-in registry are emitted as spans named
 `execute_tool {tool.name}` with `gen_ai.tool.*` and `orka.tool.*` attributes and
 a duration metric. External HTTP/MCP tools use the same span name and
-`orka.tool.kind=http`.
+`orka.tool.kind=http`. OpenAI-compatible and Anthropic-compatible API requests
+emit the same GenAI model-call spans as native Orka chat and AI worker calls.
 
 ## GenAI metrics
 
@@ -133,7 +197,7 @@ Orka records these OTLP histograms when model/tool calls run:
 | `gen_ai.client.operation.duration` | `s` | One datapoint per model call |
 | `gen_ai.client.token.usage` | `{token}` | Separate datapoints for `gen_ai.token.type=input` and `output` |
 | `gen_ai.client.operation.time_to_first_chunk` | `s` | Streaming calls |
-| `gen_ai.execute_tool.duration` | `s` | Built-in registry tool calls |
+| `gen_ai.execute_tool.duration` | `s` | Built-in registry and external HTTP/MCP tool calls |
 
 Metric dimensions are intentionally low-cardinality: operation, provider, model, token
 type, tool name/type, and error type when applicable. High-cardinality fields such

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -407,16 +407,23 @@ Usage:
   orka task [command]
 
 Available Commands:
+  approvals   List task approvals
+  approve     Approve a pending task approval
   artifacts   List artifacts for a task
   children    List child tasks
   create      Create a new task
+  decline     Decline a pending task approval
   delete      Delete a task
   download    Download task artifacts
+  events      List task execution events
+  follow      Follow task execution events
+  fork        Fork a task from an execution event checkpoint
   get         Get task details
   list        List tasks
   logs        Get task logs
   plan        Get task autonomous plan state
   result      Get task result
+  trace       Show a task trace summary
   wait        Wait for a task to complete
 
 Flags:
@@ -593,6 +600,163 @@ Usage:
 Flags:
   -h, --help            help for children
   -o, --output string   Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task events`
+
+```text
+List task execution events
+
+Usage:
+  orka task events <task> [flags]
+
+Flags:
+      --after int          Only return events after this sequence
+  -h, --help               help for events
+      --limit int          Maximum events to return (default 100)
+  -o, --output string      Output format: table, json, yaml (default "table")
+      --type stringArray   Filter by event type (repeatable; streaming supports repeats)
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task follow`
+
+```text
+Follow task execution events
+
+Usage:
+  orka task follow <task> [flags]
+
+Flags:
+      --after int          Resume after this sequence
+  -h, --help               help for follow
+      --type stringArray   Filter by event type (repeatable)
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task trace`
+
+```text
+Show a task trace summary
+
+Usage:
+  orka task trace <task> [flags]
+
+Flags:
+  -h, --help            help for trace
+  -o, --output string   Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task approvals`
+
+```text
+List task approvals
+
+Usage:
+  orka task approvals <task> [flags]
+
+Flags:
+  -h, --help            help for approvals
+  -o, --output string   Output format: table, json, yaml (default "table")
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task approve`
+
+```text
+Approve a pending task approval
+
+Usage:
+  orka task approve <task> <approvalID> [flags]
+
+Flags:
+  -h, --help            help for approve
+  -o, --output string   Output format: table, json, yaml (default "json")
+      --reason string   Decision reason
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task decline`
+
+```text
+Decline a pending task approval
+
+Usage:
+  orka task decline <task> <approvalID> [flags]
+
+Flags:
+  -h, --help            help for decline
+  -o, --output string   Output format: table, json, yaml (default "json")
+      --reason string   Decision reason
+
+Global Flags:
+      --kubeconfig string       Path to kubeconfig file
+  -n, --namespace string        Kubernetes namespace (default "default")
+  -s, --server string           Orka server URL (default "http://localhost:8080")
+  -t, --token string            Bearer token for authentication
+      --txn-token string        Kontxt transaction token to send via Txn-Token header
+      --txn-token-file string   Path to file containing a Kontxt transaction token (use - for stdin)
+```
+
+## `orka task fork`
+
+```text
+Fork a task from an execution event checkpoint
+
+Usage:
+  orka task fork <task> [flags]
+
+Flags:
+      --after int       Checkpoint sequence (default: latest) (default -1)
+      --agent string    Override agent reference
+  -h, --help            help for fork
+      --name string     Forked task name
+  -o, --output string   Output format: table, json, yaml (default "table")
+      --prompt string   Override prompt
 
 Global Flags:
       --kubeconfig string       Path to kubeconfig file
@@ -1420,6 +1584,8 @@ Usage:
 
 Available Commands:
   delete      Delete a session resource
+  events      List session execution events
+  follow      Follow session execution events
   get         Get a session resource
   list        List session resources
 
@@ -2454,11 +2620,15 @@ Usage:
   orka security dropped-findings list <repo> [flags]
 
 Flags:
-      --continue string   Continue token
-      --cursor string     Cursor token
-  -h, --help              help for list
-      --limit int         Maximum number of results (default 50)
-  -o, --output string     Output format: table, json, yaml (default "table")
+      --continue string      Continue token
+      --cursor string        Cursor token
+  -h, --help                 help for list
+      --layer string         Filter by dropped-finding layer (validation, filter, cap)
+      --limit int            Maximum number of results (default 50)
+  -o, --output string        Output format: table, json, yaml (default "table")
+      --reason string        Filter by exact reason or contains=<text>
+      --scan-run-id string   Filter by scan run ID
+      --slice-id string      Filter by review slice ID
 
 Global Flags:
       --kubeconfig string       Path to kubeconfig file

--- a/website/docs/reference/execution-events.md
+++ b/website/docs/reference/execution-events.md
@@ -107,6 +107,10 @@ Session streams do not close on task terminal events because a session can have 
 
 ## Task trace API
 
+This is Orka's event-derived task trace read model. It is separate from
+OpenTelemetry distributed traces: `orka task trace` reads stored execution
+events through the Orka API, not your OTLP collector/backend.
+
 ```http
 GET /api/v1/tasks/:id/trace?namespace=<ns>
 ```


### PR DESCRIPTION
## Summary

- Expand the Observability guide with complete OpenTelemetry enablement examples, OTLP protocol options, worker-safe environment propagation rules, harness-wrapper opt-in, and OTel-vs-task-trace clarification.
- Refresh Configuration, Architecture, README, Development, and Execution Events docs to consistently describe OpenTelemetry traces plus GenAI OTLP metrics.
- Regenerate CLI command docs for the task event/trace/approval/fork commands that were missing from the generated task reference.

## Validation

- `bash -n scripts/generate-cli-docs.sh`
- `scripts/generate-cli-docs.sh --check`
- `cd website && yarn install --frozen-lockfile && yarn build`
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean; ignored one pre-existing/out-of-scope CLI generator gap for session event commands
