### PR TITLE
perf: reduce task execution overhead

### DIFF
--- a/internal/api/execution_event_dto.go
+++ b/internal/api/execution_event_dto.go
@@ -137,7 +137,7 @@ func NewExecutionEventResponse(event store.ExecutionEvent) ExecutionEventRespons
 		StreamID:     event.StreamID,
 		Seq:          event.Seq,
 		Type:         event.Type,
-		Severity:     events.NormalizeExecutionEventSeverity(event.Severity),
+		Severity:     normalizeExecutionEventResponseSeverity(event.Severity),
 		TaskName:     event.TaskName,
 		SessionName:  event.SessionName,
 		AgentName:    event.AgentName,
@@ -158,9 +158,9 @@ func NewExecutionEventResponse(event store.ExecutionEvent) ExecutionEventRespons
 
 // NewListExecutionEventsResponse builds a list DTO from store events.
 func NewListExecutionEventsResponse(namespace, streamType, streamID string, afterSeq, latestSeq int64, storeEvents []store.ExecutionEvent) ListExecutionEventsResponse {
-	responses := make([]ExecutionEventResponse, 0, len(storeEvents))
-	for _, event := range storeEvents {
-		responses = append(responses, NewExecutionEventResponse(event))
+	responses := make([]ExecutionEventResponse, len(storeEvents))
+	for i := range storeEvents {
+		responses[i] = NewExecutionEventResponse(storeEvents[i])
 	}
 	return ListExecutionEventsResponse{
 		Namespace:  namespace,
@@ -187,9 +187,9 @@ func NewSessionExecutionEventResponse(event store.SessionExecutionEvent) Session
 
 // NewListSessionExecutionEventsResponse builds a session timeline DTO.
 func NewListSessionExecutionEventsResponse(namespace, sessionName string, afterSeq, latestSeq int64, storeEvents []store.SessionExecutionEvent) ListSessionExecutionEventsResponse {
-	responses := make([]SessionExecutionEventResponse, 0, len(storeEvents))
-	for _, event := range storeEvents {
-		responses = append(responses, NewSessionExecutionEventResponse(event))
+	responses := make([]SessionExecutionEventResponse, len(storeEvents))
+	for i := range storeEvents {
+		responses[i] = NewSessionExecutionEventResponse(storeEvents[i])
 	}
 	return ListSessionExecutionEventsResponse{
 		Namespace:  namespace,
@@ -198,6 +198,18 @@ func NewListSessionExecutionEventsResponse(namespace, sessionName string, afterS
 		AfterSeq:   afterSeq,
 		LatestSeq:  latestSeq,
 		Events:     responses,
+	}
+}
+
+func normalizeExecutionEventResponseSeverity(severity string) string {
+	switch severity {
+	case events.ExecutionEventSeverityDebug,
+		events.ExecutionEventSeverityInfo,
+		events.ExecutionEventSeverityWarning,
+		events.ExecutionEventSeverityError:
+		return severity
+	default:
+		return events.NormalizeExecutionEventSeverity(severity)
 	}
 }
 

--- a/internal/api/execution_event_dto_test.go
+++ b/internal/api/execution_event_dto_test.go
@@ -271,6 +271,37 @@ func TestExecutionEventFixturesValidate(t *testing.T) {
 	}
 }
 
+func BenchmarkNewListExecutionEventsResponseTaskEvents(b *testing.B) {
+	createdAt := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	storeEvents := make([]store.ExecutionEvent, 1024)
+	for i := range storeEvents {
+		storeEvents[i] = store.ExecutionEvent{
+			ID:          "event-1",
+			Namespace:   "default",
+			StreamType:  events.ExecutionEventStreamTypeTask,
+			StreamID:    "task-1",
+			Seq:         int64(i + 1),
+			Type:        events.ExecutionEventTypeTaskPhaseChanged,
+			Severity:    events.ExecutionEventSeverityInfo,
+			TaskName:    "task-1",
+			SessionName: "session-a",
+			AgentName:   "codex",
+			Summary:     "phase changed",
+			ContentText: "Running",
+			CreatedAt:   createdAt,
+		}
+	}
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		response := NewListExecutionEventsResponse("default", events.ExecutionEventStreamTypeTask, "task-1", 0, int64(len(storeEvents)), storeEvents)
+		if len(response.Events) != len(storeEvents) {
+			b.Fatalf("events = %d, want %d", len(response.Events), len(storeEvents))
+		}
+	}
+}
+
 func assertFixtureContainsNoSecrets(t *testing.T, raw string) {
 	t.Helper()
 	for _, marker := range []string{"Authorization:", "Bearer ", "Co" + "okie:", "Txn-Token", "Transaction-Token", "sk-test", "sk-ant", "github" + "_pat_", "gh" + "p_", "xox" + "b-"} {

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -239,6 +239,26 @@ func agentHasFallbackProviders(agent *corev1alpha1.Agent) bool {
 	return agent != nil && agent.Spec.Model != nil && len(agent.Spec.Model.Fallbacks) > 0
 }
 
+var (
+	defaultTaskResourceCPURequest    = *resource.NewMilliQuantity(100, resource.DecimalSI)
+	defaultTaskResourceMemoryRequest = *resource.NewQuantity(512*1024*1024, resource.BinarySI)
+	defaultTaskResourceCPULimit      = *resource.NewQuantity(1, resource.DecimalSI)
+	defaultTaskResourceMemoryLimit   = *resource.NewQuantity(2*1024*1024*1024, resource.BinarySI)
+)
+
+func defaultTaskResourceRequirements() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    defaultTaskResourceCPURequest,
+			corev1.ResourceMemory: defaultTaskResourceMemoryRequest,
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    defaultTaskResourceCPULimit,
+			corev1.ResourceMemory: defaultTaskResourceMemoryLimit,
+		},
+	}
+}
+
 func (b *JobBuilder) needsSecretVolumes(task *corev1alpha1.Task, agent *corev1alpha1.Agent, provider *corev1alpha1.Provider) bool {
 	if taskRequestsReadOnlyAgent(task) && agent != nil && agent.Spec.SecretRef != nil {
 		return true
@@ -551,16 +571,7 @@ func (b *JobBuilder) buildResources(task *corev1alpha1.Task, agent *corev1alpha1
 	// test suites — 512Mi was too small for `go test ./...` on medium repos
 	// and silently OOMKilled workers. Agents/tasks can still override via
 	// agent.spec.resources or task.spec.resources (checked above).
-	return corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("100m"),
-			corev1.ResourceMemory: resource.MustParse("512Mi"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("1"),
-			corev1.ResourceMemory: resource.MustParse("2Gi"),
-		},
-	}
+	return defaultTaskResourceRequirements()
 }
 
 // buildEnvVars builds the environment variables for the container

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -927,6 +927,25 @@ func TestJobBuilder_buildResources_Defaults(t *testing.T) {
 	}
 }
 
+func TestJobBuilder_buildResources_DefaultsAreIndependent(t *testing.T) {
+	builder := setupJobBuilder()
+	task := &corev1alpha1.Task{Spec: corev1alpha1.TaskSpec{}}
+
+	first := builder.buildResources(task, nil)
+	second := builder.buildResources(task, nil)
+
+	first.Requests[corev1.ResourceCPU] = resource.MustParse("900m")
+	delete(first.Limits, corev1.ResourceMemory)
+
+	cpuReq := second.Requests[corev1.ResourceCPU]
+	if got := cpuReq.String(); got != "100m" {
+		t.Fatalf("second default CPU request = %s after mutating first result, want 100m", got)
+	}
+	if _, ok := second.Limits[corev1.ResourceMemory]; !ok {
+		t.Fatal("second default memory limit disappeared after mutating first result")
+	}
+}
+
 func TestJobBuilder_buildEnvVars(t *testing.T) {
 	builder := setupJobBuilder()
 	task := &corev1alpha1.Task{
@@ -2919,4 +2938,17 @@ func TestJobBuilder_buildEnvVars_Telemetry(t *testing.T) {
 		t.Fatal("generic container tasks must not receive telemetry enablement")
 	}
 
+}
+
+var benchmarkResourceRequirementsSink corev1.ResourceRequirements
+
+func BenchmarkJobBuilderBuildResourcesDefaults(b *testing.B) {
+	builder := &JobBuilder{}
+	task := &corev1alpha1.Task{Spec: corev1alpha1.TaskSpec{}}
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		benchmarkResourceRequirementsSink = builder.buildResources(task, nil)
+	}
 }

--- a/internal/llm/tracing.go
+++ b/internal/llm/tracing.go
@@ -9,6 +9,8 @@ package llm
 import (
 	"context"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -22,15 +24,66 @@ import (
 
 // TracingProvider wraps an LLM Provider with OpenTelemetry GenAI tracing.
 type TracingProvider struct {
-	inner             Provider
+	inner Provider
+
+	initMu  sync.Mutex
+	tracer  atomic.Pointer[tracingTracer]
+	metrics atomic.Pointer[tracingMetrics]
+}
+
+type tracingTracer struct {
+	tracer trace.Tracer
+}
+
+type tracingMetrics struct {
 	operationDuration metric.Float64Histogram
 	usage             metric.Int64Histogram
 	timeToFirstChunk  metric.Float64Histogram
 }
 
+var noopTracingSpan = trace.SpanFromContext(context.Background())
+
 // NewTracingProvider returns a Provider that records a GenAI span and metrics
-// for every LLM call. Legacy llm.* attributes are dual-emitted during migration.
+// for every LLM call once an OpenTelemetry provider is configured. Legacy llm.*
+// attributes are dual-emitted during migration.
 func NewTracingProvider(p Provider) Provider {
+	tp := &TracingProvider{inner: p}
+	tp.ensureTelemetry()
+	return tp
+}
+
+func (tp *TracingProvider) ensureTelemetry() bool {
+	if tp.tracer.Load() == nil && !tracing.GlobalTracerProviderExplicitNoop() {
+		tp.initTracer()
+	}
+	if tp.metrics.Load() == nil && tracing.GlobalMeterProviderActive() {
+		tp.initMetrics()
+	}
+	return tp.tracer.Load() != nil || tp.metrics.Load() != nil
+}
+
+func (tp *TracingProvider) initTracer() {
+	if tp.tracer.Load() != nil {
+		return
+	}
+	tp.initMu.Lock()
+	defer tp.initMu.Unlock()
+	if tp.tracer.Load() != nil || tracing.GlobalTracerProviderExplicitNoop() {
+		return
+	}
+	tp.tracer.Store(&tracingTracer{tracer: tracing.GenAITracer(genai.InstrumentationName)})
+}
+
+func (tp *TracingProvider) initMetrics() {
+	if tp.metrics.Load() != nil {
+		return
+	}
+	tp.initMu.Lock()
+	defer tp.initMu.Unlock()
+	if tp.metrics.Load() != nil || !tracing.GlobalMeterProviderActive() {
+		return
+	}
+
 	meter := tracing.GenAIMeter(genai.InstrumentationName)
 	operationDuration, _ := meter.Float64Histogram(
 		genai.MetricClientOperationDuration,
@@ -47,12 +100,11 @@ func NewTracingProvider(p Provider) Provider {
 		metric.WithUnit(genai.UnitSeconds),
 		metric.WithExplicitBucketBoundaries(genai.OperationDurationBuckets...),
 	)
-	return &TracingProvider{
-		inner:             p,
+	tp.metrics.Store(&tracingMetrics{
 		operationDuration: operationDuration,
 		usage:             usage,
 		timeToFirstChunk:  timeToFirstChunk,
-	}
+	})
 }
 
 func (tp *TracingProvider) Name() string { return tp.inner.Name() }
@@ -60,39 +112,62 @@ func (tp *TracingProvider) Name() string { return tp.inner.Name() }
 func (tp *TracingProvider) TelemetryProviderName() string { return ProviderTelemetryName(tp.inner) }
 
 func (tp *TracingProvider) Complete(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error) {
+	if !tp.ensureTelemetry() {
+		return tp.inner.Complete(ctx, req)
+	}
+
 	start := time.Now()
 	providerName := ProviderTelemetryName(tp.inner)
-	attrs := requestAttributes(req, providerName, false)
-	tracer := tracing.GenAITracer(genai.InstrumentationName)
-	ctx, span := tracer.Start(ctx, spanName(req), trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attrs...))
-	defer span.End()
+	span := noopTracingSpan
+	if tracer := tp.tracer.Load(); tracer != nil {
+		attrs := requestAttributes(req, providerName, false)
+		ctx, span = tracer.tracer.Start(ctx, spanName(req), trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attrs...))
+		defer span.End()
+	}
+
+	spanRecording := span.IsRecording()
+	metricsActive := tp.metrics.Load() != nil
 
 	resp, err := tp.inner.Complete(ctx, req)
 	durationSeconds := time.Since(start).Seconds()
 	if err != nil {
 		if isStreamingRequiredErr(err) {
-			span.SetAttributes(attribute.Bool("orka.llm.streaming_fallback_required", true))
+			if spanRecording {
+				span.SetAttributes(attribute.Bool("orka.llm.streaming_fallback_required", true))
+			}
 			return nil, err
 		}
 		if IsContextTooLongErr(err) {
-			span.SetAttributes(attribute.Bool("orka.llm.context_truncation_retry_required", true))
+			if spanRecording {
+				span.SetAttributes(attribute.Bool("orka.llm.context_truncation_retry_required", true))
+			}
+			return nil, err
+		}
+		if !spanRecording && !metricsActive {
 			return nil, err
 		}
 		errType := errorType(err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		if errType != "" {
-			span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+		if spanRecording {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			if errType != "" {
+				span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+			}
 		}
 		tp.recordOperationDuration(ctx, durationSeconds, providerName, requestModel(req), errType)
 		return nil, err
 	}
 
+	if !spanRecording && !metricsActive {
+		return resp, nil
+	}
 	providerName = responseProviderName(resp, tp.inner)
-	setResponseAttributes(span, resp, providerName)
+	if spanRecording {
+		setResponseAttributes(span, resp, providerName)
+	}
 	modelName := responseModel(resp, req)
 	errType := stopReasonErrorType(resp.StopReason)
-	if errType != "" {
+	if errType != "" && spanRecording {
 		span.SetStatus(codes.Error, resp.StopReason)
 		span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
 	}
@@ -101,24 +176,41 @@ func (tp *TracingProvider) Complete(ctx context.Context, req *CompletionRequest)
 	return resp, nil
 }
 
+//nolint:gocyclo // Streaming telemetry handles independent provider/model/token/error/cancel signals inline.
 func (tp *TracingProvider) Stream(ctx context.Context, req *CompletionRequest) (<-chan StreamChunk, error) {
+	if !tp.ensureTelemetry() {
+		return tp.inner.Stream(ctx, req)
+	}
+
 	start := time.Now()
 	providerName := ProviderTelemetryName(tp.inner)
-	attrs := requestAttributes(req, providerName, true)
-	tracer := tracing.GenAITracer(genai.InstrumentationName)
-	ctx, span := tracer.Start(ctx, spanName(req), trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attrs...))
+	span := noopTracingSpan
+	if tracer := tp.tracer.Load(); tracer != nil {
+		attrs := requestAttributes(req, providerName, true)
+		ctx, span = tracer.tracer.Start(ctx, spanName(req), trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attrs...))
+	}
+	spanRecording := span.IsRecording()
+	metricsActive := tp.metrics.Load() != nil
 
 	innerCh, err := tp.inner.Stream(ctx, req)
 	if err != nil {
+		if !spanRecording && !metricsActive {
+			return nil, err
+		}
 		errType := errorType(err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		if errType != "" {
-			span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+		if spanRecording {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			if errType != "" {
+				span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+			}
 		}
 		tp.recordOperationDuration(ctx, time.Since(start).Seconds(), providerName, requestModel(req), errType)
 		span.End()
 		return nil, err
+	}
+	if !spanRecording && !metricsActive {
+		return innerCh, nil
 	}
 
 	out := make(chan StreamChunk)
@@ -130,12 +222,14 @@ func (tp *TracingProvider) Stream(ctx context.Context, req *CompletionRequest) (
 		selectedModel := requestModel(req)
 		streamResp := &CompletionResponse{}
 		defer func() {
-			if len(finishReasons) > 0 {
+			if spanRecording && len(finishReasons) > 0 {
 				span.SetAttributes(attribute.StringSlice(genai.AttrResponseFinishReasons, finishReasons))
 			}
 			if streamResp.InputTokens > 0 || streamResp.OutputTokens > 0 {
 				streamResp.Model = selectedModel
-				setResponseAttributes(span, streamResp, selectedProviderName)
+				if spanRecording {
+					setResponseAttributes(span, streamResp, selectedProviderName)
+				}
 				tp.recordTokenUsage(ctx, streamResp, selectedProviderName, selectedModel)
 			}
 			tp.recordOperationDuration(ctx, time.Since(start).Seconds(), selectedProviderName, selectedModel, errType)
@@ -168,16 +262,20 @@ func (tp *TracingProvider) Stream(ctx context.Context, req *CompletionRequest) (
 				finishReasons = []string{chunk.StopReason}
 				if stopErrType := stopReasonErrorType(chunk.StopReason); stopErrType != "" && chunk.Error == nil {
 					errType = stopErrType
-					span.SetStatus(codes.Error, chunk.StopReason)
-					span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+					if spanRecording {
+						span.SetStatus(codes.Error, chunk.StopReason)
+						span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+					}
 				}
 			}
 			if chunk.Error != nil {
 				errType = errorType(chunk.Error)
-				span.RecordError(chunk.Error)
-				span.SetStatus(codes.Error, chunk.Error.Error())
-				if errType != "" {
-					span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+				if spanRecording {
+					span.RecordError(chunk.Error)
+					span.SetStatus(codes.Error, chunk.Error.Error())
+					if errType != "" {
+						span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+					}
 				}
 			}
 			select {
@@ -185,9 +283,11 @@ func (tp *TracingProvider) Stream(ctx context.Context, req *CompletionRequest) (
 			case <-ctx.Done():
 				if ctx.Err() != nil {
 					errType = errorType(ctx.Err())
-					span.RecordError(ctx.Err())
-					span.SetStatus(codes.Error, ctx.Err().Error())
-					span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+					if spanRecording {
+						span.RecordError(ctx.Err())
+						span.SetStatus(codes.Error, ctx.Err().Error())
+						span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+					}
 				}
 				return
 			}
@@ -308,28 +408,31 @@ func metricAttributes(providerName, model, errType string) []attribute.KeyValue 
 }
 
 func (tp *TracingProvider) recordOperationDuration(ctx context.Context, seconds float64, providerName, model, errType string) {
-	if tp.operationDuration == nil {
+	metrics := tp.metrics.Load()
+	if metrics == nil || metrics.operationDuration == nil {
 		return
 	}
-	tp.operationDuration.Record(ctx, seconds, metric.WithAttributes(metricAttributes(providerName, model, errType)...))
+	metrics.operationDuration.Record(ctx, seconds, metric.WithAttributes(metricAttributes(providerName, model, errType)...))
 }
 
 func (tp *TracingProvider) recordTimeToFirstChunk(ctx context.Context, seconds float64, providerName, model string) {
-	if tp.timeToFirstChunk == nil {
+	metrics := tp.metrics.Load()
+	if metrics == nil || metrics.timeToFirstChunk == nil {
 		return
 	}
-	tp.timeToFirstChunk.Record(ctx, seconds, metric.WithAttributes(metricAttributes(providerName, model, "")...))
+	metrics.timeToFirstChunk.Record(ctx, seconds, metric.WithAttributes(metricAttributes(providerName, model, "")...))
 }
 
 func (tp *TracingProvider) recordTokenUsage(ctx context.Context, resp *CompletionResponse, providerName, model string) {
-	if tp.usage == nil || resp == nil || (resp.InputTokens == 0 && resp.OutputTokens == 0) {
+	metrics := tp.metrics.Load()
+	if metrics == nil || metrics.usage == nil || resp == nil || (resp.InputTokens == 0 && resp.OutputTokens == 0) {
 		return
 	}
 	base := metricAttributes(providerName, model, "")
 	if resp.InputTokens > 0 {
-		tp.usage.Record(ctx, int64(resp.InputTokens), metric.WithAttributes(append(base, attribute.String(genai.AttrTokenType, genai.TokenTypeInput))...))
+		metrics.usage.Record(ctx, int64(resp.InputTokens), metric.WithAttributes(append(base, attribute.String(genai.AttrTokenType, genai.TokenTypeInput))...))
 	}
 	if resp.OutputTokens > 0 {
-		tp.usage.Record(ctx, int64(resp.OutputTokens), metric.WithAttributes(append(base, attribute.String(genai.AttrTokenType, genai.TokenTypeOutput))...))
+		metrics.usage.Record(ctx, int64(resp.OutputTokens), metric.WithAttributes(append(base, attribute.String(genai.AttrTokenType, genai.TokenTypeOutput))...))
 	}
 }

--- a/internal/llm/tracing_test.go
+++ b/internal/llm/tracing_test.go
@@ -12,11 +12,14 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/sozercan/orka/internal/tracing"
 	"github.com/sozercan/orka/internal/tracing/genai"
@@ -252,6 +255,111 @@ func TestTracingProviderCompleteEmitsGenAISpan(t *testing.T) {
 	if got := histogramPointCount(rm, genai.MetricClientTokenUsage); got != 2 {
 		t.Fatalf("token usage datapoints = %d, want 2", got)
 	}
+}
+
+func TestTracingProviderInitializesAfterTelemetryConfigured(t *testing.T) {
+	setNoopTelemetry(t)
+
+	tp := NewTracingProvider(&telemetryProvider{
+		name:          "openai",
+		telemetryName: "openai",
+		resp: &CompletionResponse{
+			Content:      "ok",
+			Model:        "gpt-4o",
+			InputTokens:  3,
+			OutputTokens: 5,
+		},
+	})
+	h := testutil.NewSpanHarness(t)
+	mh := testutil.NewMetricHarness(t)
+
+	resp, err := tp.Complete(context.Background(), &CompletionRequest{Model: "gpt-4o"})
+	if err != nil || resp == nil {
+		t.Fatalf("Complete() resp=%#v err=%v", resp, err)
+	}
+	if span := testutil.SpanNamed(h.Recorder.Ended(), "chat gpt-4o"); span == nil {
+		t.Fatal("missing chat span after telemetry provider was configured")
+	}
+	rm := mh.Collect(t)
+	if got := histogramPointCount(rm, genai.MetricClientOperationDuration); got != 1 {
+		t.Fatalf("operation duration datapoints = %d, want 1", got)
+	}
+}
+
+func TestTracingProviderInitializesSignalsIndependently(t *testing.T) {
+	t.Run("metrics after tracer", func(t *testing.T) {
+		setNoopTelemetry(t)
+		h := testutil.NewSpanHarness(t)
+		tp := NewTracingProvider(&telemetryProvider{
+			name:          "openai",
+			telemetryName: "openai",
+			resp: &CompletionResponse{
+				Content:      "ok",
+				Model:        "gpt-4o",
+				InputTokens:  3,
+				OutputTokens: 5,
+			},
+		})
+
+		if _, err := tp.Complete(context.Background(), &CompletionRequest{Model: "gpt-4o"}); err != nil {
+			t.Fatalf("Complete() error = %v", err)
+		}
+		if span := testutil.SpanNamed(h.Recorder.Ended(), "chat gpt-4o"); span == nil {
+			t.Fatal("missing chat span with tracer configured")
+		}
+
+		mh := testutil.NewMetricHarness(t)
+		if _, err := tp.Complete(context.Background(), &CompletionRequest{Model: "gpt-4o"}); err != nil {
+			t.Fatalf("Complete() after meter configured error = %v", err)
+		}
+		rm := mh.Collect(t)
+		if got := histogramPointCount(rm, genai.MetricClientOperationDuration); got != 1 {
+			t.Fatalf("operation duration datapoints = %d, want 1", got)
+		}
+	})
+
+	t.Run("tracer after metrics", func(t *testing.T) {
+		setNoopTelemetry(t)
+		mh := testutil.NewMetricHarness(t)
+		tp := NewTracingProvider(&telemetryProvider{
+			name:          "openai",
+			telemetryName: "openai",
+			resp: &CompletionResponse{
+				Content:      "ok",
+				Model:        "gpt-4o",
+				InputTokens:  3,
+				OutputTokens: 5,
+			},
+		})
+
+		if _, err := tp.Complete(context.Background(), &CompletionRequest{Model: "gpt-4o"}); err != nil {
+			t.Fatalf("Complete() error = %v", err)
+		}
+		rm := mh.Collect(t)
+		if got := histogramPointCount(rm, genai.MetricClientOperationDuration); got != 1 {
+			t.Fatalf("operation duration datapoints = %d, want 1", got)
+		}
+
+		h := testutil.NewSpanHarness(t)
+		if _, err := tp.Complete(context.Background(), &CompletionRequest{Model: "gpt-4o"}); err != nil {
+			t.Fatalf("Complete() after tracer configured error = %v", err)
+		}
+		if span := testutil.SpanNamed(h.Recorder.Ended(), "chat gpt-4o"); span == nil {
+			t.Fatal("missing chat span after tracer configured")
+		}
+	})
+}
+
+func setNoopTelemetry(t *testing.T) {
+	t.Helper()
+	previousTracerProvider := otel.GetTracerProvider()
+	previousMeterProvider := otel.GetMeterProvider()
+	otel.SetTracerProvider(tracenoop.NewTracerProvider())
+	otel.SetMeterProvider(metricnoop.NewMeterProvider())
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousTracerProvider)
+		otel.SetMeterProvider(previousMeterProvider)
+	})
 }
 
 func TestTracingProviderCompleteSkipsTokenUsageWhenCountsMissing(t *testing.T) {

--- a/internal/store/sqlite/message_store.go
+++ b/internal/store/sqlite/message_store.go
@@ -8,6 +8,8 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
+	"strings"
 	"time"
 
 	"github.com/sozercan/orka/internal/store"
@@ -93,13 +95,10 @@ func (s *Store) GetMessages(ctx context.Context, namespace, taskName, parentTask
 		return nil, err
 	}
 
-	// Mark as read within the same transaction
-	if len(ids) > 0 {
-		for _, id := range ids {
-			if _, err := tx.ExecContext(ctx, `UPDATE messages SET read = TRUE WHERE id = ?`, id); err != nil {
-				return nil, err
-			}
-		}
+	// Mark exactly the messages returned by the read query. Batch IDs to avoid
+	// issuing one UPDATE per message while staying below SQLite variable limits.
+	if err := markMessagesReadByID(ctx, tx, ids); err != nil {
+		return nil, err
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -125,4 +124,32 @@ func (s *Store) DeleteParentMessages(ctx context.Context, namespace, parentTask 
 		namespace, parentTask,
 	)
 	return err
+}
+
+const sqliteMessageReadUpdateBatchSize = 500
+
+func markMessagesReadByID(ctx context.Context, tx *sql.Tx, ids []int64) error {
+	for len(ids) > 0 {
+		batchSize := min(len(ids), sqliteMessageReadUpdateBatchSize)
+		batch := ids[:batchSize]
+
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			args[i] = id
+		}
+		query := `UPDATE messages SET read = TRUE WHERE id IN (` + sqlitePlaceholders(len(batch)) + `)`
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return err
+		}
+
+		ids = ids[batchSize:]
+	}
+	return nil
+}
+
+func sqlitePlaceholders(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return "?" + strings.Repeat(",?", n-1)
 }

--- a/internal/store/sqlite/message_store_benchmark_test.go
+++ b/internal/store/sqlite/message_store_benchmark_test.go
@@ -1,0 +1,89 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func BenchmarkGetMessagesMarkRead100(b *testing.B) {
+	ctx := context.Background()
+	s := setupBenchmarkStore(b)
+	const (
+		namespace  = "bench-messages"
+		taskName   = "reader"
+		parentTask = "parent"
+		count      = 100
+	)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		resetBenchmarkMessages(ctx, b, s, namespace, taskName, parentTask, count)
+
+		b.StartTimer()
+		messages, err := s.GetMessages(ctx, namespace, taskName, parentTask, true)
+		b.StopTimer()
+
+		if err != nil {
+			b.Fatalf("GetMessages: %v", err)
+		}
+		if len(messages) != count {
+			b.Fatalf("got %d messages, want %d", len(messages), count)
+		}
+	}
+}
+
+func setupBenchmarkStore(b *testing.B) *Store {
+	b.Helper()
+	db, err := NewDB(":memory:")
+	if err != nil {
+		b.Fatalf("NewDB(:memory:): %v", err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+	return NewStore(db, ":memory:")
+}
+
+func resetBenchmarkMessages(ctx context.Context, b *testing.B, s *Store, namespace, taskName, parentTask string, count int) {
+	b.Helper()
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM messages WHERE namespace = ?`, namespace); err != nil {
+		b.Fatalf("delete benchmark messages: %v", err)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		b.Fatalf("begin seed tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmt, err := tx.PrepareContext(ctx,
+		`INSERT INTO messages (namespace, from_task, to_task, parent_task, content, read, created_at)
+		 VALUES (?, ?, ?, ?, ?, FALSE, ?)`,
+	)
+	if err != nil {
+		b.Fatalf("prepare seed insert: %v", err)
+	}
+	defer func() { _ = stmt.Close() }()
+
+	createdAt := time.Unix(1_700_000_000, 0).UTC()
+	for i := range count {
+		toTask := taskName
+		if i%4 == 0 {
+			toTask = "*"
+		}
+		if _, err := stmt.ExecContext(
+			ctx,
+			namespace,
+			fmt.Sprintf("sender-%02d", i%10),
+			toTask,
+			parentTask,
+			fmt.Sprintf("message-%03d", i),
+			createdAt,
+		); err != nil {
+			b.Fatalf("insert benchmark message %d: %v", i, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		b.Fatalf("commit seed tx: %v", err)
+	}
+}

--- a/internal/store/sqlite/message_store_test.go
+++ b/internal/store/sqlite/message_store_test.go
@@ -118,6 +118,46 @@ func TestGetMessagesMultipleMarkRead(t *testing.T) {
 	}
 }
 
+func TestGetMessagesMarkReadBatchesLargeInbox(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+	const (
+		namespace  = "ns-large-mark-read"
+		taskName   = "reader"
+		parentTask = "parent"
+	)
+	count := sqliteMessageReadUpdateBatchSize + 3
+
+	for i := range count {
+		msg := &store.Message{
+			Namespace:  namespace,
+			FromTask:   fmt.Sprintf("sender-%d", i%10),
+			ToTask:     taskName,
+			ParentTask: parentTask,
+			Content:    fmt.Sprintf("msg-%d", i),
+		}
+		if err := s.SendMessage(ctx, msg); err != nil {
+			t.Fatalf("SendMessage %d: %v", i, err)
+		}
+	}
+
+	msgs, err := s.GetMessages(ctx, namespace, taskName, parentTask, true)
+	if err != nil {
+		t.Fatalf("GetMessages markRead: %v", err)
+	}
+	if len(msgs) != count {
+		t.Fatalf("got %d messages, want %d", len(msgs), count)
+	}
+
+	msgs, err = s.GetMessages(ctx, namespace, taskName, parentTask, false)
+	if err != nil {
+		t.Fatalf("GetMessages after markRead: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Fatalf("got %d messages after markRead, want 0", len(msgs))
+	}
+}
+
 func TestMessageStore(t *testing.T) { //nolint:gocyclo
 	s := setupTestStore(t)
 	ctx := context.Background()

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -154,6 +154,18 @@ type Tool interface {
 type Registry struct {
 	mu    sync.RWMutex
 	tools map[string]Tool
+
+	telemetryMu            sync.Mutex
+	tracerProvider         any
+	tracer                 trace.Tracer
+	meterProvider          any
+	toolDurationHistogram  metric.Float64Histogram
+	toolDurationMetricOpts map[toolDurationMetricKey]metric.MeasurementOption
+}
+
+type toolDurationMetricKey struct {
+	toolName string
+	toolType string
 }
 
 // NewRegistry creates a new tool registry
@@ -175,6 +187,13 @@ func (r *Registry) Get(name string) (Tool, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	tool, ok := r.tools[name]
+	return tool, ok
+}
+
+func (r *Registry) get(name string) (Tool, bool) {
+	r.mu.RLock()
+	tool, ok := r.tools[name]
+	r.mu.RUnlock()
 	return tool, ok
 }
 
@@ -204,26 +223,43 @@ func (r *Registry) Names() []string {
 // Execute executes a tool by name. It is the DRY instrumentation point for
 // built-in registry tools used by chat, proxy-compatible handlers, and workers.
 func (r *Registry) Execute(ctx context.Context, name string, args json.RawMessage) (string, error) {
+	tool, ok := r.get(name)
+	if telemetryDisabled() {
+		if !ok {
+			return "", fmt.Errorf("tool %q not found", name)
+		}
+		return tool.Execute(ctx, args)
+	}
+
 	start := time.Now()
-	tool, ok := r.Get(name)
 	toolTelemetryName := name
 	if !ok {
 		toolTelemetryName = unknownToolTelemetryName
 	}
 	toolTypeValue := toolType(ctx, tool)
 	toolKind := registryToolKind(name)
-	attrs := []attribute.KeyValue{
+	attrs := make([]attribute.KeyValue, 0, 10)
+	attrs = append(attrs,
 		attribute.String(genai.AttrOperationName, genai.OperationExecuteTool),
 		attribute.String(genai.AttrToolName, toolTelemetryName),
 		attribute.String(genai.AttrToolType, toolTypeValue),
-	}
-	attrs = append(attrs, tracing.ToolAttributes(toolTelemetryName, toolKind, -1, "")...)
+		attribute.String(tracing.AttrToolName, toolTelemetryName),
+		attribute.String(tracing.AttrToolKind, toolKind),
+	)
 	if tc := GetToolContext(ctx); tc != nil {
 		tenant := tc.Tenant
 		if tenant == "" {
 			tenant = tc.Namespace
 		}
-		attrs = append(attrs, tracing.TaskAttributes(tc.TaskID, tc.Namespace, tenant, "", "")...)
+		if tc.TaskID != "" {
+			attrs = append(attrs, attribute.String(tracing.AttrTaskID, tc.TaskID))
+		}
+		if tc.Namespace != "" {
+			attrs = append(attrs, attribute.String(tracing.AttrTaskNamespace, tc.Namespace))
+		}
+		if tenant != "" {
+			attrs = append(attrs, attribute.String(tracing.AttrTenant, tenant))
+		}
 		if tc.ToolCallID != "" {
 			attrs = append(attrs, attribute.String(genai.AttrToolCallID, tc.ToolCallID))
 		}
@@ -233,42 +269,139 @@ func (r *Registry) Execute(ctx context.Context, name string, args json.RawMessag
 			attrs = append(attrs, attribute.String(genai.AttrToolDescription, description))
 		}
 	}
-	tracer := tracing.GenAITracer(genai.InstrumentationName)
+	tracer := r.genAITracer()
 	ctx, span := tracer.Start(ctx, genai.OperationExecuteTool+" "+toolTelemetryName, trace.WithSpanKind(trace.SpanKindInternal), trace.WithAttributes(attrs...))
 	defer span.End()
+	spanRecording := span.IsRecording()
+	meterActive := tracing.GlobalMeterProviderActive()
 
-	// Keep histogram labels low-cardinality and separate from span-only task/result attributes.
-	metricAttrs := []attribute.KeyValue{
-		attribute.String(genai.AttrOperationName, genai.OperationExecuteTool),
-		attribute.String(genai.AttrToolName, toolTelemetryName),
-		attribute.String(genai.AttrToolType, toolTypeValue),
-	}
 	if !ok {
 		err := fmt.Errorf("tool %q not found", name)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		span.SetAttributes(attribute.String(genai.AttrErrorType, "tool_not_found"))
-		metricAttrs = append(metricAttrs, attribute.String(genai.AttrErrorType, "tool_not_found"))
-		recordToolDuration(ctx, time.Since(start).Seconds(), metricAttrs...)
+		if spanRecording {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			span.SetAttributes(attribute.String(genai.AttrErrorType, "tool_not_found"))
+		}
+		if meterActive {
+			r.recordToolDuration(ctx, time.Since(start).Seconds(), toolTelemetryName, toolTypeValue, "tool_not_found")
+		}
 		return "", err
 	}
 
 	result, err := tool.Execute(ctx, args)
 	duration := time.Since(start).Seconds()
-	span.SetAttributes(tracing.ToolAttributes("", "", len(result), "")...)
+	if spanRecording {
+		span.SetAttributes(attribute.Int(tracing.AttrToolResultSizeBytes, len(result)))
+	}
+	metricErrType := ""
 	if err != nil {
 		errType := fmt.Sprintf("%T", err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
-		metricAttrs = append(metricAttrs, attribute.String(genai.AttrErrorType, errType))
-	} else if failed, errType, message := failedToolResult(result); failed {
-		span.SetStatus(codes.Error, message)
-		span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
-		metricAttrs = append(metricAttrs, attribute.String(genai.AttrErrorType, errType))
+		if spanRecording {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+		}
+		metricErrType = errType
+	} else if spanRecording || meterActive {
+		if failed, errType, message := failedToolResult(result); failed {
+			if spanRecording {
+				span.SetStatus(codes.Error, message)
+				span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+			}
+			metricErrType = errType
+		}
 	}
-	recordToolDuration(ctx, duration, metricAttrs...)
+	if meterActive {
+		if metricErrType != "" {
+			r.recordToolDuration(ctx, duration, toolTelemetryName, toolTypeValue, metricErrType)
+		} else {
+			r.recordSuccessfulToolDuration(ctx, duration, toolTelemetryName, toolTypeValue)
+		}
+	}
 	return result, err
+}
+
+func (r *Registry) genAITracer() trace.Tracer {
+	provider := tracing.GlobalTracerProvider()
+	r.telemetryMu.Lock()
+	defer r.telemetryMu.Unlock()
+	if r.tracer != nil && tracing.SameProvider(r.tracerProvider, provider) {
+		return r.tracer
+	}
+	r.tracerProvider = provider
+	r.tracer = provider.Tracer(genai.InstrumentationName, trace.WithSchemaURL(genai.SchemaURL))
+	return r.tracer
+}
+
+func (r *Registry) getToolDurationHistogram() (metric.Float64Histogram, bool) {
+	if !tracing.GlobalMeterProviderActive() {
+		return nil, false
+	}
+	provider := tracing.GlobalMeterProvider()
+	r.telemetryMu.Lock()
+	defer r.telemetryMu.Unlock()
+	if r.toolDurationHistogram != nil && tracing.SameProvider(r.meterProvider, provider) {
+		return r.toolDurationHistogram, true
+	}
+	meter := provider.Meter(genai.InstrumentationName, metric.WithSchemaURL(genai.SchemaURL))
+	histogram, err := meter.Float64Histogram(
+		genai.MetricExecuteToolDuration,
+		metric.WithUnit(genai.UnitSeconds),
+		metric.WithExplicitBucketBoundaries(genai.ToolDurationBuckets...),
+	)
+	if err != nil {
+		r.meterProvider = provider
+		r.toolDurationHistogram = nil
+		return nil, false
+	}
+	r.meterProvider = provider
+	r.toolDurationHistogram = histogram
+	return histogram, true
+}
+
+func (r *Registry) toolDurationMetricOption(toolName, toolType string) metric.MeasurementOption {
+	key := toolDurationMetricKey{toolName: toolName, toolType: toolType}
+	r.telemetryMu.Lock()
+	defer r.telemetryMu.Unlock()
+	if r.toolDurationMetricOpts == nil {
+		r.toolDurationMetricOpts = make(map[toolDurationMetricKey]metric.MeasurementOption)
+	}
+	if opt, ok := r.toolDurationMetricOpts[key]; ok {
+		return opt
+	}
+	attrs := attribute.NewSet(
+		attribute.String(genai.AttrOperationName, genai.OperationExecuteTool),
+		attribute.String(genai.AttrToolName, toolName),
+		attribute.String(genai.AttrToolType, toolType),
+	)
+	opt := metric.WithAttributeSet(attrs)
+	r.toolDurationMetricOpts[key] = opt
+	return opt
+}
+
+func (r *Registry) recordSuccessfulToolDuration(ctx context.Context, seconds float64, toolName, toolType string) {
+	histogram, ok := r.getToolDurationHistogram()
+	if !ok {
+		return
+	}
+	histogram.Record(ctx, seconds, r.toolDurationMetricOption(toolName, toolType))
+}
+
+func (r *Registry) recordToolDuration(ctx context.Context, seconds float64, toolName, toolType, errType string) {
+	histogram, ok := r.getToolDurationHistogram()
+	if !ok {
+		return
+	}
+	histogram.Record(ctx, seconds, metric.WithAttributes(
+		attribute.String(genai.AttrOperationName, genai.OperationExecuteTool),
+		attribute.String(genai.AttrToolName, toolName),
+		attribute.String(genai.AttrToolType, toolType),
+		attribute.String(genai.AttrErrorType, errType),
+	))
+}
+
+func telemetryDisabled() bool {
+	return tracing.GlobalTracerProviderExplicitNoop() && !tracing.GlobalMeterProviderActive()
 }
 
 // RecordRejectedToolCall records a failed tool invocation that is rejected before
@@ -314,12 +447,22 @@ func FailedToolResultForTelemetry(result string) (bool, string, string) {
 }
 
 func failedToolResult(result string) (bool, string, string) {
-	var body map[string]any
+	// Most successful tool results are compact JSON with "success":true and no
+	// false literal. Avoid the generic map unmarshal on that hot path; only parse
+	// when a structured failure is possible.
+	if !strings.Contains(result, "false") {
+		return false, "", ""
+	}
+	var body map[string]json.RawMessage
 	if json.Unmarshal([]byte(result), &body) != nil {
 		return false, "", ""
 	}
-	success, ok := body["success"].(bool)
-	if !ok || success {
+	successJSON, ok := body["success"]
+	if !ok {
+		return false, "", ""
+	}
+	var success bool
+	if json.Unmarshal(successJSON, &success) != nil || success {
 		return false, "", ""
 	}
 

--- a/internal/tools/registry_tracing_test.go
+++ b/internal/tools/registry_tracing_test.go
@@ -187,3 +187,55 @@ func TestRegistryExecuteMissingToolEmitsFailedSpanAndMetric(t *testing.T) {
 		t.Fatalf("missing %s datapoint", genai.MetricExecuteToolDuration)
 	}
 }
+
+func TestFailedToolResultForTelemetry(t *testing.T) {
+	tests := []struct {
+		name        string
+		result      string
+		wantFailed  bool
+		wantErrType string
+		wantMessage string
+	}{
+		{
+			name:   "success true skips failure",
+			result: `{"success":true}`,
+		},
+		{
+			name:        "structured failure",
+			result:      `{"success":false,"error":"bad input","errorType":"invalid_arguments"}`,
+			wantFailed:  true,
+			wantErrType: "invalid_arguments",
+			wantMessage: "bad input",
+		},
+		{
+			name:        "escaped success key keeps structured failure semantics",
+			result:      `{"\u0073uccess":false}`,
+			wantFailed:  true,
+			wantErrType: "tool_error",
+			wantMessage: "tool_error",
+		},
+		{
+			name:   "case variant is not structured failure",
+			result: `{"Success":false,"error":"bad input","errorType":"invalid_arguments"}`,
+		},
+		{
+			name:   "plain JSON with false is not structured failure",
+			result: `{"data":false}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFailed, gotErrType, gotMessage := FailedToolResultForTelemetry(tt.result)
+			if gotFailed != tt.wantFailed {
+				t.Fatalf("failed = %v, want %v", gotFailed, tt.wantFailed)
+			}
+			if gotErrType != tt.wantErrType {
+				t.Fatalf("errType = %q, want %q", gotErrType, tt.wantErrType)
+			}
+			if gotMessage != tt.wantMessage {
+				t.Fatalf("message = %q, want %q", gotMessage, tt.wantMessage)
+			}
+		})
+	}
+}

--- a/internal/tracing/provider_state.go
+++ b/internal/tracing/provider_state.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package tracing
+
+import (
+	"reflect"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	otelGlobalPkg      = "go.opentelemetry.io/otel/internal/global"
+	otelTraceNoopPkg   = "go.opentelemetry.io/otel/trace/noop"
+	otelMetricNoopPkg  = "go.opentelemetry.io/otel/metric/noop"
+	otelTracerProvider = "TracerProvider"
+	otelMeterProvider  = "MeterProvider"
+)
+
+// GlobalTracerProvider returns the currently configured OpenTelemetry tracer provider.
+func GlobalTracerProvider() trace.TracerProvider { return otel.GetTracerProvider() }
+
+// GlobalMeterProvider returns the currently configured OpenTelemetry meter provider.
+func GlobalMeterProvider() metric.MeterProvider { return otel.GetMeterProvider() }
+
+// GlobalTracerProviderExplicitNoop reports whether tracing was explicitly set
+// to the OpenTelemetry noop tracer provider. The default global tracer provider
+// is not considered inactive because OpenTelemetry auto-instrumentation can
+// activate it without changing its concrete type.
+func GlobalTracerProviderExplicitNoop() bool {
+	return isOTelProviderType(otel.GetTracerProvider(), otelTraceNoopPkg, otelTracerProvider)
+}
+
+// GlobalMeterProviderActive reports whether a real OpenTelemetry meter provider
+// is currently configured. Unlike the tracer provider, the default global meter
+// provider only records no-op measurements until an SDK meter provider is set.
+func GlobalMeterProviderActive() bool {
+	provider := otel.GetMeterProvider()
+	return !isOTelProviderType(provider, otelGlobalPkg, "meterProvider") &&
+		!isOTelProviderType(provider, otelMetricNoopPkg, otelMeterProvider)
+}
+
+func isOTelProviderType(provider any, pkgPath, name string) bool {
+	typ := reflect.TypeOf(provider)
+	if typ == nil {
+		return true
+	}
+	if typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	return typ.PkgPath() == pkgPath && typ.Name() == name
+}
+
+// SameProvider reports whether two provider interface values refer to the same
+// comparable concrete provider. It returns false for non-comparable provider
+// implementations instead of panicking on interface equality.
+func SameProvider(a, b any) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	typ := reflect.TypeOf(a)
+	if typ != reflect.TypeOf(b) || !typ.Comparable() {
+		return false
+	}
+	return a == b
+}

--- a/internal/worker/tool_executor.go
+++ b/internal/worker/tool_executor.go
@@ -50,6 +50,17 @@ const (
 	mcpInitializeMethod              = "initialize"
 	mcpInitializedNotificationMethod = "notifications/initialized"
 	toolIdempotencyKeyHeader         = "Idempotency-Key"
+	toolHTTPResponseBodyLimit        = 10 << 20
+)
+
+var (
+	executeToolOperationAttr = attribute.String(genai.AttrOperationName, genai.OperationExecuteTool)
+	extensionToolTypeAttr    = attribute.String(genai.AttrToolType, genai.ToolTypeExtension)
+
+	executeToolDurationOptions = []metric.Float64HistogramOption{
+		metric.WithUnit(genai.UnitSeconds),
+		metric.WithExplicitBucketBoundaries(genai.ToolDurationBuckets...),
+	}
 )
 
 type toolCallIDContextKey struct{}
@@ -106,32 +117,50 @@ func NewToolExecutor() *ToolExecutor {
 func (e *ToolExecutor) Execute(ctx context.Context, tool *corev1alpha1.Tool, args json.RawMessage) (result string, err error) {
 	start := time.Now()
 	toolName := toolTelemetryName(tool)
-	attrs := []attribute.KeyValue{
-		attribute.String(genai.AttrOperationName, genai.OperationExecuteTool),
+	attrs := make([]attribute.KeyValue, 0, 8)
+	attrs = append(attrs,
+		executeToolOperationAttr,
 		attribute.String(genai.AttrToolName, toolName),
-		attribute.String(genai.AttrToolType, genai.ToolTypeExtension),
+		extensionToolTypeAttr,
+		attribute.String(tracing.AttrToolName, toolName),
+		attribute.String(tracing.AttrToolKind, tracing.ToolKindHTTP),
+	)
+	if taskName := os.Getenv(workerenv.TaskName); taskName != "" {
+		attrs = append(attrs, attribute.String(tracing.AttrTaskID, taskName))
 	}
-	attrs = append(attrs, tracing.ToolAttributes(toolName, tracing.ToolKindHTTP, -1, "")...)
-	attrs = append(attrs, tracing.TaskAttributes(os.Getenv(workerenv.TaskName), e.namespace, e.namespace, "", "")...)
+	if e.namespace != "" {
+		attrs = append(attrs,
+			attribute.String(tracing.AttrTaskNamespace, e.namespace),
+			attribute.String(tracing.AttrTenant, e.namespace),
+		)
+	}
 	if toolCallID := toolCallIDFromContext(ctx); toolCallID != "" {
 		attrs = append(attrs, attribute.String(genai.AttrToolCallID, toolCallID))
 	}
 	ctx, span := tracing.GenAITracer(genai.InstrumentationName).Start(ctx, genai.OperationExecuteTool+" "+toolName, trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attrs...))
 	defer func() {
 		resultSize := len(result)
-		span.SetAttributes(tracing.ToolAttributes("", "", resultSize, "")...)
-		metricAttrs := []attribute.KeyValue{
-			attribute.String(genai.AttrOperationName, genai.OperationExecuteTool),
-			attribute.String(genai.AttrToolName, toolName),
-			attribute.String(genai.AttrToolType, genai.ToolTypeExtension),
-		}
+		meterActive := tracing.GlobalMeterProviderActive()
 		if err != nil {
 			errType := toolExecutionErrorType(err)
-			span.SetStatus(codes.Error, errType)
-			span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
-			metricAttrs = append(metricAttrs, attribute.String(genai.AttrErrorType, errType))
+			if span.IsRecording() {
+				span.SetStatus(codes.Error, errType)
+				span.SetAttributes(
+					attribute.Int(tracing.AttrToolResultSizeBytes, resultSize),
+					attribute.String(genai.AttrErrorType, errType),
+				)
+			}
+			if meterActive {
+				recordExternalToolDuration(ctx, time.Since(start).Seconds(), executeToolOperationAttr, attribute.String(genai.AttrToolName, toolName), extensionToolTypeAttr, attribute.String(genai.AttrErrorType, errType))
+			}
+		} else {
+			if span.IsRecording() {
+				span.SetAttributes(attribute.Int(tracing.AttrToolResultSizeBytes, resultSize))
+			}
+			if meterActive {
+				recordExternalToolDuration(ctx, time.Since(start).Seconds(), executeToolOperationAttr, attribute.String(genai.AttrToolName, toolName), extensionToolTypeAttr)
+			}
 		}
-		recordExternalToolDuration(ctx, time.Since(start).Seconds(), metricAttrs...)
 		span.End()
 	}()
 
@@ -140,7 +169,9 @@ func (e *ToolExecutor) Execute(ctx context.Context, tool *corev1alpha1.Tool, arg
 		return "", err
 	}
 	if prepared.request != nil {
-		span.SetAttributes(httpToolRequestAttributes(prepared.request)...)
+		if span.IsRecording() {
+			span.SetAttributes(httpToolRequestAttributes(prepared.request)...)
+		}
 		injectTraceHeaders(ctx, prepared.request.Header)
 	}
 
@@ -181,8 +212,7 @@ func recordExternalToolDuration(ctx context.Context, seconds float64, attrs ...a
 	meter := tracing.GenAIMeter(genai.InstrumentationName)
 	histogram, err := meter.Float64Histogram(
 		genai.MetricExecuteToolDuration,
-		metric.WithUnit(genai.UnitSeconds),
-		metric.WithExplicitBucketBoundaries(genai.ToolDurationBuckets...),
+		executeToolDurationOptions...,
 	)
 	if err != nil {
 		return
@@ -213,8 +243,10 @@ func toolExecutionErrorType(err error) string {
 }
 
 func toolTelemetryName(tool *corev1alpha1.Tool) string {
-	if tool != nil && strings.TrimSpace(tool.Name) != "" {
-		return strings.TrimSpace(tool.Name)
+	if tool != nil {
+		if name := strings.TrimSpace(tool.Name); name != "" {
+			return name
+		}
 	}
 	return "http_tool"
 }
@@ -223,7 +255,7 @@ func httpToolRequestAttributes(req *http.Request) []attribute.KeyValue {
 	if req == nil {
 		return nil
 	}
-	attrs := []attribute.KeyValue{}
+	attrs := make([]attribute.KeyValue, 0, 3)
 	if req.Method != "" {
 		attrs = append(attrs, attribute.String("http.request.method", req.Method))
 	}
@@ -252,7 +284,7 @@ func executeToolHTTPRequest(httpClient *http.Client, req *http.Request, secrets 
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20)) // 10MB limit
+	respBody, err := readLimitedHTTPResponseBody(resp.Body, resp.ContentLength)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -260,6 +292,17 @@ func executeToolHTTPRequest(httpClient *http.Client, req *http.Request, secrets 
 		return nil, fmt.Errorf("tool returned HTTP %d: %s", resp.StatusCode, redactToolHTTPErrorBody(string(respBody), secrets...))
 	}
 	return respBody, nil
+}
+
+func readLimitedHTTPResponseBody(body io.Reader, contentLength int64) ([]byte, error) {
+	limited := io.LimitReader(body, toolHTTPResponseBodyLimit)
+	if contentLength > 0 && contentLength <= toolHTTPResponseBodyLimit {
+		var respBody bytes.Buffer
+		respBody.Grow(int(contentLength))
+		_, err := respBody.ReadFrom(limited)
+		return respBody.Bytes(), err
+	}
+	return io.ReadAll(limited)
 }
 
 type toolIdempotencyKeyContextKey struct{}
@@ -653,7 +696,7 @@ func (e *ToolExecutor) terminateMCPSession(ctx context.Context, httpClient *http
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20)) // 10MB limit
+	respBody, err := readLimitedHTTPResponseBody(resp.Body, resp.ContentLength)
 	if err != nil {
 		return fmt.Errorf("failed to read MCP session termination response: %w", err)
 	}
@@ -725,7 +768,7 @@ func readMCPHTTPResponseBody(resp *http.Response, expectedResponseID string) ([]
 	if isMCPEventStream(resp.Header.Get("Content-Type")) && strings.TrimSpace(expectedResponseID) != "" && resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return readMCPEventStreamResponse(resp.Body, expectedResponseID)
 	}
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20)) // 10MB limit
+	respBody, err := readLimitedHTTPResponseBody(resp.Body, resp.ContentLength)
 	if err != nil {
 		return nil, err
 	}
@@ -813,7 +856,7 @@ func isMCPEventStream(contentType string) bool {
 
 func readMCPEventStreamResponse(body io.Reader, expectedResponseID string) ([]byte, error) {
 	scanner := bufio.NewScanner(body)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10<<20)
+	scanner.Buffer(make([]byte, 0, 64*1024), toolHTTPResponseBodyLimit)
 	totalDataBytes := 0
 	var data []string
 	flush := func() []byte {
@@ -842,7 +885,7 @@ func readMCPEventStreamResponse(body io.Reader, expectedResponseID string) ([]by
 		if after, ok := strings.CutPrefix(line, "data:"); ok {
 			after = strings.TrimPrefix(after, " ")
 			totalDataBytes += len(after)
-			if totalDataBytes > 10<<20 {
+			if totalDataBytes > toolHTTPResponseBodyLimit {
 				return nil, fmt.Errorf("MCP event stream response exceeded 10MB limit")
 			}
 			data = append(data, after)
@@ -859,7 +902,7 @@ func readMCPEventStreamResponse(body io.Reader, expectedResponseID string) ([]by
 
 func firstSSEData(body []byte) []byte {
 	scanner := bufio.NewScanner(bytes.NewReader(body))
-	scanner.Buffer(make([]byte, 0, 64*1024), 10<<20)
+	scanner.Buffer(make([]byte, 0, 64*1024), toolHTTPResponseBodyLimit)
 	var data []string
 	flush := func() []byte {
 		if len(data) == 0 {
@@ -1000,15 +1043,18 @@ func toolAuthInject(httpConfig corev1alpha1.HTTPExecution) string {
 }
 
 func interpolateToolURL(url string, params map[string]any) string {
-	interpolatedKeys := map[string]bool{}
+	if !strings.Contains(url, "{{") {
+		return url
+	}
+	var interpolatedKeys []string
 	for key, val := range params {
 		placeholder := "{{" + key + "}}"
 		if strings.Contains(url, placeholder) {
 			url = strings.ReplaceAll(url, placeholder, neturl.PathEscape(fmt.Sprintf("%v", val)))
-			interpolatedKeys[key] = true
+			interpolatedKeys = append(interpolatedKeys, key)
 		}
 	}
-	for key := range interpolatedKeys {
+	for _, key := range interpolatedKeys {
 		delete(params, key)
 	}
 	return url

--- a/internal/worker/tool_executor.go
+++ b/internal/worker/tool_executor.go
@@ -117,7 +117,7 @@ func NewToolExecutor() *ToolExecutor {
 func (e *ToolExecutor) Execute(ctx context.Context, tool *corev1alpha1.Tool, args json.RawMessage) (result string, err error) {
 	start := time.Now()
 	toolName := toolTelemetryName(tool)
-	attrs := make([]attribute.KeyValue, 0, 8)
+	attrs := make([]attribute.KeyValue, 0, 9)
 	attrs = append(attrs,
 		executeToolOperationAttr,
 		attribute.String(genai.AttrToolName, toolName),

--- a/internal/worker/tool_executor_test.go
+++ b/internal/worker/tool_executor_test.go
@@ -134,6 +134,67 @@ func TestToolExecutor_Execute_PreservesLargeJSONIntegers(t *testing.T) {
 	}
 }
 
+type zeroLengthRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f zeroLengthRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestToolExecutor_Execute_CustomTransportReadsZeroContentLengthBody(t *testing.T) {
+	executor := &ToolExecutor{
+		client: &http.Client{Transport: zeroLengthRoundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			}, nil
+		})},
+		namespace:  "default",
+		secretPath: "/secrets/tools",
+	}
+	tool := &corev1alpha1.Tool{
+		Spec: corev1alpha1.ToolSpec{
+			HTTP: &corev1alpha1.HTTPExecution{URL: "http://tool.test"},
+		},
+	}
+
+	result, err := executor.Execute(context.Background(), tool, json.RawMessage(`{"x":1}`))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result != `{"ok":true}` {
+		t.Fatalf("Execute() = %q, want response body", result)
+	}
+}
+
+func TestToolExecutor_Execute_CustomTransportAllowsEmptyBodyWithContentLength(t *testing.T) {
+	executor := &ToolExecutor{
+		client: &http.Client{Transport: zeroLengthRoundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode:    http.StatusOK,
+				Header:        make(http.Header),
+				Body:          io.NopCloser(strings.NewReader(``)),
+				ContentLength: 42,
+			}, nil
+		})},
+		namespace:  "default",
+		secretPath: "/secrets/tools",
+	}
+	tool := &corev1alpha1.Tool{
+		Spec: corev1alpha1.ToolSpec{
+			HTTP: &corev1alpha1.HTTPExecution{URL: "http://tool.test"},
+		},
+	}
+
+	result, err := executor.Execute(context.Background(), tool, json.RawMessage(`{"x":1}`))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result != "" {
+		t.Fatalf("Execute() = %q, want empty response body", result)
+	}
+}
+
 func TestToolExecutor_Execute_MCPSubstrateActorUsesStatusEndpointAndRouteHost(t *testing.T) {
 	var gotHosts []string
 	var calls int


### PR DESCRIPTION
## Summary

- Optimize telemetry-disabled hot paths for LLM tracing, built-in tool registry execution, and external worker tool execution.
- Add focused benchmarks and optimizations for API execution-event DTO conversion, controller default resource rendering, and SQLite message mark-read handling.
- Add regression coverage for OpenTelemetry provider activation, independent resource defaults, batched SQLite mark-read updates, and short/empty HTTP response bodies.

## Benchmark impact

Round 1 telemetry-disabled hot paths, median baseline -> final:

- `BenchmarkRegistryExecuteTelemetryDisabled`: 2599.5 ns/op, 3760 B/op, 32 allocs/op -> 641.0 ns/op, 1048 B/op, 8 allocs/op.
- `BenchmarkTracingProviderCompleteTelemetryDisabled`: 969.6 ns/op, 1624 B/op, 17 allocs/op -> 464.4 ns/op, 840 B/op, 9 allocs/op.
- `BenchmarkToolExecutorTelemetryDisabled`: 69620.5 ns/op, 13256 B/op, 124 allocs/op -> 65558.5 ns/op, 10273 B/op, 109 allocs/op.

Round 2 focused API/controller/store benchmarks, median reconstructed baseline -> final:

- `BenchmarkNewListExecutionEventsResponseTaskEvents`: 110404.0 ns/op -> 94332.5 ns/op.
- `BenchmarkJobBuilderBuildResourcesDefaults`: 503.2 ns/op -> 468.6 ns/op.
- `BenchmarkGetMessagesMarkRead100`: 514700.0 ns/op -> 493536.5 ns/op.

Detailed progress and benchmark artifacts are tracked locally in `/tmp/perf-orka.md`.

## Verification

- `make lint-fix`
- `go test -race ./internal/llm ./internal/tools ./internal/worker ./internal/tracing -count=1`
- `go test -race ./internal/api ./internal/controller ./internal/store/sqlite -count=1`
- `make test`
- `$autoreview` clean for both optimization rounds:
  - `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "go test ./internal/llm ./internal/tools ./internal/worker ./internal/tracing -count=1"`
  - `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "go test ./internal/api ./internal/controller ./internal/store/sqlite -count=1"`
