### PR TITLE
perf: reduce telemetry and message store overhead

### DIFF
--- a/internal/api/execution_event_dto.go
+++ b/internal/api/execution_event_dto.go
@@ -125,12 +125,18 @@ type ListSessionExecutionEventsResponse struct {
 // NewExecutionEventResponse converts a store event to an API DTO and intentionally
 // omits store-only fields such as ExecutionEvent.Internal.
 func NewExecutionEventResponse(event store.ExecutionEvent) ExecutionEventResponse {
+	var response ExecutionEventResponse
+	fillExecutionEventResponse(&response, &event)
+	return response
+}
+
+func fillExecutionEventResponse(response *ExecutionEventResponse, event *store.ExecutionEvent) {
 	var provider, model, stopReason string
 	var inTok, outTok int
 	if executionEventTypeCarriesModelTelemetry(event.Type) {
 		provider, model, stopReason, inTok, outTok = executionEventTelemetryFields(event.Type, event.Content)
 	}
-	return ExecutionEventResponse{
+	*response = ExecutionEventResponse{
 		ID:           event.ID,
 		Namespace:    event.Namespace,
 		StreamType:   event.StreamType,
@@ -160,7 +166,7 @@ func NewExecutionEventResponse(event store.ExecutionEvent) ExecutionEventRespons
 func NewListExecutionEventsResponse(namespace, streamType, streamID string, afterSeq, latestSeq int64, storeEvents []store.ExecutionEvent) ListExecutionEventsResponse {
 	responses := make([]ExecutionEventResponse, len(storeEvents))
 	for i := range storeEvents {
-		responses[i] = NewExecutionEventResponse(storeEvents[i])
+		fillExecutionEventResponse(&responses[i], &storeEvents[i])
 	}
 	return ListExecutionEventsResponse{
 		Namespace:  namespace,
@@ -174,22 +180,14 @@ func NewListExecutionEventsResponse(namespace, streamType, streamID string, afte
 
 // NewSessionExecutionEventResponse converts an aggregated store event to a session DTO.
 func NewSessionExecutionEventResponse(event store.SessionExecutionEvent) SessionExecutionEventResponse {
-	response := NewExecutionEventResponse(event.ExecutionEvent)
-	response.Seq = event.SessionSeq
-	response.StreamType = events.ExecutionEventStreamTypeSession
-	response.StreamID = event.SessionName
-	return SessionExecutionEventResponse{
-		ExecutionEventResponse: response,
-		TaskSeq:                event.TaskSeq,
-		TaskStreamID:           event.StreamID,
-	}
+	return newSessionExecutionEventResponse(&event)
 }
 
 // NewListSessionExecutionEventsResponse builds a session timeline DTO.
 func NewListSessionExecutionEventsResponse(namespace, sessionName string, afterSeq, latestSeq int64, storeEvents []store.SessionExecutionEvent) ListSessionExecutionEventsResponse {
 	responses := make([]SessionExecutionEventResponse, len(storeEvents))
 	for i := range storeEvents {
-		responses[i] = NewSessionExecutionEventResponse(storeEvents[i])
+		fillSessionExecutionEventResponse(&responses[i], &storeEvents[i])
 	}
 	return ListSessionExecutionEventsResponse{
 		Namespace:  namespace,
@@ -199,6 +197,21 @@ func NewListSessionExecutionEventsResponse(namespace, sessionName string, afterS
 		LatestSeq:  latestSeq,
 		Events:     responses,
 	}
+}
+
+func newSessionExecutionEventResponse(event *store.SessionExecutionEvent) SessionExecutionEventResponse {
+	var response SessionExecutionEventResponse
+	fillSessionExecutionEventResponse(&response, event)
+	return response
+}
+
+func fillSessionExecutionEventResponse(response *SessionExecutionEventResponse, event *store.SessionExecutionEvent) {
+	fillExecutionEventResponse(&response.ExecutionEventResponse, &event.ExecutionEvent)
+	response.Seq = event.SessionSeq
+	response.StreamType = events.ExecutionEventStreamTypeSession
+	response.StreamID = event.SessionName
+	response.TaskSeq = event.TaskSeq
+	response.TaskStreamID = event.StreamID
 }
 
 func normalizeExecutionEventResponseSeverity(severity string) string {

--- a/internal/llm/tracing.go
+++ b/internal/llm/tracing.go
@@ -8,6 +8,7 @@ package llm
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -32,7 +33,8 @@ type TracingProvider struct {
 }
 
 type tracingTracer struct {
-	tracer trace.Tracer
+	tracer               trace.Tracer
+	deferStartAttributes bool
 }
 
 type tracingMetrics struct {
@@ -53,7 +55,11 @@ func NewTracingProvider(p Provider) Provider {
 }
 
 func (tp *TracingProvider) ensureTelemetry() bool {
-	if tp.tracer.Load() == nil && !tracing.GlobalTracerProviderExplicitNoop() {
+	if tracer := tp.tracer.Load(); tracer == nil {
+		if !tracing.GlobalTracerProviderExplicitNoop() {
+			tp.initTracer()
+		}
+	} else if tracer.deferStartAttributes && !defaultGlobalTracerProvider(tracing.GlobalTracerProvider()) {
 		tp.initTracer()
 	}
 	if tp.metrics.Load() == nil && tracing.GlobalMeterProviderActive() {
@@ -63,15 +69,43 @@ func (tp *TracingProvider) ensureTelemetry() bool {
 }
 
 func (tp *TracingProvider) initTracer() {
-	if tp.tracer.Load() != nil {
+	if tracing.GlobalTracerProviderExplicitNoop() {
+		return
+	}
+	provider := tracing.GlobalTracerProvider()
+	deferStartAttributes := defaultGlobalTracerProvider(provider)
+	if current := tp.tracer.Load(); current != nil && (!current.deferStartAttributes || deferStartAttributes) {
 		return
 	}
 	tp.initMu.Lock()
 	defer tp.initMu.Unlock()
-	if tp.tracer.Load() != nil || tracing.GlobalTracerProviderExplicitNoop() {
+	if tracing.GlobalTracerProviderExplicitNoop() {
 		return
 	}
-	tp.tracer.Store(&tracingTracer{tracer: tracing.GenAITracer(genai.InstrumentationName)})
+	provider = tracing.GlobalTracerProvider()
+	deferStartAttributes = defaultGlobalTracerProvider(provider)
+	if current := tp.tracer.Load(); current != nil && (!current.deferStartAttributes || deferStartAttributes) {
+		return
+	}
+	tp.tracer.Store(&tracingTracer{
+		tracer:               provider.Tracer(genai.InstrumentationName, trace.WithSchemaURL(genai.SchemaURL)),
+		deferStartAttributes: deferStartAttributes,
+	})
+}
+
+func defaultGlobalTracerProvider(provider any) bool {
+	return isOTelProviderType(provider, "go.opentelemetry.io/otel/internal/global", "tracerProvider")
+}
+
+func isOTelProviderType(provider any, pkgPath, name string) bool {
+	typ := reflect.TypeOf(provider)
+	if typ == nil {
+		return true
+	}
+	if typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	return typ.PkgPath() == pkgPath && typ.Name() == name
 }
 
 func (tp *TracingProvider) initMetrics() {
@@ -116,18 +150,42 @@ func (tp *TracingProvider) Complete(ctx context.Context, req *CompletionRequest)
 		return tp.inner.Complete(ctx, req)
 	}
 
-	start := time.Now()
-	providerName := ProviderTelemetryName(tp.inner)
+	var providerName string
 	span := noopTracingSpan
+	spanStarted := false
+	deferStartAttributes := false
 	if tracer := tp.tracer.Load(); tracer != nil {
-		attrs := requestAttributes(req, providerName, false)
-		ctx, span = tracer.tracer.Start(ctx, spanName(req), trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attrs...))
-		defer span.End()
+		deferStartAttributes = tracer.deferStartAttributes
+		if deferStartAttributes {
+			ctx, span = tracer.tracer.Start(ctx, spanName(req), trace.WithSpanKind(trace.SpanKindClient))
+		} else {
+			providerName = ProviderTelemetryName(tp.inner)
+			attrs := requestAttributes(req, providerName, false)
+			ctx, span = tracer.tracer.Start(ctx, spanName(req), trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attrs...))
+		}
+		spanStarted = true
 	}
 
 	spanRecording := span.IsRecording()
 	metricsActive := tp.metrics.Load() != nil
+	if !spanRecording && !metricsActive {
+		resp, err := tp.inner.Complete(ctx, req)
+		if spanStarted {
+			span.End()
+		}
+		return resp, err
+	}
+	if spanStarted {
+		defer span.End()
+	}
+	if providerName == "" {
+		providerName = ProviderTelemetryName(tp.inner)
+	}
+	if spanRecording && deferStartAttributes {
+		span.SetAttributes(requestAttributes(req, providerName, false)...)
+	}
 
+	start := time.Now()
 	resp, err := tp.inner.Complete(ctx, req)
 	durationSeconds := time.Since(start).Seconds()
 	if err != nil {

--- a/internal/llm/tracing.go
+++ b/internal/llm/tracing.go
@@ -8,7 +8,6 @@ package llm
 
 import (
 	"context"
-	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -59,7 +58,7 @@ func (tp *TracingProvider) ensureTelemetry() bool {
 		if !tracing.GlobalTracerProviderExplicitNoop() {
 			tp.initTracer()
 		}
-	} else if tracer.deferStartAttributes && !defaultGlobalTracerProvider(tracing.GlobalTracerProvider()) {
+	} else if tracer.deferStartAttributes && !tracing.IsDefaultGlobalTracerProvider(tracing.GlobalTracerProvider()) {
 		tp.initTracer()
 	}
 	if tp.metrics.Load() == nil && tracing.GlobalMeterProviderActive() {
@@ -73,7 +72,7 @@ func (tp *TracingProvider) initTracer() {
 		return
 	}
 	provider := tracing.GlobalTracerProvider()
-	deferStartAttributes := defaultGlobalTracerProvider(provider)
+	deferStartAttributes := tracing.IsDefaultGlobalTracerProvider(provider)
 	if current := tp.tracer.Load(); current != nil && (!current.deferStartAttributes || deferStartAttributes) {
 		return
 	}
@@ -83,7 +82,7 @@ func (tp *TracingProvider) initTracer() {
 		return
 	}
 	provider = tracing.GlobalTracerProvider()
-	deferStartAttributes = defaultGlobalTracerProvider(provider)
+	deferStartAttributes = tracing.IsDefaultGlobalTracerProvider(provider)
 	if current := tp.tracer.Load(); current != nil && (!current.deferStartAttributes || deferStartAttributes) {
 		return
 	}
@@ -91,21 +90,6 @@ func (tp *TracingProvider) initTracer() {
 		tracer:               provider.Tracer(genai.InstrumentationName, trace.WithSchemaURL(genai.SchemaURL)),
 		deferStartAttributes: deferStartAttributes,
 	})
-}
-
-func defaultGlobalTracerProvider(provider any) bool {
-	return isOTelProviderType(provider, "go.opentelemetry.io/otel/internal/global", "tracerProvider")
-}
-
-func isOTelProviderType(provider any, pkgPath, name string) bool {
-	typ := reflect.TypeOf(provider)
-	if typ == nil {
-		return true
-	}
-	if typ.Kind() == reflect.Pointer {
-		typ = typ.Elem()
-	}
-	return typ.PkgPath() == pkgPath && typ.Name() == name
 }
 
 func (tp *TracingProvider) initMetrics() {

--- a/internal/store/sqlite/message_store.go
+++ b/internal/store/sqlite/message_store.go
@@ -9,11 +9,12 @@ package sqlite
 import (
 	"context"
 	"database/sql"
-	"strings"
 	"time"
 
 	"github.com/sozercan/orka/internal/store"
 )
+
+const initialMessageBatchCapacity = 32
 
 // SendMessage stores a new inter-agent message.
 func (s *Store) SendMessage(ctx context.Context, msg *store.Message) error {
@@ -31,32 +32,13 @@ func (s *Store) SendMessage(ctx context.Context, msg *store.Message) error {
 func (s *Store) GetMessages(ctx context.Context, namespace, taskName, parentTask string, markRead bool) ([]store.Message, error) {
 	if !markRead {
 		// Read-only path doesn't need a transaction
-		rows, err := s.db.QueryContext(ctx,
-			`SELECT id, namespace, from_task, to_task, parent_task, content, read, created_at
-			 FROM messages
-			 WHERE namespace = ? AND read = FALSE
-			   AND from_task != ?
-			   AND (to_task = ? OR (to_task = '*' AND parent_task = ?))
-			 ORDER BY id ASC`,
-			namespace, taskName, taskName, parentTask,
-		)
+		rows, err := s.db.QueryContext(ctx, selectUnreadMessagesSQL, namespace, taskName, taskName, parentTask)
 		if err != nil {
 			return nil, err
 		}
 		defer rows.Close() //nolint:errcheck
 
-		var messages []store.Message
-		for rows.Next() {
-			var m store.Message
-			if err := rows.Scan(&m.ID, &m.Namespace, &m.FromTask, &m.ToTask, &m.ParentTask, &m.Content, &m.Read, &m.CreatedAt); err != nil {
-				return nil, err
-			}
-			messages = append(messages, m)
-		}
-		if err := rows.Err(); err != nil {
-			return nil, err
-		}
-		return messages, nil
+		return scanUnreadMessages(rows, namespace)
 	}
 
 	// Transactional mark-read path
@@ -66,45 +48,62 @@ func (s *Store) GetMessages(ctx context.Context, namespace, taskName, parentTask
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	rows, err := tx.QueryContext(ctx,
-		`SELECT id, namespace, from_task, to_task, parent_task, content, read, created_at
-		 FROM messages
-		 WHERE namespace = ? AND read = FALSE
-		   AND from_task != ?
-		   AND (to_task = ? OR (to_task = '*' AND parent_task = ?))
-		 ORDER BY id ASC`,
-		namespace, taskName, taskName, parentTask,
-	)
+	rows, err := tx.QueryContext(ctx, selectUnreadMessagesSQL, namespace, taskName, taskName, parentTask)
 	if err != nil {
 		return nil, err
 	}
 
-	var messages []store.Message
-	var ids []int64
-	for rows.Next() {
-		var m store.Message
-		if err := rows.Scan(&m.ID, &m.Namespace, &m.FromTask, &m.ToTask, &m.ParentTask, &m.Content, &m.Read, &m.CreatedAt); err != nil {
-			_ = rows.Close()
-			return nil, err
-		}
-		messages = append(messages, m)
-		ids = append(ids, m.ID)
-	}
+	messages, err := scanUnreadMessages(rows, namespace)
 	_ = rows.Close()
-	if err := rows.Err(); err != nil {
+	if err != nil {
 		return nil, err
 	}
 
-	// Mark exactly the messages returned by the read query. Batch IDs to avoid
-	// issuing one UPDATE per message while staying below SQLite variable limits.
-	if err := markMessagesReadByID(ctx, tx, ids); err != nil {
-		return nil, err
+	// Mark the same unread direct/broadcast predicate inside the transaction.
+	// The read snapshot is fixed by the SELECT above, so this avoids building a
+	// large IN clause while preserving the set of messages observed by the read.
+	if len(messages) > 0 {
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE messages
+			 SET read = TRUE
+			 WHERE namespace = ? AND read = FALSE
+			   AND from_task != ?
+			   AND (to_task = ? OR (to_task = '*' AND parent_task = ?))`,
+			namespace, taskName, taskName, parentTask,
+		); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
 
+	return messages, nil
+}
+
+const selectUnreadMessagesSQL = `SELECT id, from_task, to_task, parent_task, content, created_at
+	 FROM messages
+	 WHERE namespace = ? AND read = FALSE
+	   AND from_task != ?
+	   AND (to_task = ? OR (to_task = '*' AND parent_task = ?))
+	 ORDER BY id ASC`
+
+func scanUnreadMessages(rows *sql.Rows, namespace string) ([]store.Message, error) {
+	var messages []store.Message
+	for rows.Next() {
+		if messages == nil {
+			messages = make([]store.Message, 0, initialMessageBatchCapacity)
+		}
+		m := store.Message{Namespace: namespace}
+		if err := rows.Scan(&m.ID, &m.FromTask, &m.ToTask, &m.ParentTask, &m.Content, &m.CreatedAt); err != nil {
+			return nil, err
+		}
+		messages = append(messages, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return messages, nil
 }
 
@@ -124,32 +123,4 @@ func (s *Store) DeleteParentMessages(ctx context.Context, namespace, parentTask 
 		namespace, parentTask,
 	)
 	return err
-}
-
-const sqliteMessageReadUpdateBatchSize = 500
-
-func markMessagesReadByID(ctx context.Context, tx *sql.Tx, ids []int64) error {
-	for len(ids) > 0 {
-		batchSize := min(len(ids), sqliteMessageReadUpdateBatchSize)
-		batch := ids[:batchSize]
-
-		args := make([]any, len(batch))
-		for i, id := range batch {
-			args[i] = id
-		}
-		query := `UPDATE messages SET read = TRUE WHERE id IN (` + sqlitePlaceholders(len(batch)) + `)`
-		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-			return err
-		}
-
-		ids = ids[batchSize:]
-	}
-	return nil
-}
-
-func sqlitePlaceholders(n int) string {
-	if n <= 0 {
-		return ""
-	}
-	return "?" + strings.Repeat(",?", n-1)
 }

--- a/internal/store/sqlite/message_store_benchmark_test.go
+++ b/internal/store/sqlite/message_store_benchmark_test.go
@@ -18,11 +18,13 @@ func BenchmarkGetMessagesMarkRead100(b *testing.B) {
 	)
 
 	b.ReportAllocs()
+	b.ResetTimer()
 
-	for b.Loop() {
+	for i := 0; i < b.N; i++ { //nolint:intrange,modernize // b.Loop requires the timer to be running at loop boundaries.
+		b.StopTimer()
 		resetBenchmarkMessages(ctx, b, s, namespace, taskName, parentTask, count)
-
 		b.StartTimer()
+
 		messages, err := s.GetMessages(ctx, namespace, taskName, parentTask, true)
 		b.StopTimer()
 

--- a/internal/store/sqlite/message_store_test.go
+++ b/internal/store/sqlite/message_store_test.go
@@ -118,15 +118,15 @@ func TestGetMessagesMultipleMarkRead(t *testing.T) {
 	}
 }
 
-func TestGetMessagesMarkReadBatchesLargeInbox(t *testing.T) {
+func TestGetMessagesMarkReadLargeInbox(t *testing.T) {
 	s := setupTestStore(t)
 	ctx := context.Background()
 	const (
 		namespace  = "ns-large-mark-read"
 		taskName   = "reader"
 		parentTask = "parent"
+		count      = 503
 	)
-	count := sqliteMessageReadUpdateBatchSize + 3
 
 	for i := range count {
 		msg := &store.Message{

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -246,7 +245,7 @@ func (r *Registry) Execute(ctx context.Context, name string, args json.RawMessag
 
 	tracer := r.genAITracer()
 	spanName := genai.OperationExecuteTool + " " + toolTelemetryName
-	deferStartAttributes := defaultGlobalTracerProvider(tracing.GlobalTracerProvider())
+	deferStartAttributes := tracing.IsDefaultGlobalTracerProvider(tracing.GlobalTracerProvider())
 	var span trace.Span
 	if deferStartAttributes {
 		ctx, span = tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindInternal))
@@ -431,21 +430,6 @@ func (r *Registry) recordToolDuration(ctx context.Context, seconds float64, tool
 
 func telemetryDisabled() bool {
 	return tracing.GlobalTracerProviderExplicitNoop() && !tracing.GlobalMeterProviderActive()
-}
-
-func defaultGlobalTracerProvider(provider any) bool {
-	return isOTelProviderType(provider, "go.opentelemetry.io/otel/internal/global", "tracerProvider")
-}
-
-func isOTelProviderType(provider any, pkgPath, name string) bool {
-	typ := reflect.TypeOf(provider)
-	if typ == nil {
-		return true
-	}
-	if typ.Kind() == reflect.Pointer {
-		typ = typ.Elem()
-	}
-	return typ.PkgPath() == pkgPath && typ.Name() == name
 }
 
 // RecordRejectedToolCall records a failed tool invocation that is rejected before

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -231,49 +232,42 @@ func (r *Registry) Execute(ctx context.Context, name string, args json.RawMessag
 		return tool.Execute(ctx, args)
 	}
 
-	start := time.Now()
 	toolTelemetryName := name
 	if !ok {
 		toolTelemetryName = unknownToolTelemetryName
 	}
 	toolTypeValue := toolType(ctx, tool)
 	toolKind := registryToolKind(name)
-	attrs := make([]attribute.KeyValue, 0, 10)
-	attrs = append(attrs,
-		attribute.String(genai.AttrOperationName, genai.OperationExecuteTool),
-		attribute.String(genai.AttrToolName, toolTelemetryName),
-		attribute.String(genai.AttrToolType, toolTypeValue),
-		attribute.String(tracing.AttrToolName, toolTelemetryName),
-		attribute.String(tracing.AttrToolKind, toolKind),
-	)
-	if tc := GetToolContext(ctx); tc != nil {
-		tenant := tc.Tenant
-		if tenant == "" {
-			tenant = tc.Namespace
-		}
-		if tc.TaskID != "" {
-			attrs = append(attrs, attribute.String(tracing.AttrTaskID, tc.TaskID))
-		}
-		if tc.Namespace != "" {
-			attrs = append(attrs, attribute.String(tracing.AttrTaskNamespace, tc.Namespace))
-		}
-		if tenant != "" {
-			attrs = append(attrs, attribute.String(tracing.AttrTenant, tenant))
-		}
-		if tc.ToolCallID != "" {
-			attrs = append(attrs, attribute.String(genai.AttrToolCallID, tc.ToolCallID))
-		}
-	}
-	if ok {
-		if description := tool.Description(); description != "" {
-			attrs = append(attrs, attribute.String(genai.AttrToolDescription, description))
-		}
-	}
-	tracer := r.genAITracer()
-	ctx, span := tracer.Start(ctx, genai.OperationExecuteTool+" "+toolTelemetryName, trace.WithSpanKind(trace.SpanKindInternal), trace.WithAttributes(attrs...))
-	defer span.End()
-	spanRecording := span.IsRecording()
 	meterActive := tracing.GlobalMeterProviderActive()
+	var start time.Time
+	if meterActive {
+		start = time.Now()
+	}
+
+	tracer := r.genAITracer()
+	spanName := genai.OperationExecuteTool + " " + toolTelemetryName
+	deferStartAttributes := defaultGlobalTracerProvider(tracing.GlobalTracerProvider())
+	var span trace.Span
+	if deferStartAttributes {
+		ctx, span = tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindInternal))
+	} else {
+		attrs := registryToolSpanAttributes(ctx, toolTelemetryName, tool, ok, toolTypeValue, toolKind)
+		ctx, span = tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindInternal), trace.WithAttributes(attrs...))
+	}
+	spanRecording := span.IsRecording()
+	if spanRecording && deferStartAttributes {
+		span.SetAttributes(registryToolSpanAttributes(ctx, toolTelemetryName, tool, ok, toolTypeValue, toolKind)...)
+	}
+	if !spanRecording && !meterActive {
+		if !ok {
+			span.End()
+			return "", fmt.Errorf("tool %q not found", name)
+		}
+		result, err := tool.Execute(ctx, args)
+		span.End()
+		return result, err
+	}
+	defer span.End()
 
 	if !ok {
 		err := fmt.Errorf("tool %q not found", name)
@@ -319,6 +313,41 @@ func (r *Registry) Execute(ctx context.Context, name string, args json.RawMessag
 		}
 	}
 	return result, err
+}
+
+func registryToolSpanAttributes(ctx context.Context, toolTelemetryName string, tool Tool, ok bool, toolTypeValue, toolKind string) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 10)
+	attrs = append(attrs,
+		attribute.String(genai.AttrOperationName, genai.OperationExecuteTool),
+		attribute.String(genai.AttrToolName, toolTelemetryName),
+		attribute.String(genai.AttrToolType, toolTypeValue),
+		attribute.String(tracing.AttrToolName, toolTelemetryName),
+		attribute.String(tracing.AttrToolKind, toolKind),
+	)
+	if tc := GetToolContext(ctx); tc != nil {
+		tenant := tc.Tenant
+		if tenant == "" {
+			tenant = tc.Namespace
+		}
+		if tc.TaskID != "" {
+			attrs = append(attrs, attribute.String(tracing.AttrTaskID, tc.TaskID))
+		}
+		if tc.Namespace != "" {
+			attrs = append(attrs, attribute.String(tracing.AttrTaskNamespace, tc.Namespace))
+		}
+		if tenant != "" {
+			attrs = append(attrs, attribute.String(tracing.AttrTenant, tenant))
+		}
+		if tc.ToolCallID != "" {
+			attrs = append(attrs, attribute.String(genai.AttrToolCallID, tc.ToolCallID))
+		}
+	}
+	if ok {
+		if description := tool.Description(); description != "" {
+			attrs = append(attrs, attribute.String(genai.AttrToolDescription, description))
+		}
+	}
+	return attrs
 }
 
 func (r *Registry) genAITracer() trace.Tracer {
@@ -404,11 +433,26 @@ func telemetryDisabled() bool {
 	return tracing.GlobalTracerProviderExplicitNoop() && !tracing.GlobalMeterProviderActive()
 }
 
+func defaultGlobalTracerProvider(provider any) bool {
+	return isOTelProviderType(provider, "go.opentelemetry.io/otel/internal/global", "tracerProvider")
+}
+
+func isOTelProviderType(provider any, pkgPath, name string) bool {
+	typ := reflect.TypeOf(provider)
+	if typ == nil {
+		return true
+	}
+	if typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	return typ.PkgPath() == pkgPath && typ.Name() == name
+}
+
 // RecordRejectedToolCall records a failed tool invocation that is rejected before
 // dispatch, for example by request-level allowlists or invalid arguments. It
 // intentionally does not execute the tool.
 func RecordRejectedToolCall(ctx context.Context, name, toolCallID, errType, message string) {
-	if strings.TrimSpace(name) == "" {
+	if strings.TrimSpace(name) == "" || telemetryDisabled() {
 		return
 	}
 	start := time.Now()

--- a/internal/tracing/provider_state.go
+++ b/internal/tracing/provider_state.go
@@ -36,6 +36,14 @@ func GlobalTracerProviderExplicitNoop() bool {
 	return isOTelProviderType(otel.GetTracerProvider(), otelTraceNoopPkg, otelTracerProvider)
 }
 
+// IsDefaultGlobalTracerProvider reports whether provider is OpenTelemetry's
+// default delegating global tracer provider. That provider returns no-op spans
+// unless an SDK or auto-instrumentation delegate is active, so hot paths can
+// defer expensive span attribute construction until a returned span records.
+func IsDefaultGlobalTracerProvider(provider any) bool {
+	return isOTelProviderType(provider, otelGlobalPkg, "tracerProvider")
+}
+
 // GlobalMeterProviderActive reports whether a real OpenTelemetry meter provider
 // is currently configured. Unlike the tracer provider, the default global meter
 // provider only records no-op measurements until an SDK meter provider is set.

--- a/internal/worker/tool_executor.go
+++ b/internal/worker/tool_executor.go
@@ -17,7 +17,6 @@ import (
 	"net/http"
 	neturl "net/url"
 	"os"
-	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -129,7 +128,7 @@ func (e *ToolExecutor) Execute(ctx context.Context, tool *corev1alpha1.Tool, arg
 
 	tracer := tracing.GenAITracer(genai.InstrumentationName)
 	spanName := genai.OperationExecuteTool + " " + toolName
-	deferStartAttributes := defaultGlobalTracerProvider(tracing.GlobalTracerProvider())
+	deferStartAttributes := tracing.IsDefaultGlobalTracerProvider(tracing.GlobalTracerProvider())
 	var span trace.Span
 	if deferStartAttributes {
 		ctx, span = tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient))
@@ -257,21 +256,6 @@ func ToolRequestWasAttempted(err error) bool {
 
 func toolExecutorTelemetryDisabled() bool {
 	return tracing.GlobalTracerProviderExplicitNoop() && !tracing.GlobalMeterProviderActive()
-}
-
-func defaultGlobalTracerProvider(provider any) bool {
-	return isOTelProviderType(provider, "go.opentelemetry.io/otel/internal/global", "tracerProvider")
-}
-
-func isOTelProviderType(provider any, pkgPath, name string) bool {
-	typ := reflect.TypeOf(provider)
-	if typ == nil {
-		return true
-	}
-	if typ.Kind() == reflect.Pointer {
-		typ = typ.Elem()
-	}
-	return typ.PkgPath() == pkgPath && typ.Name() == name
 }
 
 func recordExternalToolDuration(ctx context.Context, seconds float64, attrs ...attribute.KeyValue) {

--- a/internal/worker/tool_executor.go
+++ b/internal/worker/tool_executor.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	neturl "net/url"
 	"os"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -115,35 +116,42 @@ func NewToolExecutor() *ToolExecutor {
 
 // Execute executes a Tool CRD by making an HTTP request.
 func (e *ToolExecutor) Execute(ctx context.Context, tool *corev1alpha1.Tool, args json.RawMessage) (result string, err error) {
-	start := time.Now()
+	if toolExecutorTelemetryDisabled() {
+		return e.executeToolRequest(ctx, tool, args)
+	}
+
 	toolName := toolTelemetryName(tool)
-	attrs := make([]attribute.KeyValue, 0, 9)
-	attrs = append(attrs,
-		executeToolOperationAttr,
-		attribute.String(genai.AttrToolName, toolName),
-		extensionToolTypeAttr,
-		attribute.String(tracing.AttrToolName, toolName),
-		attribute.String(tracing.AttrToolKind, tracing.ToolKindHTTP),
-	)
-	if taskName := os.Getenv(workerenv.TaskName); taskName != "" {
-		attrs = append(attrs, attribute.String(tracing.AttrTaskID, taskName))
+	meterActive := tracing.GlobalMeterProviderActive()
+	var start time.Time
+	if meterActive {
+		start = time.Now()
 	}
-	if e.namespace != "" {
-		attrs = append(attrs,
-			attribute.String(tracing.AttrTaskNamespace, e.namespace),
-			attribute.String(tracing.AttrTenant, e.namespace),
-		)
+
+	tracer := tracing.GenAITracer(genai.InstrumentationName)
+	spanName := genai.OperationExecuteTool + " " + toolName
+	deferStartAttributes := defaultGlobalTracerProvider(tracing.GlobalTracerProvider())
+	var span trace.Span
+	if deferStartAttributes {
+		ctx, span = tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient))
+	} else {
+		attrs := toolExecutorSpanAttributes(ctx, e.namespace, toolName)
+		ctx, span = tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attrs...))
 	}
-	if toolCallID := toolCallIDFromContext(ctx); toolCallID != "" {
-		attrs = append(attrs, attribute.String(genai.AttrToolCallID, toolCallID))
+	spanRecording := span.IsRecording()
+	if spanRecording && deferStartAttributes {
+		span.SetAttributes(toolExecutorSpanAttributes(ctx, e.namespace, toolName)...)
 	}
-	ctx, span := tracing.GenAITracer(genai.InstrumentationName).Start(ctx, genai.OperationExecuteTool+" "+toolName, trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attrs...))
+	if !spanRecording && !meterActive {
+		result, err = e.executeToolRequest(ctx, tool, args)
+		span.End()
+		return result, err
+	}
+
 	defer func() {
 		resultSize := len(result)
-		meterActive := tracing.GlobalMeterProviderActive()
 		if err != nil {
 			errType := toolExecutionErrorType(err)
-			if span.IsRecording() {
+			if spanRecording {
 				span.SetStatus(codes.Error, errType)
 				span.SetAttributes(
 					attribute.Int(tracing.AttrToolResultSizeBytes, resultSize),
@@ -154,7 +162,7 @@ func (e *ToolExecutor) Execute(ctx context.Context, tool *corev1alpha1.Tool, arg
 				recordExternalToolDuration(ctx, time.Since(start).Seconds(), executeToolOperationAttr, attribute.String(genai.AttrToolName, toolName), extensionToolTypeAttr, attribute.String(genai.AttrErrorType, errType))
 			}
 		} else {
-			if span.IsRecording() {
+			if spanRecording {
 				span.SetAttributes(attribute.Int(tracing.AttrToolResultSizeBytes, resultSize))
 			}
 			if meterActive {
@@ -169,12 +177,51 @@ func (e *ToolExecutor) Execute(ctx context.Context, tool *corev1alpha1.Tool, arg
 		return "", err
 	}
 	if prepared.request != nil {
-		if span.IsRecording() {
+		if spanRecording {
 			span.SetAttributes(httpToolRequestAttributes(prepared.request)...)
 		}
 		injectTraceHeaders(ctx, prepared.request.Header)
 	}
 
+	return e.executePreparedToolRequest(ctx, prepared)
+}
+
+func toolExecutorSpanAttributes(ctx context.Context, namespace, toolName string) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 9)
+	attrs = append(attrs,
+		executeToolOperationAttr,
+		attribute.String(genai.AttrToolName, toolName),
+		extensionToolTypeAttr,
+		attribute.String(tracing.AttrToolName, toolName),
+		attribute.String(tracing.AttrToolKind, tracing.ToolKindHTTP),
+	)
+	if taskName := os.Getenv(workerenv.TaskName); taskName != "" {
+		attrs = append(attrs, attribute.String(tracing.AttrTaskID, taskName))
+	}
+	if namespace != "" {
+		attrs = append(attrs,
+			attribute.String(tracing.AttrTaskNamespace, namespace),
+			attribute.String(tracing.AttrTenant, namespace),
+		)
+	}
+	if toolCallID := toolCallIDFromContext(ctx); toolCallID != "" {
+		attrs = append(attrs, attribute.String(genai.AttrToolCallID, toolCallID))
+	}
+	return attrs
+}
+
+func (e *ToolExecutor) executeToolRequest(ctx context.Context, tool *corev1alpha1.Tool, args json.RawMessage) (string, error) {
+	prepared, err := e.prepareRequest(ctx, tool, args)
+	if err != nil {
+		return "", err
+	}
+	if prepared.request != nil {
+		injectTraceHeaders(ctx, prepared.request.Header)
+	}
+	return e.executePreparedToolRequest(ctx, prepared)
+}
+
+func (e *ToolExecutor) executePreparedToolRequest(ctx context.Context, prepared preparedToolRequest) (string, error) {
 	// Configure timeout
 	httpClient := e.client
 	if prepared.httpConfig.Timeout != nil {
@@ -206,6 +253,25 @@ func (e ToolRequestAttemptedError) Unwrap() error { return e.Err }
 func ToolRequestWasAttempted(err error) bool {
 	var attempted ToolRequestAttemptedError
 	return errors.As(err, &attempted)
+}
+
+func toolExecutorTelemetryDisabled() bool {
+	return tracing.GlobalTracerProviderExplicitNoop() && !tracing.GlobalMeterProviderActive()
+}
+
+func defaultGlobalTracerProvider(provider any) bool {
+	return isOTelProviderType(provider, "go.opentelemetry.io/otel/internal/global", "tracerProvider")
+}
+
+func isOTelProviderType(provider any, pkgPath, name string) bool {
+	typ := reflect.TypeOf(provider)
+	if typ == nil {
+		return true
+	}
+	if typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	return typ.PkgPath() == pkgPath && typ.Name() == name
 }
 
 func recordExternalToolDuration(ctx context.Context, seconds float64, attrs ...attribute.KeyValue) {


### PR DESCRIPTION
## Summary

- optimize execution-event DTO list conversion by filling preallocated response slices in place
- reduce SQLite message mark-read overhead by narrowing scanned columns and replacing per-ID update batching with one same-predicate transactional update
- reduce default-off telemetry overhead in LLM, built-in tool registry, and custom ToolExecutor paths while preserving OpenTelemetry default-provider span creation for auto-instrumentation

## Benchmark impact

Final benchmark artifacts are recorded in `/tmp/perf2-orka.md`.

Key results:

- API event DTO list conversion: **10.63% faster** (`89.07µs` → `79.61µs`)
- SQLite `GetMessagesMarkRead100`: focused count=10 A/B showed **24.97% faster**, **19.86% fewer bytes**, **18.30% fewer allocs**
- LLM disabled-telemetry completion: **39.61% faster**, **50.48% fewer bytes**, **22.22% fewer allocs**
- Tool registry disabled telemetry: **52.50% faster**, **70.99% fewer bytes**, **25.00% fewer allocs**
- ToolExecutor disabled telemetry: latency noisy/not significant, but **8.28% fewer bytes** and **1.83% fewer allocs**

## Validation

- `git diff --check`
- `make lint-fix`
- `make test`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt-file /tmp/perf2-review-notes.md`

Autoreview result:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.84)
```

Transcript intentionally omitted per request.
