### PR TITLE
fix: enforce Kubernetes RBAC and reject worker SAs for approval decisions

### DIFF
--- a/internal/api/approval_handlers.go
+++ b/internal/api/approval_handlers.go
@@ -82,6 +82,9 @@ func (h *Handlers) DecideTaskApproval(c fiber.Ctx) error {
 	if err := h.authorizeContextTokenAction(c, "decideTaskApproval", h.contextTokenAuthorization.TaskUpdateScopes); err != nil {
 		return err
 	}
+	if err := authorizeKubernetesApprovalDecision(c.Context(), h.clientset, GetUserInfo(c), namespace, taskName); err != nil {
+		return err
+	}
 	task, err := h.loadReadableTask(c, namespace, taskName, "decideTaskApproval")
 	if err != nil {
 		return err

--- a/internal/api/kubernetes_task_authorization.go
+++ b/internal/api/kubernetes_task_authorization.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"reflect"
+	"strings"
 
 	"github.com/gofiber/fiber/v3"
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -16,13 +17,32 @@ func authorizeKubernetesTaskCreate(ctx context.Context, clientset kubernetes.Int
 	if userInfo == nil || userInfo.AuthType != AuthTypeTokenReview || task == nil {
 		return nil
 	}
-	if kubernetesClientsetIsNil(clientset) {
-		log.Info("task create authorization unavailable: missing Kubernetes clientset",
+	return authorizeKubernetesTaskAction(ctx, clientset, userInfo, task.Namespace, task.Name, "create", "", "task create", "not authorized to create tasks")
+}
+
+func authorizeKubernetesApprovalDecision(ctx context.Context, clientset kubernetes.Interface, userInfo *UserInfo, namespace, taskName string) error {
+	if userInfo == nil || userInfo.AuthType != AuthTypeTokenReview {
+		return nil
+	}
+	if isWorkerServiceAccount(userInfo.Username) {
+		log.Info("approval decision authorization denied for worker service account",
 			"username", userInfo.Username,
-			"namespace", task.Namespace,
-			"task", task.Name,
+			"namespace", namespace,
+			"task", taskName,
 		)
-		return fiber.NewError(fiber.StatusForbidden, "not authorized to create tasks")
+		return fiber.NewError(fiber.StatusForbidden, "not authorized to decide task approvals")
+	}
+	return authorizeKubernetesTaskAction(ctx, clientset, userInfo, namespace, taskName, "update", "approvals", "approval decision", "not authorized to decide task approvals")
+}
+
+func authorizeKubernetesTaskAction(ctx context.Context, clientset kubernetes.Interface, userInfo *UserInfo, namespace, taskName, verb, subresource, action, forbiddenMessage string) error {
+	if kubernetesClientsetIsNil(clientset) {
+		log.Info(action+" authorization unavailable: missing Kubernetes clientset",
+			"username", userInfo.Username,
+			"namespace", namespace,
+			"task", taskName,
+		)
+		return fiber.NewError(fiber.StatusForbidden, forbiddenMessage)
 	}
 
 	extra := make(map[string]authorizationv1.ExtraValue, len(userInfo.Extra))
@@ -36,32 +56,51 @@ func authorizeKubernetesTaskCreate(ctx context.Context, clientset kubernetes.Int
 			Groups: userInfo.Groups,
 			Extra:  extra,
 			ResourceAttributes: &authorizationv1.ResourceAttributes{
-				Namespace: task.Namespace,
-				Verb:      "create",
-				Group:     corev1alpha1.GroupVersion.Group,
-				Resource:  "tasks",
+				Namespace:   namespace,
+				Verb:        verb,
+				Group:       corev1alpha1.GroupVersion.Group,
+				Resource:    "tasks",
+				Subresource: subresource,
+				Name:        taskName,
 			},
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {
-		log.Error(err, "task create authorization check failed",
+		log.Error(err, action+" authorization check failed",
 			"username", userInfo.Username,
-			"namespace", task.Namespace,
-			"task", task.Name,
+			"namespace", namespace,
+			"task", taskName,
 		)
-		return fiber.NewError(fiber.StatusForbidden, "not authorized to create tasks")
+		return fiber.NewError(fiber.StatusForbidden, forbiddenMessage)
 	}
 	if !review.Status.Allowed {
-		log.Info("task create authorization denied",
+		log.Info(action+" authorization denied",
 			"username", userInfo.Username,
-			"namespace", task.Namespace,
-			"task", task.Name,
+			"namespace", namespace,
+			"task", taskName,
 			"reason", review.Status.Reason,
 		)
-		return fiber.NewError(fiber.StatusForbidden, "not authorized to create tasks")
+		return fiber.NewError(fiber.StatusForbidden, forbiddenMessage)
 	}
 
 	return nil
+}
+
+func isWorkerServiceAccount(username string) bool {
+	const prefix = "system:serviceaccount:"
+	if !strings.HasPrefix(username, prefix) {
+		return false
+	}
+	parts := strings.Split(strings.TrimPrefix(username, prefix), ":")
+	if len(parts) != 2 {
+		return false
+	}
+	switch parts[1] {
+	case "ai-worker", "container-worker", "vendor-worker":
+		return true
+	default:
+		return false
+	}
 }
 
 func kubernetesClientsetIsNil(clientset kubernetes.Interface) bool {

--- a/internal/api/kubernetes_task_authorization_test.go
+++ b/internal/api/kubernetes_task_authorization_test.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -187,4 +189,77 @@ func tokenReviewUserMiddleware(userInfo *UserInfo) fiber.Handler {
 		c.Locals(UserInfoContextKey, userInfo)
 		return c.Next()
 	}
+}
+
+func TestTaskApprovalDecisionRequiresKubernetesApprovalRBACForTokenReviewUser(t *testing.T) {
+	eventStore := store.NewFakeExecutionEventStore()
+	content, _ := json.Marshal(map[string]string{"approvalID": "approval-1", "action": "create_pr"})
+	_, err := eventStore.AppendExecutionEvent(context.Background(), &store.ExecutionEvent{Namespace: "default", StreamType: store.ExecutionEventStreamTypeTask, StreamID: "approval-task", TaskName: "approval-task", Type: events.ExecutionEventTypeApprovalRequested, Content: content})
+	require.NoError(t, err)
+
+	h, app := setupTaskEventHandlers(t, eventStore, testTask("default", "approval-task"))
+	h.clientset = denyingSubjectAccessReviewClient(t, nil, func(review *authorizationv1.SubjectAccessReview) {
+		require.Equal(t, "system:serviceaccount:default:limited", review.Spec.User)
+		require.NotNil(t, review.Spec.ResourceAttributes)
+		require.Equal(t, "default", review.Spec.ResourceAttributes.Namespace)
+		require.Equal(t, "approval-task", review.Spec.ResourceAttributes.Name)
+		require.Equal(t, "update", review.Spec.ResourceAttributes.Verb)
+		require.Equal(t, corev1alpha1.GroupVersion.Group, review.Spec.ResourceAttributes.Group)
+		require.Equal(t, "tasks", review.Spec.ResourceAttributes.Resource)
+		require.Equal(t, "approvals", review.Spec.ResourceAttributes.Subresource)
+	})
+	app.Use(tokenReviewUserMiddleware(limitedTokenReviewUser("default")))
+	app.Post("/api/v1/tasks/:id/approvals/:approvalID/decision", h.DecideTaskApproval)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks/approval-task/approvals/approval-1/decision?namespace=default", bytes.NewBufferString(`{"decision":"approve"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	listed, err := eventStore.ListExecutionEvents(context.Background(), store.ExecutionEventFilter{Namespace: "default", StreamID: "approval-task"})
+	require.NoError(t, err)
+	require.Len(t, listed, 1, "denied approval decision must not append a terminal event")
+}
+
+func TestTaskApprovalDecisionRejectsWorkerServiceAccountEvenWithKubernetesRBAC(t *testing.T) {
+	eventStore := store.NewFakeExecutionEventStore()
+	content, _ := json.Marshal(map[string]string{"approvalID": "approval-1", "action": "create_pr"})
+	_, err := eventStore.AppendExecutionEvent(context.Background(), &store.ExecutionEvent{Namespace: "default", StreamType: store.ExecutionEventStreamTypeTask, StreamID: "approval-task", TaskName: "approval-task", Type: events.ExecutionEventTypeApprovalRequested, Content: content})
+	require.NoError(t, err)
+
+	h, app := setupTaskEventHandlers(t, eventStore, testTask("default", "approval-task"))
+	sarCalls := 0
+	h.clientset = allowingSubjectAccessReviewClient(t, func(review *authorizationv1.SubjectAccessReview) {
+		sarCalls++
+	})
+	app.Use(tokenReviewUserMiddleware(&UserInfo{
+		Username:  "system:serviceaccount:default:ai-worker",
+		Groups:    []string{"system:serviceaccounts", "system:serviceaccounts:default"},
+		Namespace: "default",
+		AuthType:  AuthTypeTokenReview,
+	}))
+	app.Post("/api/v1/tasks/:id/approvals/:approvalID/decision", h.DecideTaskApproval)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks/approval-task/approvals/approval-1/decision?namespace=default", bytes.NewBufferString(`{"decision":"approve"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	require.Zero(t, sarCalls, "worker service accounts should be rejected before SAR grants can authorize approval decisions")
+}
+
+func allowingSubjectAccessReviewClient(t *testing.T, assertReview func(*authorizationv1.SubjectAccessReview)) *kubefake.Clientset {
+	t.Helper()
+	kubeClient := kubefake.NewSimpleClientset()
+	kubeClient.PrependReactor("create", "subjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction := action.(k8stesting.CreateAction)
+		review := createAction.GetObject().(*authorizationv1.SubjectAccessReview)
+		if assertReview != nil {
+			assertReview(review)
+		}
+		review.Status.Allowed = true
+		return true, review, nil
+	})
+	return kubeClient
 }


### PR DESCRIPTION
### Motivation
- Close a security gap where TokenReview-authenticated Kubernetes service accounts could record terminal approval events and resume autonomous work without a Kubernetes SubjectAccessReview or explicit rejection of worker service accounts.
- Preserve the intended human approval boundary for autonomous coordinators by ensuring only authorized principals (and not worker SAs) can decide approvals.

### Description
- Add `authorizeKubernetesApprovalDecision` and `authorizeKubernetesTaskAction` to perform a Kubernetes `SubjectAccessReview` for `update` on the `tasks` resource subresource `approvals`, and reject known worker service accounts; these helpers live in `internal/api/kubernetes_task_authorization.go`.
- Call the new authorization path from `DecideTaskApproval` in `internal/api/approval_handlers.go` so TokenReview callers must pass the SAR before any terminal approval event is recorded.
- Refactor `authorizeKubernetesTaskCreate` to reuse the new generic `authorizeKubernetesTaskAction` helper and add `isWorkerServiceAccount` to centralize worker-SA detection logic.
- Add regression tests in `internal/api/kubernetes_task_authorization_test.go` to verify that low-privileged TokenReview callers are denied and that worker service accounts are rejected before any terminal approval event is appended.

### Testing
- Ran focused API tests: `go test ./internal/api -run 'TestTaskApprovalDecision(RequiresKubernetesApprovalRBACForTokenReviewUser|RejectsWorkerServiceAccountEvenWithKubernetesRBAC)|TestTaskApprovalDecisionAPIAppendsEvent' -count=1 -v -timeout=120s` and they passed.
- Ran broader package test: `GOFLAGS=-vet=off go test ./internal/api -count=1 -timeout=120s` and it passed.
- `make lint-fix` and full `make test` were blocked by the environment when downloading external tools from the Go proxy (forbidden), and the local `autoreview` helper could not run because the `codex` executable was not available, and `pr_closeout` snapshot could not run because `gh` is not present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fee66b6a0832a89f522e2ea6041d2)