### PR TITLE
fix(harness): avoid large Codex prompts in child env

### DIFF
--- a/workers/harness/cliwrapper/adapter.go
+++ b/workers/harness/cliwrapper/adapter.go
@@ -61,6 +61,7 @@ type CommandSpec struct {
 	Path       string
 	Args       []string
 	Env        []string
+	UnsetEnv   []string // Removed after inherited and explicit Env entries are merged.
 	Dir        string
 	Stdin      []byte
 	ResultFile string

--- a/workers/harness/cliwrapper/codex_adapter.go
+++ b/workers/harness/cliwrapper/codex_adapter.go
@@ -84,6 +84,7 @@ func (a *CodexAdapter) BuildCommand(_ context.Context, turn TurnContext) (*Comma
 		Path:       firstNonEmpty(a.config.Path, os.Getenv(workerenv.CodexCLIPath), defaultCodexPath),
 		Args:       buildCodexArgs(agentCfg, outputPath, instructionsPath, false, baseURL),
 		Env:        buildCodexEnv(turn.Env),
+		UnsetEnv:   []string{workerenv.Prompt},
 		Dir:        dir,
 		Stdin:      []byte(turn.Prompt),
 		ResultFile: outputPath,
@@ -215,7 +216,13 @@ func buildCodexInstructions(cfg *agentEnvConfig) string {
 
 func buildCodexEnv(extra []string) []string {
 	baseURL := firstNonEmpty(codexOpenAIBaseURL(), envEntryValue(extra, workerenv.OpenAIBaseURL))
-	env := removeTurnEnv(append([]string(nil), extra...), workerenv.OpenAIBaseURL)
+	// Codex receives the turn prompt on stdin. Remove the explicit copy here;
+	// BuildCommand also unsets any inherited copy after the final environment merge.
+	env := removeTurnEnv(
+		append([]string(nil), extra...),
+		workerenv.OpenAIBaseURL,
+		workerenv.Prompt,
+	)
 	env = setEnv(env, "HOME", firstNonEmpty(envEntryValue(env, "HOME"), "/home/worker"))
 	if baseURL != "" {
 		env = setEnv(env, workerenv.OpenAIBaseURL, baseURL)

--- a/workers/harness/cliwrapper/codex_adapter_test.go
+++ b/workers/harness/cliwrapper/codex_adapter_test.go
@@ -130,6 +130,178 @@ printf 'progress for %s' "$prompt"
 	}
 }
 
+func TestCodexAdapterRunsLargePromptThroughStdinWithoutPromptEnv(t *testing.T) {
+	dir := t.TempDir()
+	stdinCapture := filepath.Join(dir, "codex-stdin.txt")
+	envCapture := filepath.Join(dir, "codex-prompt-env.txt")
+	fakeCodex := filepath.Join(dir, "codex-large-prompt.sh")
+	if err := os.WriteFile(fakeCodex, []byte(`#!/bin/sh
+set -eu
+out=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--output-last-message" ]; then out="$arg"; fi
+  prev="$arg"
+done
+if [ "${ORKA_PROMPT+x}" = "x" ]; then
+  printf 'set' > "$CODEX_PROMPT_ENV_CAPTURE"
+  exit 64
+fi
+printf 'unset' > "$CODEX_PROMPT_ENV_CAPTURE"
+if [ "${CODEX_INHERITED_ENV:-}" != "inherited-value" ]; then exit 65; fi
+if [ "${CODEX_SPEC_ENV:-}" != "spec-value" ]; then exit 66; fi
+cat > "$CODEX_STDIN_CAPTURE"
+printf 'large prompt received' > "$out"
+`), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(workerenv.AllowBash, "true")
+	t.Setenv(workerenv.Prompt, "inherited-parent-value")
+	t.Setenv("CODEX_INHERITED_ENV", "inherited-value")
+	cfg := DefaultConfig()
+	cfg.AllowUnauthenticated = true
+	cfg.Runtime = RuntimeCodex
+	cfg.WorkDir = dir
+	cfg.CommandEnv = []string{
+		"CODEX_STDIN_CAPTURE=" + stdinCapture,
+		"CODEX_PROMPT_ENV_CAPTURE=" + envCapture,
+		"CODEX_SPEC_ENV=spec-value",
+	}
+	adapter := NewCodexAdapter(CodexAdapterConfig{Path: fakeCodex, WorkDir: dir})
+	baseURL, cleanup := startWrapperServerWithConfig(t, cfg, adapter)
+	defer cleanup()
+	client, err := harness.NewClient(baseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	largePrompt := "begin\n" + strings.Repeat("0123456789abcdef", 10*1024) + "\nend"
+	if len(largePrompt) <= 128*1024 {
+		t.Fatalf("large prompt length = %d, want more than 128 KiB", len(largePrompt))
+	}
+	request := validWrapperStartTurnRequest()
+	request.Input.Prompt = largePrompt
+	if _, err := client.StartTurn(context.Background(), request); err != nil {
+		t.Fatalf("StartTurn: %v", err)
+	}
+	frames := collectWrapperFrames(t, client, request.TurnID, 0)
+	last := frames[len(frames)-1]
+	if last.Type != harness.FrameTurnCompleted || last.Completed == nil {
+		t.Fatalf("last frame = %#v, want completed", last)
+	}
+	if last.Completed.Result != "large prompt received" {
+		t.Fatalf("completed result = %q, want fake codex result", last.Completed.Result)
+	}
+	capturedStdin, err := os.ReadFile(stdinCapture)
+	if err != nil {
+		t.Fatalf("read fake Codex stdin capture: %v", err)
+	}
+	if got := string(capturedStdin); got != largePrompt {
+		t.Fatalf("fake Codex stdin length = %d, want exact %d-byte prompt", len(got), len(largePrompt))
+	}
+	capturedEnv, err := os.ReadFile(envCapture)
+	if err != nil {
+		t.Fatalf("read fake Codex prompt env capture: %v", err)
+	}
+	if got := string(capturedEnv); got != "unset" {
+		t.Fatalf("fake Codex ORKA_PROMPT state = %q, want unset", got)
+	}
+}
+
+func TestCodexAdapterSecurityArtifactFollowUpUsesStdinWithoutPromptEnv(t *testing.T) {
+	dir := t.TempDir()
+	invocationMarker := filepath.Join(dir, "codex-invoked")
+	followUpStdinCapture := filepath.Join(dir, "codex-follow-up-stdin.txt")
+	followUpEnvCapture := filepath.Join(dir, "codex-follow-up-prompt-env.txt")
+	fakeCodex := filepath.Join(dir, "codex-security-follow-up.sh")
+	if err := os.WriteFile(fakeCodex, []byte(`#!/bin/sh
+set -eu
+out=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--output-last-message" ]; then out="$arg"; fi
+  prev="$arg"
+done
+if [ -e "$CODEX_INVOCATION_MARKER" ]; then
+  if [ "${ORKA_PROMPT+x}" = "x" ]; then
+    printf 'set' > "$CODEX_FOLLOW_UP_ENV_CAPTURE"
+    exit 64
+  fi
+  printf 'unset' > "$CODEX_FOLLOW_UP_ENV_CAPTURE"
+  cat > "$CODEX_FOLLOW_UP_STDIN_CAPTURE"
+  mkdir -p "$ORKA_ARTIFACTS_DIR"
+  printf '# threat model\n' > "$ORKA_ARTIFACTS_DIR/security-threat-model.md"
+  printf 'SECURITY_ARTIFACTS_WRITTEN' > "$out"
+else
+  if [ "${ORKA_PROMPT+x}" = "x" ]; then
+    printf 'initial-set' > "$CODEX_FOLLOW_UP_ENV_CAPTURE"
+    exit 63
+  fi
+  : > "$CODEX_INVOCATION_MARKER"
+  cat > /dev/null
+  : > "$out"
+fi
+`), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(workerenv.AllowBash, "true")
+	t.Setenv(workerenv.Prompt, "inherited-parent-value")
+	cfg := DefaultConfig()
+	cfg.AllowUnauthenticated = true
+	cfg.Runtime = RuntimeCodex
+	cfg.WorkDir = dir
+	cfg.CommandEnv = []string{
+		"CODEX_INVOCATION_MARKER=" + invocationMarker,
+		"CODEX_FOLLOW_UP_STDIN_CAPTURE=" + followUpStdinCapture,
+		"CODEX_FOLLOW_UP_ENV_CAPTURE=" + followUpEnvCapture,
+	}
+	adapter := NewCodexAdapter(CodexAdapterConfig{Path: fakeCodex, WorkDir: dir})
+	baseURL, cleanup := startWrapperServerWithConfig(t, cfg, adapter)
+	defer cleanup()
+	client, err := harness.NewClient(baseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := validWrapperStartTurnRequest()
+	request.Input.Prompt = "REQUIRED_SECURITY_ARTIFACTS: security-threat-model.md\nreview the repository"
+	if _, err := client.StartTurn(context.Background(), request); err != nil {
+		t.Fatalf("StartTurn: %v", err)
+	}
+	frames := collectWrapperFrames(t, client, request.TurnID, 0)
+	last := frames[len(frames)-1]
+	if last.Type != harness.FrameTurnCompleted || last.Completed == nil {
+		t.Fatalf("last frame = %#v, want completed", last)
+	}
+	if !strings.Contains(last.Completed.Result, "SECURITY_ARTIFACTS_WRITTEN") {
+		t.Fatalf("completed result = %q, want follow-up result", last.Completed.Result)
+	}
+	expectedFollowUp := strings.Join([]string{
+		"Before responding, finish the task by writing the missing required security artifacts.",
+		"Write them under .orka-artifacts/.",
+		"Missing files:",
+		"- .orka-artifacts/security-threat-model.md",
+		"Do not inspect more repository files unless absolutely necessary.",
+		"Reuse the analysis already completed in this run.",
+		"Use shell redirection or heredocs so the files are definitely persisted on disk.",
+		"security-threat-model.md must be non-empty markdown grounded in the repository.",
+		"After writing the files, reply with only: SECURITY_ARTIFACTS_WRITTEN",
+		"",
+	}, "\n")
+	capturedFollowUp, err := os.ReadFile(followUpStdinCapture)
+	if err != nil {
+		t.Fatalf("read fake Codex follow-up stdin capture: %v", err)
+	}
+	if got := string(capturedFollowUp); got != expectedFollowUp {
+		t.Fatalf("fake Codex follow-up stdin = %q, want %q", got, expectedFollowUp)
+	}
+	capturedEnv, err := os.ReadFile(followUpEnvCapture)
+	if err != nil {
+		t.Fatalf("read fake Codex follow-up prompt env capture: %v", err)
+	}
+	if got := string(capturedEnv); got != "unset" {
+		t.Fatalf("fake Codex follow-up ORKA_PROMPT state = %q, want unset", got)
+	}
+}
+
 func TestCodexAdapterFailurePath(t *testing.T) {
 	dir := t.TempDir()
 	fakeCodex := filepath.Join(dir, "codex-fail.sh")

--- a/workers/harness/cliwrapper/command_test.go
+++ b/workers/harness/cliwrapper/command_test.go
@@ -11,11 +11,26 @@ import (
 	"github.com/orka-agents/orka/internal/workerenv"
 )
 
-const envCommandRunnerStdoutHelper = "ORKA_CLIWRAPPER_STDOUT_HELPER"
+const (
+	envCommandRunnerStdoutHelper = "ORKA_CLIWRAPPER_STDOUT_HELPER"
+	envCommandRunnerEnvHelper    = "ORKA_CLIWRAPPER_ENV_HELPER"
+	envCommandRunnerDrop         = "ORKA_CLIWRAPPER_DROP"
+	envCommandRunnerKeepParent   = "ORKA_CLIWRAPPER_KEEP_PARENT"
+	envCommandRunnerKeepSpec     = "ORKA_CLIWRAPPER_KEEP_SPEC"
+)
 
 func TestMain(m *testing.M) {
 	if os.Getenv(envCommandRunnerStdoutHelper) == "1" {
 		_, _ = os.Stdout.Write([]byte("abcdefgh"))
+		return
+	}
+	if os.Getenv(envCommandRunnerEnvHelper) == "1" {
+		if _, exists := os.LookupEnv(envCommandRunnerDrop); exists {
+			os.Exit(41)
+		}
+		_, _ = os.Stdout.Write([]byte(
+			os.Getenv(envCommandRunnerKeepParent) + "|" + os.Getenv(envCommandRunnerKeepSpec),
+		))
 		return
 	}
 	os.Exit(m.Run())
@@ -62,6 +77,27 @@ func TestCommandRunnerPreservesFullStdoutWhenLogPreviewTruncates(t *testing.T) {
 	}
 	if got := result.ExactStdout(); got != "abcdefgh" {
 		t.Fatalf("ExactStdout = %q, want full stdout", got)
+	}
+}
+
+func TestCommandRunnerUnsetsEnvAfterMerge(t *testing.T) {
+	t.Setenv(envCommandRunnerDrop, "inherited-value")
+	t.Setenv(envCommandRunnerKeepParent, "parent-value")
+	runner := CommandRunner{StdoutLimitBytes: 64, StderrLimitBytes: 64, CancelGrace: 10 * time.Millisecond}
+	result, err := runner.Run(context.Background(), &CommandSpec{
+		Path: os.Args[0],
+		Env: []string{
+			envCommandRunnerEnvHelper + "=1",
+			envCommandRunnerDrop + "=spec-value",
+			envCommandRunnerKeepSpec + "=spec-value",
+		},
+		UnsetEnv: []string{envCommandRunnerDrop},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := result.ExactStdout(); got != "parent-value|spec-value" {
+		t.Fatalf("ExactStdout = %q, want preserved inherited and spec env", got)
 	}
 }
 

--- a/workers/harness/cliwrapper/runner.go
+++ b/workers/harness/cliwrapper/runner.go
@@ -46,6 +46,7 @@ func (r CommandRunner) Run(ctx context.Context, spec *CommandSpec) (CommandResul
 	cmd := exec.Command(spec.Path, spec.Args...)
 	cmd.Dir = spec.Dir
 	cmd.Env = mergeCommandEnv(sanitizedProcessEnv(os.Environ()), spec.Env)
+	cmd.Env = unsetCommandEnv(cmd.Env, spec.UnsetEnv)
 	if len(spec.Stdin) > 0 {
 		cmd.Stdin = bytes.NewReader(spec.Stdin)
 	}
@@ -200,6 +201,32 @@ func mergeCommandEnv(base, overrides []string) []string {
 		}
 		key, _, _ := strings.Cut(entry, "=")
 		out = setEnv(out, key, strings.TrimPrefix(entry, key+"="))
+	}
+	return out
+}
+
+func unsetCommandEnv(env, names []string) []string {
+	if len(env) == 0 || len(names) == 0 {
+		return env
+	}
+	unset := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if name = strings.TrimSpace(name); name != "" {
+			unset[name] = struct{}{}
+		}
+	}
+	if len(unset) == 0 {
+		return env
+	}
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			if _, remove := unset[key]; remove {
+				continue
+			}
+		}
+		out = append(out, entry)
 	}
 	return out
 }


### PR DESCRIPTION
## Summary

- add explicit per-command environment unsetting after inherited and task environment values are merged
- remove `ORKA_PROMPT` from Codex child processes while keeping stdin as the authoritative prompt transport
- cover initial and security-artifact follow-up Codex turns with prompts larger than Linux's per-string exec limit

## Root cause

Security review Tasks can build prompts larger than 128 KiB after appending the threat model and deterministic source context. Codex already receives the prompt through stdin, but the harness also copied it into the `ORKA_PROMPT` environment entry. Linux rejects an individual argument or environment entry around that size before Codex starts, producing `fork/exec /usr/local/bin/codex: argument list too long`.

Removing the entry only from adapter-provided environment values was insufficient because `CommandRunner` also inherits `os.Environ()`. This change introduces `CommandSpec.UnsetEnv`, applies it after the final environment merge, and has Codex explicitly unset `ORKA_PROMPT`.

Other runtime adapters leave `UnsetEnv` empty and preserve their existing behavior.

## Validation

- large prompt delivered byte-for-byte through Codex stdin with inherited `ORKA_PROMPT` absent from the child
- security-artifact follow-up delivered through stdin with no prompt environment entry
- unrelated inherited and explicit environment values preserved
- command-level unset occurs after environment merging
- implementation review returned clean after one validator-requested correction
- independent GPT-5.6-Sol validation verdict: `validated`

Commands run:

```text
ORKA_PROMPT=inherited-parent-value go test ./workers/harness/cliwrapper -run '^TestCodexAdapterRunsLargePromptThroughStdinWithoutPromptEnv$' -count=1 -v
go test ./workers/harness/cliwrapper -run '^(TestCommandRunnerUnsetsEnvAfterMerge|TestCodexAdapterSecurityArtifactFollowUpUsesStdinWithoutPromptEnv)$' -count=10
go test ./workers/harness/... -count=1
go test -race ./workers/harness/cliwrapper -count=1
go vet ./workers/harness/cliwrapper
git diff --check -- workers/harness/cliwrapper
```

## Out of scope

This fixes Codex process launch. It does not change the separate RepositoryScan behavior where a failed review slice can prevent later successful slice results from being ingested.
