### PR TITLE
fix: reject incomplete AI worker completions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -144,7 +144,7 @@ require (
 	github.com/valyala/fastjson v1.6.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	github.com/yuin/goldmark v1.7.13 // indirect
+	github.com/yuin/goldmark v1.7.17 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
-github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
-github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/goldmark v1.7.17 h1:p36OVWwRb246iHxA/U4p8OPEpOTESm4n+g+8t0EE5uA=
+github.com/yuin/goldmark v1.7.17/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yuin/goldmark-emoji v1.0.6 h1:QWfF2FYaXwL74tfGOW5izeiZepUDroDJfWubQI9HTHs=
 github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJpI31LTKmWuA=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/api/anthropic_compat.go
+++ b/internal/api/anthropic_compat.go
@@ -347,6 +347,14 @@ func (h *AnthropicCompatHandler) HandleMessages(c fiber.Ctx) error {
 			return anthropicError(c, 500, "api_error", "completion failed: "+err.Error())
 		}
 	}
+	stopReason, ok := mapAnthropicCompletionStopReason(resp)
+	if !ok {
+		message := "provider returned an invalid completion outcome"
+		if resp != nil && strings.TrimSpace(resp.StopReason) != "" {
+			message = fmt.Sprintf("provider returned non-success outcome %q", resp.StopReason)
+		}
+		return anthropicError(c, fiber.StatusBadGateway, "api_error", message)
+	}
 
 	user := ""
 	if ui := GetUserInfo(c); ui != nil {
@@ -361,7 +369,7 @@ func (h *AnthropicCompatHandler) HandleMessages(c fiber.Ctx) error {
 		"duration", time.Since(start).String(),
 	)
 
-	result := convertToAnthropicResponse(resp, model)
+	result := convertToAnthropicResponse(resp, model, stopReason)
 	return c.JSON(result)
 }
 
@@ -532,8 +540,18 @@ func convertAnthropicTools(inputTools []AnthropicTool) []llm.Tool {
 	return result
 }
 
+func mapAnthropicCompletionStopReason(resp *llm.CompletionResponse) (string, bool) {
+	if resp == nil {
+		return "", false
+	}
+	return mapAnthropicStreamStopReason(
+		resp.StopReason,
+		len(resp.ToolCalls) > 0,
+	)
+}
+
 // convertToAnthropicResponse converts an internal CompletionResponse to Anthropic format.
-func convertToAnthropicResponse(resp *llm.CompletionResponse, model string) AnthropicResponse {
+func convertToAnthropicResponse(resp *llm.CompletionResponse, model, stopReason string) AnthropicResponse {
 	id := "msg_" + uuid.New().String()
 
 	content := make([]AnthropicContentBlock, 0, len(resp.ToolCalls)+1)
@@ -552,8 +570,6 @@ func convertToAnthropicResponse(resp *llm.CompletionResponse, model string) Anth
 		})
 	}
 
-	stopReason := mapAnthropicStopReason(resp.StopReason)
-
 	return AnthropicResponse{
 		ID:         id,
 		Type:       "message",
@@ -565,20 +581,6 @@ func convertToAnthropicResponse(resp *llm.CompletionResponse, model string) Anth
 			InputTokens:  resp.InputTokens,
 			OutputTokens: resp.OutputTokens,
 		},
-	}
-}
-
-// mapAnthropicStopReason maps internal stop reasons to Anthropic stop_reason values.
-func mapAnthropicStopReason(reason string) string {
-	switch strings.ToLower(reason) {
-	case "stop", oaiStopReasonEndTurn, "":
-		return oaiStopReasonEndTurn
-	case "tool_calls", oaiStopReasonToolUse:
-		return oaiStopReasonToolUse
-	case "max_tokens", "length":
-		return "max_tokens"
-	default:
-		return oaiStopReasonEndTurn
 	}
 }
 

--- a/internal/api/anthropic_compat_test.go
+++ b/internal/api/anthropic_compat_test.go
@@ -556,7 +556,7 @@ func TestConvertToAnthropicResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := convertToAnthropicResponse(tt.resp, tt.model)
+			result := convertToAnthropicResponse(tt.resp, tt.model, tt.wantStopReason)
 
 			if result.Type != "message" {
 				t.Errorf("type = %q, want message", result.Type)
@@ -592,11 +592,38 @@ func TestConvertToAnthropicResponse(t *testing.T) {
 	}
 }
 
+func TestMapAnthropicCompletionStopReason(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *llm.CompletionResponse
+		want string
+		ok   bool
+	}{
+		{name: "nil response"},
+		{name: "blank completion", resp: &llm.CompletionResponse{StopReason: "end_turn"}, want: "end_turn", ok: true},
+		{name: "completed", resp: &llm.CompletionResponse{Content: "done", StopReason: "end_turn"}, want: "end_turn", ok: true},
+		{name: "completed tool call", resp: &llm.CompletionResponse{StopReason: "end_turn", ToolCalls: []llm.ToolCall{{ID: "call-1", Name: "search"}}}, want: "tool_use", ok: true},
+		{name: "refusal", resp: &llm.CompletionResponse{StopReason: "refusal"}, want: "refusal", ok: true},
+		{name: "pause turn", resp: &llm.CompletionResponse{StopReason: "pause_turn"}, want: "pause_turn", ok: true},
+		{name: "failed", resp: &llm.CompletionResponse{StopReason: "failed"}},
+		{name: "missing reason", resp: &llm.CompletionResponse{Content: "partial"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := mapAnthropicCompletionStopReason(tt.resp)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("mapAnthropicCompletionStopReason() = (%q, %t), want (%q, %t)", got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
 func TestConvertToAnthropicResponse_PreservesGoalStateSentinelForTransparentProxy(t *testing.T) {
 	result := convertToAnthropicResponse(&llm.CompletionResponse{
 		Content:    goalStateSentinel + "\nPR ready: https://example.test/pr/3",
 		StopReason: oaiStopReasonEndTurn,
-	}, "claude-sonnet-4-20250514")
+	}, "claude-sonnet-4-20250514", oaiStopReasonEndTurn)
 
 	if len(result.Content) != 1 {
 		t.Fatalf("expected one text block, got %d", len(result.Content))
@@ -614,7 +641,7 @@ func TestAnthropicToolLoopFormatting_StripsGoalStateSentinel(t *testing.T) {
 		Content:    goalStateSentinel + "\nPR ready: https://example.test/pr/3",
 		StopReason: oaiStopReasonEndTurn,
 	})
-	result := convertToAnthropicResponse(resp, "claude-sonnet-4-20250514")
+	result := convertToAnthropicResponse(resp, "claude-sonnet-4-20250514", oaiStopReasonEndTurn)
 
 	if len(result.Content) != 1 {
 		t.Fatalf("expected one text block, got %d", len(result.Content))
@@ -624,36 +651,6 @@ func TestAnthropicToolLoopFormatting_StripsGoalStateSentinel(t *testing.T) {
 	}
 	if strings.Contains(result.Content[0].Text, goalStateSentinel) {
 		t.Fatalf("tool-loop formatted response leaked sentinel: %q", result.Content[0].Text)
-	}
-}
-
-// --- Tests: mapAnthropicStopReason ---
-
-func TestMapAnthropicStopReason(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"stop", "end_turn"},
-		{"end_turn", "end_turn"},
-		{"", "end_turn"},
-		{"tool_calls", oaiStopReasonToolUse},
-		{oaiStopReasonToolUse, oaiStopReasonToolUse},
-		{"max_tokens", "max_tokens"},
-		{"length", "max_tokens"},
-		{"unknown_reason", "end_turn"},
-		{"STOP", "end_turn"},                 // case insensitive
-		{"Tool_Calls", oaiStopReasonToolUse}, // case insensitive
-		{"MAX_TOKENS", "max_tokens"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			got := mapAnthropicStopReason(tt.input)
-			if got != tt.want {
-				t.Errorf("mapAnthropicStopReason(%q) = %q, want %q", tt.input, got, tt.want)
-			}
-		})
 	}
 }
 
@@ -1090,6 +1087,44 @@ func TestHandleStreamingMessages_ForwardsTerminalUsage(t *testing.T) {
 	}
 }
 
+func TestHandleStreamingMessages_RejectsInvalidProviderOutcome(t *testing.T) {
+	tests := []struct {
+		name string
+		mock *mockAnthropicProvider
+	}{
+		{name: "failed stream", mock: &mockAnthropicProvider{streamChunks: []llm.StreamChunk{{Done: true, StopReason: "failed"}}}},
+		{name: "missing terminal", mock: &mockAnthropicProvider{streamChunks: []llm.StreamChunk{{Content: "partial"}}}},
+		{name: "fallback failed", mock: &mockAnthropicProvider{streamErr: fmt.Errorf("streaming not supported"), responses: []*llm.CompletionResponse{{StopReason: "failed"}}}},
+		{name: "fallback nil", mock: &mockAnthropicProvider{streamErr: fmt.Errorf("streaming not supported"), responses: []*llm.CompletionResponse{nil}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, app := setupTestAnthropicHandler()
+			app.Post("/test", func(c fiber.Ctx) error {
+				return handler.handleStreamingMessages(
+					c, context.Background(), tt.mock,
+					&llm.CompletionRequest{Model: "claude-sonnet-4-20250514"},
+					"claude-sonnet-4-20250514", nil,
+				)
+			})
+
+			resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			bodyStr := string(body)
+			if !strings.Contains(bodyStr, "event: error") {
+				t.Fatalf("expected stream error, got: %s", bodyStr)
+			}
+			if strings.Contains(bodyStr, "message_stop") {
+				t.Fatalf("invalid tool loop completed successfully: %s", bodyStr)
+			}
+		})
+	}
+}
+
 func TestHandleStreamingRawMessages_ForwardsTerminalUsage(t *testing.T) {
 	mock := &mockAnthropicProvider{
 		streamChunks: []llm.StreamChunk{
@@ -1116,6 +1151,240 @@ func TestHandleStreamingRawMessages_ForwardsTerminalUsage(t *testing.T) {
 	bodyStr := string(body)
 	if !strings.Contains(bodyStr, `"usage":{"input_tokens":0,"output_tokens":9`) {
 		t.Fatalf("expected streamed usage in body, got: %s", bodyStr)
+	}
+}
+
+func TestHandleStreamingRawMessages_PreservesRefusal(t *testing.T) {
+	mock := &mockAnthropicProvider{
+		streamChunks: []llm.StreamChunk{{Done: true, StopReason: "refusal"}},
+	}
+
+	handler, app := setupTestAnthropicHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingProxy(
+			c, context.Background(), mock,
+			&llm.CompletionRequest{Model: "claude-sonnet-4-20250514"},
+			"claude-sonnet-4-20250514",
+		)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, `"stop_reason":"refusal"`) {
+		t.Fatalf("expected refusal stop reason, got: %s", bodyStr)
+	}
+	if strings.Contains(bodyStr, "event: error") {
+		t.Fatalf("refusal was emitted as an error: %s", bodyStr)
+	}
+}
+
+func TestHandleStreamingRawMessages_RejectsFailedOutcome(t *testing.T) {
+	mock := &mockAnthropicProvider{
+		streamChunks: []llm.StreamChunk{{Done: true, StopReason: "failed"}},
+	}
+
+	handler, app := setupTestAnthropicHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingProxy(
+			c, context.Background(), mock,
+			&llm.CompletionRequest{Model: "claude-sonnet-4-20250514"},
+			"claude-sonnet-4-20250514",
+		)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, "event: error") || !strings.Contains(bodyStr, `non-success outcome \"failed\"`) {
+		t.Fatalf("expected stream error, got: %s", bodyStr)
+	}
+	if strings.Contains(bodyStr, `"stop_reason":"end_turn"`) || strings.Contains(bodyStr, "message_stop") {
+		t.Fatalf("failed stream was completed successfully: %s", bodyStr)
+	}
+}
+
+func TestHandleStreamingRawMessages_PreservesBlankEndTurn(t *testing.T) {
+	mock := &mockAnthropicProvider{
+		streamChunks: []llm.StreamChunk{{Done: true, StopReason: "end_turn"}},
+	}
+
+	handler, app := setupTestAnthropicHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingProxy(
+			c, context.Background(), mock,
+			&llm.CompletionRequest{Model: "claude-sonnet-4-20250514"},
+			"claude-sonnet-4-20250514",
+		)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, `"stop_reason":"end_turn"`) || !strings.Contains(bodyStr, "message_stop") {
+		t.Fatalf("expected blank end_turn completion, got: %s", bodyStr)
+	}
+	if strings.Contains(bodyStr, "event: error") {
+		t.Fatalf("blank end_turn emitted an error: %s", bodyStr)
+	}
+}
+
+func TestHandleStreamingRawMessages_FallbackPreservesBlankEndTurn(t *testing.T) {
+	mock := &mockAnthropicProvider{
+		streamErr: fmt.Errorf("streaming not supported"),
+		responses: []*llm.CompletionResponse{{Content: " \n", StopReason: "end_turn"}},
+	}
+
+	handler, app := setupTestAnthropicHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingProxy(
+			c, context.Background(), mock,
+			&llm.CompletionRequest{Model: "claude-sonnet-4-20250514"},
+			"claude-sonnet-4-20250514",
+		)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, `"stop_reason":"end_turn"`) || !strings.Contains(bodyStr, "message_stop") {
+		t.Fatalf("expected blank fallback end_turn, got: %s", bodyStr)
+	}
+	if strings.Contains(bodyStr, "event: error") {
+		t.Fatalf("blank fallback emitted an error: %s", bodyStr)
+	}
+}
+
+func TestHandleStreamingRawMessages_FallbackRejectsFailedOutcome(t *testing.T) {
+	mock := &mockAnthropicProvider{
+		streamErr: fmt.Errorf("streaming not supported"),
+		responses: []*llm.CompletionResponse{{Content: "partial", StopReason: "failed"}},
+	}
+
+	handler, app := setupTestAnthropicHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingProxy(
+			c, context.Background(), mock,
+			&llm.CompletionRequest{Model: "claude-sonnet-4-20250514"},
+			"claude-sonnet-4-20250514",
+		)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, "event: error") || !strings.Contains(bodyStr, `non-success outcome \"failed\"`) {
+		t.Fatalf("expected fallback stream error, got: %s", bodyStr)
+	}
+	if strings.Contains(bodyStr, "partial") || strings.Contains(bodyStr, "message_stop") {
+		t.Fatalf("failed fallback emitted completion data: %s", bodyStr)
+	}
+}
+
+func TestHandleStreamingRawMessages_FallbackProviderError(t *testing.T) {
+	mock := &mockAnthropicProvider{
+		streamErr: fmt.Errorf("streaming not supported"),
+		responses: []*llm.CompletionResponse{nil},
+		errors:    []error{fmt.Errorf("completion failed")},
+	}
+
+	handler, app := setupTestAnthropicHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingProxy(
+			c, context.Background(), mock,
+			&llm.CompletionRequest{Model: "claude-sonnet-4-20250514"},
+			"claude-sonnet-4-20250514",
+		)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, "event: error") || !strings.Contains(bodyStr, `non-success outcome \"provider_error\"`) {
+		t.Fatalf("expected provider error event, got: %s", bodyStr)
+	}
+	if strings.Contains(bodyStr, "completion failed") || strings.Contains(bodyStr, "message_stop") {
+		t.Fatalf("provider error leaked or completed successfully: %s", bodyStr)
+	}
+}
+
+func TestHandleStreamingRawMessages_FallbackNilResponse(t *testing.T) {
+	mock := &mockAnthropicProvider{
+		streamErr: fmt.Errorf("streaming not supported"),
+		responses: []*llm.CompletionResponse{nil},
+	}
+
+	handler, app := setupTestAnthropicHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingProxy(
+			c, context.Background(), mock,
+			&llm.CompletionRequest{Model: "claude-sonnet-4-20250514"},
+			"claude-sonnet-4-20250514",
+		)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, "event: error") || !strings.Contains(bodyStr, "without a successful terminal outcome") {
+		t.Fatalf("expected nil response error event, got: %s", bodyStr)
+	}
+	if strings.Contains(bodyStr, "message_stop") {
+		t.Fatalf("nil response completed successfully: %s", bodyStr)
+	}
+}
+
+func TestMapAnthropicStreamStopReason(t *testing.T) {
+	tests := []struct {
+		name         string
+		reason       string
+		hasToolCalls bool
+		want         string
+		wantOK       bool
+	}{
+		{name: "completed", reason: "end_turn", want: "end_turn", wantOK: true},
+		{name: "blank completed", reason: "end_turn", want: "end_turn", wantOK: true},
+		{name: "completed with calls", reason: "stop", hasToolCalls: true, want: "tool_use", wantOK: true},
+		{name: "empty stop sequence", reason: finishReasonStopSequence, want: finishReasonStopSequence, wantOK: true},
+		{name: "stop sequence with calls", reason: finishReasonStopSequence, hasToolCalls: true, want: oaiStopReasonToolUse, wantOK: true},
+		{name: "tool use", reason: "tool_calls", hasToolCalls: true, want: "tool_use", wantOK: true},
+		{name: "tool reason without calls", reason: "tool_use"},
+		{name: "max tokens", reason: "length", want: "max_tokens", wantOK: true},
+		{name: "pause turn", reason: "pause_turn", want: "pause_turn", wantOK: true},
+		{name: "refusal", reason: "refusal", want: "refusal", wantOK: true},
+		{name: "context window exceeded", reason: anthropicStopReasonModelContextWindowExceeded, want: anthropicStopReasonModelContextWindowExceeded, wantOK: true},
+		{name: "failed", reason: "failed"},
+		{name: "missing reason"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := mapAnthropicStreamStopReason(tt.reason, tt.hasToolCalls)
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("mapAnthropicStreamStopReason() = (%q, %t), want (%q, %t)", got, ok, tt.want, tt.wantOK)
+			}
+		})
 	}
 }
 

--- a/internal/api/anthropic_compat_test.go
+++ b/internal/api/anthropic_compat_test.go
@@ -1087,6 +1087,41 @@ func TestHandleStreamingMessages_ForwardsTerminalUsage(t *testing.T) {
 	}
 }
 
+func TestHandleStreamingMessages_FallsBackAfterInitialChunkError(t *testing.T) {
+	mock := &mockAnthropicProvider{
+		streamChunks: []llm.StreamChunk{{Error: fmt.Errorf("stream unavailable"), Done: true}},
+		responses: []*llm.CompletionResponse{{
+			Content:    goalStateSentinel + "fallback response",
+			StopReason: oaiStopReasonEndTurn,
+		}},
+	}
+
+	handler, app := setupTestAnthropicHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingMessages(
+			c, context.Background(), mock,
+			&llm.CompletionRequest{Model: "claude-sonnet-4-20250514"},
+			"claude-sonnet-4-20250514", nil,
+		)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if strings.Contains(bodyStr, "event: error") {
+		t.Fatalf("initial stream error prevented fallback: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, "fallback response") || !strings.Contains(bodyStr, "message_stop") {
+		t.Fatalf("expected completed fallback response, got: %s", bodyStr)
+	}
+	if mock.callIdx != 1 {
+		t.Fatalf("Complete calls = %d, want 1", mock.callIdx)
+	}
+}
+
 func TestHandleStreamingMessages_RejectsInvalidProviderOutcome(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/api/anthropic_streaming.go
+++ b/internal/api/anthropic_streaming.go
@@ -10,7 +10,9 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/google/uuid"
@@ -90,84 +92,39 @@ func (h *AnthropicCompatHandler) handleStreamingMessages( //nolint:gocyclo
 				Temperature:  capturedReq.Temperature,
 			}
 
-			// Try streaming from provider
-			var toolCalls []llm.ToolCall
-			var textContent string
-
-			streamCh, err := capturedProvider.Stream(streamCtx, compReq)
-			if err != nil {
-				// Fallback to Complete
-				resp, completeErr := capturedProvider.Complete(streamCtx, compReq)
-				if completeErr != nil {
-					anthropicLog.Error(completeErr, "completion failed in tool loop")
-					if err := writeContentBlockStart(w, blockIndex, AnthropicContentBlock{Type: "text", Text: ""}); err == nil {
-						_ = writeContentBlockDelta(w, blockIndex, AnthropicDelta{Type: "text_delta", Text: "Error: " + completeErr.Error()})
-						_ = writeContentBlockStop(w, blockIndex)
-					}
-					_ = writeMessageDelta(w, oaiStopReasonEndTurn, totalOutputTokens)
-					_ = writeMessageStop(w)
+			// Aggregate a validated provider turn before exposing or executing it.
+			resp, streamErr := completeViaStream(streamCtx, capturedProvider, compReq)
+			usedStream := streamErr == nil
+			if streamErr != nil {
+				if !errors.Is(streamErr, errStreamOpen) {
+					anthropicLog.Error(streamErr, "invalid provider stream in tool loop")
+					_ = writeAnthropicStreamError(w, "provider_error")
 					return
 				}
+				var completeErr error
+				resp, completeErr = capturedProvider.Complete(streamCtx, compReq)
+				if completeErr != nil {
+					anthropicLog.Error(completeErr, "completion failed in tool loop")
+					_ = writeAnthropicStreamError(w, "provider_error")
+					return
+				}
+				if err := validateToolLoopCompletion(resp); err != nil {
+					anthropicLog.Error(err, "invalid completion in tool loop")
+					reason := ""
+					if resp != nil {
+						reason = resp.StopReason
+					}
+					_ = writeAnthropicStreamError(w, reason)
+					return
+				}
+			}
 
+			textContent := resp.Content
+			toolCalls := resp.ToolCalls
+			if resp.OutputTokens > 0 {
 				totalOutputTokens += resp.OutputTokens
-
-				// Capture text content. It is emitted after tool-call/final-state
-				// classification so control markers can be stripped first.
-				if resp.Content != "" {
-					textContent = resp.Content
-				}
-
-				// Capture tool calls for server-side execution (don't emit tool_use blocks
-				// to the client — the client must not see them or it will try to execute locally)
-				toolCalls = resp.ToolCalls
-			} else {
-				// Consume stream chunks. Text is buffered until this iteration's
-				// tool-call/final-state classification is known, so internal
-				// sentinels are never leaked to the client.
-				streamError := false
-				for chunk := range streamCh {
-					if chunk.Error != nil {
-						anthropicLog.Error(chunk.Error, "stream chunk error in tool loop")
-						streamError = true
-						break
-					}
-
-					// Handle text content
-					if chunk.Content != "" {
-						textContent += chunk.Content
-					}
-
-					// Handle tool calls — capture for server-side execution but don't
-					// emit tool_use blocks to the client stream
-					if chunk.ToolCall != nil {
-						toolCalls = append(toolCalls, *chunk.ToolCall)
-					}
-
-					if chunk.Done {
-						if chunk.OutputTokens > 0 {
-							totalOutputTokens += chunk.OutputTokens
-						} else {
-							totalOutputTokens += estimateTokens(textContent)
-						}
-						break
-					}
-				}
-
-				// If stream errored with no content, fall back to Complete
-				if streamError && textContent == "" && len(toolCalls) == 0 {
-					resp, completeErr := capturedProvider.Complete(streamCtx, compReq)
-					if completeErr != nil {
-						anthropicLog.Error(completeErr, "fallback completion also failed")
-						_ = writeMessageDelta(w, oaiStopReasonEndTurn, totalOutputTokens)
-						_ = writeMessageStop(w)
-						return
-					}
-					totalOutputTokens += resp.OutputTokens
-					if resp.Content != "" {
-						textContent = resp.Content
-					}
-					toolCalls = resp.ToolCalls
-				}
+			} else if usedStream {
+				totalOutputTokens += estimateTokens(textContent)
 			}
 
 			// No tool calls — potentially final response. Guard against premature
@@ -366,11 +323,13 @@ func (h *AnthropicCompatHandler) handleStreamingProxy(
 		inTextBlock := false
 		hasToolCalls := false
 		outputTokens := 0
+		terminalStopReason := ""
 
 		for chunk := range streamCh {
 			if chunk.Error != nil {
 				anthropicLog.Error(chunk.Error, "stream chunk error")
-				break
+				_ = writeAnthropicStreamError(w, "provider_error")
+				return
 			}
 
 			if chunk.Content != "" {
@@ -414,6 +373,7 @@ func (h *AnthropicCompatHandler) handleStreamingProxy(
 			}
 
 			if chunk.Done {
+				terminalStopReason = chunk.StopReason
 				if inTextBlock {
 					_ = writeContentBlockStop(w, blockIndex)
 					inTextBlock = false
@@ -426,10 +386,10 @@ func (h *AnthropicCompatHandler) handleStreamingProxy(
 			_ = writeContentBlockStop(w, blockIndex)
 		}
 
-		// Use the correct stop reason — "tool_use" if tool calls were emitted
-		stopReason := oaiStopReasonEndTurn
-		if hasToolCalls {
-			stopReason = oaiStopReasonToolUse
+		stopReason, ok := mapAnthropicStreamStopReason(terminalStopReason, hasToolCalls)
+		if !ok {
+			_ = writeAnthropicStreamError(w, terminalStopReason)
+			return
 		}
 		_ = writeMessageDelta(w, stopReason, outputTokens)
 		_ = writeMessageStop(w)
@@ -439,6 +399,36 @@ func (h *AnthropicCompatHandler) handleStreamingProxy(
 // estimateTokens provides a rough token count estimate from text length.
 func estimateTokens(text string) int {
 	return len(text) / 4
+}
+
+func mapAnthropicStreamStopReason(reason string, hasToolCalls bool) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(reason)) {
+	case finishReasonStop, oaiStopReasonEndTurn, completionStatusCompleted, "response.completed":
+		if hasToolCalls {
+			return oaiStopReasonToolUse, true
+		}
+		return oaiStopReasonEndTurn, true
+	case finishReasonStopSequence:
+		if hasToolCalls {
+			return oaiStopReasonToolUse, true
+		}
+		return finishReasonStopSequence, true
+	case finishReasonToolCalls, oaiStopReasonToolUse, finishReasonFunctionCall:
+		if !hasToolCalls {
+			return "", false
+		}
+		return oaiStopReasonToolUse, true
+	case oaiParamMaxTokens, oaiStopReasonLength:
+		return oaiParamMaxTokens, true
+	case "pause_turn":
+		return "pause_turn", true
+	case "refusal":
+		return "refusal", true
+	case anthropicStopReasonModelContextWindowExceeded:
+		return anthropicStopReasonModelContextWindowExceeded, true
+	default:
+		return "", false
+	}
 }
 
 // handleStreamingFallback uses provider.Complete() and emits the result as a complete SSE sequence.
@@ -451,13 +441,16 @@ func (h *AnthropicCompatHandler) handleStreamingFallback(
 	resp, err := provider.Complete(ctx, req)
 	if err != nil {
 		anthropicLog.Error(err, "fallback complete failed")
-		// Emit an error as text content and close
-		_ = writeContentBlockStart(w, 0, AnthropicContentBlock{Type: "text", Text: ""})
-		_ = writeContentBlockDelta(w, 0, AnthropicDelta{Type: "text_delta", Text: "Error: " + err.Error()})
-		_ = writeContentBlockStop(w, 0)
-		stopReason := oaiStopReasonEndTurn
-		_ = writeMessageDelta(w, stopReason, 0)
-		_ = writeMessageStop(w)
+		_ = writeAnthropicStreamError(w, "provider_error")
+		return
+	}
+	stopReason, ok := mapAnthropicCompletionStopReason(resp)
+	if !ok {
+		reason := ""
+		if resp != nil {
+			reason = resp.StopReason
+		}
+		_ = writeAnthropicStreamError(w, reason)
 		return
 	}
 
@@ -511,14 +504,6 @@ func (h *AnthropicCompatHandler) handleStreamingFallback(
 		blockIndex++
 	}
 
-	stopReason := resp.StopReason
-	if stopReason == "" {
-		stopReason = oaiStopReasonEndTurn
-	}
-	if len(resp.ToolCalls) > 0 && stopReason == oaiStopReasonEndTurn {
-		stopReason = "tool_use"
-	}
-
 	_ = writeMessageDelta(w, stopReason, resp.OutputTokens)
 	_ = writeMessageStop(w)
 }
@@ -531,6 +516,20 @@ func writeAnthropicSSE(w *bufio.Writer, eventType string, data any) error {
 	}
 	_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, jsonData)
 	return w.Flush()
+}
+
+func writeAnthropicStreamError(w *bufio.Writer, reason string) error {
+	message := "provider stream ended without a successful terminal outcome"
+	if strings.TrimSpace(reason) != "" {
+		message = fmt.Sprintf("provider stream ended with non-success outcome %q", reason)
+	}
+	return writeAnthropicSSE(w, "error", AnthropicError{
+		Type: "error",
+		Error: AnthropicErrorDetail{
+			Type:    "api_error",
+			Message: message,
+		},
+	})
 }
 
 func writeAnthropicTextProgress(w *bufio.Writer, blockIndex *int, text string) {

--- a/internal/api/anthropic_streaming.go
+++ b/internal/api/anthropic_streaming.go
@@ -96,7 +96,7 @@ func (h *AnthropicCompatHandler) handleStreamingMessages( //nolint:gocyclo
 			resp, streamErr := completeViaStream(streamCtx, capturedProvider, compReq)
 			usedStream := streamErr == nil
 			if streamErr != nil {
-				if !errors.Is(streamErr, errStreamOpen) {
+				if !errors.Is(streamErr, errStreamUnavailable) {
 					anthropicLog.Error(streamErr, "invalid provider stream in tool loop")
 					_ = writeAnthropicStreamError(w, "provider_error")
 					return

--- a/internal/api/anthropic_tool_loop.go
+++ b/internal/api/anthropic_tool_loop.go
@@ -9,6 +9,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -27,6 +28,8 @@ import (
 // emits "## Progress Summary" mid-workflow, which terminates the SSE stream
 // and skips validation/review/PR.
 const goalStateSentinel = "<ORKA_GOAL_STATE_REACHED>"
+
+var errStreamOpen = errors.New("stream open")
 
 // truncateForLog returns s clipped to max runes, appending "…" if clipped.
 // Used so log lines stay scannable when the model dumps a long progress
@@ -62,15 +65,16 @@ func isStreamingRequiredErr(err error) bool {
 // fallback path when provider.Complete is refused with
 // "streaming is required for operations that may take longer than N minutes".
 // The aggregation is intentionally simple: concatenate text content and append
-// each tool call exactly once. Final stop_reason follows
-// the last chunk's reason or defaults to "end_turn".
+// each tool call exactly once. A terminal chunk with an explicit stop reason
+// is required so truncated streams cannot be mistaken for completion.
 func completeViaStream(ctx context.Context, provider llm.Provider, req *llm.CompletionRequest) (*llm.CompletionResponse, error) {
 	streamCh, err := provider.Stream(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("stream open: %w", err)
+		return nil, fmt.Errorf("%w: %w", errStreamOpen, err)
 	}
 
 	resp := &llm.CompletionResponse{}
+	terminalSeen := false
 	for chunk := range streamCh {
 		if chunk.Error != nil {
 			return nil, fmt.Errorf("stream chunk: %w", chunk.Error)
@@ -94,20 +98,35 @@ func completeViaStream(ctx context.Context, provider llm.Provider, req *llm.Comp
 			resp.Provider = chunk.Provider
 		}
 		if chunk.Done {
-			if chunk.StopReason != "" {
-				resp.StopReason = chunk.StopReason
-			}
+			terminalSeen = true
+			resp.StopReason = chunk.StopReason
 			break
 		}
 	}
-	if resp.StopReason == "" {
-		if len(resp.ToolCalls) > 0 {
-			resp.StopReason = "tool_use"
-		} else {
-			resp.StopReason = "end_turn"
-		}
+	if !terminalSeen {
+		return nil, fmt.Errorf("stream closed without a terminal chunk")
+	}
+	if err := validateToolLoopCompletion(resp); err != nil {
+		return nil, err
 	}
 	return resp, nil
+}
+
+func validateToolLoopCompletion(resp *llm.CompletionResponse) error {
+	outcome := llm.NormalizeCompletionOutcome(resp)
+	switch outcome {
+	case llm.CompletionOutcomeCompleted, llm.CompletionOutcomeToolCalls:
+		return nil
+	default:
+		reason := ""
+		if resp != nil {
+			reason = strings.TrimSpace(resp.StopReason)
+		}
+		if reason == "" {
+			return fmt.Errorf("LLM returned %s completion outcome without a stop reason", outcome)
+		}
+		return fmt.Errorf("LLM returned %s completion outcome with stop reason %q", outcome, reason)
+	}
 }
 
 // toolLoopObserver receives best-effort progress events from the server-side
@@ -152,7 +171,7 @@ func (o *toolLoopObserver) autoPoll() {
 }
 
 func formatToolProgress(tc llm.ToolCall, result string) string {
-	status := "completed"
+	status := completionStatusCompleted
 	var parsed struct {
 		Success *bool `json:"success"`
 		Data    struct {
@@ -660,6 +679,9 @@ func runToolLoopWithObserver(
 				observer.finalContent(resp.Content)
 				return resp, nil
 			}
+			if err := validateToolLoopCompletion(resp); err != nil {
+				return nil, err
+			}
 			observer.finalContent(resp.Content)
 			return resp, nil
 		}
@@ -703,6 +725,9 @@ func runToolLoopWithObserver(
 		}
 		if err != nil {
 			return nil, fmt.Errorf("LLM completion failed: %w", err)
+		}
+		if err := validateToolLoopCompletion(resp); err != nil {
+			return nil, err
 		}
 
 		// No tool calls → potentially final response. Guard against premature

--- a/internal/api/anthropic_tool_loop.go
+++ b/internal/api/anthropic_tool_loop.go
@@ -29,7 +29,7 @@ import (
 // and skips validation/review/PR.
 const goalStateSentinel = "<ORKA_GOAL_STATE_REACHED>"
 
-var errStreamOpen = errors.New("stream open")
+var errStreamUnavailable = errors.New("stream unavailable before output")
 
 // truncateForLog returns s clipped to max runes, appending "…" if clipped.
 // Used so log lines stay scannable when the model dumps a long progress
@@ -70,13 +70,16 @@ func isStreamingRequiredErr(err error) bool {
 func completeViaStream(ctx context.Context, provider llm.Provider, req *llm.CompletionRequest) (*llm.CompletionResponse, error) {
 	streamCh, err := provider.Stream(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", errStreamOpen, err)
+		return nil, fmt.Errorf("%w: open: %w", errStreamUnavailable, err)
 	}
 
 	resp := &llm.CompletionResponse{}
 	terminalSeen := false
 	for chunk := range streamCh {
 		if chunk.Error != nil {
+			if resp.Content == "" && len(resp.ToolCalls) == 0 {
+				return nil, fmt.Errorf("%w: chunk: %w", errStreamUnavailable, chunk.Error)
+			}
 			return nil, fmt.Errorf("stream chunk: %w", chunk.Error)
 		}
 		if chunk.Content != "" {

--- a/internal/api/anthropic_tool_loop_stream_test.go
+++ b/internal/api/anthropic_tool_loop_stream_test.go
@@ -49,13 +49,46 @@ func TestCompleteViaStreamPreservesOpenErrorChain(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !errors.Is(err, errStreamOpen) {
-		t.Fatalf("error = %v, want stream-open sentinel", err)
+	if !errors.Is(err, errStreamUnavailable) {
+		t.Fatalf("error = %v, want stream-unavailable sentinel", err)
 	}
 	if !llm.IsContextTooLongErr(err) {
 		t.Fatalf("error = %v, want context-too-long provider cause", err)
 	}
 }
+
+func TestCompleteViaStreamMarksInitialChunkErrorFallbackEligible(t *testing.T) {
+	providerErr := &llm.ProviderError{StatusCode: 503, Message: "stream unavailable"}
+	_, err := completeViaStream(context.Background(), streamChunksProvider{
+		chunks: []llm.StreamChunk{{Error: providerErr, Done: true}},
+	}, &llm.CompletionRequest{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, errStreamUnavailable) {
+		t.Fatalf("error = %v, want stream-unavailable sentinel", err)
+	}
+	if !errors.Is(err, providerErr) {
+		t.Fatalf("error = %v, want provider cause", err)
+	}
+}
+
+func TestCompleteViaStreamRejectsChunkErrorAfterOutput(t *testing.T) {
+	providerErr := &llm.ProviderError{StatusCode: 503, Message: "stream interrupted"}
+	_, err := completeViaStream(context.Background(), streamChunksProvider{
+		chunks: []llm.StreamChunk{{Content: "partial"}, {Error: providerErr, Done: true}},
+	}, &llm.CompletionRequest{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, errStreamUnavailable) {
+		t.Fatalf("error = %v, must not allow fallback after partial output", err)
+	}
+	if !errors.Is(err, providerErr) {
+		t.Fatalf("error = %v, want provider cause", err)
+	}
+}
+
 func (streamUsageProvider) Stream(context.Context, *llm.CompletionRequest) (<-chan llm.StreamChunk, error) {
 	ch := make(chan llm.StreamChunk, 3)
 	ch <- llm.StreamChunk{Content: "hello", Model: "stream-model", Provider: "anthropic"}

--- a/internal/api/anthropic_tool_loop_stream_test.go
+++ b/internal/api/anthropic_tool_loop_stream_test.go
@@ -9,6 +9,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/orka-agents/orka/internal/llm"
@@ -19,6 +20,41 @@ type streamUsageProvider struct{}
 func (streamUsageProvider) Name() string { return "stream-usage" }
 func (streamUsageProvider) Complete(context.Context, *llm.CompletionRequest) (*llm.CompletionResponse, error) {
 	return nil, nil
+}
+
+type streamChunksProvider struct {
+	chunks []llm.StreamChunk
+	err    error
+}
+
+func (streamChunksProvider) Name() string { return "stream-chunks" }
+func (streamChunksProvider) Complete(context.Context, *llm.CompletionRequest) (*llm.CompletionResponse, error) {
+	return nil, nil
+}
+func (p streamChunksProvider) Stream(context.Context, *llm.CompletionRequest) (<-chan llm.StreamChunk, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	ch := make(chan llm.StreamChunk, len(p.chunks))
+	for _, chunk := range p.chunks {
+		ch <- chunk
+	}
+	close(ch)
+	return ch, nil
+}
+
+func TestCompleteViaStreamPreservesOpenErrorChain(t *testing.T) {
+	providerErr := &llm.ProviderError{StatusCode: 400, Message: "context length exceeded"}
+	_, err := completeViaStream(context.Background(), streamChunksProvider{err: providerErr}, &llm.CompletionRequest{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, errStreamOpen) {
+		t.Fatalf("error = %v, want stream-open sentinel", err)
+	}
+	if !llm.IsContextTooLongErr(err) {
+		t.Fatalf("error = %v, want context-too-long provider cause", err)
+	}
 }
 func (streamUsageProvider) Stream(context.Context, *llm.CompletionRequest) (<-chan llm.StreamChunk, error) {
 	ch := make(chan llm.StreamChunk, 3)
@@ -42,5 +78,25 @@ func TestCompleteViaStreamPreservesTerminalUsageMetadata(t *testing.T) {
 	}
 	if resp.Model != "stream-model" || resp.Provider != "anthropic" {
 		t.Fatalf("metadata = model:%q provider:%q", resp.Model, resp.Provider)
+	}
+}
+
+func TestCompleteViaStreamRejectsMissingTerminalOutcome(t *testing.T) {
+	tests := []struct {
+		name   string
+		chunks []llm.StreamChunk
+	}{
+		{name: "channel closes without terminal", chunks: []llm.StreamChunk{{Content: "partial"}}},
+		{name: "terminal missing reason", chunks: []llm.StreamChunk{{Done: true}}},
+		{name: "failed terminal", chunks: []llm.StreamChunk{{Done: true, StopReason: "failed"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := completeViaStream(context.Background(), streamChunksProvider{chunks: tt.chunks}, &llm.CompletionRequest{})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
 	}
 }

--- a/internal/api/openai_compat.go
+++ b/internal/api/openai_compat.go
@@ -37,8 +37,13 @@ const (
 var oaiLog = logf.Log.WithName("openai-compat")
 
 const (
-	finishReasonStop      = "stop"
-	finishReasonToolCalls = "tool_calls"
+	anthropicStopReasonModelContextWindowExceeded = "model_context_window_exceeded"
+	completionStatusCompleted                     = "completed"
+	finishReasonContentFilter                     = "content_filter"
+	finishReasonFunctionCall                      = "function_call"
+	finishReasonStop                              = "stop"
+	finishReasonStopSequence                      = "stop_sequence"
+	finishReasonToolCalls                         = "tool_calls"
 )
 
 // OpenAICompatHandler implements OpenAI-compatible /openai/v1/chat/completions and /openai/v1/models endpoints.
@@ -489,14 +494,24 @@ func (h *OpenAICompatHandler) handleStreamingToolLoop(
 		resp, err := runToolLoopWithObserver(streamCtx, capturedProvider, capturedReq, model, h.config, capturedToolCtx, observer)
 		if err != nil {
 			oaiLog.Error(err, "streaming tool loop failed")
-			writeContent("Error: " + err.Error())
+			_ = writeStreamError(w, "provider_error")
+			return
+		}
+		if resp == nil {
+			_ = writeStreamError(w, "")
+			return
+		}
+		finishReason, ok := mapStreamFinishReason(
+			resp.StopReason,
+			strings.TrimSpace(stripGoalStateSentinel(resp.Content)) != "",
+			len(resp.ToolCalls) > 0,
+		)
+		if !ok {
+			_ = writeStreamError(w, resp.StopReason)
+			return
 		}
 
 		// Send finish chunk
-		finishReason := finishReasonStop
-		if resp != nil {
-			finishReason = mapFinishReason(resp.StopReason)
-		}
 		finishChunk := OAIResponse{
 			ID:      completionID,
 			Object:  "chat.completion.chunk",
@@ -559,8 +574,17 @@ func stripGoalStateSentinelFromResponse(resp *llm.CompletionResponse) *llm.Compl
 
 // formatOAIResponse formats a CompletionResponse into OpenAI API format.
 func (h *OpenAICompatHandler) formatOAIResponse(c fiber.Ctx, resp *llm.CompletionResponse, completionID, model string, created int64) error {
-
-	finishReason := mapFinishReason(resp.StopReason)
+	if resp == nil {
+		return openAICompletionOutcomeError(c, "")
+	}
+	finishReason, ok := mapStreamFinishReason(
+		resp.StopReason,
+		strings.TrimSpace(resp.Content) != "",
+		len(resp.ToolCalls) > 0,
+	)
+	if !ok {
+		return openAICompletionOutcomeError(c, resp.StopReason)
+	}
 
 	msg := &OAIMessage{
 		Role:    "assistant",
@@ -605,6 +629,17 @@ func (h *OpenAICompatHandler) formatOAIResponse(c fiber.Ctx, resp *llm.Completio
 	})
 }
 
+func openAICompletionOutcomeError(c fiber.Ctx, reason string) error {
+	message := "provider returned an invalid completion outcome"
+	if strings.TrimSpace(reason) != "" {
+		message = fmt.Sprintf("provider returned non-success outcome %q", reason)
+	}
+	return c.Status(fiber.StatusBadGateway).JSON(OAIError{Error: OAIErrorDetail{
+		Message: message,
+		Type:    "server_error",
+	}})
+}
+
 // handleStreamingCompletion handles a streaming chat completion request.
 func (h *OpenAICompatHandler) handleStreamingCompletion(
 	c fiber.Ctx,
@@ -634,18 +669,21 @@ func (h *OpenAICompatHandler) handleStreamingCompletion(
 			// Try non-streaming fallback via Complete
 			resp, completeErr := capturedProvider.Complete(streamCtx, capturedReq)
 			if completeErr != nil {
-				errChunk := OAIResponse{
-					ID:      completionID,
-					Object:  "chat.completion.chunk",
-					Created: created,
-					Model:   model,
-					Choices: []OAIChoice{{
-						Index: 0,
-						Delta: &OAIMessage{Role: "assistant", Content: "Error: " + completeErr.Error()},
-					}},
-				}
-				_ = writeStreamChunk(w, errChunk)
-				_ = writeStreamDone(w)
+				oaiLog.Error(completeErr, "stream fallback completion failed")
+				_ = writeStreamError(w, "provider_error")
+				return
+			}
+			if resp == nil {
+				_ = writeStreamError(w, "")
+				return
+			}
+			finishReason, ok := mapStreamFinishReason(
+				resp.StopReason,
+				strings.TrimSpace(resp.Content) != "",
+				len(resp.ToolCalls) > 0,
+			)
+			if !ok {
+				_ = writeStreamError(w, resp.StopReason)
 				return
 			}
 
@@ -704,10 +742,6 @@ func (h *OpenAICompatHandler) handleStreamingCompletion(
 			}
 
 			// Send finish
-			finishReason := mapFinishReason(resp.StopReason)
-			if len(resp.ToolCalls) > 0 {
-				finishReason = finishReasonToolCalls
-			}
 			finishChunk := OAIResponse{
 				ID:      completionID,
 				Object:  "chat.completion.chunk",
@@ -756,13 +790,17 @@ func (h *OpenAICompatHandler) handleStreamingCompletion(
 		_ = writeStreamChunk(w, roleChunk)
 
 		toolCallIndex := 0
+		hasNonBlankContent := false
+		terminalSeen := false
 		for chunk := range streamCh {
 			if chunk.Error != nil {
 				oaiLog.Error(chunk.Error, "stream error")
-				break
+				_ = writeStreamError(w, "provider_error")
+				return
 			}
 
 			if chunk.Content != "" {
+				hasNonBlankContent = hasNonBlankContent || strings.TrimSpace(chunk.Content) != ""
 				contentChunk := OAIResponse{
 					ID:      completionID,
 					Object:  "chat.completion.chunk",
@@ -804,7 +842,15 @@ func (h *OpenAICompatHandler) handleStreamingCompletion(
 			}
 
 			if chunk.Done {
-				finishReason := mapFinishReason(chunk.StopReason)
+				finishReason, ok := mapStreamFinishReason(
+					chunk.StopReason,
+					hasNonBlankContent,
+					toolCallIndex > 0,
+				)
+				if !ok {
+					_ = writeStreamError(w, chunk.StopReason)
+					return
+				}
 				finishChunk := OAIResponse{
 					ID:      completionID,
 					Object:  "chat.completion.chunk",
@@ -832,7 +878,13 @@ func (h *OpenAICompatHandler) handleStreamingCompletion(
 					}
 					_ = writeStreamChunk(w, usageChunk)
 				}
+				terminalSeen = true
+				break
 			}
+		}
+		if !terminalSeen {
+			_ = writeStreamError(w, "missing_terminal_chunk")
+			return
 		}
 
 		_ = writeStreamDone(w)
@@ -1007,16 +1059,63 @@ func mapFinishReason(reason string) string {
 		return finishReasonToolCalls
 	case oaiParamMaxTokens, oaiStopReasonLength:
 		return oaiStopReasonLength
-	case "content_filter":
-		return "content_filter"
+	case finishReasonContentFilter:
+		return finishReasonContentFilter
 	default:
 		return finishReasonStop
+	}
+}
+
+func mapStreamFinishReason(reason string, hasNonBlankContent, hasToolCalls bool) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(reason)) {
+	case finishReasonStopSequence:
+		if hasToolCalls {
+			return finishReasonToolCalls, true
+		}
+		return finishReasonStop, true
+	case oaiStopReasonEndTurn, finishReasonStop, completionStatusCompleted, "response.completed":
+		if hasToolCalls {
+			return finishReasonToolCalls, true
+		}
+		if !hasNonBlankContent {
+			return "", false
+		}
+		return finishReasonStop, true
+	case oaiStopReasonToolUse, finishReasonToolCalls, finishReasonFunctionCall:
+		if !hasToolCalls {
+			return "", false
+		}
+		return finishReasonToolCalls, true
+	case oaiParamMaxTokens, oaiStopReasonLength:
+		return oaiStopReasonLength, true
+	case finishReasonContentFilter:
+		return finishReasonContentFilter, true
+	default:
+		return "", false
 	}
 }
 
 // writeStreamChunk writes a single SSE chunk in OpenAI streaming format.
 func writeStreamChunk(w *bufio.Writer, chunk OAIResponse) error {
 	data, err := json.Marshal(chunk)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+func writeStreamError(w *bufio.Writer, reason string) error {
+	message := "provider stream ended without a successful terminal outcome"
+	if strings.TrimSpace(reason) != "" {
+		message = fmt.Sprintf("provider stream ended with non-success outcome %q", reason)
+	}
+	data, err := json.Marshal(OAIError{Error: OAIErrorDetail{
+		Message: message,
+		Type:    "server_error",
+	}})
 	if err != nil {
 		return err
 	}

--- a/internal/api/openai_compat_test.go
+++ b/internal/api/openai_compat_test.go
@@ -341,6 +341,39 @@ func TestMapFinishReason(t *testing.T) {
 	}
 }
 
+func TestMapStreamFinishReason(t *testing.T) {
+	tests := []struct {
+		name               string
+		reason             string
+		hasNonBlankContent bool
+		hasToolCalls       bool
+		want               string
+		wantOK             bool
+	}{
+		{name: "completed", reason: "end_turn", hasNonBlankContent: true, want: finishReasonStop, wantOK: true},
+		{name: "blank completed", reason: "end_turn"},
+		{name: "completed with calls", reason: "stop", hasToolCalls: true, want: finishReasonToolCalls, wantOK: true},
+		{name: "empty stop sequence", reason: finishReasonStopSequence, want: finishReasonStop, wantOK: true},
+		{name: "stop sequence with calls", reason: finishReasonStopSequence, hasToolCalls: true, want: finishReasonToolCalls, wantOK: true},
+		{name: "tool calls", reason: "tool_use", hasToolCalls: true, want: finishReasonToolCalls, wantOK: true},
+		{name: "tool reason without calls", reason: "tool_calls"},
+		{name: "length", reason: "max_tokens", want: oaiStopReasonLength, wantOK: true},
+		{name: "content filter", reason: "content_filter", want: "content_filter", wantOK: true},
+		{name: "refusal", reason: "refusal"},
+		{name: "failed", reason: "failed"},
+		{name: "missing reason"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := mapStreamFinishReason(tt.reason, tt.hasNonBlankContent, tt.hasToolCalls)
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("mapStreamFinishReason() = (%q, %t), want (%q, %t)", got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
 func TestExtractContent(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -474,6 +507,19 @@ func TestWriteStreamDone(t *testing.T) {
 	got := buf.String()
 	if got != "data: [DONE]\n\n" {
 		t.Errorf("writeStreamDone() = %q, want %q", got, "data: [DONE]\n\n")
+	}
+}
+
+func TestWriteStreamError(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	if err := writeStreamError(w, "refusal"); err != nil {
+		t.Fatalf("writeStreamError() error = %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, `"type":"server_error"`) || !strings.Contains(got, `non-success outcome \"refusal\"`) {
+		t.Fatalf("writeStreamError() = %q", got)
 	}
 }
 
@@ -648,6 +694,48 @@ func TestHandleNonStreamingCompletion_Error(t *testing.T) {
 	}
 }
 
+func TestHandleNonStreamingCompletion_RejectsInvalidOutcome(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *llm.CompletionResponse
+	}{
+		{name: "nil response"},
+		{name: "blank completion", resp: &llm.CompletionResponse{StopReason: "end_turn"}},
+		{name: "refusal", resp: &llm.CompletionResponse{StopReason: "refusal"}},
+		{name: "failed", resp: &llm.CompletionResponse{StopReason: "failed"}},
+		{name: "missing reason", resp: &llm.CompletionResponse{Content: "partial"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &oaiMockProvider{resp: tt.resp}
+			handler, app := setupTestOpenAIHandler()
+			app.Post("/test", func(c fiber.Ctx) error {
+				return handler.handleNonStreamingCompletion(
+					c, context.Background(), mock,
+					&llm.CompletionRequest{Model: "gpt-4"},
+					"chatcmpl-invalid", "gpt-4", 1234567890,
+				)
+			})
+
+			resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp.StatusCode != fiber.StatusBadGateway {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, fiber.StatusBadGateway)
+			}
+			var oaiErr OAIError
+			if err := json.NewDecoder(resp.Body).Decode(&oaiErr); err != nil {
+				t.Fatalf("decode error response: %v", err)
+			}
+			if oaiErr.Error.Type != "server_error" {
+				t.Fatalf("error type = %q", oaiErr.Error.Type)
+			}
+		})
+	}
+}
+
 // --- Tests: handleStreamingCompletion ---
 
 func TestHandleStreamingCompletion_StreamSuccess(t *testing.T) {
@@ -684,6 +772,176 @@ func TestHandleStreamingCompletion_StreamSuccess(t *testing.T) {
 	}
 	if !strings.Contains(bodyStr, "[DONE]") {
 		t.Errorf("expected [DONE] in stream, got: %s", bodyStr)
+	}
+}
+
+func TestHandleStreamingCompletion_RejectsNonSuccessOutcome(t *testing.T) {
+	ch := make(chan llm.StreamChunk, 1)
+	ch <- llm.StreamChunk{Done: true, StopReason: "refusal"}
+	close(ch)
+
+	mock := &oaiMockProvider{streamCh: ch}
+	handler, app := setupTestOpenAIHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingCompletion(
+			c, context.Background(), mock,
+			&llm.CompletionRequest{Model: "gpt-4", Messages: []llm.Message{{Role: "user", Content: "hi"}}},
+			"chatcmpl-refusal", "gpt-4", 1234567890, nil,
+		)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, `"type":"server_error"`) || !strings.Contains(bodyStr, `non-success outcome \"refusal\"`) {
+		t.Fatalf("expected stream error, got: %s", bodyStr)
+	}
+	if strings.Contains(bodyStr, `"finish_reason":"stop"`) || strings.Contains(bodyStr, "[DONE]") {
+		t.Fatalf("non-success stream was completed successfully: %s", bodyStr)
+	}
+}
+
+func TestHandleStreamingCompletion_RejectsBlankCompletion(t *testing.T) {
+	ch := make(chan llm.StreamChunk, 1)
+	ch <- llm.StreamChunk{Done: true, StopReason: "end_turn"}
+	close(ch)
+
+	mock := &oaiMockProvider{streamCh: ch}
+	handler, app := setupTestOpenAIHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingCompletion(
+			c, context.Background(), mock,
+			&llm.CompletionRequest{Model: "gpt-4", Messages: []llm.Message{{Role: "user", Content: "hi"}}},
+			"chatcmpl-blank", "gpt-4", 1234567890, nil,
+		)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, `non-success outcome \"end_turn\"`) {
+		t.Fatalf("expected blank completion error, got: %s", bodyStr)
+	}
+	if strings.Contains(bodyStr, "[DONE]") {
+		t.Fatalf("blank completion emitted [DONE]: %s", bodyStr)
+	}
+}
+
+func TestHandleStreamingCompletion_FallbackRejectsBlankCompletion(t *testing.T) {
+	mock := &oaiMockProvider{
+		streamErr: fmt.Errorf("streaming not supported"),
+		resp:      &llm.CompletionResponse{Content: " \n", StopReason: "end_turn"},
+	}
+	handler, app := setupTestOpenAIHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingCompletion(
+			c, context.Background(), mock,
+			&llm.CompletionRequest{Model: "gpt-4", Messages: []llm.Message{{Role: "user", Content: "hi"}}},
+			"chatcmpl-blank-fallback", "gpt-4", 1234567890, nil,
+		)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, `non-success outcome \"end_turn\"`) {
+		t.Fatalf("expected blank fallback error, got: %s", bodyStr)
+	}
+	if strings.Contains(bodyStr, "[DONE]") {
+		t.Fatalf("blank fallback emitted [DONE]: %s", bodyStr)
+	}
+}
+
+func TestHandleStreamingCompletion_FallbackRejectsNilResponse(t *testing.T) {
+	mock := &oaiMockProvider{
+		streamErr: fmt.Errorf("streaming not supported"),
+	}
+	handler, app := setupTestOpenAIHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingCompletion(
+			c, context.Background(), mock,
+			&llm.CompletionRequest{Model: "gpt-4", Messages: []llm.Message{{Role: "user", Content: "hi"}}},
+			"chatcmpl-nil-fallback", "gpt-4", 1234567890, nil,
+		)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, `"type":"server_error"`) || !strings.Contains(bodyStr, "without a successful terminal outcome") {
+		t.Fatalf("expected nil fallback error, got: %s", bodyStr)
+	}
+	if strings.Contains(bodyStr, "[DONE]") {
+		t.Fatalf("nil fallback emitted [DONE]: %s", bodyStr)
+	}
+}
+
+func TestHandleStreamingCompletion_RejectsMissingTerminalChunk(t *testing.T) {
+	ch := make(chan llm.StreamChunk, 1)
+	ch <- llm.StreamChunk{Content: "partial"}
+	close(ch)
+
+	mock := &oaiMockProvider{streamCh: ch}
+	handler, app := setupTestOpenAIHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingCompletion(
+			c, context.Background(), mock,
+			&llm.CompletionRequest{Model: "gpt-4", Messages: []llm.Message{{Role: "user", Content: "hi"}}},
+			"chatcmpl-missing-terminal", "gpt-4", 1234567890, nil,
+		)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, `non-success outcome \"missing_terminal_chunk\"`) {
+		t.Fatalf("expected missing terminal error, got: %s", bodyStr)
+	}
+	if strings.Contains(bodyStr, "[DONE]") {
+		t.Fatalf("truncated stream emitted [DONE]: %s", bodyStr)
+	}
+}
+
+func TestHandleStreamingCompletion_FallbackRejectsNonSuccessOutcome(t *testing.T) {
+	mock := &oaiMockProvider{
+		streamErr: fmt.Errorf("streaming not supported"),
+		resp:      &llm.CompletionResponse{Content: "partial", StopReason: "failed"},
+	}
+	handler, app := setupTestOpenAIHandler()
+	app.Post("/test", func(c fiber.Ctx) error {
+		return handler.handleStreamingCompletion(
+			c, context.Background(), mock,
+			&llm.CompletionRequest{Model: "gpt-4", Messages: []llm.Message{{Role: "user", Content: "hi"}}},
+			"chatcmpl-failed", "gpt-4", 1234567890, nil,
+		)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, `"type":"server_error"`) || !strings.Contains(bodyStr, `non-success outcome \"failed\"`) {
+		t.Fatalf("expected fallback stream error, got: %s", bodyStr)
+	}
+	if strings.Contains(bodyStr, "partial") || strings.Contains(bodyStr, "[DONE]") {
+		t.Fatalf("non-success fallback emitted completion data: %s", bodyStr)
 	}
 }
 
@@ -747,11 +1005,11 @@ func TestHandleStreamingCompletion_BothFail(t *testing.T) {
 
 	body, _ := io.ReadAll(resp.Body)
 	bodyStr := string(body)
-	if !strings.Contains(bodyStr, "Error:") {
-		t.Errorf("expected error chunk, got: %s", bodyStr)
+	if !strings.Contains(bodyStr, `"type":"server_error"`) || !strings.Contains(bodyStr, `non-success outcome \"provider_error\"`) {
+		t.Errorf("expected stream error, got: %s", bodyStr)
 	}
-	if !strings.Contains(bodyStr, "[DONE]") {
-		t.Errorf("expected [DONE], got: %s", bodyStr)
+	if strings.Contains(bodyStr, "[DONE]") {
+		t.Errorf("failed stream emitted [DONE]: %s", bodyStr)
 	}
 }
 
@@ -985,6 +1243,43 @@ func TestHandleStreamingToolLoop_StreamsProgressAndHidesServerSideToolCalls(t *t
 	}
 	if mock.callIdx != 2 {
 		t.Fatalf("expected 2 LLM calls, got %d", mock.callIdx)
+	}
+}
+
+func TestHandleStreamingToolLoop_RejectsInvalidOutcome(t *testing.T) {
+	tests := []struct {
+		name string
+		mock *oaiMockProvider
+	}{
+		{name: "provider error", mock: &oaiMockProvider{err: fmt.Errorf("provider failed")}},
+		{name: "nil response", mock: &oaiMockProvider{}},
+		{name: "failed outcome", mock: &oaiMockProvider{resp: &llm.CompletionResponse{StopReason: "failed"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, app := setupTestOpenAIHandler()
+			app.Post("/test", func(c fiber.Ctx) error {
+				return handler.handleStreamingToolLoop(
+					c, context.Background(), tt.mock,
+					&llm.CompletionRequest{Model: "gpt-4", Messages: []llm.Message{{Role: "user", Content: "ship"}}},
+					"chatcmpl-invalid-tool-loop", "gpt-4", 1234567890, nil, nil,
+				)
+			})
+
+			resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/test", nil))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			bodyStr := string(body)
+			if !strings.Contains(bodyStr, `"type":"server_error"`) {
+				t.Fatalf("expected stream error, got: %s", bodyStr)
+			}
+			if strings.Contains(bodyStr, "[DONE]") || strings.Contains(bodyStr, `"finish_reason":"stop"`) {
+				t.Fatalf("invalid tool loop completed successfully: %s", bodyStr)
+			}
+		})
 	}
 }
 

--- a/internal/llm/openai/provider.go
+++ b/internal/llm/openai/provider.go
@@ -38,6 +38,12 @@ const (
 	eventTypeFunctionCall   = "function_call"
 	providerTypeOpenAI      = "openai"
 	providerTypeAzureOpenAI = "azure-openai"
+	stopReasonCompleted     = "completed"
+	stopReasonFunctionCall  = "function_call"
+	stopReasonIncomplete    = "incomplete"
+	stopReasonRefusal       = "refusal"
+	stopReasonStop          = "stop"
+	stopReasonToolCalls     = "tool_calls"
 )
 
 func init() {
@@ -381,12 +387,47 @@ func (p *Provider) completeResponses(ctx context.Context, req *llm.CompletionReq
 			})
 		}
 	}
-	if len(result.ToolCalls) > 0 {
-		result.StopReason = "tool_calls"
-	} else if result.StopReason == "completed" {
-		result.StopReason = "stop"
-	}
+	result.StopReason = normalizeResponsesStopReason(result.StopReason, resp.Output, false)
 	return result, nil
+}
+
+func normalizeResponsesStopReason(
+	status string,
+	output []responses.ResponseOutputItemUnion,
+	blankIsIncomplete bool,
+) string {
+	status = strings.TrimSpace(status)
+	if status != stopReasonCompleted {
+		return status
+	}
+
+	hasToolCalls := false
+	for _, item := range output {
+		if item.Status != "" && item.Status != stopReasonCompleted {
+			return item.Status
+		}
+		if item.Type == "message" {
+			for _, content := range item.Content {
+				if content.Type == stopReasonRefusal {
+					return stopReasonRefusal
+				}
+			}
+		}
+		if item.Type == eventTypeFunctionCall {
+			hasToolCalls = true
+		}
+	}
+	if hasToolCalls {
+		return stopReasonToolCalls
+	}
+	if blankIsIncomplete {
+		// Streaming callers do not have the agent loop's tool-free final-answer retry state.
+		return stopReasonIncomplete
+	}
+	if status == stopReasonCompleted {
+		return stopReasonStop
+	}
+	return status
 }
 
 type streamSender func(llm.StreamChunk) bool
@@ -680,16 +721,21 @@ func handleResponseOutputItem(evt responses.ResponseStreamEventUnion, tracker *r
 }
 
 func handleResponseCompleted(evt responses.ResponseStreamEventUnion, tracker *responseFuncCallTracker, providerName string, send streamSender) bool {
-	stopReason := "stop"
-	for i, item := range evt.Response.Output {
-		if item.Type != eventTypeFunctionCall {
-			continue
-		}
-		stopReason = "tool_calls"
-		fc := tracker.get(item.ID, int64(i), true, item.CallID)
-		tracker.mergeItem(fc, item, true)
-		if !tracker.emit(fc, send) {
-			return false
+	stopReason := normalizeResponsesStopReason(
+		string(evt.Response.Status),
+		evt.Response.Output,
+		strings.TrimSpace(evt.Response.OutputText()) == "",
+	)
+	if stopReason == stopReasonToolCalls {
+		for i, item := range evt.Response.Output {
+			if item.Type != eventTypeFunctionCall {
+				continue
+			}
+			fc := tracker.get(item.ID, int64(i), true, item.CallID)
+			tracker.mergeItem(fc, item, true)
+			if !tracker.emit(fc, send) {
+				return false
+			}
 		}
 	}
 	send(llm.StreamChunk{
@@ -856,6 +902,9 @@ func (p *Provider) completeChatCompletions(ctx context.Context, req *llm.Complet
 		choice := resp.Choices[0]
 		result.Content = choice.Message.Content
 		result.StopReason = choice.FinishReason
+		if strings.TrimSpace(choice.Message.Refusal) != "" {
+			result.StopReason = stopReasonRefusal
+		}
 		for _, tc := range choice.Message.ToolCalls {
 			if tc.Type == "function" {
 				result.ToolCalls = append(result.ToolCalls, llm.ToolCall{
@@ -912,6 +961,9 @@ func (p *Provider) streamChatCompletionsWithUsage(ctx context.Context, req *llm.
 		stream := p.client.Chat.Completions.NewStreaming(ctx, params)
 		acc := openai.ChatCompletionAccumulator{}
 		finishReason := ""
+		hasContent := false
+		hasRefusal := false
+		hasToolCalls := false
 		var inputTokens, outputTokens int
 		streamModel := req.Model
 
@@ -921,14 +973,19 @@ func (p *Provider) streamChatCompletionsWithUsage(ctx context.Context, req *llm.
 			if len(chunk.Choices) > 0 {
 				delta := chunk.Choices[0].Delta
 				if delta.Content != "" {
+					hasContent = hasContent || strings.TrimSpace(delta.Content) != ""
 					if !send(llm.StreamChunk{Content: delta.Content}) {
 						return
 					}
+				}
+				if strings.TrimSpace(delta.Refusal) != "" {
+					hasRefusal = true
 				}
 			}
 
 			if acc.AddChunk(chunk) {
 				if tc, ok := acc.JustFinishedToolCall(); ok {
+					hasToolCalls = true
 					if !send(llm.StreamChunk{
 						ToolCall: &llm.ToolCall{
 							ID:        tc.ID,
@@ -967,6 +1024,7 @@ func (p *Provider) streamChatCompletionsWithUsage(ctx context.Context, req *llm.
 			send(llm.StreamChunk{Error: providerErr, Done: true})
 			return
 		}
+		finishReason = normalizeChatStreamStopReason(finishReason, hasContent, hasRefusal, hasToolCalls)
 		send(llm.StreamChunk{
 			Done:         true,
 			StopReason:   finishReason,
@@ -977,6 +1035,30 @@ func (p *Provider) streamChatCompletionsWithUsage(ctx context.Context, req *llm.
 		})
 	}()
 	return ch
+}
+
+func normalizeChatStreamStopReason(finishReason string, hasContent, hasRefusal, hasToolCalls bool) string {
+	if hasRefusal {
+		return stopReasonRefusal
+	}
+	if finishReason == "" {
+		return stopReasonIncomplete
+	}
+	if finishReason == stopReasonStop {
+		if hasToolCalls {
+			return stopReasonToolCalls
+		}
+		if !hasContent {
+			return stopReasonIncomplete
+		}
+	}
+	if finishReason == stopReasonToolCalls || finishReason == stopReasonFunctionCall {
+		if !hasToolCalls {
+			return stopReasonIncomplete
+		}
+		return stopReasonToolCalls
+	}
+	return finishReason
 }
 
 func isUnsupportedStreamOptionsError(err error) bool {

--- a/internal/llm/openai/provider.go
+++ b/internal/llm/openai/provider.go
@@ -914,6 +914,14 @@ func (p *Provider) completeChatCompletions(ctx context.Context, req *llm.Complet
 				})
 			}
 		}
+		legacyName, legacyArguments := legacyFunctionCallFromJSON(choice.Message.RawJSON())
+		if len(result.ToolCalls) == 0 && strings.TrimSpace(legacyName) != "" {
+			result.ToolCalls = append(result.ToolCalls, llm.ToolCall{
+				ID:        legacyFunctionCallID(resp.ID),
+				Name:      legacyName,
+				Arguments: legacyFunctionCallArguments(legacyArguments),
+			})
+		}
 	}
 	return result, nil
 }
@@ -922,7 +930,7 @@ func (p *Provider) streamChatCompletions(ctx context.Context, req *llm.Completio
 	return p.streamChatCompletionsWithUsage(ctx, req, true)
 }
 
-func (p *Provider) streamChatCompletionsWithUsage(ctx context.Context, req *llm.CompletionRequest, includeUsage bool) <-chan llm.StreamChunk {
+func (p *Provider) streamChatCompletionsWithUsage(ctx context.Context, req *llm.CompletionRequest, includeUsage bool) <-chan llm.StreamChunk { //nolint:gocyclo // Handles modern and legacy streaming fields inline.
 	ch := make(chan llm.StreamChunk)
 	go func() {
 		defer close(ch)
@@ -964,6 +972,10 @@ func (p *Provider) streamChatCompletionsWithUsage(ctx context.Context, req *llm.
 		hasContent := false
 		hasRefusal := false
 		hasToolCalls := false
+		legacyFunctionCallSeen := false
+		legacyFunctionCallIDValue := ""
+		var legacyFunctionCallName strings.Builder
+		var legacyFunctionCallArgs strings.Builder
 		var inputTokens, outputTokens int
 		streamModel := req.Model
 
@@ -980,6 +992,15 @@ func (p *Provider) streamChatCompletionsWithUsage(ctx context.Context, req *llm.
 				}
 				if strings.TrimSpace(delta.Refusal) != "" {
 					hasRefusal = true
+				}
+				legacyName, legacyArguments := legacyFunctionCallFromJSON(delta.RawJSON())
+				if legacyName != "" {
+					legacyFunctionCallSeen = true
+					legacyFunctionCallName.WriteString(legacyName)
+				}
+				if legacyArguments != "" {
+					legacyFunctionCallSeen = true
+					legacyFunctionCallArgs.WriteString(legacyArguments)
 				}
 			}
 
@@ -1000,6 +1021,9 @@ func (p *Provider) streamChatCompletionsWithUsage(ctx context.Context, req *llm.
 
 			if strings.TrimSpace(chunk.Model) != "" {
 				streamModel = chunk.Model
+			}
+			if strings.TrimSpace(chunk.ID) != "" {
+				legacyFunctionCallIDValue = chunk.ID
 			}
 			if chunk.JSON.Usage.Valid() && (chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0) {
 				inputTokens = int(chunk.Usage.PromptTokens)
@@ -1024,6 +1048,17 @@ func (p *Provider) streamChatCompletionsWithUsage(ctx context.Context, req *llm.
 			send(llm.StreamChunk{Error: providerErr, Done: true})
 			return
 		}
+		legacyName := legacyFunctionCallName.String()
+		if legacyFunctionCallSeen && !hasToolCalls && strings.TrimSpace(legacyName) != "" {
+			hasToolCalls = true
+			if !send(llm.StreamChunk{ToolCall: &llm.ToolCall{
+				ID:        legacyFunctionCallID(legacyFunctionCallIDValue),
+				Name:      legacyName,
+				Arguments: legacyFunctionCallArguments(legacyFunctionCallArgs.String()),
+			}}) {
+				return
+			}
+		}
 		finishReason = normalizeChatStreamStopReason(finishReason, hasContent, hasRefusal, hasToolCalls)
 		send(llm.StreamChunk{
 			Done:         true,
@@ -1035,6 +1070,34 @@ func (p *Provider) streamChatCompletionsWithUsage(ctx context.Context, req *llm.
 		})
 	}()
 	return ch
+}
+
+func legacyFunctionCallID(responseID string) string {
+	responseID = strings.TrimSpace(responseID)
+	if responseID == "" {
+		return "legacy_function_call"
+	}
+	return responseID + "_function_call"
+}
+
+func legacyFunctionCallFromJSON(raw string) (string, string) {
+	var payload struct {
+		FunctionCall struct {
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		} `json:"function_call"`
+	}
+	if raw == "" || json.Unmarshal([]byte(raw), &payload) != nil {
+		return "", ""
+	}
+	return payload.FunctionCall.Name, payload.FunctionCall.Arguments
+}
+
+func legacyFunctionCallArguments(arguments string) json.RawMessage {
+	if strings.TrimSpace(arguments) == "" {
+		return json.RawMessage("{}")
+	}
+	return json.RawMessage(arguments)
 }
 
 func normalizeChatStreamStopReason(finishReason string, hasContent, hasRefusal, hasToolCalls bool) string {

--- a/internal/llm/openai/provider_test.go
+++ b/internal/llm/openai/provider_test.go
@@ -16,18 +16,18 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/openai/openai-go/v3/responses"
+
 	"github.com/orka-agents/orka/internal/llm"
 )
 
 const (
-	testProviderOpenAI      = "openai"
-	testToolNameSearch      = "search"
-	testResponsesPath       = "/responses"
-	testStopReasonStop      = "stop"
-	testStopReasonToolCalls = "tool_calls"
-	testFallbackWorks       = "Fallback works!"
-	testFallbackStream      = "Fallback"
-	testCopilotBaseURL      = "https://api.githubcopilot.com"
+	testProviderOpenAI = "openai"
+	testToolNameSearch = "search"
+	testResponsesPath  = "/responses"
+	testFallbackWorks  = "Fallback works!"
+	testFallbackStream = "Fallback"
+	testCopilotBaseURL = "https://api.githubcopilot.com"
 )
 
 func TestNewProvider(t *testing.T) {
@@ -464,7 +464,7 @@ func TestComplete_ChatCompletions_Success(t *testing.T) {
 		}
 
 		//nolint:errcheck // multiline test response
-		fmt.Fprint(w, `{
+		_, _ = fmt.Fprint(w, `{
 			"id": "chatcmpl-123",
 			"object": "chat.completion",
 			"model": "gpt-4",
@@ -501,6 +501,53 @@ func TestComplete_ChatCompletions_Success(t *testing.T) {
 	}
 	if resp.InputTokens != 10 {
 		t.Errorf("expected 10 input tokens, got %d", resp.InputTokens)
+	}
+}
+
+func TestComplete_ChatCompletions_Refusal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{
+			"id": "chatcmpl-refusal",
+			"object": "chat.completion",
+			"model": "gpt-4",
+			"choices": [{
+				"index": 0,
+				"message": {
+					"role": "assistant",
+					"content": "",
+					"refusal": "Cannot comply",
+					"tool_calls": [{
+						"id": "call_1",
+						"type": "function",
+						"function": {"name": "search", "arguments": "{}"}
+					}]
+				},
+				"finish_reason": "tool_calls"
+			}],
+			"usage": {"prompt_tokens": 10, "completion_tokens": 1, "total_tokens": 11}
+		}`) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	provider, err := NewProvider(llm.ProviderConfig{APIKey: "test-key", BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("NewProvider() error = %v", err)
+	}
+	provider.mode.Store(int32(apiModeChatCompletions))
+
+	resp, err := provider.Complete(context.Background(), &llm.CompletionRequest{
+		Model:    "gpt-4",
+		Messages: []llm.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if resp.StopReason != stopReasonRefusal {
+		t.Fatalf("StopReason = %q, want refusal", resp.StopReason)
+	}
+	if len(resp.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls = %d, want 1", len(resp.ToolCalls))
 	}
 }
 
@@ -916,6 +963,62 @@ func TestStream_ChatCompletions(t *testing.T) {
 	}
 }
 
+func TestStream_ChatCompletions_NormalizesTerminalOutcome(t *testing.T) {
+	tests := []struct {
+		name       string
+		chunk      string
+		wantReason string
+	}{
+		{
+			name:       "refusal overrides tool calls",
+			chunk:      `{"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"refusal":"Cannot comply"},"finish_reason":"tool_calls"}]}`,
+			wantReason: stopReasonRefusal,
+		},
+		{
+			name:       "blank stop is incomplete",
+			chunk:      `{"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+			wantReason: stopReasonIncomplete,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = fmt.Fprintf(w, "data: %s\n\ndata: [DONE]\n\n", tt.chunk)
+			}))
+			defer server.Close()
+
+			provider, err := NewProvider(llm.ProviderConfig{APIKey: "test-key", BaseURL: server.URL})
+			if err != nil {
+				t.Fatalf("NewProvider() error = %v", err)
+			}
+			provider.mode.Store(int32(apiModeChatCompletions))
+
+			ch, err := provider.Stream(context.Background(), &llm.CompletionRequest{
+				Model:    "gpt-4",
+				Messages: []llm.Message{{Role: "user", Content: "hi"}},
+			})
+			if err != nil {
+				t.Fatalf("Stream() error = %v", err)
+			}
+
+			var stopReason string
+			for chunk := range ch {
+				if chunk.Error != nil {
+					t.Fatalf("stream error = %v", chunk.Error)
+				}
+				if chunk.Done {
+					stopReason = chunk.StopReason
+				}
+			}
+			if stopReason != tt.wantReason {
+				t.Fatalf("stop reason = %q, want %q", stopReason, tt.wantReason)
+			}
+		})
+	}
+}
+
 // responsesJSON returns a valid Responses API JSON body.
 func responsesJSON(text string, inputTokens, outputTokens int) string {
 	return fmt.Sprintf(`{
@@ -1036,7 +1139,7 @@ func TestComplete_ResponsesAPI_Success(t *testing.T) {
 	if resp.Content != "Hello from Responses!" {
 		t.Errorf("expected 'Hello from Responses!', got %q", resp.Content)
 	}
-	if resp.StopReason != testStopReasonStop {
+	if resp.StopReason != stopReasonStop {
 		t.Errorf("expected stop reason 'stop', got %q", resp.StopReason)
 	}
 	if resp.InputTokens != 10 {
@@ -1044,6 +1147,257 @@ func TestComplete_ResponsesAPI_Success(t *testing.T) {
 	}
 	if resp.OutputTokens != 5 {
 		t.Errorf("expected 5 output tokens, got %d", resp.OutputTokens)
+	}
+}
+
+func TestComplete_ResponsesAPI_NormalizesStructuredOutcomes(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     string
+		output     string
+		wantReason string
+	}{
+		{
+			name:   "refusal",
+			status: "completed",
+			output: `{
+				"id": "msg_1",
+				"type": "message",
+				"role": "assistant",
+				"status": "completed",
+				"content": [{"type": "refusal", "refusal": "Cannot comply"}]
+			}`,
+			wantReason: stopReasonRefusal,
+		},
+		{
+			name:   "incomplete output item",
+			status: "completed",
+			output: `{
+				"id": "msg_1",
+				"type": "message",
+				"role": "assistant",
+				"status": "incomplete",
+				"content": [{"type": "output_text", "text": "partial"}]
+			}`,
+			wantReason: stopReasonIncomplete,
+		},
+		{
+			name:   "failed response with partial tool call",
+			status: "failed",
+			output: `{
+				"id": "fc_1",
+				"type": "function_call",
+				"status": "incomplete",
+				"call_id": "call_1",
+				"name": "search",
+				"arguments": "{}"
+			}`,
+			wantReason: "failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{
+					"id": "resp_test",
+					"object": "response",
+					"created_at": 1700000000,
+					"status": %q,
+					"model": "gpt-4",
+					"output": [%s],
+					"usage": {"input_tokens": 10, "output_tokens": 1, "total_tokens": 11}
+				}`, tt.status, tt.output) //nolint:errcheck
+			}))
+			defer server.Close()
+
+			provider, err := NewProvider(llm.ProviderConfig{APIKey: "test-key", BaseURL: server.URL})
+			if err != nil {
+				t.Fatalf("NewProvider() error = %v", err)
+			}
+			provider.mode.Store(int32(apiModeResponses))
+
+			resp, err := provider.Complete(context.Background(), &llm.CompletionRequest{
+				Model:    "gpt-4",
+				Messages: []llm.Message{{Role: "user", Content: "hi"}},
+			})
+			if err != nil {
+				t.Fatalf("Complete() error = %v", err)
+			}
+			if resp.StopReason != tt.wantReason {
+				t.Fatalf("StopReason = %q, want %q", resp.StopReason, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestNormalizeResponsesStopReason(t *testing.T) {
+	tests := []struct {
+		name              string
+		status            string
+		output            []responses.ResponseOutputItemUnion
+		blankIsIncomplete bool
+		want              string
+	}{
+		{name: "completed text", status: "completed", want: stopReasonStop},
+		{name: "blank completed", status: "completed", blankIsIncomplete: true, want: stopReasonIncomplete},
+		{
+			name:   "refusal",
+			status: "completed",
+			output: []responses.ResponseOutputItemUnion{{
+				Type:    "message",
+				Content: []responses.ResponseOutputMessageContentUnion{{Type: stopReasonRefusal}},
+			}},
+			want: stopReasonRefusal,
+		},
+		{
+			name:   "incomplete item",
+			status: "completed",
+			output: []responses.ResponseOutputItemUnion{{
+				Type:   "message",
+				Status: stopReasonIncomplete,
+			}},
+			want: stopReasonIncomplete,
+		},
+		{
+			name:   "tool call",
+			status: "completed",
+			output: []responses.ResponseOutputItemUnion{{
+				Type: eventTypeFunctionCall,
+			}},
+			blankIsIncomplete: true,
+			want:              stopReasonToolCalls,
+		},
+		{
+			name:   "failed response",
+			status: "failed",
+			output: []responses.ResponseOutputItemUnion{{
+				Type: eventTypeFunctionCall,
+			}},
+			want: "failed",
+		},
+		{
+			name:   "missing response status with tool call",
+			output: []responses.ResponseOutputItemUnion{{Type: eventTypeFunctionCall}},
+			want:   "",
+		},
+		{
+			name:   "in progress output item",
+			status: "completed",
+			output: []responses.ResponseOutputItemUnion{{
+				Type:   "message",
+				Status: "in_progress",
+			}},
+			want: "in_progress",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeResponsesStopReason(tt.status, tt.output, tt.blankIsIncomplete); got != tt.want {
+				t.Fatalf("normalizeResponsesStopReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeChatStreamStopReason(t *testing.T) {
+	tests := []struct {
+		name         string
+		finishReason string
+		hasContent   bool
+		hasRefusal   bool
+		hasToolCalls bool
+		want         string
+	}{
+		{name: "content stop", finishReason: stopReasonStop, hasContent: true, want: stopReasonStop},
+		{name: "tool calls stop", finishReason: stopReasonStop, hasToolCalls: true, want: stopReasonToolCalls},
+		{name: "missing reason with tool calls", hasToolCalls: true, want: stopReasonIncomplete},
+		{name: "blank stop", finishReason: stopReasonStop, want: stopReasonIncomplete},
+		{name: "tool reason without calls", finishReason: stopReasonToolCalls, want: stopReasonIncomplete},
+		{name: "legacy function reason without calls", finishReason: stopReasonFunctionCall, want: stopReasonIncomplete},
+		{name: "legacy function reason with call", finishReason: stopReasonFunctionCall, hasToolCalls: true, want: stopReasonToolCalls},
+		{name: "refusal overrides calls", finishReason: stopReasonToolCalls, hasRefusal: true, hasToolCalls: true, want: stopReasonRefusal},
+		{name: "length preserved", finishReason: "length", hasContent: true, want: "length"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeChatStreamStopReason(tt.finishReason, tt.hasContent, tt.hasRefusal, tt.hasToolCalls)
+			if got != tt.want {
+				t.Fatalf("normalizeChatStreamStopReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStream_ResponsesAPI_NormalizesTerminalOutcome(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     string
+		wantReason string
+	}{
+		{
+			name: "refusal",
+			output: `[{"id":"msg_1","type":"message","role":"assistant","status":"completed",` +
+				`"content":[{"type":"refusal","refusal":"Cannot comply"}]}]`,
+			wantReason: stopReasonRefusal,
+		},
+		{
+			name: "incomplete item",
+			output: `[{"id":"msg_1","type":"message","role":"assistant","status":"incomplete",` +
+				`"content":[{"type":"output_text","text":"partial"}]}]`,
+			wantReason: stopReasonIncomplete,
+		},
+		{
+			name:       "blank output",
+			output:     `[]`,
+			wantReason: stopReasonIncomplete,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = fmt.Fprintf(w,
+					"event: response.completed\ndata: "+
+						`{"type":"response.completed","response":{"id":"resp_1","status":"completed",`+
+						`"model":"gpt-4","output":%s,"usage":{"input_tokens":5,"output_tokens":1,"total_tokens":6}}}`+
+						"\n\n",
+					tt.output,
+				)
+			}))
+			defer server.Close()
+
+			provider, err := NewProvider(llm.ProviderConfig{APIKey: "test-key", BaseURL: server.URL})
+			if err != nil {
+				t.Fatalf("NewProvider() error = %v", err)
+			}
+			provider.mode.Store(int32(apiModeResponses))
+
+			ch, err := provider.Stream(context.Background(), &llm.CompletionRequest{
+				Model:    "gpt-4",
+				Messages: []llm.Message{{Role: "user", Content: "hi"}},
+			})
+			if err != nil {
+				t.Fatalf("Stream() error = %v", err)
+			}
+
+			var stopReason string
+			for chunk := range ch {
+				if chunk.Error != nil {
+					t.Fatalf("stream error = %v", chunk.Error)
+				}
+				if chunk.Done {
+					stopReason = chunk.StopReason
+				}
+			}
+			if stopReason != tt.wantReason {
+				t.Fatalf("stop reason = %q, want %q", stopReason, tt.wantReason)
+			}
+		})
 	}
 }
 
@@ -1096,7 +1450,7 @@ func TestComplete_ResponsesAPI_WithToolCalls(t *testing.T) {
 	if resp.ToolCalls[0].ID != "call_1" {
 		t.Errorf("expected tool call ID 'call_1', got %q", resp.ToolCalls[0].ID)
 	}
-	if resp.StopReason != testStopReasonToolCalls {
+	if resp.StopReason != stopReasonToolCalls {
 		t.Errorf("expected stop reason 'tool_calls', got %q", resp.StopReason)
 	}
 }
@@ -1404,7 +1758,7 @@ func TestStream_ResponsesAPI_WithToolCalls(t *testing.T) {
 	if !gotToolCall {
 		t.Error("expected tool call chunk")
 	}
-	if stopReason != testStopReasonToolCalls {
+	if stopReason != stopReasonToolCalls {
 		t.Errorf("expected stop reason 'tool_calls', got %q", stopReason)
 	}
 }
@@ -1465,7 +1819,7 @@ func TestStream_ResponsesAPI_ToolCallNameFromCompletedOutput(t *testing.T) {
 	if string(toolCalls[0].Arguments) != `{"q":"test"}` {
 		t.Errorf("expected arguments %q, got %q", `{"q":"test"}`, string(toolCalls[0].Arguments))
 	}
-	if stopReason != testStopReasonToolCalls {
+	if stopReason != stopReasonToolCalls {
 		t.Errorf("expected stop reason 'tool_calls', got %q", stopReason)
 	}
 }
@@ -1864,7 +2218,7 @@ func TestStream_ChatCompletions_WithToolCalls(t *testing.T) {
 	if !gotToolCall {
 		t.Error("expected tool call chunk")
 	}
-	if stopReason != testStopReasonToolCalls {
+	if stopReason != stopReasonToolCalls {
 		t.Errorf("expected stop reason 'tool_calls', got %q", stopReason)
 	}
 }

--- a/internal/llm/openai/provider_test.go
+++ b/internal/llm/openai/provider_test.go
@@ -24,6 +24,7 @@ import (
 const (
 	testProviderOpenAI = "openai"
 	testToolNameSearch = "search"
+	testToolArguments  = `{"q":"test"}`
 	testResponsesPath  = "/responses"
 	testFallbackWorks  = "Fallback works!"
 	testFallbackStream = "Fallback"
@@ -246,7 +247,7 @@ func TestConvertInputItems(t *testing.T) {
 				Role:    "assistant",
 				Content: "thinking",
 				ToolCalls: []llm.ToolCall{
-					{ID: "tc1", Name: testToolNameSearch, Arguments: json.RawMessage(`{"q":"test"}`)},
+					{ID: "tc1", Name: testToolNameSearch, Arguments: json.RawMessage(testToolArguments)},
 				},
 			}},
 			2, // function_call + assistant content message
@@ -256,7 +257,7 @@ func TestConvertInputItems(t *testing.T) {
 			[]llm.Message{{
 				Role: "assistant",
 				ToolCalls: []llm.ToolCall{
-					{ID: "tc1", Name: testToolNameSearch, Arguments: json.RawMessage(`{"q":"test"}`)},
+					{ID: "tc1", Name: testToolNameSearch, Arguments: json.RawMessage(testToolArguments)},
 				},
 			}},
 			1, // just function_call
@@ -353,7 +354,7 @@ func TestConvertMessages(t *testing.T) {
 			[]llm.Message{{
 				Role: "assistant",
 				ToolCalls: []llm.ToolCall{
-					{ID: "tc1", Name: testToolNameSearch, Arguments: json.RawMessage(`{"q":"test"}`)},
+					{ID: "tc1", Name: testToolNameSearch, Arguments: json.RawMessage(testToolArguments)},
 				},
 			}},
 			"",
@@ -631,6 +632,57 @@ func TestComplete_ChatCompletions_WithToolCalls(t *testing.T) {
 	}
 	if resp.ToolCalls[0].Name != testToolNameSearch {
 		t.Errorf("expected tool call name 'search', got %q", resp.ToolCalls[0].Name)
+	}
+}
+
+func TestComplete_ChatCompletions_WithLegacyFunctionCall(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{
+			"id": "chatcmpl-legacy",
+			"object": "chat.completion",
+			"model": "gpt-4",
+			"choices": [{
+				"index": 0,
+				"message": {
+					"role": "assistant",
+					"content": "",
+					"function_call": {"name": "search", "arguments": "{\"q\":\"test\"}"}
+				},
+				"finish_reason": "function_call"
+			}],
+			"usage": {"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30}
+		}`)
+	}))
+	defer server.Close()
+
+	provider, err := NewProvider(llm.ProviderConfig{APIKey: "test-key", BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("NewProvider() error = %v", err)
+	}
+	provider.mode.Store(int32(apiModeChatCompletions))
+
+	resp, err := provider.Complete(context.Background(), &llm.CompletionRequest{
+		Model:    "gpt-4",
+		Messages: []llm.Message{{Role: "user", Content: "search for test"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if len(resp.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls = %d, want 1", len(resp.ToolCalls))
+	}
+	if resp.ToolCalls[0].ID != "chatcmpl-legacy_function_call" {
+		t.Fatalf("tool call ID = %q", resp.ToolCalls[0].ID)
+	}
+	if resp.ToolCalls[0].Name != testToolNameSearch {
+		t.Fatalf("tool call name = %q", resp.ToolCalls[0].Name)
+	}
+	if string(resp.ToolCalls[0].Arguments) != testToolArguments {
+		t.Fatalf("tool call arguments = %q", resp.ToolCalls[0].Arguments)
+	}
+	if got := llm.NormalizeCompletionOutcome(resp); got != llm.CompletionOutcomeToolCalls {
+		t.Fatalf("outcome = %q, want %q", got, llm.CompletionOutcomeToolCalls)
 	}
 }
 
@@ -1016,6 +1068,57 @@ func TestStream_ChatCompletions_NormalizesTerminalOutcome(t *testing.T) {
 				t.Fatalf("stop reason = %q, want %q", stopReason, tt.wantReason)
 			}
 		})
+	}
+}
+
+func TestStream_ChatCompletions_LegacyFunctionCall(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: {\"id\":\"chatcmpl-legacy\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"function_call\":{\"name\":\"se\",\"arguments\":\"{\\\"q\\\":\"}},\"finish_reason\":null}]}\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"id\":\"chatcmpl-legacy\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"function_call\":{\"name\":\"arch\",\"arguments\":\"\\\"test\\\"}\"}},\"finish_reason\":null}]}\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"id\":\"chatcmpl-legacy\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"function_call\"}]}\n\n")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	provider, err := NewProvider(llm.ProviderConfig{APIKey: "test-key", BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("NewProvider() error = %v", err)
+	}
+	provider.mode.Store(int32(apiModeChatCompletions))
+
+	ch, err := provider.Stream(context.Background(), &llm.CompletionRequest{
+		Model:    "gpt-4",
+		Messages: []llm.Message{{Role: "user", Content: "search for test"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+
+	var toolCalls []llm.ToolCall
+	var stopReason string
+	for chunk := range ch {
+		if chunk.Error != nil {
+			t.Fatalf("stream error = %v", chunk.Error)
+		}
+		if chunk.ToolCall != nil {
+			toolCalls = append(toolCalls, *chunk.ToolCall)
+		}
+		if chunk.Done {
+			stopReason = chunk.StopReason
+		}
+	}
+	if len(toolCalls) != 1 {
+		t.Fatalf("tool calls = %d, want 1", len(toolCalls))
+	}
+	if toolCalls[0].ID != "chatcmpl-legacy_function_call" || toolCalls[0].Name != testToolNameSearch {
+		t.Fatalf("tool call = %#v", toolCalls[0])
+	}
+	if string(toolCalls[0].Arguments) != testToolArguments {
+		t.Fatalf("tool call arguments = %q", toolCalls[0].Arguments)
+	}
+	if stopReason != stopReasonToolCalls {
+		t.Fatalf("stop reason = %q, want %q", stopReason, stopReasonToolCalls)
 	}
 }
 
@@ -1816,8 +1919,8 @@ func TestStream_ResponsesAPI_ToolCallNameFromCompletedOutput(t *testing.T) {
 	if toolCalls[0].ID != "call_123" {
 		t.Errorf("expected tool ID 'call_123', got %q", toolCalls[0].ID)
 	}
-	if string(toolCalls[0].Arguments) != `{"q":"test"}` {
-		t.Errorf("expected arguments %q, got %q", `{"q":"test"}`, string(toolCalls[0].Arguments))
+	if string(toolCalls[0].Arguments) != testToolArguments {
+		t.Errorf("expected arguments %q, got %q", testToolArguments, string(toolCalls[0].Arguments))
 	}
 	if stopReason != stopReasonToolCalls {
 		t.Errorf("expected stop reason 'tool_calls', got %q", stopReason)

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -63,6 +63,55 @@ type CompletionResponse struct {
 	ID           string     `json:"id,omitempty"`
 }
 
+// CompletionOutcome describes the provider-neutral result of a completion.
+type CompletionOutcome string
+
+const (
+	CompletionOutcomeCompleted  CompletionOutcome = "completed"
+	CompletionOutcomeToolCalls  CompletionOutcome = "tool_calls"
+	CompletionOutcomeIncomplete CompletionOutcome = "incomplete"
+	CompletionOutcomeRefused    CompletionOutcome = "refused"
+	CompletionOutcomeFailed     CompletionOutcome = "failed"
+	CompletionOutcomeUnknown    CompletionOutcome = "unknown"
+)
+
+// NormalizeCompletionOutcome maps provider-specific stop reasons to a shared outcome.
+func NormalizeCompletionOutcome(resp *CompletionResponse) CompletionOutcome {
+	if resp == nil {
+		return CompletionOutcomeUnknown
+	}
+
+	outcome := completionOutcomeForStopReason(resp.StopReason)
+	switch outcome {
+	case CompletionOutcomeCompleted:
+		if len(resp.ToolCalls) > 0 {
+			return CompletionOutcomeToolCalls
+		}
+	case CompletionOutcomeToolCalls:
+		if len(resp.ToolCalls) == 0 {
+			return CompletionOutcomeUnknown
+		}
+	}
+	return outcome
+}
+
+func completionOutcomeForStopReason(reason string) CompletionOutcome {
+	switch strings.ToLower(strings.TrimSpace(reason)) {
+	case "stop", "end_turn", "stop_sequence", "completed", "response.completed":
+		return CompletionOutcomeCompleted
+	case "tool_use", "tool_calls", "function_call":
+		return CompletionOutcomeToolCalls
+	case "length", "max_tokens", "incomplete", "response.incomplete", "pause_turn":
+		return CompletionOutcomeIncomplete
+	case "content_filter", "refusal", "refused":
+		return CompletionOutcomeRefused
+	case "failed", "response.failed", "cancelled", "canceled", "response.cancelled", "response.canceled":
+		return CompletionOutcomeFailed
+	default:
+		return CompletionOutcomeUnknown
+	}
+}
+
 // Message represents a chat message
 type Message struct {
 	Role       string     `json:"role"` // user, assistant, system, tool

--- a/internal/llm/provider_test.go
+++ b/internal/llm/provider_test.go
@@ -189,6 +189,46 @@ func TestCompletionResponse(t *testing.T) {
 	}
 }
 
+func TestNormalizeCompletionOutcome(t *testing.T) {
+	tests := []struct {
+		name       string
+		stopReason string
+		toolCalls  []ToolCall
+		want       CompletionOutcome
+	}{
+		{name: "empty reason unknown", want: CompletionOutcomeUnknown},
+		{name: "OpenAI stop completes", stopReason: "stop", want: CompletionOutcomeCompleted},
+		{name: "Anthropic end turn completes", stopReason: "end_turn", want: CompletionOutcomeCompleted},
+		{name: "stop sequence completes", stopReason: "stop_sequence", want: CompletionOutcomeCompleted},
+		{name: "tool use with calls", stopReason: "tool_use", toolCalls: []ToolCall{{ID: "call-1"}}, want: CompletionOutcomeToolCalls},
+		{name: "calls override completed reason", stopReason: "stop", toolCalls: []ToolCall{{ID: "call-1"}}, want: CompletionOutcomeToolCalls},
+		{name: "tool reason without calls", stopReason: "tool_calls", want: CompletionOutcomeUnknown},
+		{name: "OpenAI length incomplete", stopReason: "length", want: CompletionOutcomeIncomplete},
+		{name: "Anthropic max tokens incomplete", stopReason: "max_tokens", want: CompletionOutcomeIncomplete},
+		{name: "incomplete overrides calls", stopReason: "max_tokens", toolCalls: []ToolCall{{ID: "call-1"}}, want: CompletionOutcomeIncomplete},
+		{name: "Responses API incomplete", stopReason: "incomplete", want: CompletionOutcomeIncomplete},
+		{name: "Anthropic pause turn incomplete", stopReason: "pause_turn", want: CompletionOutcomeIncomplete},
+		{name: "content filter refused", stopReason: "content_filter", want: CompletionOutcomeRefused},
+		{name: "structured refusal refused", stopReason: "refusal", want: CompletionOutcomeRefused},
+		{name: "failed", stopReason: "failed", want: CompletionOutcomeFailed},
+		{name: "cancelled", stopReason: "cancelled", want: CompletionOutcomeFailed},
+		{name: "unknown reason", stopReason: "unexpected", want: CompletionOutcomeUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &CompletionResponse{StopReason: tt.stopReason, ToolCalls: tt.toolCalls}
+			if got := NormalizeCompletionOutcome(resp); got != tt.want {
+				t.Fatalf("NormalizeCompletionOutcome() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	if got := NormalizeCompletionOutcome(nil); got != CompletionOutcomeUnknown {
+		t.Fatalf("NormalizeCompletionOutcome(nil) = %q, want %q", got, CompletionOutcomeUnknown)
+	}
+}
+
 func TestMessage(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/llm/tracing.go
+++ b/internal/llm/tracing.go
@@ -44,6 +44,8 @@ type tracingMetrics struct {
 
 var noopTracingSpan = trace.SpanFromContext(context.Background())
 
+const unknownStopReasonErrorType = "unknown_stop_reason"
+
 // NewTracingProvider returns a Provider that records a GenAI span and metrics
 // for every LLM call once an OpenTelemetry provider is configured. Legacy llm.*
 // attributes are dual-emitted during migration.
@@ -208,9 +210,13 @@ func (tp *TracingProvider) Complete(ctx context.Context, req *CompletionRequest)
 		setResponseAttributes(span, resp, providerName)
 	}
 	modelName := responseModel(resp, req)
-	errType := stopReasonErrorType(resp.StopReason)
+	errType := completionResponseErrorType(resp)
 	if errType != "" && spanRecording {
-		span.SetStatus(codes.Error, resp.StopReason)
+		statusDescription := errType
+		if resp != nil && strings.TrimSpace(resp.StopReason) != "" {
+			statusDescription = resp.StopReason
+		}
+		span.SetStatus(codes.Error, statusDescription)
 		span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
 	}
 	tp.recordOperationDuration(ctx, durationSeconds, providerName, modelName, errType)
@@ -279,6 +285,10 @@ func (tp *TracingProvider) Stream(ctx context.Context, req *CompletionRequest) (
 		}()
 
 		var firstChunkRecorded bool
+		var lastStopReason string
+		var toolCallSeen bool
+		var providerErrorSeen bool
+		var terminalSignalSeen bool
 		for chunk := range innerCh {
 			if strings.TrimSpace(chunk.Provider) != "" {
 				selectedProviderName = genai.NormalizeProviderName(chunk.Provider)
@@ -301,21 +311,34 @@ func (tp *TracingProvider) Stream(ctx context.Context, req *CompletionRequest) (
 				tp.recordTimeToFirstChunk(ctx, latency, selectedProviderName, selectedModel)
 			}
 			if chunk.StopReason != "" {
+				lastStopReason = chunk.StopReason
 				finishReasons = []string{chunk.StopReason}
-				if stopErrType := stopReasonErrorType(chunk.StopReason); stopErrType != "" && chunk.Error == nil {
-					errType = stopErrType
-					if spanRecording {
-						span.SetStatus(codes.Error, chunk.StopReason)
-						span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
-					}
-				}
+			}
+			if chunk.ToolCall != nil {
+				toolCallSeen = true
 			}
 			if chunk.Error != nil {
+				providerErrorSeen = true
+				terminalSignalSeen = true
 				errType = errorType(chunk.Error)
 				if spanRecording {
 					span.RecordError(chunk.Error)
 					span.SetStatus(codes.Error, chunk.Error.Error())
 					if errType != "" {
+						span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+					}
+				}
+			}
+			if chunk.Done {
+				terminalSignalSeen = true
+				if !providerErrorSeen {
+					errType = streamCompletionErrorType(lastStopReason, toolCallSeen)
+					if errType != "" && spanRecording {
+						statusDescription := lastStopReason
+						if statusDescription == "" {
+							statusDescription = errType
+						}
+						span.SetStatus(codes.Error, statusDescription)
 						span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
 					}
 				}
@@ -334,6 +357,22 @@ func (tp *TracingProvider) Stream(ctx context.Context, req *CompletionRequest) (
 				return
 			}
 		}
+		if !terminalSignalSeen {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				errType = errorType(ctxErr)
+				if spanRecording {
+					span.RecordError(ctxErr)
+					span.SetStatus(codes.Error, ctxErr.Error())
+					span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+				}
+				return
+			}
+			errType = stopReasonErrorType("")
+			if spanRecording {
+				span.SetStatus(codes.Error, errType)
+				span.SetAttributes(attribute.String(genai.AttrErrorType, errType))
+			}
+		}
 	}()
 	return out, nil
 }
@@ -346,9 +385,31 @@ func isStreamingRequiredErr(err error) bool {
 }
 
 func stopReasonErrorType(reason string) string {
+	return completionOutcomeErrorType(completionOutcomeForStopReason(reason), reason)
+}
+
+func streamCompletionErrorType(reason string, hasToolCall bool) string {
+	resp := &CompletionResponse{StopReason: reason}
+	if hasToolCall {
+		resp.ToolCalls = []ToolCall{{}}
+	}
+	return completionOutcomeErrorType(NormalizeCompletionOutcome(resp), reason)
+}
+
+func completionResponseErrorType(resp *CompletionResponse) string {
+	if resp == nil {
+		return unknownStopReasonErrorType
+	}
+	return completionOutcomeErrorType(NormalizeCompletionOutcome(resp), resp.StopReason)
+}
+
+func completionOutcomeErrorType(outcome CompletionOutcome, reason string) string {
 	trimmed := strings.TrimSpace(reason)
-	switch completionOutcomeForStopReason(trimmed) {
-	case CompletionOutcomeIncomplete, CompletionOutcomeRefused, CompletionOutcomeFailed:
+	switch outcome {
+	case CompletionOutcomeIncomplete, CompletionOutcomeRefused, CompletionOutcomeFailed, CompletionOutcomeUnknown:
+		if trimmed == "" {
+			return unknownStopReasonErrorType
+		}
 		return trimmed
 	default:
 		return ""

--- a/internal/llm/tracing.go
+++ b/internal/llm/tracing.go
@@ -347,8 +347,8 @@ func isStreamingRequiredErr(err error) bool {
 
 func stopReasonErrorType(reason string) string {
 	trimmed := strings.TrimSpace(reason)
-	switch strings.ToLower(trimmed) {
-	case "failed", "incomplete", "cancelled", "canceled", "response.failed", "response.incomplete", "response.cancelled", "response.canceled":
+	switch completionOutcomeForStopReason(trimmed) {
+	case CompletionOutcomeIncomplete, CompletionOutcomeRefused, CompletionOutcomeFailed:
 		return trimmed
 	default:
 		return ""

--- a/internal/llm/tracing_test.go
+++ b/internal/llm/tracing_test.go
@@ -166,6 +166,44 @@ func (p *telemetryProvider) Complete(context.Context, *CompletionRequest) (*Comp
 }
 func (p *telemetryProvider) Stream(context.Context, *CompletionRequest) (<-chan StreamChunk, error) {
 	ch := make(chan StreamChunk, 2)
+	if p.name == "stream-missing-reason" {
+		ch <- StreamChunk{Done: true}
+		close(ch)
+		return ch, nil
+	}
+	if p.name == "stream-reason-then-done" {
+		ch <- StreamChunk{StopReason: "stop"}
+		ch <- StreamChunk{Done: true}
+		close(ch)
+		return ch, nil
+	}
+	if p.name == "stream-reason-then-close" {
+		ch <- StreamChunk{StopReason: "stop"}
+		close(ch)
+		return ch, nil
+	}
+	if p.name == "stream-error-then-done" {
+		ch <- StreamChunk{Error: &ProviderError{Message: "provider failed", StatusCode: 503}}
+		ch <- StreamChunk{Done: true}
+		close(ch)
+		return ch, nil
+	}
+	if p.name == "stream-closes-without-terminal" {
+		ch <- StreamChunk{Content: "partial"}
+		close(ch)
+		return ch, nil
+	}
+	if p.name == "stream-tool-reason-without-call" {
+		ch <- StreamChunk{Done: true, StopReason: "tool_calls"}
+		close(ch)
+		return ch, nil
+	}
+	if p.name == "stream-tool-reason-with-call" {
+		ch <- StreamChunk{ToolCall: &ToolCall{ID: "call-1", Name: "search"}}
+		ch <- StreamChunk{Done: true, StopReason: "tool_calls"}
+		close(ch)
+		return ch, nil
+	}
 	chunk := StreamChunk{Content: "hello"}
 	if p.name == "fallback(openai)" {
 		chunk.Provider = "azure-openai"
@@ -435,7 +473,7 @@ func TestTracingProviderCompleteFailureStopReasonSetsError(t *testing.T) {
 }
 
 func TestStopReasonErrorType(t *testing.T) {
-	for _, reason := range []string{"length", "max_tokens", "incomplete", "pause_turn", "content_filter", "refusal", "failed", "cancelled"} {
+	for _, reason := range []string{"length", "max_tokens", "incomplete", "pause_turn", "content_filter", "refusal", "failed", "cancelled", "unexpected"} {
 		t.Run(reason, func(t *testing.T) {
 			if got := stopReasonErrorType(reason); got != reason {
 				t.Fatalf("stopReasonErrorType(%q) = %q, want %q", reason, got, reason)
@@ -443,13 +481,61 @@ func TestStopReasonErrorType(t *testing.T) {
 		})
 	}
 
-	for _, reason := range []string{"", "stop", "end_turn", "tool_use", "tool_calls"} {
+	if got := stopReasonErrorType(""); got != unknownStopReasonErrorType {
+		t.Fatalf("stopReasonErrorType(empty) = %q, want unknown_stop_reason", got)
+	}
+
+	for _, reason := range []string{"stop", "end_turn", "tool_use", "tool_calls"} {
 		t.Run("successful_"+reason, func(t *testing.T) {
 			if got := stopReasonErrorType(reason); got != "" {
 				t.Fatalf("stopReasonErrorType(%q) = %q, want empty", reason, got)
 			}
 		})
 	}
+}
+
+func TestCompletionResponseErrorType(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *CompletionResponse
+		want string
+	}{
+		{name: "nil response", want: unknownStopReasonErrorType},
+		{name: "missing reason", resp: &CompletionResponse{}, want: unknownStopReasonErrorType},
+		{name: "unknown reason", resp: &CompletionResponse{StopReason: "unexpected"}, want: "unexpected"},
+		{name: "tool reason without calls", resp: &CompletionResponse{StopReason: "tool_calls"}, want: "tool_calls"},
+		{name: "completed", resp: &CompletionResponse{StopReason: "stop", Content: "done"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := completionResponseErrorType(tt.resp); got != tt.want {
+				t.Fatalf("completionResponseErrorType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTracingProviderCompleteNilResponseSetsUnknownError(t *testing.T) {
+	h := testutil.NewSpanHarness(t)
+	tp := NewTracingProvider(&telemetryProvider{
+		name:          "openai",
+		telemetryName: "openai",
+	})
+
+	resp, err := tp.Complete(context.Background(), &CompletionRequest{Model: "gpt-4o"})
+	if err != nil || resp != nil {
+		t.Fatalf("Complete() resp=%#v err=%v", resp, err)
+	}
+	spans := h.Recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if spans[0].Status().Code != codes.Error || spans[0].Status().Description != unknownStopReasonErrorType {
+		t.Fatalf("status = %#v, want error %q", spans[0].Status(), unknownStopReasonErrorType)
+	}
+	attrs := spanAttrs(spans[0])
+	assertStringAttr(t, attrs, genai.AttrErrorType, unknownStopReasonErrorType)
 }
 
 func TestTracingProviderCompleteErrorPreservesWrappedProviderTelemetryName(t *testing.T) {
@@ -541,6 +627,170 @@ func TestTracingProviderStreamFailureStopReasonSetsError(t *testing.T) {
 	}
 	attrs := spanAttrs(spans[0])
 	assertStringAttr(t, attrs, genai.AttrErrorType, "response.failed")
+}
+
+func TestTracingProviderStreamMissingStopReasonSetsError(t *testing.T) {
+	h := testutil.NewSpanHarness(t)
+	tp := NewTracingProvider(&telemetryProvider{name: "stream-missing-reason", telemetryName: "openai"})
+	ch, err := tp.Stream(context.Background(), &CompletionRequest{Model: "gpt"})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	for range ch {
+	}
+	spans := h.Recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if spans[0].Status().Code != codes.Error || spans[0].Status().Description != unknownStopReasonErrorType {
+		t.Fatalf("status = %#v, want error %q", spans[0].Status(), unknownStopReasonErrorType)
+	}
+	attrs := spanAttrs(spans[0])
+	assertStringAttr(t, attrs, genai.AttrErrorType, unknownStopReasonErrorType)
+}
+
+func TestTracingProviderStreamEmptyDonePreservesPriorStopReason(t *testing.T) {
+	h := testutil.NewSpanHarness(t)
+	tp := NewTracingProvider(&telemetryProvider{name: "stream-reason-then-done", telemetryName: "openai"})
+	ch, err := tp.Stream(context.Background(), &CompletionRequest{Model: "gpt"})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	for range ch {
+	}
+	spans := h.Recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if spans[0].Status().Code == codes.Error {
+		t.Fatalf("status = %#v, want non-error", spans[0].Status())
+	}
+	if value, ok := spanAttrs(spans[0])[genai.AttrErrorType]; ok {
+		t.Fatalf("error type = %q, want absent", value.AsString())
+	}
+}
+
+func TestTracingProviderStreamStopReasonWithoutTerminalSetsUnknownError(t *testing.T) {
+	h := testutil.NewSpanHarness(t)
+	tp := NewTracingProvider(&telemetryProvider{name: "stream-reason-then-close", telemetryName: "openai"})
+	ch, err := tp.Stream(context.Background(), &CompletionRequest{Model: "gpt"})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	for range ch {
+	}
+	spans := h.Recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if spans[0].Status().Code != codes.Error || spans[0].Status().Description != unknownStopReasonErrorType {
+		t.Fatalf("status = %#v, want error %q", spans[0].Status(), unknownStopReasonErrorType)
+	}
+	attrs := spanAttrs(spans[0])
+	assertStringAttr(t, attrs, genai.AttrErrorType, unknownStopReasonErrorType)
+}
+
+func TestTracingProviderStreamToolReasonWithoutCallSetsError(t *testing.T) {
+	h := testutil.NewSpanHarness(t)
+	tp := NewTracingProvider(&telemetryProvider{name: "stream-tool-reason-without-call", telemetryName: "openai"})
+	ch, err := tp.Stream(context.Background(), &CompletionRequest{Model: "gpt"})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	for range ch {
+	}
+	spans := h.Recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if spans[0].Status().Code != codes.Error {
+		t.Fatalf("status = %#v, want error", spans[0].Status())
+	}
+	attrs := spanAttrs(spans[0])
+	assertStringAttr(t, attrs, genai.AttrErrorType, "tool_calls")
+}
+
+func TestTracingProviderStreamToolReasonWithCallRemainsSuccessful(t *testing.T) {
+	h := testutil.NewSpanHarness(t)
+	tp := NewTracingProvider(&telemetryProvider{name: "stream-tool-reason-with-call", telemetryName: "openai"})
+	ch, err := tp.Stream(context.Background(), &CompletionRequest{Model: "gpt"})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	for range ch {
+	}
+	spans := h.Recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if spans[0].Status().Code == codes.Error {
+		t.Fatalf("status = %#v, want non-error", spans[0].Status())
+	}
+	if value, ok := spanAttrs(spans[0])[genai.AttrErrorType]; ok {
+		t.Fatalf("error type = %q, want absent", value.AsString())
+	}
+}
+
+func TestTracingProviderStreamEmptyDonePreservesPriorError(t *testing.T) {
+	h := testutil.NewSpanHarness(t)
+	tp := NewTracingProvider(&telemetryProvider{name: "stream-error-then-done", telemetryName: "openai"})
+	ch, err := tp.Stream(context.Background(), &CompletionRequest{Model: "gpt"})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	for range ch {
+	}
+	spans := h.Recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if spans[0].Status().Code != codes.Error {
+		t.Fatalf("status = %#v, want error", spans[0].Status())
+	}
+	attrs := spanAttrs(spans[0])
+	assertStringAttr(t, attrs, genai.AttrErrorType, "503")
+}
+
+func TestTracingProviderStreamCloseWithoutTerminalSetsUnknownError(t *testing.T) {
+	h := testutil.NewSpanHarness(t)
+	tp := NewTracingProvider(&telemetryProvider{name: "stream-closes-without-terminal", telemetryName: "openai"})
+	ch, err := tp.Stream(context.Background(), &CompletionRequest{Model: "gpt"})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	for range ch {
+	}
+	spans := h.Recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if spans[0].Status().Code != codes.Error || spans[0].Status().Description != unknownStopReasonErrorType {
+		t.Fatalf("status = %#v, want error %q", spans[0].Status(), unknownStopReasonErrorType)
+	}
+	attrs := spanAttrs(spans[0])
+	assertStringAttr(t, attrs, genai.AttrErrorType, unknownStopReasonErrorType)
+}
+
+func TestTracingProviderStreamCancellationPreservesContextError(t *testing.T) {
+	h := testutil.NewSpanHarness(t)
+	tp := NewTracingProvider(cancelClosingStreamProvider{})
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := tp.Stream(ctx, &CompletionRequest{Model: "gpt"})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	cancel()
+	for range ch {
+	}
+	spans := h.Recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if spans[0].Status().Code != codes.Error || spans[0].Status().Description != context.Canceled.Error() {
+		t.Fatalf("status = %#v, want context cancellation", spans[0].Status())
+	}
+	attrs := spanAttrs(spans[0])
+	assertStringAttr(t, attrs, genai.AttrErrorType, errorType(context.Canceled))
 }
 
 func TestTracingProviderStreamEmitsFirstChunk(t *testing.T) {
@@ -667,5 +917,20 @@ func (p *bufferedStreamProvider) Stream(context.Context, *CompletionRequest) (<-
 	ch := make(chan StreamChunk, 1)
 	ch <- StreamChunk{Content: "hello"}
 	close(ch)
+	return ch, nil
+}
+
+type cancelClosingStreamProvider struct{}
+
+func (cancelClosingStreamProvider) Name() string { return "openai" }
+func (cancelClosingStreamProvider) Complete(context.Context, *CompletionRequest) (*CompletionResponse, error) {
+	return nil, nil
+}
+func (cancelClosingStreamProvider) Stream(ctx context.Context, _ *CompletionRequest) (<-chan StreamChunk, error) {
+	ch := make(chan StreamChunk)
+	go func() {
+		defer close(ch)
+		<-ctx.Done()
+	}()
 	return ch, nil
 }

--- a/internal/llm/tracing_test.go
+++ b/internal/llm/tracing_test.go
@@ -434,6 +434,24 @@ func TestTracingProviderCompleteFailureStopReasonSetsError(t *testing.T) {
 	assertStringAttr(t, attrs, genai.AttrErrorType, "failed")
 }
 
+func TestStopReasonErrorType(t *testing.T) {
+	for _, reason := range []string{"length", "max_tokens", "incomplete", "pause_turn", "content_filter", "refusal", "failed", "cancelled"} {
+		t.Run(reason, func(t *testing.T) {
+			if got := stopReasonErrorType(reason); got != reason {
+				t.Fatalf("stopReasonErrorType(%q) = %q, want %q", reason, got, reason)
+			}
+		})
+	}
+
+	for _, reason := range []string{"", "stop", "end_turn", "tool_use", "tool_calls"} {
+		t.Run("successful_"+reason, func(t *testing.T) {
+			if got := stopReasonErrorType(reason); got != "" {
+				t.Fatalf("stopReasonErrorType(%q) = %q, want empty", reason, got)
+			}
+		})
+	}
+}
+
 func TestTracingProviderCompleteErrorPreservesWrappedProviderTelemetryName(t *testing.T) {
 	h := testutil.NewSpanHarness(t)
 	inner := &telemetryProvider{

--- a/workers/ai/coverage_test.go
+++ b/workers/ai/coverage_test.go
@@ -46,7 +46,7 @@ func (s *sequenceProvider) Complete(_ context.Context, _ *llm.CompletionRequest)
 	if idx < len(s.responses) {
 		return s.responses[idx], nil
 	}
-	return &llm.CompletionResponse{Content: "fallback"}, nil
+	return &llm.CompletionResponse{Content: "fallback", StopReason: "stop"}, nil
 }
 
 func (s *sequenceProvider) Stream(_ context.Context, _ *llm.CompletionRequest) (<-chan llm.StreamChunk, error) {

--- a/workers/ai/main.go
+++ b/workers/ai/main.go
@@ -994,6 +994,7 @@ func executeAgentLoopWithEvents(
 			)
 			resp, err = provider.Complete(stepCtx, req)
 		}
+		err = completionCallError(resp, err)
 		if err != nil {
 			errType := aiWorkerErrorType(err)
 			stepSpan.SetStatus(codes.Error, errType)
@@ -1322,6 +1323,16 @@ func evaluateCompletionResponse(
 	default:
 		return completionDecisionReturn, "", fmt.Errorf("model returned an unsupported completion outcome")
 	}
+}
+
+func completionCallError(resp *llm.CompletionResponse, err error) error {
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return completionOutcomeError(llm.CompletionOutcomeUnknown, "")
+	}
+	return nil
 }
 
 func completionOutcomeError(outcome llm.CompletionOutcome, stopReason string) error {

--- a/workers/ai/main.go
+++ b/workers/ai/main.go
@@ -72,6 +72,17 @@ var memoryToolNames = []string{"recall_memory", "remember", "propose_memory", "s
 
 const modelLoopEventTimeout = 250 * time.Millisecond
 
+const finalAnswerRetryPrompt = "Your last response was empty. Return the final answer now using the evidence " +
+	"already gathered. Do not call tools."
+
+type completionDecision int
+
+const (
+	completionDecisionReturn completionDecision = iota
+	completionDecisionToolCalls
+	completionDecisionRetryFinal
+)
+
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -923,19 +934,9 @@ func executeAgentLoopWithEvents(
 	eventRecorder common.EventRecorder,
 	baseToolCtxOpt ...*tools.ToolContext,
 ) (string, error) {
-	var baseToolCtx *tools.ToolContext
-	if len(baseToolCtxOpt) > 0 {
-		baseToolCtx = baseToolCtxOpt[0]
-	}
-
+	baseToolCtx := optionalToolContext(baseToolCtxOpt)
 	coordinationEnv := workerenv.ParseCoordinationEnv(os.Getenv)
-	maxIterations := 10
-	if coordinationEnv.Enabled {
-		maxIterations = 50
-	}
-	if coordinationEnv.AutonomousMode {
-		maxIterations = 100
-	}
+	maxIterations := agentLoopMaxIterations(coordinationEnv)
 	allowedToolCalls := advertisedToolNames(llmTools)
 	if !coordinationEnv.AutonomousMode && approvalToolingRequested(coordinationEnv, allowedToolCalls) {
 		return "", fmt.Errorf("human approval tools require autonomous coordination mode")
@@ -946,14 +947,21 @@ func executeAgentLoopWithEvents(
 		return "", err
 	}
 
-	for iteration := range maxIterations {
-		stepCtx, stepSpan := startAgentStepSpan(ctx, iteration, provider, model, llmTools, baseToolCtx)
+	iterationLimit := maxIterations
+	blankFinalRetried := false
+	finalAnswerRetry := false
+	for iteration := 0; iteration < iterationLimit; iteration++ {
+		requestTools := llmTools
+		if finalAnswerRetry {
+			requestTools = nil
+		}
+		stepCtx, stepSpan := startAgentStepSpan(ctx, iteration, provider, model, requestTools, baseToolCtx)
 		req := &llm.CompletionRequest{
 			Model:        model,
 			Messages:     messages,
 			SystemPrompt: systemPrompt,
 			MaxTokens:    4096,
-			Tools:        llmTools,
+			Tools:        requestTools,
 		}
 		common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeModelRequestStarted, modelLoopEventTimeout,
 			common.WithEventSummary("model request started"),
@@ -962,7 +970,7 @@ func executeAgentLoopWithEvents(
 				"model":        model,
 				"provider":     llm.ProviderTelemetryName(provider),
 				"messageCount": len(messages),
-				"toolCount":    len(llmTools),
+				"toolCount":    len(requestTools),
 			})),
 		)
 
@@ -1026,10 +1034,28 @@ func executeAgentLoopWithEvents(
 			common.WithEventContentText(resp.Content),
 		)
 
-		// If no tool calls, we're done
-		if len(resp.ToolCalls) == 0 {
+		decision, result, completionErr := evaluateCompletionResponse(resp, finalAnswerRetry, blankFinalRetried)
+		if completionErr != nil {
+			stepSpan.RecordError(completionErr)
+			stepSpan.SetStatus(codes.Error, aiWorkerErrorType(completionErr))
+			stepSpan.SetAttributes(attribute.String(genai.AttrErrorType, aiWorkerErrorType(completionErr)))
 			stepSpan.End()
-			return resp.Content, nil
+			return "", completionErr
+		}
+
+		switch decision {
+		case completionDecisionReturn:
+			stepSpan.End()
+			return result, nil
+		case completionDecisionRetryFinal:
+			blankFinalRetried = true
+			finalAnswerRetry = true
+			iterationLimit++
+			messages = append(messages, llm.Message{Role: "user", Content: finalAnswerRetryPrompt})
+			stepSpan.End()
+			continue
+		case completionDecisionToolCalls:
+			finalAnswerRetry = false
 		}
 
 		// Add assistant message with tool calls
@@ -1171,6 +1197,23 @@ func executeAgentLoopWithEvents(
 	return "", fmt.Errorf("max iterations reached without completion")
 }
 
+func optionalToolContext(contexts []*tools.ToolContext) *tools.ToolContext {
+	if len(contexts) == 0 {
+		return nil
+	}
+	return contexts[0]
+}
+
+func agentLoopMaxIterations(coordinationEnv workerenv.CoordinationEnv) int {
+	if coordinationEnv.AutonomousMode {
+		return 100
+	}
+	if coordinationEnv.Enabled {
+		return 50
+	}
+	return 10
+}
+
 func approvalToolingRequested(coordinationEnv workerenv.CoordinationEnv, allowedToolCalls map[string]struct{}) bool {
 	if len(coordinationEnv.ApprovalRequiredTools) > 0 {
 		return true
@@ -1246,6 +1289,46 @@ func firstNonBlankOriginal(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func evaluateCompletionResponse(
+	resp *llm.CompletionResponse,
+	finalAnswerRetry bool,
+	blankFinalRetried bool,
+) (completionDecision, string, error) {
+	outcome := llm.NormalizeCompletionOutcome(resp)
+	if finalAnswerRetry && outcome == llm.CompletionOutcomeToolCalls {
+		return completionDecisionReturn, "", fmt.Errorf(
+			"model returned tool calls during final answer retry with tools disabled",
+		)
+	}
+
+	switch outcome {
+	case llm.CompletionOutcomeCompleted:
+		if strings.TrimSpace(resp.Content) != "" {
+			return completionDecisionReturn, resp.Content, nil
+		}
+		if blankFinalRetried {
+			return completionDecisionReturn, "", fmt.Errorf("model returned an empty final response after one retry")
+		}
+		return completionDecisionRetryFinal, "", nil
+	case llm.CompletionOutcomeToolCalls:
+		return completionDecisionToolCalls, "", nil
+	case llm.CompletionOutcomeIncomplete,
+		llm.CompletionOutcomeRefused,
+		llm.CompletionOutcomeFailed,
+		llm.CompletionOutcomeUnknown:
+		return completionDecisionReturn, "", completionOutcomeError(outcome, resp.StopReason)
+	default:
+		return completionDecisionReturn, "", fmt.Errorf("model returned an unsupported completion outcome")
+	}
+}
+
+func completionOutcomeError(outcome llm.CompletionOutcome, stopReason string) error {
+	if strings.TrimSpace(stopReason) == "" {
+		return fmt.Errorf("model returned an unsupported completion outcome")
+	}
+	return fmt.Errorf("model returned %s response with stop reason %q", outcome, stopReason)
 }
 
 // writeResult submits the result to the controller via HTTP POST.

--- a/workers/ai/main_test.go
+++ b/workers/ai/main_test.go
@@ -611,6 +611,100 @@ func TestExecuteAgentLoop_NoToolCalls(t *testing.T) {
 	}
 }
 
+func TestExecuteAgentLoop_RetriesBlankFinalResponseOnceWithoutTools(t *testing.T) {
+	provider := &mockProvider{responses: []*llm.CompletionResponse{
+		{Content: " \n", StopReason: "end_turn"},
+		{Content: "final answer", StopReason: "end_turn"},
+	}}
+	llmTools := []llm.Tool{{Name: "web_search"}}
+
+	result, err := executeAgentLoop(
+		context.Background(), provider, []llm.Message{{Role: "user", Content: "investigate"}}, "", "test-model",
+		llmTools, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("executeAgentLoop() error = %v", err)
+	}
+	if result != "final answer" {
+		t.Fatalf("result = %q, want final answer", result)
+	}
+	if len(provider.requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(provider.requests))
+	}
+	if len(provider.requests[0].Tools) != 1 {
+		t.Fatalf("first request tools = %d, want 1", len(provider.requests[0].Tools))
+	}
+	if len(provider.requests[1].Tools) != 0 {
+		t.Fatalf("retry request tools = %d, want 0", len(provider.requests[1].Tools))
+	}
+	retryMessages := provider.requests[1].Messages
+	if len(retryMessages) != 2 || retryMessages[1].Role != roleUser || retryMessages[1].Content != finalAnswerRetryPrompt {
+		t.Fatalf("retry messages = %#v", retryMessages)
+	}
+}
+
+func TestExecuteAgentLoop_RejectsBlankFinalResponseAfterRetry(t *testing.T) {
+	provider := &mockProvider{responses: []*llm.CompletionResponse{
+		{Content: "", StopReason: "stop"},
+		{Content: "\t", StopReason: "end_turn"},
+	}}
+
+	_, err := executeAgentLoop(
+		context.Background(), provider, []llm.Message{{Role: roleUser, Content: "investigate"}}, "", "test-model",
+		[]llm.Tool{{Name: "web_search"}}, nil, nil,
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "empty final response after one retry") {
+		t.Fatalf("error = %q", err)
+	}
+	if len(provider.requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(provider.requests))
+	}
+	if len(provider.requests[1].Tools) != 0 {
+		t.Fatalf("retry request tools = %d, want 0", len(provider.requests[1].Tools))
+	}
+}
+
+func TestExecuteAgentLoop_RejectsNonCompletionStopReasons(t *testing.T) {
+	stopReasons := []string{"length", "max_tokens", "incomplete", "failed", "pause_turn", "content_filter", "refusal"}
+	for _, stopReason := range stopReasons {
+		t.Run(stopReason, func(t *testing.T) {
+			provider := &mockProvider{response: &llm.CompletionResponse{
+				Content:    "partial output",
+				StopReason: stopReason,
+			}}
+
+			_, err := executeAgentLoop(
+				context.Background(), provider, []llm.Message{{Role: roleUser, Content: "investigate"}}, "", "test-model",
+				nil, nil, nil,
+			)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), stopReason) {
+				t.Fatalf("error = %q, want stop reason %q", err, stopReason)
+			}
+		})
+	}
+}
+
+func TestExecuteAgentLoop_RejectsMissingStopReason(t *testing.T) {
+	provider := &mockProvider{response: &llm.CompletionResponse{Content: "partial output"}}
+
+	_, err := executeAgentLoop(
+		context.Background(), provider, []llm.Message{{Role: roleUser, Content: "investigate"}}, "", "test-model",
+		nil, nil, nil,
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "unsupported completion outcome") {
+		t.Fatalf("error = %q", err)
+	}
+}
+
 func TestAIWorkerEventCompletenessSmoke(t *testing.T) {
 	provider := &mockProvider{
 		response: &llm.CompletionResponse{
@@ -969,10 +1063,14 @@ type mockProvider struct {
 	responses []*llm.CompletionResponse
 	err       error
 	errs      []error
+	requests  []*llm.CompletionRequest
 }
 
 func (m *mockProvider) Complete(_ context.Context, req *llm.CompletionRequest) (*llm.CompletionResponse, error) {
-	_ = req
+	reqCopy := *req
+	reqCopy.Messages = append([]llm.Message(nil), req.Messages...)
+	reqCopy.Tools = append([]llm.Tool(nil), req.Tools...)
+	m.requests = append(m.requests, &reqCopy)
 	if len(m.errs) > 0 {
 		err := m.errs[0]
 		m.errs = m.errs[1:]

--- a/workers/ai/main_test.go
+++ b/workers/ai/main_test.go
@@ -705,6 +705,21 @@ func TestExecuteAgentLoop_RejectsMissingStopReason(t *testing.T) {
 	}
 }
 
+func TestExecuteAgentLoop_RejectsNilResponse(t *testing.T) {
+	provider := &mockProvider{}
+
+	_, err := executeAgentLoop(
+		context.Background(), provider, []llm.Message{{Role: roleUser, Content: "investigate"}}, "", "test-model",
+		nil, nil, nil,
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "unsupported completion outcome") {
+		t.Fatalf("error = %q", err)
+	}
+}
+
 func TestAIWorkerEventCompletenessSmoke(t *testing.T) {
 	provider := &mockProvider{
 		response: &llm.CompletionResponse{

--- a/workers/common/result.go
+++ b/workers/common/result.go
@@ -37,6 +37,10 @@ var resultStdoutMarkerPath = agentSandboxResultMarkerExecPath
 // It reads ORKA_RESULT_ENDPOINT or constructs the URL from ORKA_CONTROLLER_URL.
 // Retries up to 5 times with exponential backoff (2s, 4s, 8s, 16s) on failure.
 func SubmitResult(result []byte) error {
+	if len(bytes.TrimSpace(result)) == 0 {
+		return fmt.Errorf("result must not be blank")
+	}
+
 	if workerenv.IsTrue(os.Getenv(workerenv.ResultStdout)) {
 		marker := workerenv.ResultStdoutPrefix + base64.StdEncoding.EncodeToString(result)
 		fileData := marker + "\n"

--- a/workers/common/result_test.go
+++ b/workers/common/result_test.go
@@ -47,6 +47,25 @@ func TestSubmitResult_Success(t *testing.T) {
 	}
 }
 
+func TestSubmitResult_RejectsBlank(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	t.Setenv("ORKA_RESULT_ENDPOINT", srv.URL)
+
+	for _, result := range [][]byte{nil, {}, []byte(" \n\t")} {
+		if err := SubmitResult(result); err == nil || !strings.Contains(err.Error(), "must not be blank") {
+			t.Fatalf("SubmitResult(%q) error = %v, want blank result error", result, err)
+		}
+	}
+	if got := attempts.Load(); got != 0 {
+		t.Fatalf("submission attempts = %d, want 0", got)
+	}
+}
+
 func TestSubmitResult_ResultStdoutWritesMarkerFile(t *testing.T) {
 	markerPath := filepath.Join(t.TempDir(), "orka-result-marker")
 	originalMarkerPath := resultStdoutMarkerPath


### PR DESCRIPTION
## Summary

- normalize provider completion outcomes so missing, incomplete, failed, paused, filtered, refused, cancelled, and unknown terminal states cannot be reported as successful results
- retry a successful blank final response exactly once with tools disabled, then return an explicit error if the retry is also blank
- preserve valid empty-content tool-call turns while rejecting missing or inconsistent tool-call outcomes
- preserve structured OpenAI refusals and incomplete states across Responses and Chat Completions, including streaming and legacy `function_call` paths
- reject empty and whitespace-only results before HTTP or stdout submission
- align tracing error classification and add focused regression coverage for provider, agent-loop, streaming, and result-submission behavior

## Why

The AI worker previously treated any response without tool calls as a completed answer, regardless of the provider’s stop reason or whether the content was blank. Partial responses caused by token limits, content filters, refusals, provider failures, or paused turns could therefore be accepted as successful task output.

Whitespace-only results could also pass result submission and mark a Task successful with no meaningful output. Provider adapters further flattened some structured refusals and incomplete responses into apparently successful empty responses.

This change makes the completion contract explicit and fail closed while allowing one controlled recovery attempt for a genuinely completed but blank model turn.

## Impact

AI tasks no longer succeed with blank, partial, refused, filtered, failed, or otherwise nonterminal model output. A blank completed response gets one tool-free opportunity to produce the final answer using the evidence already gathered.

Valid tool-call turns remain unchanged, including tool calls with empty assistant text. Streaming consumers now receive consistent non-success outcomes for blank, unfinished, or malformed terminal responses, and blank results cannot reach the controller or stdout result channel.

## Validation

- `make lint-fix`
- `make test`
- focused completion normalization, OpenAI provider, agent-loop, and result-submission tests
- Codex autoreview: clean, no accepted/actionable findings
- branch is clean and pushed at `5d7eda5`

Closes #284