### PR TITLE
feat(ai): harden validated analysis for weaker models

### DIFF
--- a/internal/events/execution_event.go
+++ b/internal/events/execution_event.go
@@ -21,6 +21,7 @@ const (
 	ExecutionEventTypeToolCallStarted               = "ToolCallStarted"
 	ExecutionEventTypeToolCallCompleted             = "ToolCallCompleted"
 	ExecutionEventTypeToolCallFailed                = "ToolCallFailed"
+	ExecutionEventTypeToolCallSkipped               = "ToolCallSkipped"
 	ExecutionEventTypeWorkspacePreparationStarted   = "WorkspacePreparationStarted"
 	ExecutionEventTypeWorkspacePreparationCompleted = "WorkspacePreparationCompleted"
 	ExecutionEventTypeWorkspacePreparationFailed    = "WorkspacePreparationFailed"
@@ -74,6 +75,7 @@ var executionEventTypes = []string{
 	ExecutionEventTypeToolCallStarted,
 	ExecutionEventTypeToolCallCompleted,
 	ExecutionEventTypeToolCallFailed,
+	ExecutionEventTypeToolCallSkipped,
 	ExecutionEventTypeWorkspacePreparationStarted,
 	ExecutionEventTypeWorkspacePreparationCompleted,
 	ExecutionEventTypeWorkspacePreparationFailed,

--- a/internal/events/execution_event_test.go
+++ b/internal/events/execution_event_test.go
@@ -26,6 +26,7 @@ func TestExecutionEventTypeConstantsCoverP0Taxonomy(t *testing.T) {
 		ExecutionEventTypeToolCallStarted,
 		ExecutionEventTypeToolCallCompleted,
 		ExecutionEventTypeToolCallFailed,
+		ExecutionEventTypeToolCallSkipped,
 		ExecutionEventTypeWorkspacePreparationStarted,
 		ExecutionEventTypeWorkspacePreparationCompleted,
 		ExecutionEventTypeWorkspacePreparationFailed,

--- a/internal/tasktrace/tasktrace.go
+++ b/internal/tasktrace/tasktrace.go
@@ -16,6 +16,7 @@ const (
 	StatusRunning   = "running"
 	StatusCompleted = "completed"
 	StatusFailed    = "failed"
+	StatusSkipped   = "skipped"
 )
 
 // TaskMetadata supplies task summary state that is not part of the event stream.
@@ -261,6 +262,17 @@ func BuildTaskTrace(meta TaskMetadata, input []store.ExecutionEvent, generatedAt
 			} else {
 				trace.ModelRequests[idx].Status = StatusCompleted
 			}
+		case events.ExecutionEventTypeToolCallSkipped:
+			id := toolCallID(event)
+			if id == "" {
+				id = fmt.Sprintf("tool-call-%d", event.Seq)
+			}
+			createdAt := event.CreatedAt
+			trace.ToolCalls = append(trace.ToolCalls, ToolCallTrace{
+				ID: id, Name: event.ToolName, Status: StatusSkipped,
+				StartSeq: event.Seq, EndSeq: event.Seq,
+				StartedAt: &createdAt, EndedAt: &createdAt, Summary: event.Summary,
+			})
 		case events.ExecutionEventTypeToolCallStarted:
 			id := toolCallID(event)
 			if id == "" {

--- a/internal/tasktrace/tasktrace_test.go
+++ b/internal/tasktrace/tasktrace_test.go
@@ -85,3 +85,20 @@ func TestBuildTaskTraceExplicitModelCompletionDequeuesOpenRequest(t *testing.T) 
 		t.Fatalf("warnings = %#v, want none", trace.Warnings)
 	}
 }
+
+func TestBuildTaskTraceIncludesSkippedToolCall(t *testing.T) {
+	now := time.Now().UTC()
+	trace := BuildTaskTrace(TaskMetadata{Name: "task"}, []store.ExecutionEvent{{
+		Seq: 1, Type: events.ExecutionEventTypeToolCallSkipped,
+		ToolName: "read_artifact", ToolCallID: "call-1",
+		Summary: "parallel tool call skipped", CreatedAt: now,
+	}}, now)
+	if len(trace.ToolCalls) != 1 {
+		t.Fatalf("tool calls = %#v", trace.ToolCalls)
+	}
+	got := trace.ToolCalls[0]
+	if got.Status != StatusSkipped || got.StartSeq != 1 || got.EndSeq != 1 ||
+		got.StartedAt == nil || got.EndedAt == nil {
+		t.Fatalf("skipped tool trace = %#v", got)
+	}
+}

--- a/ui/src/components/events/trace-status-pill.tsx
+++ b/ui/src/components/events/trace-status-pill.tsx
@@ -13,6 +13,7 @@ function statusToken(status?: string): { className: string; live: boolean; label
     case 'failed':
       return { className: 'text-status-failed', live: false, label: status ?? 'failed' }
     case 'cancelled':
+    case 'skipped':
       return { className: 'text-muted-foreground', live: false, label: status ?? 'cancelled' }
     default:
       return { className: 'text-muted-foreground', live: false, label: status || 'unknown' }

--- a/ui/src/lib/execution-events.test.ts
+++ b/ui/src/lib/execution-events.test.ts
@@ -164,6 +164,7 @@ describe('executionEventCategory', () => {
     expect(executionEventCategory('TaskStarted')).toBe('lifecycle')
     expect(executionEventCategory('ModelRequestStarted')).toBe('model')
     expect(executionEventCategory('ToolCallFailed')).toBe('tools')
+    expect(executionEventCategory('ToolCallSkipped')).toBe('tools')
     expect(executionEventCategory('WorkspacePreparationStarted')).toBe('workspace')
     expect(executionEventCategory('ArtifactUploadCompleted')).toBe('artifacts')
     expect(executionEventCategory('ApprovalRequested')).toBe('approvals')

--- a/ui/src/lib/execution-events.ts
+++ b/ui/src/lib/execution-events.ts
@@ -73,6 +73,7 @@ const CATEGORY_BY_TYPE: Record<string, ExecutionEventCategory> = {
   ToolCallStarted: 'tools',
   ToolCallCompleted: 'tools',
   ToolCallFailed: 'tools',
+  ToolCallSkipped: 'tools',
   WorkspacePreparationStarted: 'workspace',
   WorkspacePreparationCompleted: 'workspace',
   WorkspacePreparationFailed: 'workspace',

--- a/website/docs/concepts/configuration.md
+++ b/website/docs/concepts/configuration.md
@@ -616,6 +616,32 @@ actor resume. `spec.http` may be omitted unless the resolved actor endpoint
 needs transport auth settings; when `spec.http` is present for MCP auth only,
 omit `http.url`.
 
+#### Model-facing aliases and duplicate reads
+
+AI workers can advertise a shorter model-facing name for a scoped custom Tool by
+setting the `orka.ai/tool-alias` annotation. The Task continues to reference the
+Tool resource name, and approval policy remains bound to that resource name.
+Aliases must be unique, use only letters, numbers, underscores, or hyphens, and
+be at most 64 characters.
+
+```yaml
+metadata:
+  name: read-artifact-build-7d8f
+  annotations:
+    orka.ai/tool-alias: read_artifact
+```
+
+Immutable read Tools may also opt into exact duplicate-call reuse. This avoids
+repeating the downstream request when the model calls the same Tool with
+semantically identical JSON arguments. Do not set this on mutable reads, polling
+Tools, write actions, or final submission Tools.
+
+```yaml
+metadata:
+  annotations:
+    orka.ai/cache-identical-calls: "true"
+```
+
 #### URL Path Interpolation
 
 Tool CRD URLs can contain `{{paramName}}` placeholders that are replaced with parameter values at runtime. Interpolated values are URL path-escaped, and the matching parameters are removed from the request body. This is useful for REST APIs that require path parameters.

--- a/workers/ai/analysis_budget.go
+++ b/workers/ai/analysis_budget.go
@@ -94,14 +94,22 @@ func recordSkippedAnalysisToolCalls(
 		if selectedIDs[call.ID] {
 			continue
 		}
-		common.RecordEventWithTimeout(
-			recorder,
-			events.ExecutionEventTypeToolCallSkipped,
-			modelLoopEventTimeout,
-			common.WithEventSeverity(events.ExecutionEventSeverityWarning),
-			common.WithEventToolName(call.Name),
-			common.WithEventToolCallID(call.ID),
-			common.WithEventSummary("parallel tool call skipped by analysis policy"),
-		)
+		recordSkippedAnalysisToolCall(recorder, call, "parallel tool call skipped by analysis policy")
 	}
+}
+
+func recordSkippedAnalysisToolCall(
+	recorder common.EventRecorder,
+	call llm.ToolCall,
+	summary string,
+) {
+	common.RecordEventWithTimeout(
+		recorder,
+		events.ExecutionEventTypeToolCallSkipped,
+		modelLoopEventTimeout,
+		common.WithEventSeverity(events.ExecutionEventSeverityWarning),
+		common.WithEventToolName(call.Name),
+		common.WithEventToolCallID(call.ID),
+		common.WithEventSummary(summary),
+	)
 }

--- a/workers/ai/analysis_budget.go
+++ b/workers/ai/analysis_budget.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+	"github.com/orka-agents/orka/internal/events"
+	"github.com/orka-agents/orka/internal/llm"
+	"github.com/orka-agents/orka/workers/common"
+)
+
+const analysisMaxInvestigationToolCalls = 20
+
+func (g *analysisLoopGuard) selectToolCalls(calls []llm.ToolCall) []llm.ToolCall {
+	if !g.validationRequired || len(calls) <= 1 {
+		return calls
+	}
+	for _, call := range calls {
+		if !g.timelineVerified && g.isTimelineTool(call.Name) {
+			return []llm.ToolCall{call}
+		}
+	}
+	for _, call := range calls {
+		if g.isValidationTool(call.Name) {
+			return []llm.ToolCall{call}
+		}
+	}
+	return calls[:1]
+}
+
+func (g *analysisLoopGuard) beginToolCall(name string) error {
+	if !g.validationRequired || g.isFinalizationTool(name) {
+		return nil
+	}
+	if g.investigationToolCalls >= analysisMaxInvestigationToolCalls {
+		return fmt.Errorf("analysis investigation tool-call budget exhausted")
+	}
+	g.investigationToolCalls++
+	return nil
+}
+
+func (g *analysisLoopGuard) cachedToolResult(
+	name string,
+	args json.RawMessage,
+	tool *corev1alpha1.Tool,
+) (string, bool) {
+	if !cacheIdenticalToolCalls(tool, g.isFinalizationTool(name)) {
+		return "", false
+	}
+	result, ok := g.toolResults[toolCallFingerprint(name, args)]
+	return result, ok
+}
+
+func (g *analysisLoopGuard) rememberToolResult(
+	name string,
+	args json.RawMessage,
+	result string,
+	tool *corev1alpha1.Tool,
+) {
+	if !cacheIdenticalToolCalls(tool, g.isFinalizationTool(name)) {
+		return
+	}
+	g.toolResults[toolCallFingerprint(name, args)] = result
+}
+
+func toolCallFingerprint(name string, args json.RawMessage) string {
+	canonical := bytes.TrimSpace(args)
+	var value any
+	decoder := json.NewDecoder(bytes.NewReader(canonical))
+	decoder.UseNumber()
+	if json.Valid(canonical) && decoder.Decode(&value) == nil {
+		if data, err := json.Marshal(value); err == nil {
+			canonical = data
+		}
+	}
+	sum := sha256.Sum256(append([]byte(strings.TrimSpace(name)+"\x00"), canonical...))
+	return hex.EncodeToString(sum[:])
+}
+
+func recordSkippedAnalysisToolCalls(
+	recorder common.EventRecorder,
+	original, selected []llm.ToolCall,
+) {
+	selectedIDs := make(map[string]bool, len(selected))
+	for _, call := range selected {
+		selectedIDs[call.ID] = true
+	}
+	for _, call := range original {
+		if selectedIDs[call.ID] {
+			continue
+		}
+		common.RecordEventWithTimeout(
+			recorder,
+			events.ExecutionEventTypeToolCallSkipped,
+			modelLoopEventTimeout,
+			common.WithEventSeverity(events.ExecutionEventSeverityWarning),
+			common.WithEventToolName(call.Name),
+			common.WithEventToolCallID(call.ID),
+			common.WithEventSummary("parallel tool call skipped by analysis policy"),
+		)
+	}
+}

--- a/workers/ai/analysis_budget_test.go
+++ b/workers/ai/analysis_budget_test.go
@@ -111,7 +111,7 @@ func TestCachedToolResultDoesNotBypassRequestAllowlist(t *testing.T) {
 	}}
 	args := json.RawMessage(`{"path":"build-log.txt"}`)
 	guard.rememberToolResult("read_artifact", args, "cached", tool)
-	_, err, cached := executeGuardedLoopTool(
+	_, cached, _, err := executeGuardedLoopTool(
 		context.Background(),
 		llm.ToolCall{Name: "read_artifact", Arguments: args},
 		"read_artifact",

--- a/workers/ai/analysis_budget_test.go
+++ b/workers/ai/analysis_budget_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+	"github.com/orka-agents/orka/internal/llm"
+)
+
+func TestAnalysisLoopGuardSelectsOneToolCall(t *testing.T) {
+	guard := newAnalysisLoopGuard([]llm.Tool{
+		{Name: "submit_analysis"},
+		{Name: "verify_timeline"},
+	}, nil)
+	calls := []llm.ToolCall{
+		{Name: "read_artifact"},
+		{Name: "submit_analysis"},
+		{Name: "verify_timeline"},
+	}
+	got := guard.selectToolCalls(calls)
+	if len(got) != 1 || got[0].Name != "verify_timeline" {
+		t.Fatalf("selected calls = %+v", got)
+	}
+	got = guard.selectToolCalls(calls[:2])
+	if len(got) != 1 || got[0].Name != "submit_analysis" {
+		t.Fatalf("selected calls = %+v", got)
+	}
+}
+
+func TestAnalysisLoopGuardUsesToolCallBudget(t *testing.T) {
+	guard := newAnalysisLoopGuard([]llm.Tool{
+		{Name: "read_artifact"},
+		{Name: "submit_analysis"},
+	}, nil)
+	for range analysisMaxInvestigationToolCalls {
+		if err := guard.beginToolCall("read_artifact"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := guard.beginToolCall("read_artifact"); err == nil {
+		t.Fatal("tool-call budget allowed an extra investigation call")
+	}
+	req := &llm.CompletionRequest{Tools: []llm.Tool{
+		{Name: "read_artifact"},
+		{Name: "submit_analysis"},
+	}}
+	guard.prepareRequest(req, nil, 1, analysisLoopMaxIterations)
+	if len(req.Tools) != 1 || req.Tools[0].Name != "submit_analysis" {
+		t.Fatalf("budgeted tools = %+v", req.Tools)
+	}
+}
+
+func TestAnalysisLoopGuardCachesDuplicateToolCall(t *testing.T) {
+	guard := newAnalysisLoopGuard([]llm.Tool{{Name: "submit_analysis"}}, nil)
+	first := json.RawMessage(`{"path":"build-log.txt","offset":0}`)
+	second := json.RawMessage(`{"offset":0,"path":"build-log.txt"}`)
+	tool := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{toolCacheIdenticalCallsAnnotation: "true"},
+	}}
+	guard.rememberToolResult("read_artifact", first, "evidence", tool)
+	got, ok := guard.cachedToolResult("read_artifact", second, tool)
+	if !ok || got != "evidence" {
+		t.Fatalf("cached result = %q, %t", got, ok)
+	}
+}
+
+func TestValidatedAnalysisResultSupportsFlatSubmission(t *testing.T) {
+	args := json.RawMessage(`{
+		"summary":"summary",
+		"is_transient":false,
+		"root_cause":"cause",
+		"severity":"High",
+		"suggested_fix":"fix",
+		"relevant_files":[]
+	}`)
+	result, matched, err := validatedAnalysisResult(
+		"submit_analysis",
+		args,
+		`{"gcs_bytes":123,"validation_token":"signed"}`,
+	)
+	if err != nil || !matched {
+		t.Fatalf("validatedAnalysisResult() = %q, %t, %v", result, matched, err)
+	}
+	var got validatedAnalysis
+	if err := json.Unmarshal([]byte(result), &got); err != nil {
+		t.Fatalf("unmarshal final result: %v", err)
+	}
+	if got.GCSBytes == nil || *got.GCSBytes != 123 || got.ValidationToken != "signed" {
+		t.Fatalf("final result = %+v", got)
+	}
+}
+
+func TestToolCallFingerprintDoesNotCanonicalizeTrailingData(t *testing.T) {
+	valid := toolCallFingerprint("read_artifact", json.RawMessage(`{"path":"x"}`))
+	malformed := toolCallFingerprint("read_artifact", json.RawMessage(`{"path":"x"}junk`))
+	if valid == malformed {
+		t.Fatal("malformed arguments reused the valid JSON fingerprint")
+	}
+}

--- a/workers/ai/analysis_budget_test.go
+++ b/workers/ai/analysis_budget_test.go
@@ -13,14 +13,16 @@ import (
 	"github.com/orka-agents/orka/internal/worker"
 )
 
+const testSubmissionToolName = "submit_analysis"
+
 func TestAnalysisLoopGuardSelectsOneToolCall(t *testing.T) {
 	guard := newAnalysisLoopGuard([]llm.Tool{
-		{Name: "submit_analysis"},
+		{Name: testSubmissionToolName},
 		{Name: "verify_timeline"},
 	}, nil)
 	calls := []llm.ToolCall{
 		{Name: "read_artifact"},
-		{Name: "submit_analysis"},
+		{Name: testSubmissionToolName},
 		{Name: "verify_timeline"},
 	}
 	got := guard.selectToolCalls(calls)
@@ -28,7 +30,7 @@ func TestAnalysisLoopGuardSelectsOneToolCall(t *testing.T) {
 		t.Fatalf("selected calls = %+v", got)
 	}
 	got = guard.selectToolCalls(calls[:2])
-	if len(got) != 1 || got[0].Name != "submit_analysis" {
+	if len(got) != 1 || got[0].Name != testSubmissionToolName {
 		t.Fatalf("selected calls = %+v", got)
 	}
 }
@@ -36,7 +38,7 @@ func TestAnalysisLoopGuardSelectsOneToolCall(t *testing.T) {
 func TestAnalysisLoopGuardUsesToolCallBudget(t *testing.T) {
 	guard := newAnalysisLoopGuard([]llm.Tool{
 		{Name: "read_artifact"},
-		{Name: "submit_analysis"},
+		{Name: testSubmissionToolName},
 	}, nil)
 	for range analysisMaxInvestigationToolCalls {
 		if err := guard.beginToolCall("read_artifact"); err != nil {
@@ -48,16 +50,16 @@ func TestAnalysisLoopGuardUsesToolCallBudget(t *testing.T) {
 	}
 	req := &llm.CompletionRequest{Tools: []llm.Tool{
 		{Name: "read_artifact"},
-		{Name: "submit_analysis"},
+		{Name: testSubmissionToolName},
 	}}
 	guard.prepareRequest(req, nil, 1, analysisLoopMaxIterations)
-	if len(req.Tools) != 1 || req.Tools[0].Name != "submit_analysis" {
+	if len(req.Tools) != 1 || req.Tools[0].Name != testSubmissionToolName {
 		t.Fatalf("budgeted tools = %+v", req.Tools)
 	}
 }
 
 func TestAnalysisLoopGuardCachesDuplicateToolCall(t *testing.T) {
-	guard := newAnalysisLoopGuard([]llm.Tool{{Name: "submit_analysis"}}, nil)
+	guard := newAnalysisLoopGuard([]llm.Tool{{Name: testSubmissionToolName}}, nil)
 	first := json.RawMessage(`{"path":"build-log.txt","offset":0}`)
 	second := json.RawMessage(`{"offset":0,"path":"build-log.txt"}`)
 	tool := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{
@@ -80,7 +82,7 @@ func TestValidatedAnalysisResultSupportsFlatSubmission(t *testing.T) {
 		"relevant_files":[]
 	}`)
 	result, matched, err := validatedAnalysisResult(
-		"submit_analysis",
+		testSubmissionToolName,
 		args,
 		`{"gcs_bytes":123,"validation_token":"signed"}`,
 	)
@@ -105,7 +107,7 @@ func TestToolCallFingerprintDoesNotCanonicalizeTrailingData(t *testing.T) {
 }
 
 func TestCachedToolResultDoesNotBypassRequestAllowlist(t *testing.T) {
-	guard := newAnalysisLoopGuard([]llm.Tool{{Name: "submit_analysis"}}, nil)
+	guard := newAnalysisLoopGuard([]llm.Tool{{Name: testSubmissionToolName}}, nil)
 	tool := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{
 		Annotations: map[string]string{toolCacheIdenticalCallsAnnotation: "true"},
 	}}
@@ -115,7 +117,7 @@ func TestCachedToolResultDoesNotBypassRequestAllowlist(t *testing.T) {
 		context.Background(),
 		llm.ToolCall{Name: "read_artifact", Arguments: args},
 		"read_artifact",
-		map[string]struct{}{"submit_analysis": {}},
+		map[string]struct{}{testSubmissionToolName: {}},
 		map[string]*corev1alpha1.Tool{"read_artifact": tool},
 		worker.NewToolExecutor(),
 		&approvalGate{firedKeys: map[string]bool{}},
@@ -124,5 +126,26 @@ func TestCachedToolResultDoesNotBypassRequestAllowlist(t *testing.T) {
 	)
 	if cached || err == nil || !strings.Contains(err.Error(), "not enabled") {
 		t.Fatalf("cached=%t error=%v", cached, err)
+	}
+}
+
+func TestAnalysisLoopGuardNormalizesFinalizationCallNames(t *testing.T) {
+	guard := newAnalysisLoopGuard([]llm.Tool{
+		{Name: testSubmissionToolName},
+		{Name: "verify_timeline"},
+	}, nil)
+	calls := []llm.ToolCall{
+		{Name: "read_artifact"},
+		{Name: " submit_analysis "},
+		{Name: " verify_timeline "},
+	}
+	selected := guard.selectToolCalls(calls)
+	if len(selected) != 1 || strings.TrimSpace(selected[0].Name) != "verify_timeline" {
+		t.Fatalf("selected calls = %+v", selected)
+	}
+	guard.timelineVerified = true
+	selected = guard.selectToolCalls(calls)
+	if len(selected) != 1 || strings.TrimSpace(selected[0].Name) != testSubmissionToolName {
+		t.Fatalf("selected calls after timeline = %+v", selected)
 	}
 }

--- a/workers/ai/analysis_budget_test.go
+++ b/workers/ai/analysis_budget_test.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
 	"github.com/orka-agents/orka/internal/llm"
+	"github.com/orka-agents/orka/internal/worker"
 )
 
 func TestAnalysisLoopGuardSelectsOneToolCall(t *testing.T) {
@@ -98,5 +101,28 @@ func TestToolCallFingerprintDoesNotCanonicalizeTrailingData(t *testing.T) {
 	malformed := toolCallFingerprint("read_artifact", json.RawMessage(`{"path":"x"}junk`))
 	if valid == malformed {
 		t.Fatal("malformed arguments reused the valid JSON fingerprint")
+	}
+}
+
+func TestCachedToolResultDoesNotBypassRequestAllowlist(t *testing.T) {
+	guard := newAnalysisLoopGuard([]llm.Tool{{Name: "submit_analysis"}}, nil)
+	tool := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{toolCacheIdenticalCallsAnnotation: "true"},
+	}}
+	args := json.RawMessage(`{"path":"build-log.txt"}`)
+	guard.rememberToolResult("read_artifact", args, "cached", tool)
+	_, err, cached := executeGuardedLoopTool(
+		context.Background(),
+		llm.ToolCall{Name: "read_artifact", Arguments: args},
+		"read_artifact",
+		map[string]struct{}{"submit_analysis": {}},
+		map[string]*corev1alpha1.Tool{"read_artifact": tool},
+		worker.NewToolExecutor(),
+		&approvalGate{firedKeys: map[string]bool{}},
+		nil,
+		guard,
+	)
+	if cached || err == nil || !strings.Contains(err.Error(), "not enabled") {
+		t.Fatalf("cached=%t error=%v", cached, err)
 	}
 }

--- a/workers/ai/approval_gate.go
+++ b/workers/ai/approval_gate.go
@@ -268,6 +268,11 @@ func approvalToolIdentity(
 	if customTool != nil {
 		return customTool.Name, customTool
 	}
+	for _, candidate := range customTools {
+		if candidate != nil && candidate.Name == modelToolName {
+			return candidate.Name, candidate
+		}
+	}
 	return modelToolName, nil
 }
 
@@ -643,8 +648,7 @@ func approvalTargetSpecDigestFromCustomTools(
 	refresh ...func(context.Context, string, *corev1alpha1.Tool),
 ) func(context.Context, string) (string, error) {
 	return func(ctx context.Context, targetTool string) (string, error) {
-		targetTool = strings.TrimSpace(targetTool)
-		customTool := customTools[targetTool]
+		targetTool, customTool := approvalToolIdentity(strings.TrimSpace(targetTool), customTools)
 		if customTool == nil {
 			return "", fmt.Errorf("targetTool %q is not an enabled custom tool", targetTool)
 		}
@@ -659,7 +663,8 @@ func approvalTargetArgumentsFromCustomTools(
 	customTools map[string]*corev1alpha1.Tool,
 ) func(context.Context, string, json.RawMessage) (json.RawMessage, error) {
 	return func(_ context.Context, targetTool string, args json.RawMessage) (json.RawMessage, error) {
-		return approvalTargetArguments(args, customTools[strings.TrimSpace(targetTool)])
+		_, customTool := approvalToolIdentity(strings.TrimSpace(targetTool), customTools)
+		return approvalTargetArguments(args, customTool)
 	}
 }
 
@@ -1075,7 +1080,7 @@ func explicitApprovalTargetForCall(
 	if baseToolCtx == nil {
 		return approvals.ApprovalTarget{}, fmt.Errorf("tool context is not configured")
 	}
-	targetTool := strings.TrimSpace(req.TargetTool)
+	targetTool, _ := approvalToolIdentity(strings.TrimSpace(req.TargetTool), customTools)
 	targetSpecDigest, err := approvalTargetSpecDigestFromCustomTools(
 		customTools,
 		baseToolCtx.ApprovalTargetRefresh,
@@ -1123,6 +1128,23 @@ func terminalApprovalBatchToolResults(
 	return results
 }
 
+func canonicalizeRequestApprovalCall(
+	call llm.ToolCall,
+	customTools map[string]*corev1alpha1.Tool,
+) (llm.ToolCall, error) {
+	var args requestApprovalCallArgs
+	if err := json.Unmarshal(call.Arguments, &args); err != nil {
+		return call, err
+	}
+	args.TargetTool, _ = approvalToolIdentity(strings.TrimSpace(args.TargetTool), customTools)
+	canonical, err := json.Marshal(args)
+	if err != nil {
+		return call, err
+	}
+	call.Arguments = canonical
+	return call, nil
+}
+
 func executeRequestApprovalToolCall(
 	ctx context.Context,
 	call llm.ToolCall,
@@ -1161,7 +1183,20 @@ func executeRequestApprovalToolCall(
 		}
 		execCtx = tools.WithToolContext(ctx, &toolCtxCopy)
 	}
-	result, err := tools.DefaultRegistry.Execute(execCtx, toolName, call.Arguments)
+	canonicalCall, err := canonicalizeRequestApprovalCall(call, customTools)
+	if err != nil {
+		common.RecordEventWithTimeout(
+			eventRecorder,
+			events.ExecutionEventTypeToolCallFailed,
+			modelLoopEventTimeout,
+			common.WithEventSeverity(events.ExecutionEventSeverityError),
+			common.WithEventToolName(toolName),
+			common.WithEventToolCallID(call.ID),
+			common.WithEventSummary(err.Error()),
+		)
+		return "", err
+	}
+	result, err := tools.DefaultRegistry.Execute(execCtx, toolName, canonicalCall.Arguments)
 	if err != nil {
 		common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeToolCallFailed, modelLoopEventTimeout,
 			common.WithEventSeverity(events.ExecutionEventSeverityError),

--- a/workers/ai/approval_gate.go
+++ b/workers/ai/approval_gate.go
@@ -184,10 +184,11 @@ func (g *approvalGate) preScan(
 		return nil, nil
 	}
 	for _, call := range calls {
-		toolName := strings.TrimSpace(call.Name)
+		modelToolName := strings.TrimSpace(call.Name)
+		toolName, customTool := approvalToolIdentity(modelToolName, customTools)
 		requiresApproval := g.requiresApproval(toolName)
 		if requiresApproval {
-			if _, ok := allowedToolCalls[toolName]; !ok {
+			if _, ok := allowedToolCalls[modelToolName]; !ok {
 				return &approvalBatchDecision{
 					continueLLM: true,
 					toolResults: approvalValidationBatchToolResults(
@@ -198,16 +199,16 @@ func (g *approvalGate) preScan(
 				}, nil
 			}
 		}
-		target, err := g.targetForCall(ctx, toolName, call.Arguments, customTools[toolName])
+		target, err := g.targetForCall(ctx, toolName, call.Arguments, customTool)
 		if err != nil {
 			if !requiresApproval {
-				if g.blockingOverflow && customTools[toolName] != nil {
+				if g.blockingOverflow && customTool != nil {
 					return &approvalBatchDecision{
 						continueLLM: true,
 						toolResults: blockingApprovalOverflowBatchToolResults(calls, call.ID, toolName),
 					}, nil
 				}
-				if g.hasResolvedHistoryForTool(toolName) && customTools[toolName] != nil {
+				if g.hasResolvedHistoryForTool(toolName) && customTool != nil {
 					return &approvalBatchDecision{
 						continueLLM: true,
 						toolResults: approvalValidationBatchToolResults(calls, call.ID, err),
@@ -234,7 +235,7 @@ func (g *approvalGate) preScan(
 					toolResults: staleApprovalBatchToolResults(calls, call.ID, staleDecision),
 				}, nil
 			}
-			if g.blockingOverflow && customTools[toolName] != nil {
+			if g.blockingOverflow && customTool != nil {
 				return &approvalBatchDecision{
 					continueLLM: true,
 					toolResults: blockingApprovalOverflowBatchToolResults(calls, call.ID, toolName),
@@ -257,6 +258,17 @@ func (g *approvalGate) preScan(
 		}, nil
 	}
 	return nil, nil
+}
+
+func approvalToolIdentity(
+	modelToolName string,
+	customTools map[string]*corev1alpha1.Tool,
+) (string, *corev1alpha1.Tool) {
+	customTool := customTools[modelToolName]
+	if customTool != nil {
+		return customTool.Name, customTool
+	}
+	return modelToolName, nil
 }
 
 func (g *approvalGate) targetForCall(

--- a/workers/ai/main.go
+++ b/workers/ai/main.go
@@ -933,16 +933,7 @@ func executeAgentLoopWithEvents(
 
 	coordinationEnv := workerenv.ParseCoordinationEnv(os.Getenv)
 	guard := newAnalysisLoopGuard(llmTools, customTools)
-	maxIterations := 10
-	if coordinationEnv.Enabled {
-		maxIterations = 50
-	}
-	if guard.validationRequired {
-		maxIterations = analysisLoopMaxIterations
-	}
-	if coordinationEnv.AutonomousMode {
-		maxIterations = 100
-	}
+	maxIterations := agentLoopMaxIterations(coordinationEnv, guard.validationRequired)
 	allowedToolCalls := advertisedToolNames(llmTools)
 	if !coordinationEnv.AutonomousMode && approvalToolingRequested(coordinationEnv, allowedToolCalls) {
 		return "", fmt.Errorf("human approval tools require autonomous coordination mode")

--- a/workers/ai/main.go
+++ b/workers/ai/main.go
@@ -1112,7 +1112,7 @@ func executeAgentLoopWithEvents(
 				})),
 			)
 
-			result, execErr, cached := executeGuardedLoopTool(
+			result, cached, completed, execErr := executeGuardedLoopTool(
 				stepCtx,
 				tc,
 				toolName,
@@ -1124,7 +1124,7 @@ func executeAgentLoopWithEvents(
 				guard,
 			)
 
-			inspection := guard.inspectTool(toolName, tc.Arguments, result, execErr)
+			inspection := guard.inspectTool(toolName, tc.Arguments, result, execErr, completed)
 			execErr = inspection.execErr
 			if inspection.final != "" {
 				validatedFinal = inspection.final

--- a/workers/ai/main.go
+++ b/workers/ai/main.go
@@ -385,6 +385,7 @@ func loadCustomTools(
 	toolNames []string,
 ) map[string]*corev1alpha1.Tool {
 	customTools := make(map[string]*corev1alpha1.Tool)
+	loaded := make([]*corev1alpha1.Tool, 0, len(toolNames))
 
 	for _, name := range toolNames {
 		// Skip built-in tools
@@ -401,7 +402,9 @@ func loadCustomTools(
 		bindApprovalAuthRefVersion(ctx, k8sClient, namespace, tool)
 
 		customTools[name] = tool
+		loaded = append(loaded, tool)
 	}
+	registerToolAliases(customTools, loaded)
 
 	return customTools
 }
@@ -475,7 +478,7 @@ func buildLLMTools(enabledTools []string, customTools map[string]*corev1alpha1.T
 			}
 
 			llmTools = append(llmTools, llm.Tool{
-				Name:        tool.Name,
+				Name:        advertisedCustomToolName(tool, customTools),
 				Description: tool.Spec.Description,
 				Parameters:  params,
 			})
@@ -929,7 +932,7 @@ func executeAgentLoopWithEvents(
 	}
 
 	coordinationEnv := workerenv.ParseCoordinationEnv(os.Getenv)
-	guard := newAnalysisLoopGuard(llmTools)
+	guard := newAnalysisLoopGuard(llmTools, customTools)
 	maxIterations := 10
 	if coordinationEnv.Enabled {
 		maxIterations = 50
@@ -1008,29 +1011,35 @@ func executeAgentLoopWithEvents(
 			stepSpan.End()
 			return "", fmt.Errorf("completion failed: %w", err)
 		}
-		stepSpan.SetAttributes(attribute.Int("agent.step.tool_call_count", len(resp.ToolCalls)))
+		originalToolCalls := resp.ToolCalls
+		selectedToolCalls := guard.selectToolCalls(originalToolCalls)
+		stepSpan.SetAttributes(attribute.Int("agent.step.tool_call_count", len(originalToolCalls)))
 		common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeModelRequestCompleted, modelLoopEventTimeout,
 			common.WithEventSummary("model request completed"),
 			common.WithEventContent(eventContent(map[string]any{
-				"iteration":    iteration + 1,
-				"model":        firstNonBlankOriginal(resp.Model, model),
-				"provider":     firstNonBlankOriginal(resp.Provider, llm.ProviderTelemetryName(provider)),
-				"inputTokens":  resp.InputTokens,
-				"outputTokens": resp.OutputTokens,
-				"stopReason":   resp.StopReason,
-				"toolCalls":    len(resp.ToolCalls),
+				"iteration":         iteration + 1,
+				"model":             firstNonBlankOriginal(resp.Model, model),
+				"provider":          firstNonBlankOriginal(resp.Provider, llm.ProviderTelemetryName(provider)),
+				"inputTokens":       resp.InputTokens,
+				"outputTokens":      resp.OutputTokens,
+				"stopReason":        resp.StopReason,
+				"toolCalls":         len(originalToolCalls),
+				"selectedToolCalls": len(selectedToolCalls),
 			})),
 		)
 		common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeModelMessage, modelLoopEventTimeout,
 			common.WithEventSummary("model returned message"),
 			common.WithEventContent(eventContent(map[string]any{
-				"iteration":    iteration + 1,
-				"contentChars": len([]rune(resp.Content)),
-				"toolCalls":    len(resp.ToolCalls),
-				"stopReason":   resp.StopReason,
+				"iteration":         iteration + 1,
+				"contentChars":      len([]rune(resp.Content)),
+				"toolCalls":         len(originalToolCalls),
+				"selectedToolCalls": len(selectedToolCalls),
+				"stopReason":        resp.StopReason,
 			})),
 			common.WithEventContentText(resp.Content),
 		)
+		recordSkippedAnalysisToolCalls(eventRecorder, originalToolCalls, selectedToolCalls)
+		resp.ToolCalls = selectedToolCalls
 
 		if len(resp.ToolCalls) == 0 {
 			decision := guard.handleFinalResponse(resp.Content, iteration, maxIterations, messages)
@@ -1103,7 +1112,7 @@ func executeAgentLoopWithEvents(
 				})),
 			)
 
-			result, execErr = executeLoopTool(
+			result, execErr, cached := executeGuardedLoopTool(
 				stepCtx,
 				tc,
 				toolName,
@@ -1112,6 +1121,7 @@ func executeAgentLoopWithEvents(
 				toolExecutor,
 				approvalGate,
 				baseToolCtx,
+				guard,
 			)
 
 			inspection := guard.inspectTool(toolName, tc.Arguments, result, execErr)
@@ -1126,6 +1136,10 @@ func executeAgentLoopWithEvents(
 				repeatedValidationErr = inspection.fatal
 			}
 
+			if execErr == nil && !cached {
+				guard.rememberToolResult(toolName, tc.Arguments, result, customTools[toolName])
+			}
+
 			if execErr != nil {
 				common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeToolCallFailed, modelLoopEventTimeout,
 					common.WithEventSeverity(events.ExecutionEventSeverityError),
@@ -1135,14 +1149,19 @@ func executeAgentLoopWithEvents(
 				)
 				result = fmt.Sprintf("Error executing tool: %v", execErr)
 			} else {
+				summary := "tool call completed"
+				if cached {
+					summary = "duplicate tool call reused"
+				}
 				common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeToolCallCompleted, modelLoopEventTimeout,
 					common.WithEventToolName(toolName),
 					common.WithEventToolCallID(tc.ID),
-					common.WithEventSummary("tool call completed"),
+					common.WithEventSummary(summary),
 					common.WithEventContent(eventContent(map[string]any{
 						"toolName":     toolName,
 						"toolCallID":   tc.ID,
 						"resultLength": len(result),
+						"cached":       cached,
 					})),
 				)
 			}

--- a/workers/ai/main.go
+++ b/workers/ai/main.go
@@ -1087,11 +1087,20 @@ func executeAgentLoopWithEvents(
 		validationRepair := ""
 		var repeatedValidationErr error
 		for _, tc := range resp.ToolCalls {
+			toolName := strings.TrimSpace(tc.Name)
+			if result, skip := guard.completedToolCallResult(toolName); skip {
+				recordSkippedAnalysisToolCall(
+					eventRecorder, tc, "analysis finalization tool already completed",
+				)
+				messages = append(messages, llm.Message{
+					Role: "tool", Content: result, ToolCallID: tc.ID, Name: tc.Name,
+				})
+				continue
+			}
 			fmt.Printf("Executing tool: %s\n", tc.Name)
 
 			var result string
 			var execErr error
-			toolName := strings.TrimSpace(tc.Name)
 			common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeToolCallStarted, modelLoopEventTimeout,
 				common.WithEventToolName(toolName),
 				common.WithEventToolCallID(tc.ID),

--- a/workers/ai/main.go
+++ b/workers/ai/main.go
@@ -929,9 +929,13 @@ func executeAgentLoopWithEvents(
 	}
 
 	coordinationEnv := workerenv.ParseCoordinationEnv(os.Getenv)
+	guard := newAnalysisLoopGuard(llmTools)
 	maxIterations := 10
 	if coordinationEnv.Enabled {
 		maxIterations = 50
+	}
+	if guard.validationRequired {
+		maxIterations = analysisLoopMaxIterations
 	}
 	if coordinationEnv.AutonomousMode {
 		maxIterations = 100
@@ -955,6 +959,8 @@ func executeAgentLoopWithEvents(
 			MaxTokens:    4096,
 			Tools:        llmTools,
 		}
+		guard.prepareRequest(req, messages, iteration, maxIterations)
+		requestToolCalls := advertisedToolNames(req.Tools)
 		common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeModelRequestStarted, modelLoopEventTimeout,
 			common.WithEventSummary("model request started"),
 			common.WithEventContent(eventContent(map[string]any{
@@ -962,7 +968,7 @@ func executeAgentLoopWithEvents(
 				"model":        model,
 				"provider":     llm.ProviderTelemetryName(provider),
 				"messageCount": len(messages),
-				"toolCount":    len(llmTools),
+				"toolCount":    len(req.Tools),
 			})),
 		)
 
@@ -1026,10 +1032,17 @@ func executeAgentLoopWithEvents(
 			common.WithEventContentText(resp.Content),
 		)
 
-		// If no tool calls, we're done
 		if len(resp.ToolCalls) == 0 {
+			decision := guard.handleFinalResponse(resp.Content, iteration, maxIterations, messages)
 			stepSpan.End()
-			return resp.Content, nil
+			if decision.err != nil {
+				return "", decision.err
+			}
+			if decision.retry {
+				messages = decision.messages
+				continue
+			}
+			return decision.result, nil
 		}
 
 		// Add assistant message with tool calls
@@ -1048,7 +1061,7 @@ func executeAgentLoopWithEvents(
 			messages,
 			resp.ToolCalls,
 			approvalGate,
-			allowedToolCalls,
+			requestToolCalls,
 			customTools,
 			eventRecorder,
 			baseToolCtx,
@@ -1069,7 +1082,10 @@ func executeAgentLoopWithEvents(
 			continue
 		}
 
-		// Execute tool calls
+		// Execute tool calls.
+		validatedFinal := ""
+		validationRepair := ""
+		var repeatedValidationErr error
 		for _, tc := range resp.ToolCalls {
 			fmt.Printf("Executing tool: %s\n", tc.Name)
 
@@ -1087,53 +1103,27 @@ func executeAgentLoopWithEvents(
 				})),
 			)
 
-			var execArgs json.RawMessage
-			approvalKey := ""
-			alreadyFired := false
-			customToolForCall := customTools[toolName]
-			if _, ok := allowedToolCalls[toolName]; !ok {
-				execErr = fmt.Errorf("tool %q was not enabled for this task", tc.Name)
-				tools.RecordRejectedToolCall(stepCtx, toolName, tc.ID, "tool_not_enabled", execErr.Error())
-			} else {
-				execArgs, approvalKey, alreadyFired, execErr = approvalGate.prepareApprovedCall(
-					stepCtx,
-					toolName,
-					tc.Arguments,
-					customToolForCall,
-				)
+			result, execErr = executeLoopTool(
+				stepCtx,
+				tc,
+				toolName,
+				requestToolCalls,
+				customTools,
+				toolExecutor,
+				approvalGate,
+				baseToolCtx,
+			)
+
+			inspection := guard.inspectTool(toolName, tc.Arguments, result, execErr)
+			execErr = inspection.execErr
+			if inspection.final != "" {
+				validatedFinal = inspection.final
 			}
-			if execErr != nil {
-				// execErr is handled by the common error path below.
-			} else if alreadyFired {
-				result = fmt.Sprintf("already executed approved action for idempotency key %s; skipping duplicate", approvalKey)
-			} else if customToolForCall != nil {
-				customTool := customToolForCall
-				execCtx := worker.WithToolCallID(stepCtx, tc.ID)
-				if approvalKey != "" {
-					execCtx = worker.WithToolIdempotencyKey(execCtx, approvalKey)
-				}
-				result, execErr = toolExecutor.Execute(execCtx, customTool, execArgs)
-				if execErr == nil || worker.ToolRequestWasAttempted(execErr) {
-					approvalGate.markFired(approvalKey)
-				}
-			} else {
-				// Fall back to built-in tools
-				if approvalKey != "" {
-					execArgs, execErr = injectIdempotencyKey(execArgs, approvalKey)
-				}
-				execCtx := stepCtx
-				if baseToolCtx != nil {
-					toolCtxCopy := *baseToolCtx
-					toolCtxCopy.ToolCallID = tc.ID
-					if toolCtxCopy.Tenant == "" {
-						toolCtxCopy.Tenant = toolCtxCopy.Namespace
-					}
-					execCtx = tools.WithToolContext(stepCtx, &toolCtxCopy)
-				}
-				if execErr == nil {
-					approvalGate.markFired(approvalKey)
-					result, execErr = tools.DefaultRegistry.Execute(execCtx, toolName, execArgs)
-				}
+			if inspection.repair != "" {
+				validationRepair = inspection.repair
+			}
+			if inspection.fatal != nil {
+				repeatedValidationErr = inspection.fatal
 			}
 
 			if execErr != nil {
@@ -1165,10 +1155,29 @@ func executeAgentLoopWithEvents(
 				Name:       tc.Name,
 			})
 		}
+		validatedFinal, validationRepair = guard.finishValidatedResult(validatedFinal, validationRepair)
+		if validatedFinal != "" {
+			stepSpan.End()
+			return validatedFinal, nil
+		}
+		if repeatedValidationErr != nil {
+			stepSpan.End()
+			return "", repeatedValidationErr
+		}
+		if validationRepair != "" {
+			messages = append(messages, llm.Message{Role: "user", Content: validationRepair})
+		}
 		stepSpan.End()
 	}
 
 	return "", fmt.Errorf("max iterations reached without completion")
+}
+
+// transientWithoutTimeline reports whether a parsed final answer claims a
+// transient verdict without a successful timeline verification.
+func transientWithoutTimeline(content string, timelineVerified bool) bool {
+	transient, _, err := analysisTransientState(content)
+	return err == nil && transient && !timelineVerified
 }
 
 func approvalToolingRequested(coordinationEnv workerenv.CoordinationEnv, allowedToolCalls map[string]struct{}) bool {

--- a/workers/ai/main.go
+++ b/workers/ai/main.go
@@ -975,6 +975,7 @@ func executeAgentLoopWithEvents(
 			beforeCount := len(messages)
 			messages = llm.TruncateMessages(messages, tokenEstimate/2)
 			req.Messages = messages
+			guard.prepareRequest(req, messages, iteration, maxIterations)
 			common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeContextTruncated, modelLoopEventTimeout,
 				common.WithEventSeverity(events.ExecutionEventSeverityWarning),
 				common.WithEventSummary("model context truncated after provider context limit error"),

--- a/workers/ai/main_test.go
+++ b/workers/ai/main_test.go
@@ -1136,3 +1136,25 @@ func TestExecuteAgentLoopTracingStepParentsModelAndToolSiblings(t *testing.T) {
 		t.Fatalf("step %s = %q", tracing.AttrTaskID, got)
 	}
 }
+
+func TestTransientWithoutTimeline(t *testing.T) {
+	tests := []struct {
+		name             string
+		content          string
+		timelineVerified bool
+		want             bool
+	}{
+		{name: "non-transient", content: `{"is_transient":false}`},
+		{name: "missing timeline", content: `{"is_transient":true}`, want: true},
+		{name: "carriage return whitespace", content: "{\"is_transient\":\r\n true}", want: true},
+		{name: "escaped property", content: `{"\u0069s_transient":true}`, want: true},
+		{name: "verified timeline", content: `{"is_transient":true}`, timelineVerified: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := transientWithoutTimeline(tt.content, tt.timelineVerified); got != tt.want {
+				t.Fatalf("transientWithoutTimeline() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/workers/ai/tool_alias.go
+++ b/workers/ai/tool_alias.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+	"github.com/orka-agents/orka/internal/tools"
+)
+
+const (
+	toolAliasAnnotation               = "orka.ai/tool-alias"
+	toolCacheIdenticalCallsAnnotation = "orka.ai/cache-identical-calls"
+)
+
+var toolAliasPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+
+func toolAlias(tool *corev1alpha1.Tool) string {
+	if tool == nil || tool.Annotations == nil {
+		return ""
+	}
+	return strings.TrimSpace(tool.Annotations[toolAliasAnnotation])
+}
+
+func registerToolAliases(customTools map[string]*corev1alpha1.Tool, loaded []*corev1alpha1.Tool) {
+	for _, tool := range loaded {
+		alias := toolAlias(tool)
+		if alias == "" || alias == tool.Name {
+			continue
+		}
+		if !toolAliasPattern.MatchString(alias) {
+			fmt.Printf("Warning: tool %q has invalid alias %q; using its resource name\n", tool.Name, alias)
+			continue
+		}
+		if reservedToolAlias(alias) {
+			fmt.Printf("Warning: tool %q alias %q conflicts with a built-in tool; using its resource name\n", tool.Name, alias)
+			continue
+		}
+		if existing, found := customTools[alias]; found && existing != tool {
+			fmt.Printf(
+				"Warning: tool %q alias %q conflicts with tool %q; using its resource name\n",
+				tool.Name, alias, existing.Name,
+			)
+			continue
+		}
+		customTools[alias] = tool
+	}
+}
+
+func advertisedCustomToolName(tool *corev1alpha1.Tool, customTools map[string]*corev1alpha1.Tool) string {
+	alias := toolAlias(tool)
+	if alias != "" && customTools[alias] == tool {
+		return alias
+	}
+	return tool.Name
+}
+
+func cacheIdenticalToolCalls(tool *corev1alpha1.Tool, finalization bool) bool {
+	if tool == nil || finalization || tool.Annotations == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(tool.Annotations[toolCacheIdenticalCallsAnnotation]), "true")
+}
+
+func resolvedCustomToolName(name string, customTools map[string]*corev1alpha1.Tool) string {
+	if tool := customTools[name]; tool != nil {
+		return tool.Name
+	}
+	return name
+}
+
+func reservedToolAlias(alias string) bool {
+	return slices.Contains(tools.KnownBuiltInToolNames(), alias)
+}

--- a/workers/ai/tool_alias_test.go
+++ b/workers/ai/tool_alias_test.go
@@ -154,6 +154,7 @@ func TestToolAliasUsesModelFacingSubmissionName(t *testing.T) {
 		t.Fatalf("validation prompt = %+v", req.Messages)
 	}
 	guard.timelineVerified = true
+	guard.investigationToolCalls = 0
 	guard.prepareRequest(req, nil, 2, analysisLoopMaxIterations)
 	if len(req.Tools) != 1 || req.Tools[0].Name != "finish" {
 		t.Fatalf("tools after timeline verification = %+v", req.Tools)

--- a/workers/ai/tool_alias_test.go
+++ b/workers/ai/tool_alias_test.go
@@ -10,6 +10,7 @@ import (
 
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
 	"github.com/orka-agents/orka/internal/llm"
+	toolspkg "github.com/orka-agents/orka/internal/tools"
 	"github.com/orka-agents/orka/internal/worker"
 	"github.com/orka-agents/orka/workers/common"
 )
@@ -173,4 +174,78 @@ func TestVerifiedTimelineCallIsSkipped(t *testing.T) {
 	if !skip || !strings.Contains(result, "finish") {
 		t.Fatalf("completedToolCallResult() = %q, %t", result, skip)
 	}
+}
+
+func TestRequestApprovalCanonicalizesAliasedTarget(t *testing.T) {
+	tool := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{Name: "scoped-sensitive-tool"}}
+	call := llm.ToolCall{Arguments: json.RawMessage(`{
+		"action":"run",
+		"riskSummary":"risk",
+		"severity":"warning",
+		"targetTool":"sensitive_tool",
+		"targetArguments":{}
+	}`)}
+	canonical, err := canonicalizeRequestApprovalCall(
+		call,
+		map[string]*corev1alpha1.Tool{"sensitive_tool": tool},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var args requestApprovalCallArgs
+	if err := json.Unmarshal(canonical.Arguments, &args); err != nil {
+		t.Fatal(err)
+	}
+	if args.TargetTool != tool.Name {
+		t.Fatalf("targetTool = %q, want %q", args.TargetTool, tool.Name)
+	}
+}
+
+func TestExplicitApprovalTargetCanonicalizesAlias(t *testing.T) {
+	tool := &corev1alpha1.Tool{
+		ObjectMeta: metav1.ObjectMeta{Name: "scoped-sensitive-tool"},
+		Spec: corev1alpha1.ToolSpec{
+			Description: "sensitive",
+			HTTP:        &corev1alpha1.HTTPExecution{URL: "http://example.invalid", Method: "POST"},
+		},
+	}
+	call := llm.ToolCall{Arguments: json.RawMessage(`{
+		"action":"run",
+		"riskSummary":"risk",
+		"severity":"warning",
+		"targetTool":"sensitive_tool",
+		"targetArguments":{}
+	}`)}
+	target, err := explicitApprovalTargetForCall(
+		context.Background(),
+		call,
+		map[string]*corev1alpha1.Tool{"sensitive_tool": tool},
+		&toolspkg.ToolContext{Namespace: "default", TaskID: "task", TaskUID: "uid"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.TargetTool != tool.Name {
+		t.Fatalf("target tool = %q, want %q", target.TargetTool, tool.Name)
+	}
+}
+
+func TestMalformedAliasedApprovalRecordsFailure(t *testing.T) {
+	recorder := common.NewFakeEventRecorder()
+	_, err := executeRequestApprovalToolCall(
+		context.Background(),
+		llm.ToolCall{ID: "call", Name: "request_approval", Arguments: json.RawMessage(`{`)},
+		nil,
+		recorder,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("malformed approval call succeeded")
+	}
+	for _, event := range recorder.Events() {
+		if event.Type == "ToolCallFailed" && event.ToolCallID == "call" {
+			return
+		}
+	}
+	t.Fatalf("failure event missing: %+v", recorder.Events())
 }

--- a/workers/ai/tool_alias_test.go
+++ b/workers/ai/tool_alias_test.go
@@ -67,7 +67,7 @@ func TestToolAliasPreservesApprovalPolicy(t *testing.T) {
 		namespace: "default", taskName: "task", taskUID: "uid",
 		required: map[string]struct{}{tool.Name: {}}, firedKeys: map[string]bool{},
 	}
-	_, err := executeLoopTool(
+	_, err, _ := executeLoopTool(
 		context.Background(),
 		llm.ToolCall{Name: "sensitive_tool", Arguments: json.RawMessage(`{}`)},
 		"sensitive_tool",

--- a/workers/ai/tool_alias_test.go
+++ b/workers/ai/tool_alias_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+	"github.com/orka-agents/orka/internal/llm"
+	"github.com/orka-agents/orka/internal/worker"
+	"github.com/orka-agents/orka/workers/common"
+)
+
+func TestToolAliasIsAdvertisedAndRouted(t *testing.T) {
+	tool := &corev1alpha1.Tool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "read-artifact-build-scope",
+			Annotations: map[string]string{toolAliasAnnotation: "read_artifact"},
+		},
+		Spec: corev1alpha1.ToolSpec{Description: "read artifact"},
+	}
+	customTools := map[string]*corev1alpha1.Tool{tool.Name: tool}
+	registerToolAliases(customTools, []*corev1alpha1.Tool{tool})
+	if customTools["read_artifact"] != tool {
+		t.Fatal("tool alias was not routed to the scoped Tool")
+	}
+	llmTools := buildLLMTools([]string{tool.Name}, customTools)
+	if len(llmTools) != 1 || llmTools[0].Name != "read_artifact" {
+		t.Fatalf("LLM tools = %+v", llmTools)
+	}
+}
+
+func TestToolAliasConflictFallsBackToResourceName(t *testing.T) {
+	first := &corev1alpha1.Tool{
+		ObjectMeta: metav1.ObjectMeta{Name: "first", Annotations: map[string]string{toolAliasAnnotation: "shared"}},
+	}
+	second := &corev1alpha1.Tool{
+		ObjectMeta: metav1.ObjectMeta{Name: "second", Annotations: map[string]string{toolAliasAnnotation: "shared"}},
+	}
+	customTools := map[string]*corev1alpha1.Tool{first.Name: first, second.Name: second}
+	registerToolAliases(customTools, []*corev1alpha1.Tool{first, second})
+	if customTools["shared"] != first {
+		t.Fatal("the first valid alias should remain registered")
+	}
+	llmTools := buildLLMTools([]string{second.Name}, customTools)
+	if len(llmTools) != 1 || llmTools[0].Name != second.Name {
+		t.Fatalf("conflicting alias was advertised: %+v", llmTools)
+	}
+}
+
+func TestToolAliasPreservesApprovalPolicy(t *testing.T) {
+	tool := &corev1alpha1.Tool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "scoped-sensitive-tool",
+			Annotations: map[string]string{toolAliasAnnotation: "sensitive_tool"},
+		},
+		Spec: corev1alpha1.ToolSpec{
+			Description: "sensitive",
+			HTTP:        &corev1alpha1.HTTPExecution{URL: "http://example.invalid", Method: "POST"},
+		},
+	}
+	customTools := map[string]*corev1alpha1.Tool{tool.Name: tool, "sensitive_tool": tool}
+	gate := &approvalGate{
+		namespace: "default", taskName: "task", taskUID: "uid",
+		required: map[string]struct{}{tool.Name: {}}, firedKeys: map[string]bool{},
+	}
+	_, err := executeLoopTool(
+		context.Background(),
+		llm.ToolCall{Name: "sensitive_tool", Arguments: json.RawMessage(`{}`)},
+		"sensitive_tool",
+		map[string]struct{}{"sensitive_tool": {}},
+		customTools,
+		worker.NewToolExecutor(),
+		gate,
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "approval") {
+		t.Fatalf("aliased approval-gated tool error = %v", err)
+	}
+}
+
+func TestToolAliasPreservesAnalysisClassification(t *testing.T) {
+	submit := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{Name: "submit-analysis-task"}}
+	timeline := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{Name: "verify-timeline-build"}}
+	customTools := map[string]*corev1alpha1.Tool{"finish": submit, "confirm": timeline}
+	guard := newAnalysisLoopGuard([]llm.Tool{{Name: "finish"}, {Name: "confirm"}}, customTools)
+	if !guard.validationRequired || !guard.isValidationTool("finish") || !guard.isTimelineTool("confirm") {
+		t.Fatalf("aliased analysis tools were not classified: %+v", guard)
+	}
+	guard.timelineVerified = true
+	selected := guard.selectToolCalls([]llm.ToolCall{{Name: "confirm"}, {Name: "finish"}})
+	if len(selected) != 1 || selected[0].Name != "finish" {
+		t.Fatalf("selected calls after timeline verification = %+v", selected)
+	}
+}
+
+func TestToolAliasApprovalPreScanUsesResourceName(t *testing.T) {
+	tool := &corev1alpha1.Tool{
+		ObjectMeta: metav1.ObjectMeta{Name: "scoped-sensitive-tool"},
+		Spec: corev1alpha1.ToolSpec{
+			Description: "sensitive",
+			HTTP:        &corev1alpha1.HTTPExecution{URL: "http://example.invalid", Method: "POST"},
+		},
+	}
+	customTools := map[string]*corev1alpha1.Tool{"sensitive_tool": tool}
+	gate := &approvalGate{
+		namespace: "default", taskName: "task", taskUID: "uid",
+		required: map[string]struct{}{tool.Name: {}}, firedKeys: map[string]bool{},
+		recorder: common.NewFakeEventRecorder(),
+	}
+	decision, err := gate.preScan(
+		context.Background(),
+		[]llm.ToolCall{{ID: "call", Name: "sensitive_tool", Arguments: json.RawMessage(`{}`)}},
+		map[string]struct{}{"sensitive_tool": {}},
+		customTools,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision == nil || !strings.Contains(decision.result, "approval requested") {
+		t.Fatalf("approval decision = %+v", decision)
+	}
+}
+
+func TestToolAliasRejectsConditionallyRegisteredBuiltIn(t *testing.T) {
+	tool := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{
+		Name:        "custom-approval-tool",
+		Annotations: map[string]string{toolAliasAnnotation: "request_approval"},
+	}}
+	customTools := map[string]*corev1alpha1.Tool{tool.Name: tool}
+	registerToolAliases(customTools, []*corev1alpha1.Tool{tool})
+	if customTools["request_approval"] != nil {
+		t.Fatal("reserved request_approval alias was registered")
+	}
+	llmTools := buildLLMTools([]string{tool.Name}, customTools)
+	if len(llmTools) != 1 || llmTools[0].Name != tool.Name {
+		t.Fatalf("reserved alias was advertised: %+v", llmTools)
+	}
+}

--- a/workers/ai/tool_alias_test.go
+++ b/workers/ai/tool_alias_test.go
@@ -151,7 +151,9 @@ func TestToolAliasUsesModelFacingSubmissionName(t *testing.T) {
 	guard.investigationToolCalls = analysisMaxInvestigationToolCalls
 	guard.prepareRequest(req, nil, 1, analysisLoopMaxIterations)
 	if len(req.Messages) != 1 || !strings.Contains(req.Messages[0].Content, "finish") ||
-		strings.Contains(req.Messages[0].Content, "validate_analysis") {
+		!strings.Contains(req.Messages[0].Content, "confirm") ||
+		strings.Contains(req.Messages[0].Content, "validate_analysis") ||
+		strings.Contains(req.Messages[0].Content, "verify_timeline") {
 		t.Fatalf("validation prompt = %+v", req.Messages)
 	}
 	guard.timelineVerified = true
@@ -248,4 +250,17 @@ func TestMalformedAliasedApprovalRecordsFailure(t *testing.T) {
 		}
 	}
 	t.Fatalf("failure event missing: %+v", recorder.Events())
+}
+
+func TestToolAliasPromptReplacementDoesNotCascade(t *testing.T) {
+	submit := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{Name: "submit-analysis-task"}}
+	timeline := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{Name: "verify-timeline-build"}}
+	guard := newAnalysisLoopGuard(
+		[]llm.Tool{{Name: "submit_via_verify_timeline"}, {Name: "confirm"}},
+		map[string]*corev1alpha1.Tool{"submit_via_verify_timeline": submit, "confirm": timeline},
+	)
+	got := guard.modelPrompt("call validate_analysis after verify_timeline")
+	if got != "call submit_via_verify_timeline after confirm" {
+		t.Fatalf("modelPrompt() = %q", got)
+	}
 }

--- a/workers/ai/tool_alias_test.go
+++ b/workers/ai/tool_alias_test.go
@@ -160,3 +160,17 @@ func TestToolAliasUsesModelFacingSubmissionName(t *testing.T) {
 		t.Fatalf("tools after timeline verification = %+v", req.Tools)
 	}
 }
+
+func TestVerifiedTimelineCallIsSkipped(t *testing.T) {
+	timeline := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{Name: "verify-timeline-build"}}
+	submit := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{Name: "submit-analysis-task"}}
+	guard := newAnalysisLoopGuard(
+		[]llm.Tool{{Name: "confirm"}, {Name: "finish"}},
+		map[string]*corev1alpha1.Tool{"confirm": timeline, "finish": submit},
+	)
+	guard.timelineVerified = true
+	result, skip := guard.completedToolCallResult("confirm")
+	if !skip || !strings.Contains(result, "finish") {
+		t.Fatalf("completedToolCallResult() = %q, %t", result, skip)
+	}
+}

--- a/workers/ai/tool_alias_test.go
+++ b/workers/ai/tool_alias_test.go
@@ -140,3 +140,22 @@ func TestToolAliasRejectsConditionallyRegisteredBuiltIn(t *testing.T) {
 		t.Fatalf("reserved alias was advertised: %+v", llmTools)
 	}
 }
+
+func TestToolAliasUsesModelFacingSubmissionName(t *testing.T) {
+	submit := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{Name: "submit-analysis-task"}}
+	timeline := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{Name: "verify-timeline-build"}}
+	customTools := map[string]*corev1alpha1.Tool{"finish": submit, "confirm": timeline}
+	guard := newAnalysisLoopGuard([]llm.Tool{{Name: "finish"}, {Name: "confirm"}}, customTools)
+	req := &llm.CompletionRequest{Tools: []llm.Tool{{Name: "finish"}, {Name: "confirm"}}}
+	guard.investigationToolCalls = analysisMaxInvestigationToolCalls
+	guard.prepareRequest(req, nil, 1, analysisLoopMaxIterations)
+	if len(req.Messages) != 1 || !strings.Contains(req.Messages[0].Content, "finish") ||
+		strings.Contains(req.Messages[0].Content, "validate_analysis") {
+		t.Fatalf("validation prompt = %+v", req.Messages)
+	}
+	guard.timelineVerified = true
+	guard.prepareRequest(req, nil, 2, analysisLoopMaxIterations)
+	if len(req.Tools) != 1 || req.Tools[0].Name != "finish" {
+		t.Fatalf("tools after timeline verification = %+v", req.Tools)
+	}
+}

--- a/workers/ai/tool_execution.go
+++ b/workers/ai/tool_execution.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+	"github.com/orka-agents/orka/internal/llm"
+	"github.com/orka-agents/orka/internal/tools"
+	"github.com/orka-agents/orka/internal/worker"
+)
+
+func executeLoopTool(
+	ctx context.Context,
+	call llm.ToolCall,
+	toolName string,
+	allowed map[string]struct{},
+	customTools map[string]*corev1alpha1.Tool,
+	executor *worker.ToolExecutor,
+	gate *approvalGate,
+	baseToolCtx *tools.ToolContext,
+) (string, error) {
+	var execArgs json.RawMessage
+	approvalKey := ""
+	alreadyFired := false
+	customTool := customTools[toolName]
+	var err error
+	if _, ok := allowed[toolName]; !ok {
+		err = fmt.Errorf("tool %q was not enabled for this task", call.Name)
+		tools.RecordRejectedToolCall(ctx, toolName, call.ID, "tool_not_enabled", err.Error())
+	} else {
+		execArgs, approvalKey, alreadyFired, err = gate.prepareApprovedCall(
+			ctx,
+			toolName,
+			call.Arguments,
+			customTool,
+		)
+	}
+	if err != nil {
+		return "", err
+	}
+	if alreadyFired {
+		return fmt.Sprintf("already executed approved action for idempotency key %s; skipping duplicate", approvalKey), nil
+	}
+	if customTool != nil {
+		execCtx := worker.WithToolCallID(ctx, call.ID)
+		if approvalKey != "" {
+			execCtx = worker.WithToolIdempotencyKey(execCtx, approvalKey)
+		}
+		result, execErr := executor.Execute(execCtx, customTool, execArgs)
+		if execErr == nil || worker.ToolRequestWasAttempted(execErr) {
+			gate.markFired(approvalKey)
+		}
+		return result, execErr
+	}
+	if approvalKey != "" {
+		execArgs, err = injectIdempotencyKey(execArgs, approvalKey)
+		if err != nil {
+			return "", err
+		}
+	}
+	execCtx := ctx
+	if baseToolCtx != nil {
+		toolCtxCopy := *baseToolCtx
+		toolCtxCopy.ToolCallID = call.ID
+		if toolCtxCopy.Tenant == "" {
+			toolCtxCopy.Tenant = toolCtxCopy.Namespace
+		}
+		execCtx = tools.WithToolContext(ctx, &toolCtxCopy)
+	}
+	gate.markFired(approvalKey)
+	return tools.DefaultRegistry.Execute(execCtx, toolName, execArgs)
+}

--- a/workers/ai/tool_execution.go
+++ b/workers/ai/tool_execution.go
@@ -25,6 +25,10 @@ func executeLoopTool(
 	approvalKey := ""
 	alreadyFired := false
 	customTool := customTools[toolName]
+	policyToolName := toolName
+	if customTool != nil {
+		policyToolName = customTool.Name
+	}
 	var err error
 	if _, ok := allowed[toolName]; !ok {
 		err = fmt.Errorf("tool %q was not enabled for this task", call.Name)
@@ -32,7 +36,7 @@ func executeLoopTool(
 	} else {
 		execArgs, approvalKey, alreadyFired, err = gate.prepareApprovedCall(
 			ctx,
-			toolName,
+			policyToolName,
 			call.Arguments,
 			customTool,
 		)
@@ -71,4 +75,35 @@ func executeLoopTool(
 	}
 	gate.markFired(approvalKey)
 	return tools.DefaultRegistry.Execute(execCtx, toolName, execArgs)
+}
+
+func executeGuardedLoopTool(
+	ctx context.Context,
+	call llm.ToolCall,
+	toolName string,
+	allowed map[string]struct{},
+	customTools map[string]*corev1alpha1.Tool,
+	executor *worker.ToolExecutor,
+	gate *approvalGate,
+	baseToolCtx *tools.ToolContext,
+	guard *analysisLoopGuard,
+) (result string, execErr error, cached bool) {
+	if err := guard.beginToolCall(toolName); err != nil {
+		return "", err, false
+	}
+	customTool := customTools[toolName]
+	if result, cached = guard.cachedToolResult(toolName, call.Arguments, customTool); cached {
+		return result, nil, true
+	}
+	result, execErr = executeLoopTool(
+		ctx,
+		call,
+		toolName,
+		allowed,
+		customTools,
+		executor,
+		gate,
+		baseToolCtx,
+	)
+	return result, execErr, false
 }

--- a/workers/ai/tool_execution.go
+++ b/workers/ai/tool_execution.go
@@ -20,7 +20,7 @@ func executeLoopTool(
 	executor *worker.ToolExecutor,
 	gate *approvalGate,
 	baseToolCtx *tools.ToolContext,
-) (string, error) {
+) (string, error, bool) {
 	var execArgs json.RawMessage
 	approvalKey := ""
 	alreadyFired := false
@@ -42,10 +42,14 @@ func executeLoopTool(
 		)
 	}
 	if err != nil {
-		return "", err
+		return "", err, false
 	}
 	if alreadyFired {
-		return fmt.Sprintf("already executed approved action for idempotency key %s; skipping duplicate", approvalKey), nil
+		result := fmt.Sprintf(
+			"already executed approved action for idempotency key %s; skipping duplicate",
+			approvalKey,
+		)
+		return result, nil, false
 	}
 	if customTool != nil {
 		execCtx := worker.WithToolCallID(ctx, call.ID)
@@ -56,12 +60,12 @@ func executeLoopTool(
 		if execErr == nil || worker.ToolRequestWasAttempted(execErr) {
 			gate.markFired(approvalKey)
 		}
-		return result, execErr
+		return result, execErr, execErr == nil
 	}
 	if approvalKey != "" {
 		execArgs, err = injectIdempotencyKey(execArgs, approvalKey)
 		if err != nil {
-			return "", err
+			return "", err, false
 		}
 	}
 	execCtx := ctx
@@ -74,7 +78,8 @@ func executeLoopTool(
 		execCtx = tools.WithToolContext(ctx, &toolCtxCopy)
 	}
 	gate.markFired(approvalKey)
-	return tools.DefaultRegistry.Execute(execCtx, toolName, execArgs)
+	result, execErr := tools.DefaultRegistry.Execute(execCtx, toolName, execArgs)
+	return result, execErr, execErr == nil
 }
 
 func executeGuardedLoopTool(
@@ -87,21 +92,21 @@ func executeGuardedLoopTool(
 	gate *approvalGate,
 	baseToolCtx *tools.ToolContext,
 	guard *analysisLoopGuard,
-) (result string, execErr error, cached bool) {
+) (result string, cached, completed bool, execErr error) {
 	if _, ok := allowed[toolName]; !ok {
-		result, execErr = executeLoopTool(
+		result, execErr, completed = executeLoopTool(
 			ctx, call, toolName, allowed, customTools, executor, gate, baseToolCtx,
 		)
-		return result, execErr, false
+		return result, false, completed, execErr
 	}
 	if err := guard.beginToolCall(toolName); err != nil {
-		return "", err, false
+		return "", false, false, err
 	}
 	customTool := customTools[toolName]
 	if result, cached = guard.cachedToolResult(toolName, call.Arguments, customTool); cached {
-		return result, nil, true
+		return result, true, true, nil
 	}
-	result, execErr = executeLoopTool(
+	result, execErr, completed = executeLoopTool(
 		ctx,
 		call,
 		toolName,
@@ -111,5 +116,5 @@ func executeGuardedLoopTool(
 		gate,
 		baseToolCtx,
 	)
-	return result, execErr, false
+	return result, false, completed, execErr
 }

--- a/workers/ai/tool_execution.go
+++ b/workers/ai/tool_execution.go
@@ -88,6 +88,12 @@ func executeGuardedLoopTool(
 	baseToolCtx *tools.ToolContext,
 	guard *analysisLoopGuard,
 ) (result string, execErr error, cached bool) {
+	if _, ok := allowed[toolName]; !ok {
+		result, execErr = executeLoopTool(
+			ctx, call, toolName, allowed, customTools, executor, gate, baseToolCtx,
+		)
+		return result, execErr, false
+	}
 	if err := guard.beginToolCall(toolName); err != nil {
 		return "", err, false
 	}

--- a/workers/ai/validated_analysis.go
+++ b/workers/ai/validated_analysis.go
@@ -433,10 +433,14 @@ func analysisTransientState(content string) (transient, analysisLike bool, err e
 	if !ok {
 		return false, false, nil
 	}
-	if err := json.Unmarshal(raw, &transient); err != nil {
+	var transientValue *bool
+	if err := json.Unmarshal(raw, &transientValue); err != nil {
 		return false, true, fmt.Errorf("parse final analysis is_transient: %w", err)
 	}
-	return transient, true, nil
+	if transientValue == nil {
+		return false, true, fmt.Errorf("final analysis is_transient must be a boolean")
+	}
+	return *transientValue, true, nil
 }
 
 func lastJSONObject(content string) ([]byte, bool) {

--- a/workers/ai/validated_analysis.go
+++ b/workers/ai/validated_analysis.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
 	"github.com/orka-agents/orka/internal/llm"
 )
 
@@ -30,7 +31,13 @@ type validationToolResult struct {
 
 func isAnalysisValidationTool(name string) bool {
 	normalized := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(name)), "_", "-")
-	return normalized == "validate-analysis" || strings.HasPrefix(normalized, "validate-analysis-")
+	return normalized == "validate-analysis" || strings.HasPrefix(normalized, "validate-analysis-") ||
+		normalized == "submit-analysis" || strings.HasPrefix(normalized, "submit-analysis-")
+}
+
+func isFlatAnalysisSubmissionTool(name string) bool {
+	normalized := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(name)), "_", "-")
+	return normalized == "submit-analysis" || strings.HasPrefix(normalized, "submit-analysis-")
 }
 
 func isTimelineVerificationTool(name string) bool {
@@ -43,7 +50,11 @@ func validatedAnalysisResult(toolName string, args json.RawMessage, result strin
 		return "", false, nil
 	}
 	var call validatedAnalysisCall
-	if err := json.Unmarshal(args, &call); err != nil {
+	if isFlatAnalysisSubmissionTool(toolName) {
+		if err := json.Unmarshal(args, &call.Analysis); err != nil {
+			return "", true, fmt.Errorf("parse submit_analysis arguments: %w", err)
+		}
+	} else if err := json.Unmarshal(args, &call); err != nil {
 		return "", true, fmt.Errorf("parse validate_analysis arguments: %w", err)
 	}
 	if err := validateAnalysisShape(call.Analysis); err != nil {
@@ -92,23 +103,24 @@ func validateAnalysisShape(a validatedAnalysis) error {
 	return nil
 }
 
-func analysisFinalizationTools(tools []llm.Tool) []llm.Tool {
-	out := make([]llm.Tool, 0, 2)
+func analysisToolNames(
+	tools []llm.Tool,
+	customTools map[string]*corev1alpha1.Tool,
+) (validation, timeline map[string]bool, finalization []llm.Tool) {
+	validation = map[string]bool{}
+	timeline = map[string]bool{}
 	for _, tool := range tools {
-		if isAnalysisValidationTool(tool.Name) || isTimelineVerificationTool(tool.Name) {
-			out = append(out, tool)
+		actual := resolvedCustomToolName(tool.Name, customTools)
+		switch {
+		case isAnalysisValidationTool(actual):
+			validation[tool.Name] = true
+			finalization = append(finalization, tool)
+		case isTimelineVerificationTool(actual):
+			timeline[tool.Name] = true
+			finalization = append(finalization, tool)
 		}
 	}
-	return out
-}
-
-func hasAnalysisValidationTool(tools []llm.Tool) bool {
-	for _, tool := range tools {
-		if isAnalysisValidationTool(tool.Name) {
-			return true
-		}
-	}
-	return false
+	return validation, timeline, finalization
 }
 
 func normalizedValidationFailure(err error) string {
@@ -154,11 +166,16 @@ const (
 
 type analysisLoopGuard struct {
 	validationRequired       bool
+	validationToolNames      map[string]bool
+	timelineToolNames        map[string]bool
 	finalizationTools        []llm.Tool
+	customTools              map[string]*corev1alpha1.Tool
 	validationFailures       map[string]int
 	validationFinalRetries   int
 	transientCritiqueRetries int
 	timelineVerified         bool
+	investigationToolCalls   int
+	toolResults              map[string]string
 }
 
 type finalResponseDecision struct {
@@ -175,12 +192,32 @@ type validationInspection struct {
 	fatal   error
 }
 
-func newAnalysisLoopGuard(tools []llm.Tool) *analysisLoopGuard {
+func newAnalysisLoopGuard(
+	tools []llm.Tool,
+	customTools map[string]*corev1alpha1.Tool,
+) *analysisLoopGuard {
+	validation, timeline, finalization := analysisToolNames(tools, customTools)
 	return &analysisLoopGuard{
-		validationRequired: hasAnalysisValidationTool(tools),
-		finalizationTools:  analysisFinalizationTools(tools),
-		validationFailures: map[string]int{},
+		validationRequired:  len(validation) > 0,
+		validationToolNames: validation,
+		timelineToolNames:   timeline,
+		finalizationTools:   finalization,
+		customTools:         customTools,
+		validationFailures:  map[string]int{},
+		toolResults:         map[string]string{},
 	}
+}
+
+func (g *analysisLoopGuard) isValidationTool(name string) bool {
+	return g.validationToolNames[name]
+}
+
+func (g *analysisLoopGuard) isTimelineTool(name string) bool {
+	return g.timelineToolNames[name]
+}
+
+func (g *analysisLoopGuard) isFinalizationTool(name string) bool {
+	return g.isValidationTool(name) || g.isTimelineTool(name)
 }
 
 func (g *analysisLoopGuard) prepareRequest(
@@ -188,7 +225,9 @@ func (g *analysisLoopGuard) prepareRequest(
 	messages []llm.Message,
 	iteration, maxIterations int,
 ) {
-	if g.validationRequired && iteration >= maxIterations-analysisValidationFocusRounds {
+	budgetReached := iteration >= maxIterations-analysisValidationFocusRounds ||
+		g.investigationToolCalls >= analysisMaxInvestigationToolCalls
+	if g.validationRequired && budgetReached {
 		req.Tools = g.finalizationTools
 		req.Messages = appendPrompt(messages, validationFocusPrompt)
 		return
@@ -262,16 +301,17 @@ func (g *analysisLoopGuard) inspectTool(
 ) validationInspection {
 	inspection := validationInspection{execErr: execErr}
 	if inspection.execErr == nil {
-		if isTimelineVerificationTool(toolName) {
+		if g.isTimelineTool(toolName) {
 			g.timelineVerified = true
 		}
-		final, validationCall, validationErr := validatedAnalysisResult(toolName, args, result)
+		actualToolName := resolvedCustomToolName(toolName, g.customTools)
+		final, validationCall, validationErr := validatedAnalysisResult(actualToolName, args, result)
 		if validationCall {
 			inspection.execErr = validationErr
 			inspection.final = final
 		}
 	}
-	if inspection.execErr == nil || !isAnalysisValidationTool(toolName) {
+	if inspection.execErr == nil || !g.isValidationTool(toolName) {
 		return inspection
 	}
 	failure := normalizedValidationFailure(inspection.execErr)

--- a/workers/ai/validated_analysis.go
+++ b/workers/ai/validated_analysis.go
@@ -142,6 +142,8 @@ const (
 	maxValidationFailures         = 3
 	maxValidationFinalRetries     = 2
 	maxTransientCritiqueRetries   = 2
+	defaultSubmissionToolName     = "validate_analysis"
+	defaultTimelineToolName       = "verify_timeline"
 	validationRequiredPrompt      = "The final answer cannot be accepted until validate_analysis succeeds. " +
 		"Call validate_analysis now with the complete final analysis and every supporting evidence token. " +
 		"Do not return prose or final JSON before validation succeeds."
@@ -170,6 +172,7 @@ type analysisLoopGuard struct {
 	finalizationTools        []llm.Tool
 	customTools              map[string]*corev1alpha1.Tool
 	submissionToolName       string
+	timelineToolName         string
 	validationFailures       map[string]int
 	validationFinalRetries   int
 	transientCritiqueRetries int
@@ -212,11 +215,14 @@ func newAnalysisLoopGuard(
 	customTools map[string]*corev1alpha1.Tool,
 ) *analysisLoopGuard {
 	validation, timeline, finalization := analysisToolNames(tools, customTools)
-	submissionToolName := "validate_analysis"
+	submissionToolName := defaultSubmissionToolName
+	timelineToolName := defaultTimelineToolName
 	for _, tool := range tools {
-		if validation[tool.Name] {
+		if validation[tool.Name] && submissionToolName == defaultSubmissionToolName {
 			submissionToolName = tool.Name
-			break
+		}
+		if timeline[tool.Name] && timelineToolName == defaultTimelineToolName {
+			timelineToolName = tool.Name
 		}
 	}
 	return &analysisLoopGuard{
@@ -227,6 +233,7 @@ func newAnalysisLoopGuard(
 		finalizationTools:        finalization,
 		customTools:              customTools,
 		submissionToolName:       submissionToolName,
+		timelineToolName:         timelineToolName,
 		validationFailures:       map[string]int{},
 		toolResults:              map[string]string{},
 	}
@@ -315,7 +322,7 @@ func (g *analysisLoopGuard) handleFinalResponse(
 		return finalResponseDecision{
 			messages: append(messages,
 				llm.Message{Role: "assistant", Content: content},
-				llm.Message{Role: "user", Content: transientCritiquePrompt},
+				llm.Message{Role: "user", Content: g.modelPrompt(transientCritiquePrompt)},
 			),
 			retry: true,
 		}
@@ -363,7 +370,7 @@ func (g *analysisLoopGuard) finishValidatedResult(final, repair string) (string,
 	if final == "" {
 		return "", repair
 	}
-	if validatedAnalysisIsTransient(final) && !g.timelineVerified {
+	if validatedAnalysisIsTransient(final) && len(g.timelineToolNames) > 0 && !g.timelineVerified {
 		return "", g.modelPrompt(transientValidationPrompt)
 	}
 	return final, repair
@@ -400,7 +407,10 @@ func (g *analysisLoopGuard) activeFinalizationTools() []llm.Tool {
 }
 
 func (g *analysisLoopGuard) modelPrompt(prompt string) string {
-	return strings.ReplaceAll(prompt, "validate_analysis", g.submissionToolName)
+	return strings.NewReplacer(
+		"validate_analysis", g.submissionToolName,
+		"verify_timeline", g.timelineToolName,
+	).Replace(prompt)
 }
 
 func appendPrompt(messages []llm.Message, prompt string) []llm.Message {

--- a/workers/ai/validated_analysis.go
+++ b/workers/ai/validated_analysis.go
@@ -378,6 +378,13 @@ func (g *analysisLoopGuard) withoutTimelineTools(tools []llm.Tool) []llm.Tool {
 	return out
 }
 
+func (g *analysisLoopGuard) completedToolCallResult(name string) (string, bool) {
+	if g.timelineVerified && g.isTimelineTool(name) {
+		return "timeline verification already completed; call " + g.submissionToolName + " now", true
+	}
+	return "", false
+}
+
 func (g *analysisLoopGuard) activeFinalizationTools() []llm.Tool {
 	if !g.timelineVerified {
 		return g.finalizationTools

--- a/workers/ai/validated_analysis.go
+++ b/workers/ai/validated_analysis.go
@@ -240,11 +240,11 @@ func newAnalysisLoopGuard(
 }
 
 func (g *analysisLoopGuard) isValidationTool(name string) bool {
-	return g.validationToolNames[name]
+	return g.validationToolNames[strings.TrimSpace(name)]
 }
 
 func (g *analysisLoopGuard) isTimelineTool(name string) bool {
-	return g.timelineToolNames[name]
+	return g.timelineToolNames[strings.TrimSpace(name)]
 }
 
 func (g *analysisLoopGuard) isFinalizationTool(name string) bool {

--- a/workers/ai/validated_analysis.go
+++ b/workers/ai/validated_analysis.go
@@ -7,6 +7,7 @@ import (
 
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
 	"github.com/orka-agents/orka/internal/llm"
+	"github.com/orka-agents/orka/internal/workerenv"
 )
 
 type validatedAnalysisCall struct {
@@ -193,6 +194,20 @@ type validationInspection struct {
 	fatal   error
 }
 
+func agentLoopMaxIterations(coordination workerenv.CoordinationEnv, validationRequired bool) int {
+	maxIterations := 10
+	if coordination.Enabled {
+		maxIterations = 50
+	}
+	if coordination.AutonomousMode {
+		maxIterations = 100
+	}
+	if validationRequired {
+		maxIterations = analysisLoopMaxIterations
+	}
+	return maxIterations
+}
+
 func newAnalysisLoopGuard(
 	tools []llm.Tool,
 	customTools map[string]*corev1alpha1.Tool,
@@ -234,6 +249,9 @@ func (g *analysisLoopGuard) prepareRequest(
 	messages []llm.Message,
 	iteration, maxIterations int,
 ) {
+	if g.timelineVerified {
+		req.Tools = g.withoutTimelineTools(req.Tools)
+	}
 	budgetReached := iteration >= maxIterations-analysisValidationFocusRounds ||
 		g.investigationToolCalls >= analysisMaxInvestigationToolCalls
 	if g.validationRequired && budgetReached {
@@ -345,6 +363,16 @@ func (g *analysisLoopGuard) finishValidatedResult(final, repair string) (string,
 		return "", g.modelPrompt(transientValidationPrompt)
 	}
 	return final, repair
+}
+
+func (g *analysisLoopGuard) withoutTimelineTools(tools []llm.Tool) []llm.Tool {
+	out := make([]llm.Tool, 0, len(tools))
+	for _, tool := range tools {
+		if !g.isTimelineTool(tool.Name) {
+			out = append(out, tool)
+		}
+	}
+	return out
 }
 
 func (g *analysisLoopGuard) activeFinalizationTools() []llm.Tool {

--- a/workers/ai/validated_analysis.go
+++ b/workers/ai/validated_analysis.go
@@ -1,0 +1,368 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/orka-agents/orka/internal/llm"
+)
+
+type validatedAnalysisCall struct {
+	Analysis validatedAnalysis `json:"analysis"`
+}
+
+type validatedAnalysis struct {
+	Summary         string   `json:"summary"`
+	IsTransient     *bool    `json:"is_transient"`
+	RootCause       string   `json:"root_cause"`
+	Severity        string   `json:"severity"`
+	SuggestedFix    string   `json:"suggested_fix"`
+	RelevantFiles   []string `json:"relevant_files"`
+	GCSBytes        *int     `json:"gcs_bytes,omitempty"`
+	ValidationToken string   `json:"validation_token,omitempty"`
+}
+
+type validationToolResult struct {
+	GCSBytes        *int   `json:"gcs_bytes"`
+	ValidationToken string `json:"validation_token"`
+}
+
+func isAnalysisValidationTool(name string) bool {
+	normalized := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(name)), "_", "-")
+	return normalized == "validate-analysis" || strings.HasPrefix(normalized, "validate-analysis-")
+}
+
+func isTimelineVerificationTool(name string) bool {
+	normalized := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(name)), "_", "-")
+	return normalized == "verify-timeline" || strings.HasPrefix(normalized, "verify-timeline-")
+}
+
+func validatedAnalysisResult(toolName string, args json.RawMessage, result string) (string, bool, error) {
+	if !isAnalysisValidationTool(toolName) {
+		return "", false, nil
+	}
+	var call validatedAnalysisCall
+	if err := json.Unmarshal(args, &call); err != nil {
+		return "", true, fmt.Errorf("parse validate_analysis arguments: %w", err)
+	}
+	if err := validateAnalysisShape(call.Analysis); err != nil {
+		return "", true, err
+	}
+	var validation validationToolResult
+	if err := json.Unmarshal([]byte(result), &validation); err != nil {
+		return "", true, fmt.Errorf("parse validate_analysis result: %w", err)
+	}
+	if validation.GCSBytes == nil || *validation.GCSBytes < 0 {
+		return "", true, fmt.Errorf("validate_analysis result has no gcs_bytes")
+	}
+	if strings.TrimSpace(validation.ValidationToken) == "" {
+		return "", true, fmt.Errorf("validate_analysis result has no validation_token")
+	}
+	call.Analysis.GCSBytes = validation.GCSBytes
+	call.Analysis.ValidationToken = validation.ValidationToken
+	final, err := json.Marshal(call.Analysis)
+	if err != nil {
+		return "", true, fmt.Errorf("marshal validated analysis: %w", err)
+	}
+	return string(final), true, nil
+}
+
+func validateAnalysisShape(a validatedAnalysis) error {
+	if strings.TrimSpace(a.Summary) == "" {
+		return fmt.Errorf("analysis.summary is required")
+	}
+	if strings.TrimSpace(a.RootCause) == "" {
+		return fmt.Errorf("analysis.root_cause is required")
+	}
+	switch strings.ToLower(strings.TrimSpace(a.Severity)) {
+	case "critical", "high", "medium", "low":
+	default:
+		return fmt.Errorf("analysis.severity %q is invalid", a.Severity)
+	}
+	if a.IsTransient == nil {
+		return fmt.Errorf("analysis.is_transient is required")
+	}
+	if strings.TrimSpace(a.SuggestedFix) == "" {
+		return fmt.Errorf("analysis.suggested_fix is required")
+	}
+	if a.RelevantFiles == nil {
+		return fmt.Errorf("analysis.relevant_files is required")
+	}
+	return nil
+}
+
+func analysisFinalizationTools(tools []llm.Tool) []llm.Tool {
+	out := make([]llm.Tool, 0, 2)
+	for _, tool := range tools {
+		if isAnalysisValidationTool(tool.Name) || isTimelineVerificationTool(tool.Name) {
+			out = append(out, tool)
+		}
+	}
+	return out
+}
+
+func hasAnalysisValidationTool(tools []llm.Tool) bool {
+	for _, tool := range tools {
+		if isAnalysisValidationTool(tool.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizedValidationFailure(err error) string {
+	if err == nil {
+		return ""
+	}
+	return strings.Join(strings.Fields(err.Error()), " ")
+}
+
+func validatedAnalysisIsTransient(result string) bool {
+	var analysis validatedAnalysis
+	return json.Unmarshal([]byte(result), &analysis) == nil && analysis.IsTransient != nil && *analysis.IsTransient
+}
+
+const (
+	analysisLoopMaxIterations     = 25
+	analysisValidationFocusRounds = 5
+	maxValidationFailures         = 3
+	maxValidationFinalRetries     = 2
+	maxTransientCritiqueRetries   = 2
+	validationRequiredPrompt      = "The final answer cannot be accepted until validate_analysis succeeds. " +
+		"Call validate_analysis now with the complete final analysis and every supporting evidence token. " +
+		"Do not return prose or final JSON before validation succeeds."
+	validationFocusPrompt = "You have reached the investigation budget. Stop reading artifacts. " +
+		"If is_transient is true, call verify_timeline first unless it already succeeded. " +
+		"Then call validate_analysis exactly once with the complete final analysis and all supporting evidence tokens."
+	toolsFreeFinalPrompt = "You have reached your investigation budget. Do NOT call any more tools. " +
+		"Using ONLY the evidence you have already gathered, output your FINAL answer now as the required JSON object " +
+		"and nothing else."
+	emptyFinalPrompt = "Your last response was empty. Do NOT call any tools. " +
+		"Output your FINAL answer now as the required JSON object and nothing else, " +
+		"using the evidence you have already gathered."
+	transientCritiquePrompt = "You set is_transient=true but never called verify_timeline " +
+		"to confirm the failing operation. " +
+		"A bare context deadline or transient-signature match is not proof. Call verify_timeline now. " +
+		"If you cannot prove a known transient class, set is_transient=false, then re-emit the final JSON."
+	transientValidationPrompt = "The validated analysis sets is_transient=true " +
+		"without a successful verify_timeline call. " +
+		"Call verify_timeline for the specific failing operation, then call validate_analysis again."
+	invalidAnalysisPrompt = "The final analysis JSON is malformed. Correct the JSON syntax and required field types, " +
+		"then return the complete final JSON object."
+)
+
+type analysisLoopGuard struct {
+	validationRequired       bool
+	finalizationTools        []llm.Tool
+	validationFailures       map[string]int
+	validationFinalRetries   int
+	transientCritiqueRetries int
+	timelineVerified         bool
+}
+
+type finalResponseDecision struct {
+	result   string
+	messages []llm.Message
+	retry    bool
+	err      error
+}
+
+type validationInspection struct {
+	execErr error
+	final   string
+	repair  string
+	fatal   error
+}
+
+func newAnalysisLoopGuard(tools []llm.Tool) *analysisLoopGuard {
+	return &analysisLoopGuard{
+		validationRequired: hasAnalysisValidationTool(tools),
+		finalizationTools:  analysisFinalizationTools(tools),
+		validationFailures: map[string]int{},
+	}
+}
+
+func (g *analysisLoopGuard) prepareRequest(
+	req *llm.CompletionRequest,
+	messages []llm.Message,
+	iteration, maxIterations int,
+) {
+	if g.validationRequired && iteration >= maxIterations-analysisValidationFocusRounds {
+		req.Tools = g.finalizationTools
+		req.Messages = appendPrompt(messages, validationFocusPrompt)
+		return
+	}
+	if !g.validationRequired && iteration >= maxIterations-2 {
+		req.Tools = nil
+		req.Messages = appendPrompt(messages, toolsFreeFinalPrompt)
+	}
+}
+
+func (g *analysisLoopGuard) handleFinalResponse(
+	content string,
+	iteration, maxIterations int,
+	messages []llm.Message,
+) finalResponseDecision {
+	if g.validationRequired {
+		g.validationFinalRetries++
+		if g.validationFinalRetries > maxValidationFinalRetries {
+			return finalResponseDecision{err: fmt.Errorf("analysis ended without successful validate_analysis")}
+		}
+		return finalResponseDecision{
+			messages: append(messages,
+				llm.Message{Role: "assistant", Content: content},
+				llm.Message{Role: "user", Content: validationRequiredPrompt},
+			),
+			retry: true,
+		}
+	}
+	if strings.TrimSpace(content) == "" && iteration < maxIterations-1 {
+		return finalResponseDecision{
+			messages: append(messages,
+				llm.Message{Role: "assistant", Content: content},
+				llm.Message{Role: "user", Content: emptyFinalPrompt},
+			),
+			retry: true,
+		}
+	}
+	transient, analysisLike, parseErr := analysisTransientState(content)
+	if analysisLike && parseErr != nil {
+		if g.transientCritiqueRetries >= maxTransientCritiqueRetries || iteration >= maxIterations-1 {
+			return finalResponseDecision{err: parseErr}
+		}
+		g.transientCritiqueRetries++
+		return finalResponseDecision{
+			messages: append(messages,
+				llm.Message{Role: "assistant", Content: content},
+				llm.Message{Role: "user", Content: invalidAnalysisPrompt},
+			),
+			retry: true,
+		}
+	}
+	if transient && !g.timelineVerified &&
+		g.transientCritiqueRetries < maxTransientCritiqueRetries && iteration < maxIterations-1 {
+		g.transientCritiqueRetries++
+		return finalResponseDecision{
+			messages: append(messages,
+				llm.Message{Role: "assistant", Content: content},
+				llm.Message{Role: "user", Content: transientCritiquePrompt},
+			),
+			retry: true,
+		}
+	}
+	return finalResponseDecision{result: content}
+}
+
+func (g *analysisLoopGuard) inspectTool(
+	toolName string,
+	args json.RawMessage,
+	result string,
+	execErr error,
+) validationInspection {
+	inspection := validationInspection{execErr: execErr}
+	if inspection.execErr == nil {
+		if isTimelineVerificationTool(toolName) {
+			g.timelineVerified = true
+		}
+		final, validationCall, validationErr := validatedAnalysisResult(toolName, args, result)
+		if validationCall {
+			inspection.execErr = validationErr
+			inspection.final = final
+		}
+	}
+	if inspection.execErr == nil || !isAnalysisValidationTool(toolName) {
+		return inspection
+	}
+	failure := normalizedValidationFailure(inspection.execErr)
+	g.validationFailures[failure]++
+	inspection.repair = "validate_analysis failed: " + failure +
+		". Correct the exact missing or invalid field and retry with changed arguments. Do not repeat the same call."
+	if g.validationFailures[failure] >= maxValidationFailures {
+		inspection.fatal = fmt.Errorf(
+			"validate_analysis repeated the same failure %d times: %s",
+			g.validationFailures[failure],
+			failure,
+		)
+	}
+	return inspection
+}
+
+func (g *analysisLoopGuard) finishValidatedResult(final, repair string) (string, string) {
+	if final == "" {
+		return "", repair
+	}
+	if validatedAnalysisIsTransient(final) && !g.timelineVerified {
+		return "", transientValidationPrompt
+	}
+	return final, repair
+}
+
+func appendPrompt(messages []llm.Message, prompt string) []llm.Message {
+	return append(append([]llm.Message{}, messages...), llm.Message{Role: "user", Content: prompt})
+}
+
+func analysisTransientState(content string) (transient, analysisLike bool, err error) {
+	candidate, found := lastJSONObject(content)
+	if !found {
+		if strings.Contains(content, "is_transient") {
+			return false, true, fmt.Errorf("final analysis has no valid JSON object")
+		}
+		return false, false, nil
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(candidate, &fields); err != nil {
+		return false, true, fmt.Errorf("parse final analysis JSON: %w", err)
+	}
+	raw, ok := fields["is_transient"]
+	if !ok {
+		return false, false, nil
+	}
+	if err := json.Unmarshal(raw, &transient); err != nil {
+		return false, true, fmt.Errorf("parse final analysis is_transient: %w", err)
+	}
+	return transient, true, nil
+}
+
+func lastJSONObject(content string) ([]byte, bool) {
+	var best []byte
+	depth, start := 0, -1
+	inString, escaped := false, false
+	for i := 0; i < len(content); i++ {
+		ch := content[i]
+		if inString {
+			switch {
+			case escaped:
+				escaped = false
+			case ch == '\\':
+				escaped = true
+			case ch == '"':
+				inString = false
+			}
+			continue
+		}
+		switch ch {
+		case '"':
+			if depth > 0 {
+				inString = true
+			}
+		case '{':
+			if depth == 0 {
+				start = i
+			}
+			depth++
+		case '}':
+			if depth == 0 {
+				continue
+			}
+			depth--
+			if depth == 0 && start >= 0 {
+				candidate := []byte(content[start : i+1])
+				if json.Valid(candidate) {
+					best = append(best[:0], candidate...)
+				}
+			}
+		}
+	}
+	return best, best != nil
+}

--- a/workers/ai/validated_analysis.go
+++ b/workers/ai/validated_analysis.go
@@ -148,12 +148,10 @@ const (
 	validationFocusPrompt = "You have reached the investigation budget. Stop reading artifacts. " +
 		"If is_transient is true, call verify_timeline first unless it already succeeded. " +
 		"Then call validate_analysis exactly once with the complete final analysis and all supporting evidence tokens."
-	toolsFreeFinalPrompt = "You have reached your investigation budget. Do NOT call any more tools. " +
-		"Using ONLY the evidence you have already gathered, output your FINAL answer now as the required JSON object " +
-		"and nothing else."
+	toolsFreeFinalPrompt = "You have reached your tool-use budget. Do NOT call any more tools. " +
+		"Using the information already gathered, provide the final answer in the format requested by the Task."
 	emptyFinalPrompt = "Your last response was empty. Do NOT call any tools. " +
-		"Output your FINAL answer now as the required JSON object and nothing else, " +
-		"using the evidence you have already gathered."
+		"Provide the final answer now in the format requested by the Task, using the information already gathered."
 	transientCritiquePrompt = "You set is_transient=true but never called verify_timeline " +
 		"to confirm the failing operation. " +
 		"A bare context deadline or transient-signature match is not proof. Call verify_timeline now. " +
@@ -176,6 +174,7 @@ type analysisLoopGuard struct {
 	validationFinalRetries   int
 	transientCritiqueRetries int
 	timelineVerified         bool
+	transientCritiqueEnabled bool
 	investigationToolCalls   int
 	toolResults              map[string]string
 }
@@ -221,14 +220,15 @@ func newAnalysisLoopGuard(
 		}
 	}
 	return &analysisLoopGuard{
-		validationRequired:  len(validation) > 0,
-		validationToolNames: validation,
-		timelineToolNames:   timeline,
-		finalizationTools:   finalization,
-		customTools:         customTools,
-		submissionToolName:  submissionToolName,
-		validationFailures:  map[string]int{},
-		toolResults:         map[string]string{},
+		validationRequired:       len(validation) > 0,
+		validationToolNames:      validation,
+		timelineToolNames:        timeline,
+		transientCritiqueEnabled: len(timeline) > 0,
+		finalizationTools:        finalization,
+		customTools:              customTools,
+		submissionToolName:       submissionToolName,
+		validationFailures:       map[string]int{},
+		toolResults:              map[string]string{},
 	}
 }
 
@@ -291,6 +291,9 @@ func (g *analysisLoopGuard) handleFinalResponse(
 			),
 			retry: true,
 		}
+	}
+	if !g.transientCritiqueEnabled {
+		return finalResponseDecision{result: content}
 	}
 	transient, analysisLike, parseErr := analysisTransientState(content)
 	if analysisLike && parseErr != nil {

--- a/workers/ai/validated_analysis.go
+++ b/workers/ai/validated_analysis.go
@@ -328,9 +328,10 @@ func (g *analysisLoopGuard) inspectTool(
 	args json.RawMessage,
 	result string,
 	execErr error,
+	completed bool,
 ) validationInspection {
 	inspection := validationInspection{execErr: execErr}
-	if inspection.execErr == nil {
+	if inspection.execErr == nil && completed {
 		if g.isTimelineTool(toolName) {
 			g.timelineVerified = true
 		}

--- a/workers/ai/validated_analysis.go
+++ b/workers/ai/validated_analysis.go
@@ -170,6 +170,7 @@ type analysisLoopGuard struct {
 	timelineToolNames        map[string]bool
 	finalizationTools        []llm.Tool
 	customTools              map[string]*corev1alpha1.Tool
+	submissionToolName       string
 	validationFailures       map[string]int
 	validationFinalRetries   int
 	transientCritiqueRetries int
@@ -197,12 +198,20 @@ func newAnalysisLoopGuard(
 	customTools map[string]*corev1alpha1.Tool,
 ) *analysisLoopGuard {
 	validation, timeline, finalization := analysisToolNames(tools, customTools)
+	submissionToolName := "validate_analysis"
+	for _, tool := range tools {
+		if validation[tool.Name] {
+			submissionToolName = tool.Name
+			break
+		}
+	}
 	return &analysisLoopGuard{
 		validationRequired:  len(validation) > 0,
 		validationToolNames: validation,
 		timelineToolNames:   timeline,
 		finalizationTools:   finalization,
 		customTools:         customTools,
+		submissionToolName:  submissionToolName,
 		validationFailures:  map[string]int{},
 		toolResults:         map[string]string{},
 	}
@@ -228,8 +237,8 @@ func (g *analysisLoopGuard) prepareRequest(
 	budgetReached := iteration >= maxIterations-analysisValidationFocusRounds ||
 		g.investigationToolCalls >= analysisMaxInvestigationToolCalls
 	if g.validationRequired && budgetReached {
-		req.Tools = g.finalizationTools
-		req.Messages = appendPrompt(messages, validationFocusPrompt)
+		req.Tools = g.activeFinalizationTools()
+		req.Messages = appendPrompt(messages, g.modelPrompt(validationFocusPrompt))
 		return
 	}
 	if !g.validationRequired && iteration >= maxIterations-2 {
@@ -251,7 +260,7 @@ func (g *analysisLoopGuard) handleFinalResponse(
 		return finalResponseDecision{
 			messages: append(messages,
 				llm.Message{Role: "assistant", Content: content},
-				llm.Message{Role: "user", Content: validationRequiredPrompt},
+				llm.Message{Role: "user", Content: g.modelPrompt(validationRequiredPrompt)},
 			),
 			retry: true,
 		}
@@ -316,7 +325,7 @@ func (g *analysisLoopGuard) inspectTool(
 	}
 	failure := normalizedValidationFailure(inspection.execErr)
 	g.validationFailures[failure]++
-	inspection.repair = "validate_analysis failed: " + failure +
+	inspection.repair = toolName + " failed: " + failure +
 		". Correct the exact missing or invalid field and retry with changed arguments. Do not repeat the same call."
 	if g.validationFailures[failure] >= maxValidationFailures {
 		inspection.fatal = fmt.Errorf(
@@ -333,9 +342,26 @@ func (g *analysisLoopGuard) finishValidatedResult(final, repair string) (string,
 		return "", repair
 	}
 	if validatedAnalysisIsTransient(final) && !g.timelineVerified {
-		return "", transientValidationPrompt
+		return "", g.modelPrompt(transientValidationPrompt)
 	}
 	return final, repair
+}
+
+func (g *analysisLoopGuard) activeFinalizationTools() []llm.Tool {
+	if !g.timelineVerified {
+		return g.finalizationTools
+	}
+	out := make([]llm.Tool, 0, len(g.finalizationTools))
+	for _, tool := range g.finalizationTools {
+		if !g.isTimelineTool(tool.Name) {
+			out = append(out, tool)
+		}
+	}
+	return out
+}
+
+func (g *analysisLoopGuard) modelPrompt(prompt string) string {
+	return strings.ReplaceAll(prompt, "validate_analysis", g.submissionToolName)
 }
 
 func appendPrompt(messages []llm.Message, prompt string) []llm.Message {

--- a/workers/ai/validated_analysis_test.go
+++ b/workers/ai/validated_analysis_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+	"github.com/orka-agents/orka/internal/llm"
+	"github.com/orka-agents/orka/internal/worker"
+)
+
+const testValidationToolName = "validate-analysis-task"
+
+func TestValidatedAnalysisResult(t *testing.T) {
+	args := validAnalysisArguments()
+	result, matched, err := validatedAnalysisResult(
+		testValidationToolName,
+		args,
+		`{"gcs_bytes":123,"validation_token":"signed"}`,
+	)
+	if err != nil {
+		t.Fatalf("validatedAnalysisResult() error = %v", err)
+	}
+	if !matched {
+		t.Fatal("validatedAnalysisResult() did not recognize the validation tool")
+	}
+	var got validatedAnalysis
+	if err := json.Unmarshal([]byte(result), &got); err != nil {
+		t.Fatalf("unmarshal final result: %v", err)
+	}
+	if got.GCSBytes == nil || *got.GCSBytes != 123 || got.ValidationToken != "signed" {
+		t.Fatalf("final result = %+v", got)
+	}
+	if got.RootCause != "cause" || got.Summary != "summary" {
+		t.Fatalf("validated fields changed: %+v", got)
+	}
+}
+
+func TestExecuteAgentLoopFinalizesValidatedAnalysis(t *testing.T) {
+	server := validationToolServer(t, http.StatusOK, `{"gcs_bytes":123,"validation_token":"signed"}`)
+	defer server.Close()
+	provider := &sequenceProvider{responses: []*llm.CompletionResponse{{
+		ToolCalls:  []llm.ToolCall{{ID: "validate", Name: testValidationToolName, Arguments: validAnalysisArguments()}},
+		StopReason: "tool_calls",
+	}}}
+	result, err := executeAgentLoop(
+		context.Background(), provider, []llm.Message{{Role: "user", Content: "analyze"}}, "", "model",
+		[]llm.Tool{{Name: testValidationToolName}}, validationCustomTools(server.URL), worker.NewToolExecutor(),
+	)
+	if err != nil {
+		t.Fatalf("executeAgentLoop() error = %v", err)
+	}
+	if provider.callCount != 1 {
+		t.Fatalf("provider calls = %d, want 1", provider.callCount)
+	}
+	if !strings.Contains(result, `"validation_token":"signed"`) || !strings.Contains(result, `"gcs_bytes":123`) {
+		t.Fatalf("result = %s", result)
+	}
+}
+
+func TestExecuteAgentLoopRequiresValidation(t *testing.T) {
+	server := validationToolServer(t, http.StatusOK, `{"gcs_bytes":123,"validation_token":"signed"}`)
+	defer server.Close()
+	provider := &sequenceProvider{responses: []*llm.CompletionResponse{
+		{Content: `{"summary":"unvalidated"}`, StopReason: "end_turn"},
+		{
+			ToolCalls: []llm.ToolCall{{
+				ID: "validate", Name: testValidationToolName, Arguments: validAnalysisArguments(),
+			}},
+			StopReason: "tool_calls",
+		},
+	}}
+	result, err := executeAgentLoop(
+		context.Background(), provider, []llm.Message{{Role: "user", Content: "analyze"}}, "", "model",
+		[]llm.Tool{{Name: testValidationToolName}}, validationCustomTools(server.URL), worker.NewToolExecutor(),
+	)
+	if err != nil {
+		t.Fatalf("executeAgentLoop() error = %v", err)
+	}
+	if provider.callCount != 2 {
+		t.Fatalf("provider calls = %d, want 2", provider.callCount)
+	}
+	if !strings.Contains(result, `"validation_token":"signed"`) {
+		t.Fatalf("result = %s", result)
+	}
+}
+
+func TestExecuteAgentLoopStopsRepeatedValidationFailure(t *testing.T) {
+	server := validationToolServer(t, http.StatusBadRequest, "analysis.root_cause is required")
+	defer server.Close()
+	provider := &mockProvider{response: &llm.CompletionResponse{
+		ToolCalls:  []llm.ToolCall{{ID: "validate", Name: testValidationToolName, Arguments: validAnalysisArguments()}},
+		StopReason: "tool_calls",
+	}}
+	_, err := executeAgentLoop(
+		context.Background(), provider, []llm.Message{{Role: "user", Content: "analyze"}}, "", "model",
+		[]llm.Tool{{Name: testValidationToolName}}, validationCustomTools(server.URL), worker.NewToolExecutor(),
+	)
+	if err == nil || !strings.Contains(err.Error(), "repeated the same failure 3 times") {
+		t.Fatalf("executeAgentLoop() error = %v", err)
+	}
+}
+
+func validAnalysisArguments() json.RawMessage {
+	return json.RawMessage(`{
+		"analysis": {
+			"summary": "summary",
+			"is_transient": false,
+			"root_cause": "cause",
+			"severity": "High",
+			"suggested_fix": "fix",
+			"relevant_files": []
+		},
+		"evidence_tokens": []
+	}`)
+}
+
+func validationToolServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = fmt.Fprint(w, body)
+	}))
+}
+
+func validationCustomTools(url string) map[string]*corev1alpha1.Tool {
+	return map[string]*corev1alpha1.Tool{
+		testValidationToolName: {
+			ObjectMeta: metav1.ObjectMeta{Name: testValidationToolName},
+			Spec: corev1alpha1.ToolSpec{
+				Description: "validate analysis",
+				HTTP:        &corev1alpha1.HTTPExecution{URL: url, Method: http.MethodPost},
+			},
+		},
+	}
+}
+
+func TestAnalysisTransientStateRejectsMalformedAnalysis(t *testing.T) {
+	_, analysisLike, err := analysisTransientState(`{"is_transient": tru}`)
+	if !analysisLike || err == nil {
+		t.Fatalf("analysisTransientState() = analysisLike %t, error %v", analysisLike, err)
+	}
+}
+
+func TestAnalysisLoopGuardNarrowsFinalizationTools(t *testing.T) {
+	guard := newAnalysisLoopGuard([]llm.Tool{
+		{Name: "read-artifact-build"},
+		{Name: "verify-timeline-build"},
+		{Name: testValidationToolName},
+	})
+	req := &llm.CompletionRequest{Tools: []llm.Tool{
+		{Name: "read-artifact-build"},
+		{Name: "verify-timeline-build"},
+		{Name: testValidationToolName},
+	}}
+	guard.prepareRequest(req, nil, analysisLoopMaxIterations-analysisValidationFocusRounds, analysisLoopMaxIterations)
+	allowed := advertisedToolNames(req.Tools)
+	if _, ok := allowed["read-artifact-build"]; ok {
+		t.Fatal("finalization request still advertises artifact investigation tools")
+	}
+	if _, ok := allowed[testValidationToolName]; !ok {
+		t.Fatal("finalization request omitted validate_analysis")
+	}
+}

--- a/workers/ai/validated_analysis_test.go
+++ b/workers/ai/validated_analysis_test.go
@@ -242,3 +242,10 @@ func TestValidatedTransientWithoutTimelineToolCanFinish(t *testing.T) {
 		t.Fatalf("final=%q repair=%q", final, repair)
 	}
 }
+
+func TestAnalysisTransientStateRejectsNull(t *testing.T) {
+	_, analysisLike, err := analysisTransientState(`{"is_transient":null}`)
+	if !analysisLike || err == nil {
+		t.Fatalf("analysisTransientState() = analysisLike %t, error %v", analysisLike, err)
+	}
+}

--- a/workers/ai/validated_analysis_test.go
+++ b/workers/ai/validated_analysis_test.go
@@ -155,7 +155,7 @@ func TestAnalysisLoopGuardNarrowsFinalizationTools(t *testing.T) {
 		{Name: "read-artifact-build"},
 		{Name: "verify-timeline-build"},
 		{Name: testValidationToolName},
-	})
+	}, nil)
 	req := &llm.CompletionRequest{Tools: []llm.Tool{
 		{Name: "read-artifact-build"},
 		{Name: "verify-timeline-build"},

--- a/workers/ai/validated_analysis_test.go
+++ b/workers/ai/validated_analysis_test.go
@@ -181,3 +181,25 @@ func TestValidatedAnalysisCapsAutonomousIterations(t *testing.T) {
 		t.Fatalf("ordinary autonomous iterations = %d", got)
 	}
 }
+
+func TestOrdinaryTaskFinalizationPreservesRequestedFormat(t *testing.T) {
+	guard := newAnalysisLoopGuard(nil, nil)
+	req := &llm.CompletionRequest{}
+	guard.prepareRequest(req, nil, 9, 10)
+	if len(req.Messages) != 1 || strings.Contains(req.Messages[0].Content, "JSON") ||
+		!strings.Contains(req.Messages[0].Content, "format requested by the Task") {
+		t.Fatalf("ordinary finalization prompt = %+v", req.Messages)
+	}
+	decision := guard.handleFinalResponse("is_transient is discussed in prose", 1, 10, nil)
+	if decision.err != nil || decision.retry || decision.result == "" {
+		t.Fatalf("ordinary prose decision = %+v", decision)
+	}
+}
+
+func TestTimelineToolEnablesLegacyTransientCritique(t *testing.T) {
+	guard := newAnalysisLoopGuard([]llm.Tool{{Name: "verify_timeline"}}, nil)
+	decision := guard.handleFinalResponse(`{"is_transient":true}`, 1, 10, nil)
+	if !decision.retry {
+		t.Fatalf("transient analysis was not re-prompted: %+v", decision)
+	}
+}

--- a/workers/ai/validated_analysis_test.go
+++ b/workers/ai/validated_analysis_test.go
@@ -14,6 +14,7 @@ import (
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
 	"github.com/orka-agents/orka/internal/llm"
 	"github.com/orka-agents/orka/internal/worker"
+	"github.com/orka-agents/orka/internal/workerenv"
 )
 
 const testValidationToolName = "validate-analysis-task"
@@ -168,5 +169,15 @@ func TestAnalysisLoopGuardNarrowsFinalizationTools(t *testing.T) {
 	}
 	if _, ok := allowed[testValidationToolName]; !ok {
 		t.Fatal("finalization request omitted validate_analysis")
+	}
+}
+
+func TestValidatedAnalysisCapsAutonomousIterations(t *testing.T) {
+	coordination := workerenv.CoordinationEnv{Enabled: true, AutonomousMode: true}
+	if got := agentLoopMaxIterations(coordination, true); got != analysisLoopMaxIterations {
+		t.Fatalf("validated autonomous iterations = %d", got)
+	}
+	if got := agentLoopMaxIterations(coordination, false); got != 100 {
+		t.Fatalf("ordinary autonomous iterations = %d", got)
 	}
 }

--- a/workers/ai/validated_analysis_test.go
+++ b/workers/ai/validated_analysis_test.go
@@ -203,3 +203,14 @@ func TestTimelineToolEnablesLegacyTransientCritique(t *testing.T) {
 		t.Fatalf("transient analysis was not re-prompted: %+v", decision)
 	}
 }
+
+func TestSkippedApprovedTimelineDoesNotVerify(t *testing.T) {
+	guard := newAnalysisLoopGuard([]llm.Tool{{Name: "verify_timeline"}}, nil)
+	inspection := guard.inspectTool("verify_timeline", nil, "already executed", nil, false)
+	if inspection.execErr != nil {
+		t.Fatal(inspection.execErr)
+	}
+	if guard.timelineVerified {
+		t.Fatal("idempotency-skipped timeline call counted as verified")
+	}
+}

--- a/workers/ai/validated_analysis_test.go
+++ b/workers/ai/validated_analysis_test.go
@@ -214,3 +214,15 @@ func TestSkippedApprovedTimelineDoesNotVerify(t *testing.T) {
 		t.Fatal("idempotency-skipped timeline call counted as verified")
 	}
 }
+
+func TestValidationPromptCanBeReappliedAfterCompaction(t *testing.T) {
+	guard := newAnalysisLoopGuard([]llm.Tool{{Name: testValidationToolName}}, nil)
+	guard.investigationToolCalls = analysisMaxInvestigationToolCalls
+	req := &llm.CompletionRequest{Tools: []llm.Tool{{Name: testValidationToolName}}}
+	guard.prepareRequest(req, []llm.Message{{Role: "user", Content: "before"}}, 1, analysisLoopMaxIterations)
+	req.Messages = []llm.Message{{Role: "user", Content: "compacted"}}
+	guard.prepareRequest(req, req.Messages, 1, analysisLoopMaxIterations)
+	if len(req.Messages) != 2 || !strings.Contains(req.Messages[1].Content, testValidationToolName) {
+		t.Fatalf("reapplied prompt = %+v", req.Messages)
+	}
+}

--- a/workers/ai/validated_analysis_test.go
+++ b/workers/ai/validated_analysis_test.go
@@ -226,3 +226,19 @@ func TestValidationPromptCanBeReappliedAfterCompaction(t *testing.T) {
 		t.Fatalf("reapplied prompt = %+v", req.Messages)
 	}
 }
+
+func TestValidatedTransientWithoutTimelineToolCanFinish(t *testing.T) {
+	guard := newAnalysisLoopGuard([]llm.Tool{{Name: testValidationToolName}}, nil)
+	transient := true
+	result, err := json.Marshal(validatedAnalysis{
+		Summary: "summary", IsTransient: &transient, RootCause: "cause", Severity: "High",
+		SuggestedFix: "fix", RelevantFiles: []string{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	final, repair := guard.finishValidatedResult(string(result), "")
+	if final == "" || repair != "" {
+		t.Fatalf("final=%q repair=%q", final, repair)
+	}
+}


### PR DESCRIPTION
## Summary

- require validated analysis Tasks to complete through their final submission Tool and construct the Task result from the successfully validated payload
- add model-facing aliases for scoped custom Tools while preserving resource-name approval and policy semantics
- bound validated analysis runs to one Tool call per model turn, 20 investigation Tool calls, and 25 total model iterations
- reuse exact duplicate results only for immutable Tools that explicitly opt in
- emit events for Tool calls skipped by the single-call analysis policy
- preserve successful timeline verification and stop advertising the timeline Tool after it succeeds
- fail repeated identical submission errors instead of allowing unbounded retries

## Motivation

The Prow analysis workload exposed several weak-model failure modes: repeated artifact reads, 40 to 80 round investigation loops, malformed nested validator calls, final responses without validation, and long scoped Tool names that models handled inconsistently. These controls move convergence and final-result integrity into the worker instead of relying on prompt compliance or a frontier model.

Tool aliases are model-facing only. Approval policy, Tool execution, and analysis classification continue to use the underlying Tool resource identity.

## Validation

- `make lint-fix`
- `make test`
- `go test ./workers/ai -count=1`
- `go test -race ./workers/ai -count=1`
- structured `autoreview` repeated until no accepted/actionable findings remained
- built and exercised `ghcr.io/willie-yao/orka/ai-worker:h100-7b21662-phase1` against live Kimi analysis Tasks on the H100 evaluation cluster

## Live evidence

The first Kimi comparison Task that previously timed out completed in 8m28s with a signed result under the Phase 1 worker. Follow-up comparison Tasks are being used to measure the final model-facing submission alias and bounded finalization behavior. The dashboard scheduler remains suspended and no production side effects are enabled.


### Final Kimi spike

Three weak-model comparison Tasks using the Ray Serve Kimi endpoint completed with signed `submit_analysis` results. The final DRA spike completed in 5m39s with 22 model requests and 22 Tool calls, compared with the earlier 79 to 80 request Gemini runs and the original Kimi prose-only result. The result quality still missed the earliest DRA cache error, which is the target for the dashboard evidence-seeding and pre-triage follow-up rather than this generic worker PR.
