### PR TITLE
fix(ui): paginate task inventory safely

### DIFF
--- a/ui/src/components/dashboard/overview.test.tsx
+++ b/ui/src/components/dashboard/overview.test.tsx
@@ -1,5 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, waitFor, within } from '@/test/test-utils'
+import {
+  act,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@/test/test-utils'
+import { render as rawRender } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { http, HttpResponse } from 'msw'
 import { server } from '@/test/mocks/server'
 
@@ -63,5 +71,135 @@ describe('Overview', () => {
     })
     expect(within(card).getByText('Cancelled')).toBeInTheDocument()
     expect(within(card).getByText('Running')).toBeInTheDocument()
+  })
+
+  it('loads every task page before reporting dashboard inventory', async () => {
+    const requests: Array<string | null> = []
+    const mk = (name: string) => ({
+      metadata: { name, namespace: 'default', uid: name },
+      spec: { type: 'container' },
+      status: { phase: 'Running' },
+    })
+    server.use(
+      http.get('/api/v1/tasks', ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get('continue')
+        requests.push(cursor)
+        if (!cursor) {
+          return HttpResponse.json({
+            items: [mk('first-page-task')],
+            metadata: { continue: 'page-2' },
+          })
+        }
+        return HttpResponse.json({
+          items: [mk('second-page-task')],
+          metadata: {},
+        })
+      }),
+    )
+
+    render(<Overview />)
+
+    expect(await screen.findByText('second-page-task')).toBeInTheDocument()
+    expect(screen.getByText('first-page-task')).toBeInTheDocument()
+    expect(requests).toEqual([null, 'page-2'])
+  })
+
+  it('keeps task-derived dashboard views loading until the final page arrives', async () => {
+    let releaseFinalPage: () => void = () => {}
+    const finalPageGate = new Promise<void>((resolve) => {
+      releaseFinalPage = resolve
+    })
+    let requests = 0
+    server.use(
+      http.get('/api/v1/tasks', async ({ request }) => {
+        requests += 1
+        const cursor = new URL(request.url).searchParams.get('continue')
+        if (!cursor) {
+          return HttpResponse.json({
+            items: [],
+            metadata: { continue: 'page-2' },
+          })
+        }
+        await finalPageGate
+        return HttpResponse.json({ items: [], metadata: {} })
+      }),
+    )
+
+    render(<Overview />)
+
+    await waitFor(() => expect(requests).toBe(2))
+    expect(
+      screen.getByRole('status', {
+        name: /loading complete task inventory/i,
+      }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Phase Distribution')).not.toBeInTheDocument()
+
+    releaseFinalPage()
+
+    expect(await screen.findByText('Phase Distribution')).toBeInTheDocument()
+  })
+
+  it('does not report task counts when complete inventory pagination fails', async () => {
+    server.use(
+      http.get('/api/v1/tasks', () =>
+        HttpResponse.json({
+          items: [],
+          metadata: { continue: 'same-cursor' },
+        }),
+      ),
+    )
+
+    render(<Overview />)
+
+    expect(
+      await screen.findByRole('alert', {
+        name: /unable to load complete task inventory/i,
+      }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Phase Distribution')).not.toBeInTheDocument()
+  })
+
+  it('hides cached task counts when a complete-inventory refetch fails', async () => {
+    let calls = 0
+    server.use(
+      http.get('/api/v1/tasks', () => {
+        calls += 1
+        if (calls === 1) {
+          return HttpResponse.json({ items: [], metadata: {} })
+        }
+        return HttpResponse.json({
+          items: [],
+          metadata: { continue: 'same-cursor' },
+        })
+      }),
+    )
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: 1, retryDelay: 0, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    })
+
+    rawRender(
+      <QueryClientProvider client={queryClient}>
+        <Overview />
+      </QueryClientProvider>,
+    )
+
+    expect(await screen.findByText('Phase Distribution')).toBeInTheDocument()
+    await act(async () => {
+      await queryClient.refetchQueries({
+        queryKey: ['tasks', 'all', 'default', '100'],
+      })
+    })
+
+    expect(
+      await screen.findByRole('alert', {
+        name: /unable to load complete task inventory/i,
+      }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Phase Distribution')).not.toBeInTheDocument()
+    expect(calls).toBe(3)
   })
 })

--- a/ui/src/components/dashboard/overview.tsx
+++ b/ui/src/components/dashboard/overview.tsx
@@ -1,13 +1,15 @@
-import { useTaskList } from '@/hooks/use-tasks'
+import { useTaskListAll } from '@/hooks/use-tasks'
 import { useSessionList } from '@/hooks/use-sessions'
 import { useAgentList } from '@/hooks/use-agents'
 import { useToolList } from '@/hooks/use-tools'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { PageHeader } from '@/components/layout/page-header'
 import { Distribution } from '@/components/ui/distribution'
+import { Skeleton } from '@/components/ui/skeleton'
 import { taskPhaseSchema } from '@/schemas/task'
 import { StatsCards } from './stats-cards'
 import { RecentTasks } from './recent-tasks'
+import { TaskInventoryError } from '@/components/tasks/task-inventory-error'
 
 // Drive the distribution from the full phase enum (Pending/Running/Succeeded/
 // Failed/Scheduled/Cancelled) so every task the Total card counts is also
@@ -15,7 +17,13 @@ import { RecentTasks } from './recent-tasks'
 const PHASES = taskPhaseSchema.options
 
 export function Overview() {
-  const { data: tasksData, isLoading: tasksLoading } = useTaskList('100')
+  const {
+    data: tasksData,
+    isLoading: tasksLoading,
+    error: tasksError,
+    isFetching: tasksFetching,
+    refetch: refetchTasks,
+  } = useTaskListAll('100')
   const { data: sessionsData, isLoading: sessionsLoading } = useSessionList('100')
   const { data: agentsData, isLoading: agentsLoading } = useAgentList()
   const { data: toolsData, isLoading: toolsLoading } = useToolList()
@@ -31,26 +39,44 @@ export function Overview() {
   return (
     <div className="space-y-6">
       <PageHeader title="Dashboard" description="Overview of your Orka workspace" />
-      <StatsCards
-        tasks={tasksData?.items}
-        sessionCount={sessionsData?.items?.length}
-        agentCount={agentsData?.items?.length}
-        toolCount={toolsData?.items?.length}
-        isLoading={isLoading}
-      />
-      <div className="grid gap-6 lg:grid-cols-3">
-        <Card className="lg:col-span-1">
-          <CardHeader>
-            <CardTitle className="text-sm font-medium">Phase Distribution</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <Distribution segments={distribution} />
-          </CardContent>
-        </Card>
-        <div className="lg:col-span-2">
-          <RecentTasks tasks={tasksData?.items} isLoading={tasksLoading} />
+      {tasksError ? (
+        <TaskInventoryError
+          isRetrying={tasksFetching}
+          onRetry={() => void refetchTasks()}
+        />
+      ) : !tasksData ? (
+        <div
+          role="status"
+          aria-label="Loading complete task inventory"
+          className="grid gap-6 lg:grid-cols-3"
+        >
+          <Skeleton className="h-32 w-full lg:col-span-1" />
+          <Skeleton className="h-32 w-full lg:col-span-2" />
         </div>
-      </div>
+      ) : (
+        <>
+          <StatsCards
+            tasks={tasksData.items}
+            sessionCount={sessionsData?.items?.length}
+            agentCount={agentsData?.items?.length}
+            toolCount={toolsData?.items?.length}
+            isLoading={isLoading}
+          />
+          <div className="grid gap-6 lg:grid-cols-3">
+            <Card className="lg:col-span-1">
+              <CardHeader>
+                <CardTitle className="text-sm font-medium">Phase Distribution</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Distribution segments={distribution} />
+              </CardContent>
+            </Card>
+            <div className="lg:col-span-2">
+              <RecentTasks tasks={tasksData.items} isLoading={tasksLoading} />
+            </div>
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/ui/src/components/tasks/agent-grid-view.test.tsx
+++ b/ui/src/components/tasks/agent-grid-view.test.tsx
@@ -1,5 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, waitFor } from '@/test/test-utils'
+import {
+  act,
+  createTestQueryClient,
+  render,
+  screen,
+  waitFor,
+} from '@/test/test-utils'
+import { render as rawRender } from '@testing-library/react'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { http, HttpResponse } from 'msw'
 import { server } from '@/test/mocks/server'
 
@@ -68,5 +76,143 @@ describe('AgentGridView', () => {
     await waitFor(() => {
       expect(screen.getByText('2 active tasks')).toBeInTheDocument()
     })
+  })
+
+  it('loads every task page before reporting active agents', async () => {
+    const requests: Array<string | null> = []
+    server.use(
+      http.get('/api/v1/tasks', ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get('continue')
+        requests.push(cursor)
+        if (!cursor) {
+          return HttpResponse.json({
+            items: [],
+            metadata: { continue: 'page-2' },
+          })
+        }
+        return HttpResponse.json({
+          items: [
+            {
+              metadata: {
+                name: 'second-page-agent',
+                namespace: 'default',
+                uid: 'second-page-agent',
+              },
+              spec: { type: 'agent' },
+              status: { phase: 'Running', startTime: new Date().toISOString() },
+            },
+          ],
+          metadata: {},
+        })
+      }),
+    )
+
+    render(<AgentGridView />)
+
+    expect(await screen.findByText('second-page-agent')).toBeInTheDocument()
+    expect(screen.getByText('1 active task')).toBeInTheDocument()
+    expect(requests).toEqual([null, 'page-2'])
+  })
+
+  it('keeps active-agent counts loading until the final task page arrives', async () => {
+    let releaseFinalPage: () => void = () => {}
+    const finalPageGate = new Promise<void>((resolve) => {
+      releaseFinalPage = resolve
+    })
+    let requests = 0
+    server.use(
+      http.get('/api/v1/tasks', async ({ request }) => {
+        requests += 1
+        const cursor = new URL(request.url).searchParams.get('continue')
+        if (!cursor) {
+          return HttpResponse.json({
+            items: [],
+            metadata: { continue: 'page-2' },
+          })
+        }
+        await finalPageGate
+        return HttpResponse.json({ items: [], metadata: {} })
+      }),
+    )
+
+    render(<AgentGridView />)
+
+    await waitFor(() => expect(requests).toBe(2))
+    expect(
+      screen.getByRole('status', {
+        name: /loading complete task inventory/i,
+      }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('0 active tasks')).not.toBeInTheDocument()
+
+    releaseFinalPage()
+
+    expect(await screen.findByText('0 active tasks')).toBeInTheDocument()
+  })
+
+  it('does not show an empty inventory when complete pagination fails', async () => {
+    server.use(
+      http.get('/api/v1/tasks', () =>
+        HttpResponse.json({
+          items: [],
+          metadata: { continue: 'same-cursor' },
+        }),
+      ),
+    )
+
+    render(<AgentGridView />)
+
+    expect(
+      await screen.findByRole('alert', {
+        name: /unable to load complete task inventory/i,
+      }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Task inventory unavailable')).toBeInTheDocument()
+    expect(screen.queryByText('0 active tasks')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/No tasks currently running/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('hides cached counts when a complete-inventory refetch fails', async () => {
+    let calls = 0
+    server.use(
+      http.get('/api/v1/tasks', () => {
+        calls += 1
+        if (calls === 1) {
+          return HttpResponse.json({ items: [], metadata: {} })
+        }
+        return HttpResponse.json({
+          items: [],
+          metadata: { continue: 'same-cursor' },
+        })
+      }),
+    )
+    const queryClient = createTestQueryClient()
+
+    rawRender(
+      <QueryClientProvider client={queryClient}>
+        <AgentGridView />
+      </QueryClientProvider>,
+    )
+
+    expect(await screen.findByText('0 active tasks')).toBeInTheDocument()
+    await act(async () => {
+      await queryClient.refetchQueries({
+        queryKey: ['tasks', 'all', 'default', '100'],
+      })
+    })
+
+    expect(
+      await screen.findByRole('alert', {
+        name: /unable to load complete task inventory/i,
+      }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Task inventory unavailable')).toBeInTheDocument()
+    expect(screen.queryByText('0 active tasks')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/No tasks currently running/i),
+    ).not.toBeInTheDocument()
+    expect(calls).toBe(3)
   })
 })

--- a/ui/src/components/tasks/agent-grid-view.tsx
+++ b/ui/src/components/tasks/agent-grid-view.tsx
@@ -5,9 +5,10 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { PageHeader } from '@/components/layout/page-header'
 import { EmptyState } from '@/components/ui/empty-state'
 import { SonarPing } from '@/components/ui/sonar-ping'
-import { useTaskList } from '@/hooks/use-tasks'
+import { useTaskListAll } from '@/hooks/use-tasks'
 import { useFreshness } from '@/hooks/use-freshness'
 import { cn } from '@/lib/utils'
+import { TaskInventoryError } from './task-inventory-error'
 import { TaskStatusBadge } from './task-status-badge'
 import type { Task } from '@/schemas/task'
 
@@ -61,15 +62,29 @@ function AgentMiniPanel({ task }: { task: Task }) {
 }
 
 export function AgentGridView() {
-  const { data, isLoading } = useTaskList()
+  const { data, error, isFetching, refetch } = useTaskListAll('100')
 
-  const runningTasks = (data?.items ?? []).filter(t => t.status?.phase === 'Running')
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <PageHeader title="Live Agents" description="Task inventory unavailable" />
+        <TaskInventoryError
+          isRetrying={isFetching}
+          onRetry={() => void refetch()}
+        />
+      </div>
+    )
+  }
 
-  if (isLoading) {
+  if (!data) {
     return (
       <div className="space-y-4">
         <PageHeader title="Live Agents" description="Active task execution overview" />
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        <div
+          role="status"
+          aria-label="Loading complete task inventory"
+          className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+        >
           {Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} className="h-32 w-full" />
           ))}
@@ -77,6 +92,8 @@ export function AgentGridView() {
       </div>
     )
   }
+
+  const runningTasks = data.items.filter(t => t.status?.phase === 'Running')
 
   return (
     <div className="space-y-4">

--- a/ui/src/components/tasks/kanban-board.test.tsx
+++ b/ui/src/components/tasks/kanban-board.test.tsx
@@ -1,5 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, waitFor } from '@/test/test-utils'
+import {
+  act,
+  createTestQueryClient,
+  render,
+  screen,
+  waitFor,
+} from '@/test/test-utils'
+import { render as rawRender } from '@testing-library/react'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { http, HttpResponse } from 'msw'
 import { server } from '@/test/mocks/server'
 
@@ -118,6 +126,135 @@ describe('KanbanBoard', () => {
     expect(screen.getByText('running-task')).toBeInTheDocument()
     expect(screen.getByText('done-task')).toBeInTheDocument()
     expect(screen.getByText('fail-task')).toBeInTheDocument()
+  })
+
+  it('loads every task page before populating the board', async () => {
+    const requests: Array<string | null> = []
+    server.use(
+      http.get('/api/v1/tasks', ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get('continue')
+        requests.push(cursor)
+        if (!cursor) {
+          return HttpResponse.json({
+            items: [],
+            metadata: { continue: 'page-2' },
+          })
+        }
+        return HttpResponse.json({
+          items: [
+            {
+              metadata: {
+                name: 'second-page-running',
+                namespace: 'default',
+                uid: 'second-page-running',
+              },
+              spec: { type: 'agent' },
+              status: { phase: 'Running' },
+            },
+          ],
+          metadata: {},
+        })
+      }),
+    )
+
+    render(<KanbanBoard />)
+
+    expect(await screen.findByText('second-page-running')).toBeInTheDocument()
+    expect(requests).toEqual([null, 'page-2'])
+  })
+
+  it('keeps the board loading until the final task page arrives', async () => {
+    let releaseFinalPage: () => void = () => {}
+    const finalPageGate = new Promise<void>((resolve) => {
+      releaseFinalPage = resolve
+    })
+    let requests = 0
+    server.use(
+      http.get('/api/v1/tasks', async ({ request }) => {
+        requests += 1
+        const cursor = new URL(request.url).searchParams.get('continue')
+        if (!cursor) {
+          return HttpResponse.json({
+            items: [],
+            metadata: { continue: 'page-2' },
+          })
+        }
+        await finalPageGate
+        return HttpResponse.json({ items: [], metadata: {} })
+      }),
+    )
+
+    render(<KanbanBoard />)
+
+    await waitFor(() => expect(requests).toBe(2))
+    expect(
+      screen.getByRole('status', {
+        name: /loading complete task inventory/i,
+      }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('No pending tasks')).not.toBeInTheDocument()
+
+    releaseFinalPage()
+
+    expect(await screen.findByText('No pending tasks')).toBeInTheDocument()
+  })
+
+  it('does not render empty columns when complete inventory pagination fails', async () => {
+    server.use(
+      http.get('/api/v1/tasks', () =>
+        HttpResponse.json({
+          items: [],
+          metadata: { continue: 'same-cursor' },
+        }),
+      ),
+    )
+
+    render(<KanbanBoard />)
+
+    expect(
+      await screen.findByRole('alert', {
+        name: /unable to load complete task inventory/i,
+      }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('No pending tasks')).not.toBeInTheDocument()
+  })
+
+  it('hides cached columns when a complete-inventory refetch fails', async () => {
+    let calls = 0
+    server.use(
+      http.get('/api/v1/tasks', () => {
+        calls += 1
+        if (calls === 1) {
+          return HttpResponse.json({ items: [], metadata: {} })
+        }
+        return HttpResponse.json({
+          items: [],
+          metadata: { continue: 'same-cursor' },
+        })
+      }),
+    )
+    const queryClient = createTestQueryClient()
+
+    rawRender(
+      <QueryClientProvider client={queryClient}>
+        <KanbanBoard />
+      </QueryClientProvider>,
+    )
+
+    expect(await screen.findByText('No pending tasks')).toBeInTheDocument()
+    await act(async () => {
+      await queryClient.refetchQueries({
+        queryKey: ['tasks', 'all', 'default', '100'],
+      })
+    })
+
+    expect(
+      await screen.findByRole('alert', {
+        name: /unable to load complete task inventory/i,
+      }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('No pending tasks')).not.toBeInTheDocument()
+    expect(calls).toBe(3)
   })
 
   it('column headers show correct titles', async () => {

--- a/ui/src/components/tasks/kanban-board.tsx
+++ b/ui/src/components/tasks/kanban-board.tsx
@@ -1,9 +1,10 @@
 import { Skeleton } from '@/components/ui/skeleton'
-import { useTaskList } from '@/hooks/use-tasks'
+import { useTaskListAll } from '@/hooks/use-tasks'
 import { phaseStyle } from '@/lib/task-status'
 import { cn } from '@/lib/utils'
 import { PageHeader } from '@/components/layout/page-header'
 import { KanbanCard } from './kanban-card'
+import { TaskInventoryError } from './task-inventory-error'
 import type { Task, TaskPhase } from '@/schemas/task'
 
 // One column per backend task phase, in lifecycle order, so every task lands in
@@ -34,9 +35,38 @@ function groupByPhase(tasks: Task[]): Record<string, Task[]> {
 }
 
 export function KanbanBoard() {
-  const { data, isLoading } = useTaskList('100', 5000)
-  const tasks = data?.items ?? []
-  const grouped = groupByPhase(tasks)
+  const { data, error, isFetching, refetch } = useTaskListAll('100', 5000)
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <PageHeader title="Board" description="Kanban view of task execution" />
+        <TaskInventoryError
+          isRetrying={isFetching}
+          onRetry={() => void refetch()}
+        />
+      </div>
+    )
+  }
+
+  if (!data) {
+    return (
+      <div className="space-y-4">
+        <PageHeader title="Board" description="Kanban view of task execution" />
+        <div
+          role="status"
+          aria-label="Loading complete task inventory"
+          className="flex gap-4 overflow-x-auto pb-4"
+        >
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-40 min-w-[280px] flex-1" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  const grouped = groupByPhase(data.items)
 
   return (
     <div className="space-y-4">
@@ -69,15 +99,11 @@ export function KanbanBoard() {
                   style.textClass,
                 )}
               >
-                {isLoading ? '…' : grouped[phase].length}
+                {grouped[phase].length}
               </span>
             </div>
             <div className="flex flex-col gap-2 min-h-[120px] pb-2">
-              {isLoading ? (
-                Array.from({ length: 2 }).map((_, i) => (
-                  <Skeleton key={i} className="h-20 w-full rounded-xl" />
-                ))
-              ) : grouped[phase].length === 0 ? (
+              {grouped[phase].length === 0 ? (
                 <p className="text-xs text-muted-foreground text-center py-8">No {label.toLowerCase()} tasks</p>
               ) : (
                 grouped[phase].map((task) => (

--- a/ui/src/components/tasks/task-inventory-error.tsx
+++ b/ui/src/components/tasks/task-inventory-error.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@/components/ui/button'
+
+interface TaskInventoryErrorProps {
+  isRetrying: boolean
+  onRetry: () => void
+}
+
+export function TaskInventoryError({
+  isRetrying,
+  onRetry,
+}: TaskInventoryErrorProps) {
+  return (
+    <div
+      role="alert"
+      aria-label="Unable to load complete task inventory"
+      className="flex flex-col items-start gap-3 rounded-md border border-destructive/40 bg-destructive/10 p-4"
+    >
+      <div>
+        <p className="text-sm font-medium text-destructive">
+          Unable to load complete task inventory.
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Task counts and views may be incomplete until pagination succeeds.
+        </p>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onRetry}
+        disabled={isRetrying}
+      >
+        {isRetrying ? 'Retrying task inventory…' : 'Retry task inventory'}
+      </Button>
+    </div>
+  )
+}

--- a/ui/src/components/tasks/task-list.test.tsx
+++ b/ui/src/components/tasks/task-list.test.tsx
@@ -219,6 +219,40 @@ describe('TaskList', () => {
     expect(secondPageCalls).toBe(2)
   })
 
+  it('keeps loaded rows visible and surfaces invalid pagination as incomplete', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/v1/tasks', ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get('continue')
+        if (!cursor) {
+          return HttpResponse.json({
+            items: [makeTask('task-1')],
+            metadata: { continue: 'same-cursor' },
+          })
+        }
+        return HttpResponse.json({
+          items: [makeTask('task-2')],
+          metadata: { continue: 'same-cursor' },
+        })
+      }),
+    )
+
+    render(<TaskList />)
+
+    expect(await screen.findByText('task-1')).toBeInTheDocument()
+    await user.click(
+      screen.getByRole('button', { name: /load more tasks/i }),
+    )
+
+    expect(await screen.findByText('task-2')).toBeInTheDocument()
+    expect(
+      screen.getByRole('alert', { name: /task inventory is incomplete/i }),
+    ).toHaveTextContent(/continuation did not advance/i)
+    expect(
+      screen.queryByRole('button', { name: /load more tasks/i }),
+    ).not.toBeInTheDocument()
+  })
+
   it('disables load more while the loaded pages refresh in the background', async () => {
     const user = userEvent.setup()
     const queryClient = new QueryClient({

--- a/ui/src/components/tasks/task-list.test.tsx
+++ b/ui/src/components/tasks/task-list.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, waitFor } from '@/test/test-utils'
+import { act, render, screen, waitFor, within } from '@/test/test-utils'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { server } from '@/test/mocks/server'
 
 vi.mock('zustand/middleware', () => ({
@@ -21,6 +22,19 @@ vi.mock('@tanstack/react-router', async () => {
 import { useUIStore } from '@/stores/ui'
 import { useAuthStore } from '@/stores/auth'
 import { TaskList } from './task-list'
+
+function makeTask(name: string, namespace = 'default') {
+  return {
+    metadata: {
+      name,
+      namespace,
+      uid: `uid-${namespace}-${name}`,
+      creationTimestamp: new Date().toISOString(),
+    },
+    spec: { type: 'container' },
+    status: { phase: 'Running' },
+  }
+}
 
 describe('TaskList', () => {
   beforeEach(() => {
@@ -48,6 +62,32 @@ describe('TaskList', () => {
     })
   })
 
+  it('shows an accessible initial error state and can retry', async () => {
+    const user = userEvent.setup()
+    let calls = 0
+    server.use(
+      http.get('/api/v1/tasks', () => {
+        calls += 1
+        if (calls === 1) {
+          return HttpResponse.text('temporary failure', { status: 500 })
+        }
+        return HttpResponse.json({ items: [], metadata: {} })
+      }),
+    )
+
+    render(<TaskList />)
+
+    expect(
+      await screen.findByRole('alert', { name: /failed to load tasks/i }),
+    ).toBeInTheDocument()
+    await user.click(
+      screen.getByRole('button', { name: /retry loading tasks/i }),
+    )
+
+    expect(await screen.findByText(/No tasks found/)).toBeInTheDocument()
+    expect(calls).toBe(2)
+  })
+
   it('populated table shows task rows', async () => {
     server.use(
       http.get('/api/v1/tasks', () =>
@@ -56,7 +96,7 @@ describe('TaskList', () => {
             {
               metadata: { name: 'task-1', namespace: 'default', uid: 'uid-1', creationTimestamp: new Date().toISOString() },
               spec: { type: 'container' },
-              status: { phase: 'Running' },
+              status: { phase: 'Finalizing' },
             },
             {
               metadata: { name: 'task-2', namespace: 'prod', uid: 'uid-2', creationTimestamp: new Date().toISOString() },
@@ -75,10 +115,173 @@ describe('TaskList', () => {
     expect(screen.getByText('task-2')).toBeInTheDocument()
     expect(screen.getByText('container')).toBeInTheDocument()
     expect(screen.getByText('ai')).toBeInTheDocument()
-    expect(screen.getByText('Running')).toBeInTheDocument()
+    expect(screen.getByText('Finalizing')).toBeInTheDocument()
     expect(screen.getByText('Succeeded')).toBeInTheDocument()
     expect(screen.getByText('default')).toBeInTheDocument()
     expect(screen.getByText('prod')).toBeInTheDocument()
+  })
+
+  it('loads the second page so the 26th task is visible', async () => {
+    const user = userEvent.setup()
+    const requests: (string | null)[] = []
+    let releaseSecondPage: () => void = () => {}
+    const secondPageGate = new Promise<void>((resolve) => {
+      releaseSecondPage = resolve
+    })
+    const firstPage = Array.from({ length: 25 }, (_, index) =>
+      makeTask(`task-${index + 1}`),
+    )
+
+    server.use(
+      http.get('/api/v1/tasks', async ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get('continue')
+        requests.push(cursor)
+        if (!cursor) {
+          return HttpResponse.json({
+            items: firstPage,
+            metadata: { continue: 'page-2', remainingItemCount: 1 },
+          })
+        }
+
+        expect(cursor).toBe('page-2')
+        await secondPageGate
+        return HttpResponse.json({
+          items: [makeTask('task-26')],
+          metadata: {},
+        })
+      }),
+    )
+
+    render(<TaskList />)
+
+    expect(await screen.findByText('task-25')).toBeInTheDocument()
+    expect(screen.queryByText('task-26')).not.toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: /load more tasks/i }),
+    )
+    expect(
+      screen.getByRole('button', { name: /loading more tasks/i }),
+    ).toBeDisabled()
+
+    releaseSecondPage()
+
+    expect(await screen.findByText('task-26')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /load more tasks/i }),
+    ).not.toBeInTheDocument()
+    expect(requests).toEqual([null, 'page-2'])
+  })
+
+  it('keeps loaded rows visible when loading more fails and can retry', async () => {
+    const user = userEvent.setup()
+    let secondPageCalls = 0
+    server.use(
+      http.get('/api/v1/tasks', ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get('continue')
+        if (!cursor) {
+          return HttpResponse.json({
+            items: [makeTask('task-1')],
+            metadata: { continue: 'page-2' },
+          })
+        }
+
+        secondPageCalls += 1
+        if (secondPageCalls === 1) {
+          return HttpResponse.text('temporary failure', { status: 500 })
+        }
+        return HttpResponse.json({
+          items: [makeTask('task-2')],
+          metadata: {},
+        })
+      }),
+    )
+
+    render(<TaskList />)
+
+    expect(await screen.findByText('task-1')).toBeInTheDocument()
+    await user.click(
+      screen.getByRole('button', { name: /load more tasks/i }),
+    )
+
+    expect(
+      await screen.findByRole('alert', {
+        name: /failed to load more tasks/i,
+      }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('task-1')).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: /retry loading more tasks/i }),
+    )
+
+    expect(await screen.findByText('task-2')).toBeInTheDocument()
+    expect(secondPageCalls).toBe(2)
+  })
+
+  it('disables load more while the loaded pages refresh in the background', async () => {
+    const user = userEvent.setup()
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    })
+    let firstPageCalls = 0
+    let secondPageCalls = 0
+    let releaseRefresh: () => void = () => {}
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve
+    })
+    server.use(
+      http.get('/api/v1/tasks', async ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get('continue')
+        if (cursor) {
+          secondPageCalls += 1
+          return HttpResponse.json({
+            items: [makeTask('task-2')],
+            metadata: {},
+          })
+        }
+
+        firstPageCalls += 1
+        if (firstPageCalls > 1) await refreshGate
+        return HttpResponse.json({
+          items: [makeTask('task-1')],
+          metadata: { continue: 'page-2' },
+        })
+      }),
+    )
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TaskList />
+      </QueryClientProvider>,
+    )
+    expect(
+      await screen.findByRole('button', { name: /load more tasks/i }),
+    ).toBeEnabled()
+
+    let refreshPromise: Promise<void> = Promise.resolve()
+    act(() => {
+      refreshPromise = queryClient.refetchQueries({
+        queryKey: ['tasks', 'default', '25'],
+      })
+    })
+
+    const refreshingButton = await screen.findByRole('button', {
+      name: /refreshing tasks/i,
+    })
+    expect(refreshingButton).toBeDisabled()
+    await user.click(refreshingButton)
+    expect(secondPageCalls).toBe(0)
+
+    releaseRefresh()
+    await act(async () => {
+      await refreshPromise
+    })
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /load more tasks/i }),
+      ).toBeEnabled(),
+    )
   })
 
   it('New Task button links to /tasks/new', async () => {
@@ -107,9 +310,10 @@ describe('TaskList', () => {
     await waitFor(() => {
       expect(screen.getByText('del-task')).toBeInTheDocument()
     })
-    // The New Task link button is also present, so find the trash icon button in the table row
     const row = screen.getByText('del-task').closest('tr')!
-    const deleteBtn = row.querySelector('button')!
+    const deleteBtn = within(row).getByRole('button', {
+      name: /delete task del-task/i,
+    })
     await user.click(deleteBtn)
     // Verify no error - mutation fires without throwing
     expect(screen.getByText('del-task')).toBeInTheDocument()

--- a/ui/src/components/tasks/task-list.tsx
+++ b/ui/src/components/tasks/task-list.tsx
@@ -28,6 +28,7 @@ export function TaskList() {
     isFetchingNextPage,
     isFetchNextPageError,
     refetch,
+    paginationError,
   } = useTaskList()
   const deleteTask = useDeleteTask()
 
@@ -125,9 +126,17 @@ export function TaskList() {
             )}
           </TableBody>
         </Table>
-        {(hasNextPage || isFetchNextPageError) && (
+        {(hasNextPage || isFetchNextPageError || paginationError) && (
           <div className="flex flex-col items-center justify-between gap-3 border-t p-3 sm:flex-row">
-            {isFetchNextPageError ? (
+            {paginationError ? (
+              <p
+                role="alert"
+                aria-label="Task inventory is incomplete"
+                className="text-sm text-destructive"
+              >
+                Task inventory is incomplete. {paginationError.message}.
+              </p>
+            ) : isFetchNextPageError ? (
               <p
                 role="alert"
                 aria-label="Failed to load more tasks"
@@ -136,21 +145,23 @@ export function TaskList() {
                 Failed to load more tasks. Try again.
               </p>
             ) : null}
-            <Button
-              variant="outline"
-              size="sm"
-              className="sm:ml-auto"
-              onClick={() => void fetchNextPage()}
-              disabled={isFetching}
-            >
-              {isFetchingNextPage
-                ? 'Loading more tasks…'
-                : isFetching
-                  ? 'Refreshing tasks…'
-                  : isFetchNextPageError
-                    ? 'Retry loading more tasks'
-                    : 'Load more tasks'}
-            </Button>
+            {!paginationError && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="sm:ml-auto"
+                onClick={() => void fetchNextPage()}
+                disabled={isFetching}
+              >
+                {isFetchingNextPage
+                  ? 'Loading more tasks…'
+                  : isFetching
+                    ? 'Refreshing tasks…'
+                    : isFetchNextPageError
+                      ? 'Retry loading more tasks'
+                      : 'Load more tasks'}
+              </Button>
+            )}
           </div>
         )}
       </div>

--- a/ui/src/components/tasks/task-list.tsx
+++ b/ui/src/components/tasks/task-list.tsx
@@ -18,7 +18,17 @@ function timeAgo(ts?: string): string {
 }
 
 export function TaskList() {
-  const { data, isLoading } = useTaskList()
+  const {
+    data,
+    isLoading,
+    isLoadingError,
+    isFetching,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+    isFetchNextPageError,
+    refetch,
+  } = useTaskList()
   const deleteTask = useDeleteTask()
 
   return (
@@ -56,6 +66,28 @@ export function TaskList() {
                   ))}
                 </TableRow>
               ))
+            ) : isLoadingError ? (
+              <TableRow>
+                <TableCell colSpan={6} className="py-8 text-center">
+                  <div className="flex flex-col items-center gap-3">
+                    <p
+                      role="alert"
+                      aria-label="Failed to load tasks"
+                      className="text-sm text-destructive"
+                    >
+                      Failed to load tasks.
+                    </p>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => void refetch()}
+                      disabled={isFetching}
+                    >
+                      {isFetching ? 'Retrying…' : 'Retry loading tasks'}
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
             ) : (data?.items ?? []).length === 0 ? (
               <TableRow>
                 <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
@@ -78,6 +110,7 @@ export function TaskList() {
                     <Button
                       variant="ghost"
                       size="icon"
+                      aria-label={`Delete task ${task.metadata.name}`}
                       onClick={(e) => {
                         e.preventDefault()
                         e.stopPropagation()
@@ -92,6 +125,34 @@ export function TaskList() {
             )}
           </TableBody>
         </Table>
+        {(hasNextPage || isFetchNextPageError) && (
+          <div className="flex flex-col items-center justify-between gap-3 border-t p-3 sm:flex-row">
+            {isFetchNextPageError ? (
+              <p
+                role="alert"
+                aria-label="Failed to load more tasks"
+                className="text-sm text-destructive"
+              >
+                Failed to load more tasks. Try again.
+              </p>
+            ) : null}
+            <Button
+              variant="outline"
+              size="sm"
+              className="sm:ml-auto"
+              onClick={() => void fetchNextPage()}
+              disabled={isFetching}
+            >
+              {isFetchingNextPage
+                ? 'Loading more tasks…'
+                : isFetching
+                  ? 'Refreshing tasks…'
+                  : isFetchNextPageError
+                    ? 'Retry loading more tasks'
+                    : 'Load more tasks'}
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/ui/src/hooks/use-tasks.test.tsx
+++ b/ui/src/hooks/use-tasks.test.tsx
@@ -51,7 +51,7 @@ describe('useTaskList', () => {
     expect(result.current.data).toEqual({ items: [], metadata: {} })
   })
 
-  it('stops when a continuation cursor does not advance', async () => {
+  it('surfaces an error when a continuation cursor does not advance', async () => {
     const seen: (string | null)[] = []
     server.use(
       http.get('/api/v1/tasks', ({ request }) => {
@@ -90,6 +90,9 @@ describe('useTaskList', () => {
       ]),
     )
     expect(result.current.hasNextPage).toBe(false)
+    expect(result.current.paginationError?.message).toBe(
+      'Task list pagination continuation did not advance',
+    )
 
     await act(async () => {
       await result.current.fetchNextPage()
@@ -97,7 +100,7 @@ describe('useTaskList', () => {
     expect(seen).toEqual([null, 'same-cursor'])
   })
 
-  it('stops before following a continuation cursor cycle', async () => {
+  it('surfaces an error before following a continuation cursor cycle', async () => {
     const seen: (string | null)[] = []
     server.use(
       http.get('/api/v1/tasks', ({ request }) => {
@@ -140,6 +143,9 @@ describe('useTaskList', () => {
     })
     await waitFor(() => expect(result.current.data?.items).toHaveLength(3))
     expect(result.current.hasNextPage).toBe(false)
+    expect(result.current.paginationError?.message).toBe(
+      'Task list pagination continuation cycle detected',
+    )
 
     await act(async () => {
       await result.current.fetchNextPage()
@@ -327,8 +333,8 @@ describe('useTaskListAll', () => {
     })
 
     await waitFor(() => expect(result.current.isError).toBe(true))
-    expect(result.current.error).toEqual(
-      new Error('Task list pagination continuation did not advance'),
+    expect(result.current.error?.message).toBe(
+      'Task list pagination continuation did not advance',
     )
     expect(seen).toEqual([null, 'same-cursor'])
   })
@@ -363,8 +369,8 @@ describe('useTaskListAll', () => {
     })
 
     await waitFor(() => expect(result.current.isError).toBe(true))
-    expect(result.current.error).toEqual(
-      new Error('Task list pagination continuation cycle detected'),
+    expect(result.current.error?.message).toBe(
+      'Task list pagination continuation cycle detected',
     )
     expect(seen).toEqual([null, 'cursor-a', 'cursor-b'])
   })
@@ -388,8 +394,8 @@ describe('useTaskListAll', () => {
     await waitFor(() => expect(result.current.isError).toBe(true), {
       timeout: 15_000,
     })
-    expect(result.current.error).toEqual(
-      new Error('Task list pagination page limit (1000) reached'),
+    expect(result.current.error?.message).toBe(
+      'Task list pagination page limit (1000) reached',
     )
     expect(pageCount).toBe(1000)
   })

--- a/ui/src/hooks/use-tasks.test.tsx
+++ b/ui/src/hooks/use-tasks.test.tsx
@@ -32,11 +32,223 @@ beforeEach(() => {
   useUIStore.setState({ namespace: 'default', sidebarCollapsed: false, theme: 'light' })
 })
 
+function makeTask(
+  name: string,
+  namespace = 'default',
+  uid: string | null = `uid-${namespace}-${name}`,
+) {
+  return {
+    metadata: { name, namespace, ...(uid ? { uid } : {}) },
+    spec: { type: 'container' as const },
+    status: { phase: 'Running' as const },
+  }
+}
+
 describe('useTaskList', () => {
   it('returns task list from API', async () => {
     const { result } = renderHook(() => useTaskList(), { wrapper: createWrapper() })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(result.current.data).toEqual({ items: [], metadata: {} })
+  })
+
+  it('stops when a continuation cursor does not advance', async () => {
+    const seen: (string | null)[] = []
+    server.use(
+      http.get('/api/v1/tasks', ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get('continue')
+        seen.push(cursor)
+        if (!cursor) {
+          return HttpResponse.json({
+            items: [makeTask('task-1')],
+            metadata: { continue: 'same-cursor' },
+          })
+        }
+        return HttpResponse.json({
+          items: [makeTask('task-2')],
+          metadata: { continue: 'same-cursor' },
+        })
+      }),
+    )
+
+    const { result } = renderHook(() => useTaskList('25', false), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true))
+    expect(result.current.data?.items.map((task) => task.metadata.name)).toEqual([
+      'task-1',
+    ])
+
+    await act(async () => {
+      await result.current.fetchNextPage()
+    })
+
+    await waitFor(() => expect(seen).toEqual([null, 'same-cursor']))
+    await waitFor(() =>
+      expect(result.current.data?.items.map((task) => task.metadata.name)).toEqual([
+        'task-1',
+        'task-2',
+      ]),
+    )
+    expect(result.current.hasNextPage).toBe(false)
+
+    await act(async () => {
+      await result.current.fetchNextPage()
+    })
+    expect(seen).toEqual([null, 'same-cursor'])
+  })
+
+  it('stops before following a continuation cursor cycle', async () => {
+    const seen: (string | null)[] = []
+    server.use(
+      http.get('/api/v1/tasks', ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get('continue')
+        seen.push(cursor)
+        if (!cursor) {
+          return HttpResponse.json({
+            items: [makeTask('task-1')],
+            metadata: { continue: 'cursor-a' },
+          })
+        }
+        if (cursor === 'cursor-a') {
+          return HttpResponse.json({
+            items: [makeTask('task-2')],
+            metadata: { continue: 'cursor-b' },
+          })
+        }
+        expect(cursor).toBe('cursor-b')
+        return HttpResponse.json({
+          items: [makeTask('task-3')],
+          metadata: { continue: 'cursor-a' },
+        })
+      }),
+    )
+
+    const { result } = renderHook(() => useTaskList('25', false), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true))
+    expect(result.current.data?.items).toHaveLength(1)
+
+    await act(async () => {
+      await result.current.fetchNextPage()
+    })
+    await waitFor(() => expect(result.current.data?.items).toHaveLength(2))
+    expect(result.current.hasNextPage).toBe(true)
+
+    await act(async () => {
+      await result.current.fetchNextPage()
+    })
+    await waitFor(() => expect(result.current.data?.items).toHaveLength(3))
+    expect(result.current.hasNextPage).toBe(false)
+
+    await act(async () => {
+      await result.current.fetchNextPage()
+    })
+    expect(seen).toEqual([null, 'cursor-a', 'cursor-b'])
+  })
+
+  it('deduplicates overlapping task rows across pages', async () => {
+    server.use(
+      http.get('/api/v1/tasks', ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get('continue')
+        if (!cursor) {
+          return HttpResponse.json({
+            items: [
+              makeTask('task-by-uid', 'default', 'shared-uid'),
+              makeTask('task-by-name', 'default', null),
+            ],
+            metadata: { continue: 'page-2' },
+          })
+        }
+        return HttpResponse.json({
+          items: [
+            makeTask('task-by-uid', 'default', 'shared-uid'),
+            makeTask('task-by-name', 'default', null),
+            makeTask('task-3'),
+          ],
+          metadata: {},
+        })
+      }),
+    )
+
+    const { result } = renderHook(() => useTaskList('25', false), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true))
+    expect(result.current.data?.items).toHaveLength(2)
+
+    await act(async () => {
+      await result.current.fetchNextPage()
+    })
+
+    await waitFor(() =>
+      expect(result.current.data?.items.map((task) => task.metadata.name)).toEqual([
+        'task-by-uid',
+        'task-by-name',
+        'task-3',
+      ]),
+    )
+  })
+
+  it('resets pagination when the namespace or page-size filter changes', async () => {
+    const requests: Array<{
+      namespace: string | null
+      limit: string | null
+      cursor: string | null
+    }> = []
+    server.use(
+      http.get('/api/v1/tasks', ({ request }) => {
+        const url = new URL(request.url)
+        const namespace = url.searchParams.get('namespace')
+        const limit = url.searchParams.get('limit')
+        const cursor = url.searchParams.get('continue')
+        requests.push({ namespace, limit, cursor })
+        return HttpResponse.json({
+          items: [
+            makeTask(
+              `${namespace}-${limit}-${cursor ?? 'first'}`,
+              namespace ?? 'default',
+            ),
+          ],
+          metadata: cursor ? {} : { continue: 'next-page' },
+        })
+      }),
+    )
+
+    const { result, rerender } = renderHook(
+      ({ limit }) => useTaskList(limit, false),
+      { initialProps: { limit: '25' }, wrapper: createWrapper() },
+    )
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true))
+    expect(result.current.data?.items).toHaveLength(1)
+
+    await act(async () => {
+      await result.current.fetchNextPage()
+    })
+    await waitFor(() => expect(result.current.data?.items).toHaveLength(2))
+
+    act(() => {
+      useUIStore.setState({ namespace: 'production' })
+    })
+    await waitFor(() =>
+      expect(result.current.data?.items[0]?.metadata.name).toBe(
+        'production-25-first',
+      ),
+    )
+
+    rerender({ limit: '50' })
+    await waitFor(() =>
+      expect(result.current.data?.items[0]?.metadata.name).toBe(
+        'production-50-first',
+      ),
+    )
+
+    expect(requests).toEqual([
+      { namespace: 'default', limit: '25', cursor: null },
+      { namespace: 'default', limit: '25', cursor: 'next-page' },
+      { namespace: 'production', limit: '25', cursor: null },
+      { namespace: 'production', limit: '50', cursor: null },
+    ])
   })
 })
 
@@ -44,9 +256,9 @@ describe('useTaskListAll', () => {
   it('follows continue tokens and returns all task pages', async () => {
     const seen: (string | null)[] = []
     server.use(http.get('/api/v1/tasks', ({ request }) => {
-      const token = new URL(request.url).searchParams.get('continue')
-      seen.push(token)
-      if (!token) {
+      const cursor = new URL(request.url).searchParams.get('continue')
+      seen.push(cursor)
+      if (!cursor) {
         return HttpResponse.json({ items: [], metadata: { continue: 'next-page' } })
       }
       return HttpResponse.json({
@@ -59,6 +271,127 @@ describe('useTaskListAll', () => {
 
     await waitFor(() => expect(result.current.data?.items[0]?.metadata.name).toBe('late-running'))
     expect(seen).toEqual([null, 'next-page'])
+  })
+
+  it('deduplicates overlapping task rows across automatically fetched pages', async () => {
+    server.use(
+      http.get('/api/v1/tasks', ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get('continue')
+        if (!cursor) {
+          return HttpResponse.json({
+            items: [
+              makeTask('task-by-uid', 'default', 'shared-uid'),
+              makeTask('task-by-name', 'default', null),
+            ],
+            metadata: { continue: 'next-page' },
+          })
+        }
+        return HttpResponse.json({
+          items: [
+            makeTask('task-by-uid', 'default', 'shared-uid'),
+            makeTask('task-by-name', 'default', null),
+            makeTask('task-3'),
+          ],
+          metadata: {},
+        })
+      }),
+    )
+
+    const { result } = renderHook(() => useTaskListAll('100', false), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.items.map((task) => task.metadata.name)).toEqual([
+      'task-by-uid',
+      'task-by-name',
+      'task-3',
+    ])
+  })
+
+  it('rejects a continuation cursor that does not advance', async () => {
+    const seen: (string | null)[] = []
+    server.use(
+      http.get('/api/v1/tasks', ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get('continue')
+        seen.push(cursor)
+        return HttpResponse.json({
+          items: [],
+          metadata: { continue: 'same-cursor' },
+        })
+      }),
+    )
+
+    const { result } = renderHook(() => useTaskListAll('100', false), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toEqual(
+      new Error('Task list pagination continuation did not advance'),
+    )
+    expect(seen).toEqual([null, 'same-cursor'])
+  })
+
+  it('rejects continuation cursor cycles instead of looping forever', async () => {
+    const seen: (string | null)[] = []
+    server.use(
+      http.get('/api/v1/tasks', ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get('continue')
+        seen.push(cursor)
+        if (!cursor) {
+          return HttpResponse.json({
+            items: [],
+            metadata: { continue: 'cursor-a' },
+          })
+        }
+        if (cursor === 'cursor-a') {
+          return HttpResponse.json({
+            items: [],
+            metadata: { continue: 'cursor-b' },
+          })
+        }
+        return HttpResponse.json({
+          items: [],
+          metadata: { continue: 'cursor-a' },
+        })
+      }),
+    )
+
+    const { result } = renderHook(() => useTaskListAll('100', false), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toEqual(
+      new Error('Task list pagination continuation cycle detected'),
+    )
+    expect(seen).toEqual([null, 'cursor-a', 'cursor-b'])
+  })
+
+  it('rejects pagination that exceeds the automatic page limit', async () => {
+    let pageCount = 0
+    server.use(
+      http.get('/api/v1/tasks', () => {
+        pageCount += 1
+        return HttpResponse.json({
+          items: [],
+          metadata: { continue: `cursor-${pageCount}` },
+        })
+      }),
+    )
+
+    const { result } = renderHook(() => useTaskListAll('100', false), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true), {
+      timeout: 15_000,
+    })
+    expect(result.current.error).toEqual(
+      new Error('Task list pagination page limit (1000) reached'),
+    )
+    expect(pageCount).toBe(1000)
   })
 })
 

--- a/ui/src/hooks/use-tasks.ts
+++ b/ui/src/hooks/use-tasks.ts
@@ -3,6 +3,7 @@ import {
   useQuery,
   useMutation,
   useQueryClient,
+  type InfiniteData,
 } from '@tanstack/react-query'
 import { ApiError, api } from '@/lib/api-client'
 import { useUIStore } from '@/stores/ui'
@@ -14,6 +15,13 @@ interface ListResponse<T> {
 }
 
 const maxTaskListPages = 1000
+
+interface TaskListPaginationState {
+  nextCursor?: string
+  error?: TaskListPaginationError
+}
+
+class TaskListPaginationError extends Error {}
 
 function fetchTaskListPage(namespace: string, limit: string, cursor?: string) {
   const params: Record<string, string> = { namespace, limit }
@@ -42,30 +50,81 @@ function flattenUniqueTasks(pages: ListResponse<Task>[], namespace: string) {
   return items
 }
 
+function getTaskListPaginationState(
+  lastPage: ListResponse<Task>,
+  pages: ListResponse<Task>[],
+  lastPageParam: string | undefined,
+  pageParams: Array<string | undefined>,
+): TaskListPaginationState {
+  const nextCursor = lastPage.metadata?.continue
+  if (!nextCursor) return {}
+  if (pages.length >= maxTaskListPages) {
+    return {
+      error: new TaskListPaginationError(
+        `Task list pagination page limit (${maxTaskListPages}) reached`,
+      ),
+    }
+  }
+  if (nextCursor === lastPageParam) {
+    return {
+      error: new TaskListPaginationError(
+        'Task list pagination continuation did not advance',
+      ),
+    }
+  }
+  if (pageParams.includes(nextCursor)) {
+    return {
+      error: new TaskListPaginationError(
+        'Task list pagination continuation cycle detected',
+      ),
+    }
+  }
+  return { nextCursor }
+}
+
 export function useTaskList(limit = '25', refetchInterval: number | false = 10000) {
   const namespace = useUIStore((s) => s.namespace)
-  return useInfiniteQuery({
+  const query = useInfiniteQuery<
+    ListResponse<Task>,
+    Error,
+    InfiniteData<ListResponse<Task>, string | undefined>,
+    readonly ['tasks', string, string],
+    string | undefined
+  >({
     queryKey: ['tasks', namespace, limit],
     queryFn: ({ pageParam }) => fetchTaskListPage(namespace, limit, pageParam),
     initialPageParam: undefined as string | undefined,
-    getNextPageParam: (lastPage, pages, lastPageParam, pageParams) => {
-      const nextPageParam = lastPage.metadata?.continue
-      if (
-        !nextPageParam ||
-        pages.length >= maxTaskListPages ||
-        nextPageParam === lastPageParam ||
-        pageParams.includes(nextPageParam)
-      ) {
-        return undefined
-      }
-      return nextPageParam
-    },
-    select: (data) => ({
-      items: flattenUniqueTasks(data.pages, namespace),
-      metadata: data.pages[data.pages.length - 1]?.metadata ?? {},
-    }),
+    getNextPageParam: (lastPage, pages, lastPageParam, pageParams) =>
+      getTaskListPaginationState(
+        lastPage,
+        pages,
+        lastPageParam,
+        pageParams,
+      ).nextCursor,
     refetchInterval,
   })
+
+  const paginationData = query.data
+  const lastPage = paginationData?.pages[paginationData.pages.length - 1]
+  const paginationError = paginationData && lastPage
+    ? getTaskListPaginationState(
+        lastPage,
+        paginationData.pages,
+        paginationData.pageParams[paginationData.pageParams.length - 1],
+        paginationData.pageParams,
+      ).error
+    : undefined
+
+  return {
+    ...query,
+    data: paginationData
+      ? {
+          items: flattenUniqueTasks(paginationData.pages, namespace),
+          metadata: lastPage?.metadata ?? {},
+        }
+      : undefined,
+    paginationError,
+  }
 }
 
 export function useTaskListAll(pageLimit = '100', refetchInterval: number | false = 10000) {
@@ -74,37 +133,32 @@ export function useTaskListAll(pageLimit = '100', refetchInterval: number | fals
     queryKey: ['tasks', 'all', namespace, pageLimit],
     queryFn: async () => {
       const pages: ListResponse<Task>[] = []
-      const seenCursors = new Set<string>()
+      const pageParams: Array<string | undefined> = []
       let metadata: ListResponse<Task>['metadata'] = {}
       let cursor: string | undefined
 
-      for (let pageNumber = 1; pageNumber <= maxTaskListPages; pageNumber += 1) {
+      for (;;) {
         const page = await fetchTaskListPage(namespace, pageLimit, cursor)
         pages.push(page)
+        pageParams.push(cursor)
         metadata = page.metadata ?? {}
 
-        const nextCursor = metadata.continue
-        if (!nextCursor) {
+        const pagination = getTaskListPaginationState(
+          page,
+          pages,
+          cursor,
+          pageParams,
+        )
+        if (pagination.error) throw pagination.error
+        if (!pagination.nextCursor) {
           return { items: flattenUniqueTasks(pages, namespace), metadata }
         }
-        if (nextCursor === cursor) {
-          throw new Error('Task list pagination continuation did not advance')
-        }
-        if (seenCursors.has(nextCursor)) {
-          throw new Error('Task list pagination continuation cycle detected')
-        }
-        if (pageNumber === maxTaskListPages) {
-          throw new Error(
-            `Task list pagination page limit (${maxTaskListPages}) reached`,
-          )
-        }
 
-        seenCursors.add(nextCursor)
-        cursor = nextCursor
+        cursor = pagination.nextCursor
       }
-
-      throw new Error('Task list pagination terminated unexpectedly')
     },
+    retry: (failureCount, error) =>
+      !(error instanceof TaskListPaginationError) && failureCount < 1,
     refetchInterval,
   })
 }

--- a/ui/src/hooks/use-tasks.ts
+++ b/ui/src/hooks/use-tasks.ts
@@ -24,7 +24,7 @@ interface TaskListPaginationState {
 class TaskListPaginationError extends Error {}
 
 function fetchTaskListPage(namespace: string, limit: string, cursor?: string) {
-  const params: Record<string, string> = { namespace, limit }
+  const params: Record<string, string> = { namespace, limit, paginate: 'true' }
   if (cursor) params.continue = cursor
   return api.get<ListResponse<Task>>('/tasks', params)
 }

--- a/ui/src/hooks/use-tasks.ts
+++ b/ui/src/hooks/use-tasks.ts
@@ -1,4 +1,9 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  useInfiniteQuery,
+  useQuery,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query'
 import { ApiError, api } from '@/lib/api-client'
 import { useUIStore } from '@/stores/ui'
 import type { ExecutionEvent, Task, TaskEventsResponse } from '@/schemas/task'
@@ -8,17 +13,57 @@ interface ListResponse<T> {
   metadata: { continue?: string; remainingItemCount?: number }
 }
 
-function fetchTaskListPage(namespace: string, limit: string, continueToken?: string) {
+const maxTaskListPages = 1000
+
+function fetchTaskListPage(namespace: string, limit: string, cursor?: string) {
   const params: Record<string, string> = { namespace, limit }
-  if (continueToken) params.continue = continueToken
+  if (cursor) params.continue = cursor
   return api.get<ListResponse<Task>>('/tasks', params)
+}
+
+function flattenUniqueTasks(pages: ListResponse<Task>[], namespace: string) {
+  const items: Task[] = []
+  const seenUIDs = new Set<string>()
+  const seenNames = new Set<string>()
+
+  for (const page of pages) {
+    for (const task of page.items) {
+      const uid = task.metadata.uid
+      const namespacedName = `${task.metadata.namespace ?? namespace}/${task.metadata.name}`
+      if ((uid && seenUIDs.has(uid)) || seenNames.has(namespacedName)) {
+        continue
+      }
+      if (uid) seenUIDs.add(uid)
+      seenNames.add(namespacedName)
+      items.push(task)
+    }
+  }
+
+  return items
 }
 
 export function useTaskList(limit = '25', refetchInterval: number | false = 10000) {
   const namespace = useUIStore((s) => s.namespace)
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: ['tasks', namespace, limit],
-    queryFn: () => fetchTaskListPage(namespace, limit),
+    queryFn: ({ pageParam }) => fetchTaskListPage(namespace, limit, pageParam),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage, pages, lastPageParam, pageParams) => {
+      const nextPageParam = lastPage.metadata?.continue
+      if (
+        !nextPageParam ||
+        pages.length >= maxTaskListPages ||
+        nextPageParam === lastPageParam ||
+        pageParams.includes(nextPageParam)
+      ) {
+        return undefined
+      }
+      return nextPageParam
+    },
+    select: (data) => ({
+      items: flattenUniqueTasks(data.pages, namespace),
+      metadata: data.pages[data.pages.length - 1]?.metadata ?? {},
+    }),
     refetchInterval,
   })
 }
@@ -28,16 +73,37 @@ export function useTaskListAll(pageLimit = '100', refetchInterval: number | fals
   return useQuery({
     queryKey: ['tasks', 'all', namespace, pageLimit],
     queryFn: async () => {
-      const items: Task[] = []
+      const pages: ListResponse<Task>[] = []
+      const seenCursors = new Set<string>()
       let metadata: ListResponse<Task>['metadata'] = {}
-      let continueToken: string | undefined
-      do {
-        const page = await fetchTaskListPage(namespace, pageLimit, continueToken)
-        items.push(...page.items)
+      let cursor: string | undefined
+
+      for (let pageNumber = 1; pageNumber <= maxTaskListPages; pageNumber += 1) {
+        const page = await fetchTaskListPage(namespace, pageLimit, cursor)
+        pages.push(page)
         metadata = page.metadata ?? {}
-        continueToken = metadata.continue
-      } while (continueToken)
-      return { items, metadata }
+
+        const nextCursor = metadata.continue
+        if (!nextCursor) {
+          return { items: flattenUniqueTasks(pages, namespace), metadata }
+        }
+        if (nextCursor === cursor) {
+          throw new Error('Task list pagination continuation did not advance')
+        }
+        if (seenCursors.has(nextCursor)) {
+          throw new Error('Task list pagination continuation cycle detected')
+        }
+        if (pageNumber === maxTaskListPages) {
+          throw new Error(
+            `Task list pagination page limit (${maxTaskListPages}) reached`,
+          )
+        }
+
+        seenCursors.add(nextCursor)
+        cursor = nextCursor
+      }
+
+      throw new Error('Task list pagination terminated unexpectedly')
     },
     refetchInterval,
   })


### PR DESCRIPTION
## Summary

Focused salvage from #280, rebuilt on current `main`.

- Fetch all task-list pages for the selected namespace instead of rendering only the first page.
- Detect repeated or cyclic continuation tokens and enforce a bounded page count.
- De-duplicate task rows and keep task-event refresh behavior safe across stream resets.

## Scope

This PR only changes UI task inventory and related task hook behavior. It does not change the Kubernetes list API or CLI pagination implementation.

## Verification

- `cd ui && bun run lint && bun run test`
- Full required CI