### PR TITLE
fix(controller): make cleanup and status reconciliation durable

### DIFF
--- a/internal/controller/agent_controller.go
+++ b/internal/controller/agent_controller.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -295,11 +296,15 @@ func (r *AgentReconciler) countActiveTasks(ctx context.Context, agent *corev1alp
 	var count int32
 	for i := range taskList.Items {
 		task := &taskList.Items[i]
-		if task.Spec.AgentRef != nil && task.Spec.AgentRef.Name == agent.Name {
-			phase := task.Status.Phase
-			if phase != corev1alpha1.TaskPhaseSucceeded && phase != corev1alpha1.TaskPhaseFailed {
-				count++
-			}
+		if task.Spec.AgentRef == nil || task.Spec.AgentRef.Name != agent.Name {
+			continue
+		}
+		switch task.Status.Phase {
+		case corev1alpha1.TaskPhaseSucceeded, corev1alpha1.TaskPhaseFailed, corev1alpha1.TaskPhaseCancelled:
+		default:
+			// Pending, Scheduled, Running, and Finalizing Tasks all retain
+			// Agent execution ownership. An empty phase is pending initialization.
+			count++
 		}
 	}
 	return count, nil
@@ -308,47 +313,56 @@ func (r *AgentReconciler) countActiveTasks(ctx context.Context, agent *corev1alp
 // updateStatus updates the Agent's status with validation results and active task count.
 func (r *AgentReconciler) updateStatus(ctx context.Context, agent *corev1alpha1.Agent, activeTasks int32, validationErr error) (ctrl.Result, error) {
 	now := metav1.Now()
+	observedGeneration := agent.Generation
+	inputLastUsed := agent.Status.LastUsed.DeepCopy()
 
-	agent.Status.ActiveTasks = activeTasks
-	agent.Status.Ready = validationErr == nil
-	if activeTasks > 0 {
-		agent.Status.LastUsed = &now
-	}
-
-	condition := metav1.Condition{
-		Type:               "Ready",
-		LastTransitionTime: now,
-		ObservedGeneration: agent.Generation,
-	}
-
-	if validationErr != nil {
-		condition.Status = metav1.ConditionFalse
-		condition.Reason = reasonValidationFailed
-		condition.Message = validationErr.Error()
-	} else {
-		condition.Status = metav1.ConditionTrue
-		condition.Reason = reasonValidationSucceeded
-		condition.Message = "Agent configuration is valid"
-	}
-
-	meta.SetStatusCondition(&agent.Status.Conditions, condition)
-
-	activeCount := activeTasks // capture for closure
-	lastUsed := agent.Status.LastUsed
 	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		if err := r.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, agent); err != nil {
+		current := &corev1alpha1.Agent{}
+		if err := r.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, current); err != nil {
 			return err
 		}
-		agent.Status.ActiveTasks = activeCount
-		agent.Status.Ready = validationErr == nil
-		agent.Status.LastUsed = lastUsed
-		meta.SetStatusCondition(&agent.Status.Conditions, condition)
-		return r.Status().Update(ctx, agent)
+
+		desired := current.Status.DeepCopy()
+		desired.ActiveTasks = activeTasks
+		desired.Ready = validationErr == nil
+		if desired.LastUsed == nil && inputLastUsed != nil {
+			desired.LastUsed = inputLastUsed.DeepCopy()
+		}
+		if current.Status.ActiveTasks != activeTasks || (activeTasks > 0 && current.Status.LastUsed == nil) {
+			desired.LastUsed = &now
+		}
+
+		condition := metav1.Condition{
+			Type:               "Ready",
+			LastTransitionTime: now,
+			ObservedGeneration: observedGeneration,
+		}
+		if validationErr != nil {
+			condition.Status = metav1.ConditionFalse
+			condition.Reason = reasonValidationFailed
+			condition.Message = validationErr.Error()
+		} else {
+			condition.Status = metav1.ConditionTrue
+			condition.Reason = reasonValidationSucceeded
+			condition.Message = "Agent configuration is valid"
+		}
+		meta.SetStatusCondition(&desired.Conditions, condition)
+
+		if apiequality.Semantic.DeepEqual(current.Status, *desired) {
+			agent.Status = *current.Status.DeepCopy()
+			return nil
+		}
+		current.Status = *desired
+		if err := r.Status().Update(ctx, current); err != nil {
+			return err
+		}
+		agent.Status = *current.Status.DeepCopy()
+		return nil
 	}); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	// Schedule requeue for TTL check if agent has TTL
+	// Schedule requeue for TTL check if agent has TTL.
 	if agent.Spec.TTLAfterLastTask != nil {
 		if activeTasks == 0 && agent.Status.LastUsed != nil {
 			ttl := agent.Spec.TTLAfterLastTask.Duration
@@ -372,6 +386,11 @@ func (r *AgentReconciler) checkTTLExpiry(ctx context.Context, agent *corev1alpha
 		return ctrl.Result{}, false
 	}
 	if activeTasks > 0 {
+		return ctrl.Result{}, false
+	}
+	if agent.Status.ActiveTasks > 0 {
+		// The final Task just became terminal. Let updateStatus persist the idle
+		// transition timestamp before evaluating TTL on the next reconcile.
 		return ctrl.Result{}, false
 	}
 

--- a/internal/controller/agent_controller.go
+++ b/internal/controller/agent_controller.go
@@ -36,11 +36,12 @@ type AgentReconciler struct {
 }
 
 const (
-	agentReasoningEffortLow    = "low"
-	agentReasoningEffortMedium = "medium"
-	agentReasoningEffortHigh   = "high"
-	agentReasoningEffortXHigh  = "xhigh"
-	agentReasoningEffortMax    = "max"
+	agentReasoningEffortLow               = "low"
+	agentReasoningEffortMedium            = "medium"
+	agentReasoningEffortHigh              = "high"
+	agentReasoningEffortXHigh             = "xhigh"
+	agentReasoningEffortMax               = "max"
+	agentDependencyValidationRequeueAfter = 5 * time.Minute
 )
 
 // +kubebuilder:rbac:groups=core.orka.ai,resources=agents,verbs=get;list;watch;create;update;patch;delete
@@ -362,22 +363,23 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, agent *corev1alpha1.
 		return ctrl.Result{}, err
 	}
 
-	// Schedule requeue for TTL check if agent has TTL.
+	requeueAfter := agentDependencyValidationRequeueAfter
+	// TTL checks may need a sooner reconcile than dependency validation.
 	if agent.Spec.TTLAfterLastTask != nil {
 		if activeTasks == 0 && agent.Status.LastUsed != nil {
 			ttl := agent.Spec.TTLAfterLastTask.Duration
 			elapsed := time.Since(agent.Status.LastUsed.Time)
-			if remaining := ttl - elapsed; remaining > 0 {
-				return ctrl.Result{RequeueAfter: remaining}, nil
+			if remaining := ttl - elapsed; remaining > 0 && remaining < requeueAfter {
+				requeueAfter = remaining
 			}
 		} else if activeTasks > 0 {
 			// Tasks still running; requeue to re-check after they finish.
 			// The Task watch will also trigger reconciliation on completion.
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+			requeueAfter = 30 * time.Second
 		}
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
 // checkTTLExpiry deletes the agent if its TTL has expired and no tasks are active.

--- a/internal/controller/agent_controller_unit_test.go
+++ b/internal/controller/agent_controller_unit_test.go
@@ -633,6 +633,22 @@ func TestCountActiveTasks(t *testing.T) {
 		},
 		Status: corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseFailed},
 	}
+	finalizingTask := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-finalizing", Namespace: testNS},
+		Spec: corev1alpha1.TaskSpec{
+			AgentRef: &corev1alpha1.AgentReference{Name: "count-agent"},
+			Prompt:   "do something",
+		},
+		Status: corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseFinalizing},
+	}
+	cancelledTask := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-cancelled", Namespace: testNS},
+		Spec: corev1alpha1.TaskSpec{
+			AgentRef: &corev1alpha1.AgentReference{Name: "count-agent"},
+			Prompt:   "do something",
+		},
+		Status: corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseCancelled},
+	}
 	otherAgentTask := &corev1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{Name: "task-other", Namespace: testNS},
 		Spec: corev1alpha1.TaskSpec{
@@ -659,9 +675,9 @@ func TestCountActiveTasks(t *testing.T) {
 			want: 0,
 		},
 		{
-			name: "only pending and running count",
-			objs: []runtime.Object{pendingTask, runningTask, succeededTask, failedTask},
-			want: 2,
+			name: "pending running and finalizing count",
+			objs: []runtime.Object{pendingTask, runningTask, finalizingTask, succeededTask, failedTask, cancelledTask},
+			want: 3,
 		},
 		{
 			name: "other agent tasks not counted",
@@ -675,7 +691,7 @@ func TestCountActiveTasks(t *testing.T) {
 		},
 		{
 			name: "all terminal - zero active",
-			objs: []runtime.Object{succeededTask, failedTask},
+			objs: []runtime.Object{succeededTask, failedTask, cancelledTask},
 			want: 0,
 		},
 	}
@@ -996,6 +1012,101 @@ func TestAgentReconcile_WithActiveTasks(t *testing.T) {
 	_ = fc.Get(context.Background(), types.NamespacedName{Name: "reconcile-active", Namespace: testNS}, updated)
 	if updated.Status.ActiveTasks != 1 {
 		t.Errorf("expected ActiveTasks=1, got %d", updated.Status.ActiveTasks)
+	}
+}
+
+func TestAgentReconcileSkipsUnchangedActiveStatusUpdate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	agent := baseAgent("reconcile-active-stable")
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "active-stable-task", Namespace: testNS},
+		Spec: corev1alpha1.TaskSpec{
+			AgentRef: &corev1alpha1.AgentReference{Name: agent.Name},
+		},
+		Status: corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseFinalizing},
+	}
+	countingClient := &statusUpdateCountingClient{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRuntimeObjects(agent, task).
+			WithStatusSubresource(agent).
+			Build(),
+	}
+	reconciler := &AgentReconciler{Client: countingClient, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}}
+
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("first Reconcile() error = %v", err)
+	}
+	if countingClient.statusUpdateCount != 1 {
+		t.Fatalf("status updates after first reconcile = %d, want 1", countingClient.statusUpdateCount)
+	}
+
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("second Reconcile() error = %v", err)
+	}
+	if countingClient.statusUpdateCount != 1 {
+		t.Fatalf("status updates after second reconcile = %d, want no additional update", countingClient.statusUpdateCount)
+	}
+}
+
+func TestAgentReconcileFinalActiveTaskTransitionStartsIdleTTL(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	agent := baseAgent("reconcile-idle-transition")
+	agent.Spec.TTLAfterLastTask = &metav1.Duration{Duration: 10 * time.Minute}
+	staleLastUsed := metav1.NewTime(time.Now().Add(-time.Hour))
+	agent.Status.ActiveTasks = 1
+	agent.Status.LastUsed = &staleLastUsed
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(agent).
+		WithStatusSubresource(agent).
+		Build()
+	reconciler := &AgentReconciler{Client: fc, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}}
+
+	result, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if result.RequeueAfter <= 0 {
+		t.Fatalf("RequeueAfter = %v, want idle TTL requeue", result.RequeueAfter)
+	}
+	updated := &corev1alpha1.Agent{}
+	if err := fc.Get(context.Background(), req.NamespacedName, updated); err != nil {
+		t.Fatalf("Get(Agent) error = %v, want Agent retained for idle TTL", err)
+	}
+	if updated.Status.ActiveTasks != 0 {
+		t.Fatalf("ActiveTasks = %d, want 0", updated.Status.ActiveTasks)
+	}
+	if updated.Status.LastUsed == nil || !updated.Status.LastUsed.After(staleLastUsed.Time) {
+		t.Fatalf("LastUsed = %v, want timestamp after stale active value %v", updated.Status.LastUsed, staleLastUsed.Time)
+	}
+}
+
+func TestAgentUpdateStatusRetriesConflict(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	agent := baseAgent("status-conflict")
+	countingClient := &statusUpdateCountingClient{
+		Client:             fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(agent).WithStatusSubresource(agent).Build(),
+		conflictsRemaining: 1,
+	}
+	reconciler := &AgentReconciler{Client: countingClient, Scheme: scheme}
+
+	if _, err := reconciler.updateStatus(context.Background(), agent, 1, nil); err != nil {
+		t.Fatalf("updateStatus() error = %v", err)
+	}
+	if countingClient.statusUpdateCount != 2 {
+		t.Fatalf("status update attempts = %d, want 2", countingClient.statusUpdateCount)
+	}
+	if agent.Status.ActiveTasks != 1 || !agent.Status.Ready {
+		t.Fatalf("Agent status = %#v, want active and ready", agent.Status)
 	}
 }
 

--- a/internal/controller/agent_controller_unit_test.go
+++ b/internal/controller/agent_controller_unit_test.go
@@ -727,8 +727,8 @@ func TestUpdateStatus(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if result.RequeueAfter != 0 {
-			t.Errorf("expected no requeue, got %v", result.RequeueAfter)
+		if result.RequeueAfter != agentDependencyValidationRequeueAfter {
+			t.Errorf("RequeueAfter = %v, want %v", result.RequeueAfter, agentDependencyValidationRequeueAfter)
 		}
 		if agent.Status.ActiveTasks != 0 {
 			t.Errorf("ActiveTasks = %d, want 0", agent.Status.ActiveTasks)
@@ -736,7 +736,7 @@ func TestUpdateStatus(t *testing.T) {
 		if !agent.Status.Ready {
 			t.Error("Ready = false, want true")
 		}
-		cond := findCondition(agent.Status.Conditions, "Ready")
+		cond := findReadyCondition(agent.Status.Conditions)
 		if cond == nil {
 			t.Fatal("Ready condition not found")
 		}
@@ -758,7 +758,7 @@ func TestUpdateStatus(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		cond := findCondition(agent.Status.Conditions, "Ready")
+		cond := findReadyCondition(agent.Status.Conditions)
 		if cond == nil {
 			t.Fatal("Ready condition not found")
 		}
@@ -954,7 +954,7 @@ func TestAgentReconcile_ValidationFailure(t *testing.T) {
 	// Re-fetch agent and check status condition
 	updated := &corev1alpha1.Agent{}
 	_ = fc.Get(context.Background(), types.NamespacedName{Name: "reconcile-invalid", Namespace: testNS}, updated)
-	cond := findCondition(updated.Status.Conditions, "Ready")
+	cond := findReadyCondition(updated.Status.Conditions)
 	if cond != nil && cond.Status != metav1.ConditionFalse {
 		t.Errorf("expected Ready=False, got %s", cond.Status)
 	}
@@ -1037,18 +1037,78 @@ func TestAgentReconcileSkipsUnchangedActiveStatusUpdate(t *testing.T) {
 	reconciler := &AgentReconciler{Client: countingClient, Scheme: scheme}
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}}
 
-	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+	firstResult, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
 		t.Fatalf("first Reconcile() error = %v", err)
+	}
+	if firstResult.RequeueAfter != agentDependencyValidationRequeueAfter {
+		t.Fatalf("first Reconcile() RequeueAfter = %v, want %v", firstResult.RequeueAfter, agentDependencyValidationRequeueAfter)
 	}
 	if countingClient.statusUpdateCount != 1 {
 		t.Fatalf("status updates after first reconcile = %d, want 1", countingClient.statusUpdateCount)
 	}
 
-	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+	secondResult, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
 		t.Fatalf("second Reconcile() error = %v", err)
+	}
+	if secondResult.RequeueAfter != agentDependencyValidationRequeueAfter {
+		t.Fatalf("second Reconcile() RequeueAfter = %v, want %v", secondResult.RequeueAfter, agentDependencyValidationRequeueAfter)
 	}
 	if countingClient.statusUpdateCount != 1 {
 		t.Fatalf("status updates after second reconcile = %d, want no additional update", countingClient.statusUpdateCount)
+	}
+}
+
+func TestAgentPeriodicRevalidationDetectsDeletedSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	agent := baseAgent("periodic-secret-agent")
+	agent.Spec.SecretRef = &corev1.LocalObjectReference{Name: "periodic-agent-secret"}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: agent.Spec.SecretRef.Name, Namespace: agent.Namespace}}
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(agent, secret).
+		WithStatusSubresource(agent).
+		Build()
+	reconciler := &AgentReconciler{Client: fc, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}}
+
+	result, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first Reconcile() error = %v", err)
+	}
+	if result.RequeueAfter != agentDependencyValidationRequeueAfter {
+		t.Fatalf("first Reconcile() RequeueAfter = %v, want %v", result.RequeueAfter, agentDependencyValidationRequeueAfter)
+	}
+	current := &corev1alpha1.Agent{}
+	if err := fc.Get(context.Background(), req.NamespacedName, current); err != nil {
+		t.Fatalf("Get Agent after validation: %v", err)
+	}
+	if !current.Status.Ready {
+		t.Fatal("Agent Ready = false before Secret deletion")
+	}
+	if err := fc.Delete(context.Background(), secret); err != nil {
+		t.Fatalf("Delete Secret: %v", err)
+	}
+
+	result, err = reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("periodic Reconcile() error = %v", err)
+	}
+	if result.RequeueAfter != agentDependencyValidationRequeueAfter {
+		t.Fatalf("periodic Reconcile() RequeueAfter = %v, want %v", result.RequeueAfter, agentDependencyValidationRequeueAfter)
+	}
+	if err := fc.Get(context.Background(), req.NamespacedName, current); err != nil {
+		t.Fatalf("Get Agent after Secret deletion: %v", err)
+	}
+	if current.Status.Ready {
+		t.Fatal("Agent Ready remained true after referenced Secret deletion")
+	}
+	condition := findReadyCondition(current.Status.Conditions)
+	if condition == nil || condition.Status != metav1.ConditionFalse || !strContains(condition.Message, "referenced secret") {
+		t.Fatalf("Ready condition after Secret deletion = %#v, want missing Secret validation", condition)
 	}
 }
 
@@ -1130,9 +1190,10 @@ func TestUpdateStatus_TTLExpiredNoRequeue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// TTL already expired, remaining <= 0, no requeue
-	if result.RequeueAfter != 0 {
-		t.Errorf("expected no requeue for expired TTL, got %v", result.RequeueAfter)
+	// Reconcile handles actual TTL deletion before updateStatus; direct status
+	// updates still retain bounded dependency validation.
+	if result.RequeueAfter != agentDependencyValidationRequeueAfter {
+		t.Errorf("RequeueAfter = %v, want %v", result.RequeueAfter, agentDependencyValidationRequeueAfter)
 	}
 }
 
@@ -1150,8 +1211,8 @@ func TestUpdateStatus_NoTTLNoLastUsed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.RequeueAfter != 0 {
-		t.Errorf("expected no requeue, got %v", result.RequeueAfter)
+	if result.RequeueAfter != agentDependencyValidationRequeueAfter {
+		t.Errorf("RequeueAfter = %v, want %v", result.RequeueAfter, agentDependencyValidationRequeueAfter)
 	}
 }
 
@@ -1170,9 +1231,9 @@ func strContains(s, substr string) bool {
 	return false
 }
 
-func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
+func findReadyCondition(conditions []metav1.Condition) *metav1.Condition {
 	for i := range conditions {
-		if conditions[i].Type == condType {
+		if conditions[i].Type == testConditionReady {
 			return &conditions[i]
 		}
 	}

--- a/internal/controller/harness_wrapper.go
+++ b/internal/controller/harness_wrapper.go
@@ -22,6 +22,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -52,30 +54,31 @@ func clearDeprecatedHarnessRuntimeAnnotations(annotations map[string]string) {
 }
 
 const (
-	harnessWrapperEndpointEnv                 = "ORKA_HARNESS_WRAPPER_ENDPOINT"
-	harnessWrapperAuthValueEnv                = "ORKA_HARNESS_WRAPPER_BEARER_TOKEN"
-	harnessWrapperAuthValueFileEnv            = "ORKA_HARNESS_WRAPPER_BEARER_TOKEN_FILE"
-	harnessWrapperTurnIDAnnotation            = "orka.ai/harness-wrapper-turn-id"
-	harnessWrapperRuntimeAnnotation           = "orka.ai/harness-wrapper-runtime-session-id"
-	harnessWrapperCorrelationIDAnno           = "orka.ai/harness-wrapper-correlation-id"
-	harnessWrapperLastFrameSeqAnno            = "orka.ai/harness-wrapper-last-frame-seq"
-	harnessWrapperStartedAnno                 = "orka.ai/harness-wrapper-started"
-	harnessWrapperPlannedAtAnno               = "orka.ai/harness-wrapper-planned-at"
-	harnessWrapperMetadataAnno                = "orka.ai/harness-wrapper-metadata"
-	harnessWrapperRuntimeRefAnno              = "orka.ai/harness-wrapper-runtime-ref"
-	harnessWrapperContractAnno                = "orka.ai/harness-wrapper-contract-version"
-	harnessWrapperOutputFetchRetriesAnno      = "orka.ai/harness-wrapper-output-fetch-retries"
-	harnessWrapperCancelDependencyRetriesAnno = "orka.ai/harness-wrapper-cancel-dependency-retries"
-	harnessWrapperCancelAcknowledgedAnno      = "orka.ai/harness-wrapper-cancel-acknowledged"
-	harnessWrapperAuthRetriesAnno             = "orka.ai/harness-wrapper-auth-retries"
-	harnessWrapperBrokeredContinuationAnno    = "orka.ai/harness-wrapper-brokered-continuation-pending"
-	harnessWrapperMaxOutputFetchRetries       = 3
-	harnessWrapperMaxCancelDependencyRetries  = 3
-	harnessWrapperMaxAuthRetries              = 3
-	harnessWrapperSkillsFilesMeta             = "skillsFiles"
-	harnessWrapperStreamPollTimeout           = 2 * time.Second
-	harnessWrapperNoTimeoutDuration           = time.Hour * 24 * 365 * 100
-	harnessWrapperRuntimeGeneric              = "generic"
+	harnessWrapperEndpointEnv                  = "ORKA_HARNESS_WRAPPER_ENDPOINT"
+	harnessWrapperAuthValueEnv                 = "ORKA_HARNESS_WRAPPER_BEARER_TOKEN"
+	harnessWrapperAuthValueFileEnv             = "ORKA_HARNESS_WRAPPER_BEARER_TOKEN_FILE"
+	harnessWrapperTurnIDAnnotation             = "orka.ai/harness-wrapper-turn-id"
+	harnessWrapperRuntimeAnnotation            = "orka.ai/harness-wrapper-runtime-session-id"
+	harnessWrapperCorrelationIDAnno            = "orka.ai/harness-wrapper-correlation-id"
+	harnessWrapperLastFrameSeqAnno             = "orka.ai/harness-wrapper-last-frame-seq"
+	harnessWrapperStartedAnno                  = "orka.ai/harness-wrapper-started"
+	harnessWrapperPlannedAtAnno                = "orka.ai/harness-wrapper-planned-at"
+	harnessWrapperMetadataAnno                 = "orka.ai/harness-wrapper-metadata"
+	harnessWrapperRuntimeRefAnno               = "orka.ai/harness-wrapper-runtime-ref"
+	harnessWrapperContractAnno                 = "orka.ai/harness-wrapper-contract-version"
+	harnessWrapperOutputFetchRetriesAnno       = "orka.ai/harness-wrapper-output-fetch-retries"
+	harnessWrapperCancelDependencyRetriesAnno  = "orka.ai/harness-wrapper-cancel-dependency-retries"
+	harnessWrapperLegacyCancelAcknowledgedAnno = "orka.ai/harness-wrapper-cancel-acknowledged"
+	harnessWrapperAuthRetriesAnno              = "orka.ai/harness-wrapper-auth-retries"
+	harnessWrapperBrokeredContinuationAnno     = "orka.ai/harness-wrapper-brokered-continuation-pending"
+	harnessWrapperMaxOutputFetchRetries        = 3
+	harnessWrapperMaxCancelDependencyRetries   = 3
+	harnessWrapperMaxAuthRetries               = 3
+	harnessWrapperSkillsFilesMeta              = "skillsFiles"
+	harnessWrapperStreamPollTimeout            = 2 * time.Second
+	harnessWrapperNoTimeoutDuration            = time.Hour * 24 * 365 * 100
+	harnessWrapperRuntimeGeneric               = "generic"
+	harnessWrapperCancelAcknowledgedCondition  = "HarnessCancellationAcknowledged"
 )
 
 func taskHasHarnessWrapperTurn(task *corev1alpha1.Task) bool {
@@ -969,7 +972,16 @@ func harnessWrapperCancelAcknowledged(task *corev1alpha1.Task) bool {
 	if !taskHasPlannedHarnessWrapperTurn(task) {
 		return false
 	}
-	return strings.TrimSpace(task.Annotations[harnessWrapperCancelAcknowledgedAnno]) ==
+	condition := meta.FindStatusCondition(task.Status.Conditions, harnessWrapperCancelAcknowledgedCondition)
+	return condition != nil && condition.Status == metav1.ConditionTrue &&
+		condition.Message == strings.TrimSpace(task.Annotations[harnessWrapperTurnIDAnnotation])
+}
+
+func harnessWrapperLegacyCancelAcknowledged(task *corev1alpha1.Task) bool {
+	if !taskHasPlannedHarnessWrapperTurn(task) || task.Annotations == nil {
+		return false
+	}
+	return strings.TrimSpace(task.Annotations[harnessWrapperLegacyCancelAcknowledgedAnno]) ==
 		strings.TrimSpace(task.Annotations[harnessWrapperTurnIDAnnotation])
 }
 
@@ -977,13 +989,32 @@ func (r *TaskReconciler) patchHarnessWrapperCancelAcknowledged(ctx context.Conte
 	if harnessWrapperCancelAcknowledged(task) {
 		return nil
 	}
-	patch := ctrlclient.MergeFrom(task.DeepCopy())
-	if task.Annotations == nil {
-		task.Annotations = map[string]string{}
+	expectedTurnID := strings.TrimSpace(task.Annotations[harnessWrapperTurnIDAnnotation])
+	key := types.NamespacedName{Name: task.Name, Namespace: task.Namespace}
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		current := &corev1alpha1.Task{}
+		if err := r.Get(ctx, key, current); err != nil {
+			return err
+		}
+		turnID := strings.TrimSpace(current.Annotations[harnessWrapperTurnIDAnnotation])
+		if turnID == "" || turnID != expectedTurnID {
+			return fmt.Errorf("harness turn identity changed while recording cancellation acknowledgement")
+		}
+		meta.SetStatusCondition(&current.Status.Conditions, metav1.Condition{
+			Type: harnessWrapperCancelAcknowledgedCondition, Status: metav1.ConditionTrue,
+			Reason: "CancelTurnAcknowledged", Message: turnID, ObservedGeneration: current.Generation,
+		})
+		if err := r.Status().Update(ctx, current); err != nil {
+			return err
+		}
+		task.Status = *current.Status.DeepCopy()
+		return nil
+	}); err != nil {
+		return err
 	}
-	task.Annotations[harnessWrapperCancelAcknowledgedAnno] =
-		strings.TrimSpace(task.Annotations[harnessWrapperTurnIDAnnotation])
+	patch := ctrlclient.MergeFrom(task.DeepCopy())
 	delete(task.Annotations, harnessWrapperCancelDependencyRetriesAnno)
+	delete(task.Annotations, harnessWrapperLegacyCancelAcknowledgedAnno)
 	return r.Patch(ctx, task, patch)
 }
 
@@ -1062,7 +1093,7 @@ func (r *TaskReconciler) patchHarnessWrapperPlannedTurn(
 	task.Annotations[harnessWrapperStartedAnno] = "false"
 	task.Annotations[harnessWrapperPlannedAtAnno] = time.Now().UTC().Format(time.RFC3339Nano)
 	delete(task.Annotations, harnessWrapperBrokeredContinuationAnno)
-	delete(task.Annotations, harnessWrapperCancelAcknowledgedAnno)
+	delete(task.Annotations, harnessWrapperLegacyCancelAcknowledgedAnno)
 	if runtimeRefName := strings.TrimSpace(request.Metadata["runtimeRef"]); runtimeRefName != "" {
 		task.Annotations[harnessWrapperRuntimeRefAnno] = runtimeRefName
 	} else {
@@ -1087,7 +1118,12 @@ func (r *TaskReconciler) patchHarnessWrapperPlannedTurn(
 		return err
 	}
 	task.Annotations[harnessWrapperMetadataAnno] = string(metadata)
-	return r.Patch(ctx, task, patch)
+	if err := r.Patch(ctx, task, patch); err != nil {
+		return err
+	}
+	return r.updateStatusWithRetry(ctx, task, func(t *corev1alpha1.Task) {
+		meta.RemoveStatusCondition(&t.Status.Conditions, harnessWrapperCancelAcknowledgedCondition)
+	})
 }
 
 func (r *TaskReconciler) patchHarnessWrapperStarted(ctx context.Context, task *corev1alpha1.Task) error {
@@ -1521,7 +1557,7 @@ func (r *TaskReconciler) clearHarnessWrapperTurnState(ctx context.Context, task 
 		clearDeprecatedHarnessRuntimeAnnotations(task.Annotations)
 		delete(task.Annotations, harnessWrapperOutputFetchRetriesAnno)
 		delete(task.Annotations, harnessWrapperCancelDependencyRetriesAnno)
-		delete(task.Annotations, harnessWrapperCancelAcknowledgedAnno)
+		delete(task.Annotations, harnessWrapperLegacyCancelAcknowledgedAnno)
 		delete(task.Annotations, harnessWrapperAuthRetriesAnno)
 		delete(task.Annotations, harnessWrapperBrokeredContinuationAnno)
 	}
@@ -1530,6 +1566,7 @@ func (r *TaskReconciler) clearHarnessWrapperTurnState(ctx context.Context, task 
 	}
 	return r.updateStatusWithRetry(ctx, task, func(t *corev1alpha1.Task) {
 		t.Status.HarnessRuntime = nil
+		meta.RemoveStatusCondition(&t.Status.Conditions, harnessWrapperCancelAcknowledgedCondition)
 	})
 }
 
@@ -1587,7 +1624,7 @@ func (r *TaskReconciler) cancelHarnessWrapperTurn(ctx context.Context, task *cor
 		return nil
 	}
 	if !harnessWrapperTurnAnnotationsMatchTaskAttempt(task, harnessWrapperCurrentAttempt(task)) {
-		return nil
+		return fmt.Errorf("planned harness turn identity does not match persisted task attempt")
 	}
 	target, err := r.resolveHarnessRuntimeTarget(ctx, task, nil)
 	if err != nil {

--- a/internal/controller/harness_wrapper.go
+++ b/internal/controller/harness_wrapper.go
@@ -66,6 +66,7 @@ const (
 	harnessWrapperContractAnno                = "orka.ai/harness-wrapper-contract-version"
 	harnessWrapperOutputFetchRetriesAnno      = "orka.ai/harness-wrapper-output-fetch-retries"
 	harnessWrapperCancelDependencyRetriesAnno = "orka.ai/harness-wrapper-cancel-dependency-retries"
+	harnessWrapperCancelAcknowledgedAnno      = "orka.ai/harness-wrapper-cancel-acknowledged"
 	harnessWrapperAuthRetriesAnno             = "orka.ai/harness-wrapper-auth-retries"
 	harnessWrapperBrokeredContinuationAnno    = "orka.ai/harness-wrapper-brokered-continuation-pending"
 	harnessWrapperMaxOutputFetchRetries       = 3
@@ -964,6 +965,28 @@ func (r *TaskReconciler) waitForHarnessWrapperAuthRetry(ctx context.Context, tas
 	return true, nil
 }
 
+func harnessWrapperCancelAcknowledged(task *corev1alpha1.Task) bool {
+	if !taskHasPlannedHarnessWrapperTurn(task) {
+		return false
+	}
+	return strings.TrimSpace(task.Annotations[harnessWrapperCancelAcknowledgedAnno]) ==
+		strings.TrimSpace(task.Annotations[harnessWrapperTurnIDAnnotation])
+}
+
+func (r *TaskReconciler) patchHarnessWrapperCancelAcknowledged(ctx context.Context, task *corev1alpha1.Task) error {
+	if harnessWrapperCancelAcknowledged(task) {
+		return nil
+	}
+	patch := ctrlclient.MergeFrom(task.DeepCopy())
+	if task.Annotations == nil {
+		task.Annotations = map[string]string{}
+	}
+	task.Annotations[harnessWrapperCancelAcknowledgedAnno] =
+		strings.TrimSpace(task.Annotations[harnessWrapperTurnIDAnnotation])
+	delete(task.Annotations, harnessWrapperCancelDependencyRetriesAnno)
+	return r.Patch(ctx, task, patch)
+}
+
 func harnessWrapperCancelDependencyRetries(task *corev1alpha1.Task) int {
 	if task == nil || task.Annotations == nil {
 		return 0
@@ -1039,6 +1062,7 @@ func (r *TaskReconciler) patchHarnessWrapperPlannedTurn(
 	task.Annotations[harnessWrapperStartedAnno] = "false"
 	task.Annotations[harnessWrapperPlannedAtAnno] = time.Now().UTC().Format(time.RFC3339Nano)
 	delete(task.Annotations, harnessWrapperBrokeredContinuationAnno)
+	delete(task.Annotations, harnessWrapperCancelAcknowledgedAnno)
 	if runtimeRefName := strings.TrimSpace(request.Metadata["runtimeRef"]); runtimeRefName != "" {
 		task.Annotations[harnessWrapperRuntimeRefAnno] = runtimeRefName
 	} else {
@@ -1497,6 +1521,7 @@ func (r *TaskReconciler) clearHarnessWrapperTurnState(ctx context.Context, task 
 		clearDeprecatedHarnessRuntimeAnnotations(task.Annotations)
 		delete(task.Annotations, harnessWrapperOutputFetchRetriesAnno)
 		delete(task.Annotations, harnessWrapperCancelDependencyRetriesAnno)
+		delete(task.Annotations, harnessWrapperCancelAcknowledgedAnno)
 		delete(task.Annotations, harnessWrapperAuthRetriesAnno)
 		delete(task.Annotations, harnessWrapperBrokeredContinuationAnno)
 	}

--- a/internal/controller/harness_wrapper.go
+++ b/internal/controller/harness_wrapper.go
@@ -977,14 +977,6 @@ func harnessWrapperCancelAcknowledged(task *corev1alpha1.Task) bool {
 		condition.Message == strings.TrimSpace(task.Annotations[harnessWrapperTurnIDAnnotation])
 }
 
-func harnessWrapperLegacyCancelAcknowledged(task *corev1alpha1.Task) bool {
-	if !taskHasPlannedHarnessWrapperTurn(task) || task.Annotations == nil {
-		return false
-	}
-	return strings.TrimSpace(task.Annotations[harnessWrapperLegacyCancelAcknowledgedAnno]) ==
-		strings.TrimSpace(task.Annotations[harnessWrapperTurnIDAnnotation])
-}
-
 func (r *TaskReconciler) patchHarnessWrapperCancelAcknowledged(ctx context.Context, task *corev1alpha1.Task) error {
 	if harnessWrapperCancelAcknowledged(task) {
 		return nil

--- a/internal/controller/provider_controller.go
+++ b/internal/controller/provider_controller.go
@@ -10,10 +10,13 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -112,34 +115,48 @@ func (e *ValidationError) Error() string {
 // updateStatus updates the provider status
 func (r *ProviderReconciler) updateStatus(ctx context.Context, provider *corev1alpha1.Provider, ready bool, message string) (ctrl.Result, error) {
 	now := metav1.Now()
+	observedGeneration := provider.Generation
 
-	provider.Status.Ready = ready
-	provider.Status.Message = message
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		current := &corev1alpha1.Provider{}
+		if err := r.Get(ctx, types.NamespacedName{Name: provider.Name, Namespace: provider.Namespace}, current); err != nil {
+			return err
+		}
 
-	if ready {
-		provider.Status.LastValidated = &now
-	}
+		desired := current.Status.DeepCopy()
+		desired.Ready = ready
+		desired.Message = message
+		condition := metav1.Condition{
+			Type:               "Ready",
+			LastTransitionTime: now,
+			ObservedGeneration: observedGeneration,
+		}
+		if ready {
+			condition.Status = metav1.ConditionTrue
+			condition.Reason = reasonValidationSucceeded
+			condition.Message = message
+		} else {
+			condition.Status = metav1.ConditionFalse
+			condition.Reason = reasonValidationFailed
+			condition.Message = message
+		}
+		meta.SetStatusCondition(&desired.Conditions, condition)
 
-	// Update condition
-	condition := metav1.Condition{
-		Type:               "Ready",
-		LastTransitionTime: now,
-		ObservedGeneration: provider.Generation,
-	}
-
-	if ready {
-		condition.Status = metav1.ConditionTrue
-		condition.Reason = reasonValidationSucceeded
-		condition.Message = message
-	} else {
-		condition.Status = metav1.ConditionFalse
-		condition.Reason = reasonValidationFailed
-		condition.Message = message
-	}
-
-	meta.SetStatusCondition(&provider.Status.Conditions, condition)
-
-	if err := r.Status().Update(ctx, provider); err != nil {
+		semanticChange := !apiequality.Semantic.DeepEqual(current.Status, *desired)
+		if !semanticChange && (!ready || current.Status.LastValidated != nil) {
+			provider.Status = *current.Status.DeepCopy()
+			return nil
+		}
+		if ready {
+			desired.LastValidated = &now
+		}
+		current.Status = *desired
+		if err := r.Status().Update(ctx, current); err != nil {
+			return err
+		}
+		provider.Status = *current.Status.DeepCopy()
+		return nil
+	}); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/provider_controller.go
+++ b/internal/controller/provider_controller.go
@@ -8,11 +8,12 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,6 +32,8 @@ const (
 	providerDependencyValidationRequeueAfter = 5 * time.Minute
 )
 
+var errProviderGenerationChanged = errors.New("provider generation changed during validation")
+
 // ProviderReconciler reconciles a Provider object
 type ProviderReconciler struct {
 	client.Client
@@ -48,7 +51,7 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Fetch the Provider
 	provider := &corev1alpha1.Provider{}
 	if err := r.Get(ctx, req.NamespacedName, provider); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -76,7 +79,7 @@ func (r *ProviderReconciler) validateProvider(ctx context.Context, provider *cor
 	}
 
 	if err := r.Get(ctx, secretKey, secret); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return &ValidationError{Message: "referenced secret not found: " + provider.Spec.SecretRef.Name}
 		}
 		return err
@@ -124,6 +127,9 @@ func (r *ProviderReconciler) updateStatus(ctx context.Context, provider *corev1a
 		if err := r.Get(ctx, types.NamespacedName{Name: provider.Name, Namespace: provider.Namespace}, current); err != nil {
 			return err
 		}
+		if current.Generation != observedGeneration {
+			return errProviderGenerationChanged
+		}
 
 		desired := current.Status.DeepCopy()
 		desired.Ready = ready
@@ -144,13 +150,15 @@ func (r *ProviderReconciler) updateStatus(ctx context.Context, provider *corev1a
 		}
 		meta.SetStatusCondition(&desired.Conditions, condition)
 
+		refreshLastValidated := ready && (current.Status.LastValidated == nil ||
+			now.Sub(current.Status.LastValidated.Time) >= providerDependencyValidationRequeueAfter/2)
+		if refreshLastValidated {
+			desired.LastValidated = &now
+		}
 		semanticChange := !apiequality.Semantic.DeepEqual(current.Status, *desired)
-		if !semanticChange && (!ready || current.Status.LastValidated != nil) {
+		if !semanticChange {
 			provider.Status = *current.Status.DeepCopy()
 			return nil
-		}
-		if ready {
-			desired.LastValidated = &now
 		}
 		current.Status = *desired
 		if err := r.Status().Update(ctx, current); err != nil {
@@ -159,6 +167,9 @@ func (r *ProviderReconciler) updateStatus(ctx context.Context, provider *corev1a
 		provider.Status = *current.Status.DeepCopy()
 		return nil
 	}); err != nil {
+		if errors.Is(err, errProviderGenerationChanged) {
+			return ctrl.Result{Requeue: true}, nil
+		}
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/provider_controller.go
+++ b/internal/controller/provider_controller.go
@@ -8,6 +8,7 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -25,8 +26,9 @@ import (
 )
 
 const (
-	reasonValidationSucceeded = "ValidationSucceeded"
-	reasonValidationFailed    = "ValidationFailed"
+	reasonValidationSucceeded                = "ValidationSucceeded"
+	reasonValidationFailed                   = "ValidationFailed"
+	providerDependencyValidationRequeueAfter = 5 * time.Minute
 )
 
 // ProviderReconciler reconciles a Provider object
@@ -160,7 +162,7 @@ func (r *ProviderReconciler) updateStatus(ctx context.Context, provider *corev1a
 		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: providerDependencyValidationRequeueAfter}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager

--- a/internal/controller/provider_controller_test.go
+++ b/internal/controller/provider_controller_test.go
@@ -307,6 +307,78 @@ func TestProviderReconcile_NotFound(t *testing.T) {
 	}
 }
 
+func TestProviderReconcileSkipsUnchangedStatusUpdate(t *testing.T) {
+	scheme := newProviderScheme()
+	provider := &corev1alpha1.Provider{
+		ObjectMeta: metav1.ObjectMeta{Name: "stable-provider", Namespace: "default"},
+		Spec: corev1alpha1.ProviderSpec{
+			Type:      corev1alpha1.ProviderTypeOpenAI,
+			SecretRef: corev1alpha1.ProviderSecretRef{Name: "stable-provider-secret"},
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: provider.Spec.SecretRef.Name, Namespace: provider.Namespace},
+		Data:       map[string][]byte{"api-key": []byte("test")},
+	}
+	countingClient := &statusUpdateCountingClient{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&corev1alpha1.Provider{}).
+			WithObjects(provider, secret).
+			Build(),
+	}
+	reconciler := &ProviderReconciler{Client: countingClient, Scheme: scheme}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: provider.Name, Namespace: provider.Namespace}}
+
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("first Reconcile() error = %v", err)
+	}
+	if countingClient.statusUpdateCount != 1 {
+		t.Fatalf("status updates after first reconcile = %d, want 1", countingClient.statusUpdateCount)
+	}
+	first := &corev1alpha1.Provider{}
+	if err := countingClient.Get(context.Background(), req.NamespacedName, first); err != nil {
+		t.Fatalf("Get Provider after first reconcile: %v", err)
+	}
+	if first.Status.LastValidated == nil {
+		t.Fatal("LastValidated = nil after successful validation")
+	}
+
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("second Reconcile() error = %v", err)
+	}
+	if countingClient.statusUpdateCount != 1 {
+		t.Fatalf("status updates after second reconcile = %d, want no additional update", countingClient.statusUpdateCount)
+	}
+	second := &corev1alpha1.Provider{}
+	if err := countingClient.Get(context.Background(), req.NamespacedName, second); err != nil {
+		t.Fatalf("Get Provider after second reconcile: %v", err)
+	}
+	if second.Status.LastValidated == nil || !second.Status.LastValidated.Equal(first.Status.LastValidated) {
+		t.Fatalf("LastValidated changed across no-op reconcile: first=%v second=%v", first.Status.LastValidated, second.Status.LastValidated)
+	}
+}
+
+func TestProviderUpdateStatusRetriesConflict(t *testing.T) {
+	scheme := newProviderScheme()
+	provider := &corev1alpha1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "conflict-provider", Namespace: "default"}}
+	countingClient := &statusUpdateCountingClient{
+		Client:             fake.NewClientBuilder().WithScheme(scheme).WithObjects(provider).WithStatusSubresource(provider).Build(),
+		conflictsRemaining: 1,
+	}
+	reconciler := &ProviderReconciler{Client: countingClient, Scheme: scheme}
+
+	if _, err := reconciler.updateStatus(context.Background(), provider, true, "valid"); err != nil {
+		t.Fatalf("updateStatus() error = %v", err)
+	}
+	if countingClient.statusUpdateCount != 2 {
+		t.Fatalf("status update attempts = %d, want 2", countingClient.statusUpdateCount)
+	}
+	if !provider.Status.Ready || provider.Status.LastValidated == nil {
+		t.Fatalf("Provider status = %#v, want ready with LastValidated", provider.Status)
+	}
+}
+
 // ---------- updateStatus ----------
 
 func TestProviderUpdateStatus(t *testing.T) {

--- a/internal/controller/provider_controller_test.go
+++ b/internal/controller/provider_controller_test.go
@@ -330,8 +330,12 @@ func TestProviderReconcileSkipsUnchangedStatusUpdate(t *testing.T) {
 	reconciler := &ProviderReconciler{Client: countingClient, Scheme: scheme}
 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: provider.Name, Namespace: provider.Namespace}}
 
-	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+	firstResult, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
 		t.Fatalf("first Reconcile() error = %v", err)
+	}
+	if firstResult.RequeueAfter != providerDependencyValidationRequeueAfter {
+		t.Fatalf("first Reconcile() RequeueAfter = %v, want %v", firstResult.RequeueAfter, providerDependencyValidationRequeueAfter)
 	}
 	if countingClient.statusUpdateCount != 1 {
 		t.Fatalf("status updates after first reconcile = %d, want 1", countingClient.statusUpdateCount)
@@ -344,8 +348,12 @@ func TestProviderReconcileSkipsUnchangedStatusUpdate(t *testing.T) {
 		t.Fatal("LastValidated = nil after successful validation")
 	}
 
-	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+	secondResult, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
 		t.Fatalf("second Reconcile() error = %v", err)
+	}
+	if secondResult.RequeueAfter != providerDependencyValidationRequeueAfter {
+		t.Fatalf("second Reconcile() RequeueAfter = %v, want %v", secondResult.RequeueAfter, providerDependencyValidationRequeueAfter)
 	}
 	if countingClient.statusUpdateCount != 1 {
 		t.Fatalf("status updates after second reconcile = %d, want no additional update", countingClient.statusUpdateCount)
@@ -356,6 +364,63 @@ func TestProviderReconcileSkipsUnchangedStatusUpdate(t *testing.T) {
 	}
 	if second.Status.LastValidated == nil || !second.Status.LastValidated.Equal(first.Status.LastValidated) {
 		t.Fatalf("LastValidated changed across no-op reconcile: first=%v second=%v", first.Status.LastValidated, second.Status.LastValidated)
+	}
+}
+
+func TestProviderPeriodicRevalidationDetectsDeletedSecret(t *testing.T) {
+	scheme := newProviderScheme()
+	provider := &corev1alpha1.Provider{
+		ObjectMeta: metav1.ObjectMeta{Name: "periodic-provider", Namespace: "default"},
+		Spec: corev1alpha1.ProviderSpec{
+			Type:      corev1alpha1.ProviderTypeOpenAI,
+			SecretRef: corev1alpha1.ProviderSecretRef{Name: "periodic-provider-secret"},
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: provider.Spec.SecretRef.Name, Namespace: provider.Namespace},
+		Data:       map[string][]byte{"api-key": []byte("test")},
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&corev1alpha1.Provider{}).
+		WithObjects(provider, secret).
+		Build()
+	reconciler := &ProviderReconciler{Client: cl, Scheme: scheme}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: provider.Name, Namespace: provider.Namespace}}
+
+	result, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first Reconcile() error = %v", err)
+	}
+	if result.RequeueAfter != providerDependencyValidationRequeueAfter {
+		t.Fatalf("first Reconcile() RequeueAfter = %v, want %v", result.RequeueAfter, providerDependencyValidationRequeueAfter)
+	}
+	current := &corev1alpha1.Provider{}
+	if err := cl.Get(context.Background(), req.NamespacedName, current); err != nil {
+		t.Fatalf("Get Provider after validation: %v", err)
+	}
+	if !current.Status.Ready {
+		t.Fatal("Provider Ready = false before Secret deletion")
+	}
+	if err := cl.Delete(context.Background(), secret); err != nil {
+		t.Fatalf("Delete Secret: %v", err)
+	}
+
+	result, err = reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("periodic Reconcile() error = %v", err)
+	}
+	if result.RequeueAfter != providerDependencyValidationRequeueAfter {
+		t.Fatalf("periodic Reconcile() RequeueAfter = %v, want %v", result.RequeueAfter, providerDependencyValidationRequeueAfter)
+	}
+	if err := cl.Get(context.Background(), req.NamespacedName, current); err != nil {
+		t.Fatalf("Get Provider after Secret deletion: %v", err)
+	}
+	if current.Status.Ready {
+		t.Fatal("Provider Ready remained true after referenced Secret deletion")
+	}
+	if !contains(current.Status.Message, "referenced secret not found") {
+		t.Fatalf("Provider status message = %q, want missing Secret validation", current.Status.Message)
 	}
 }
 

--- a/internal/controller/repositoryscan_controller.go
+++ b/internal/controller/repositoryscan_controller.go
@@ -19,6 +19,7 @@ import (
 
 	cron "github.com/robfig/cron/v3"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1230,7 +1231,7 @@ func (r *RepositoryScanReconciler) ingestOwnedTasks(ctx context.Context, scan *c
 	for i := range tasks.Items {
 		task := &tasks.Items[i]
 		switch task.Status.Phase {
-		case corev1alpha1.TaskPhaseSucceeded, corev1alpha1.TaskPhaseFailed:
+		case corev1alpha1.TaskPhaseSucceeded, corev1alpha1.TaskPhaseFailed, corev1alpha1.TaskPhaseCancelled:
 		default:
 			continue
 		}
@@ -1276,7 +1277,7 @@ func isTerminalScanTask(task corev1alpha1.Task) bool {
 		return false
 	}
 	switch task.Status.Phase {
-	case corev1alpha1.TaskPhaseSucceeded, corev1alpha1.TaskPhaseFailed:
+	case corev1alpha1.TaskPhaseSucceeded, corev1alpha1.TaskPhaseFailed, corev1alpha1.TaskPhaseCancelled:
 		return true
 	default:
 		return false
@@ -1309,7 +1310,7 @@ func taskPhaseToSecurityPhase(phase corev1alpha1.TaskPhase) string {
 	if phase == corev1alpha1.TaskPhaseSucceeded {
 		return scanRunPhaseSucceeded
 	}
-	if phase == corev1alpha1.TaskPhaseFailed {
+	if phase == corev1alpha1.TaskPhaseFailed || phase == corev1alpha1.TaskPhaseCancelled {
 		return scanRunPhaseFailed
 	}
 	if phase == corev1alpha1.TaskPhaseRunning {
@@ -1662,7 +1663,7 @@ func (r *RepositoryScanReconciler) collectScanRunProgress(
 			if task.Status.Phase == corev1alpha1.TaskPhaseSucceeded {
 				progress.hasThreatModelReady = true
 			}
-			if task.Status.Phase == corev1alpha1.TaskPhaseFailed {
+			if task.Status.Phase == corev1alpha1.TaskPhaseFailed || task.Status.Phase == corev1alpha1.TaskPhaseCancelled {
 				recordScanProgressFailure(&progress, task, r.pipelineTaskSummary(ctx, task, "threat model stage failed"))
 			}
 		case security.StageMapper:
@@ -1670,7 +1671,7 @@ func (r *RepositoryScanReconciler) collectScanRunProgress(
 			if task.Status.Phase == corev1alpha1.TaskPhaseSucceeded {
 				progress.hasMapperReady = true
 			}
-			if task.Status.Phase == corev1alpha1.TaskPhaseFailed {
+			if task.Status.Phase == corev1alpha1.TaskPhaseFailed || task.Status.Phase == corev1alpha1.TaskPhaseCancelled {
 				recordScanProgressFailure(&progress, task, r.pipelineTaskSummary(ctx, task, "mapper stage failed"))
 			}
 		case security.StageReview:
@@ -1679,7 +1680,7 @@ func (r *RepositoryScanReconciler) collectScanRunProgress(
 			if task.Status.Phase == corev1alpha1.TaskPhaseSucceeded {
 				progress.reviewSucceeded++
 			}
-			if task.Status.Phase == corev1alpha1.TaskPhaseFailed {
+			if task.Status.Phase == corev1alpha1.TaskPhaseFailed || task.Status.Phase == corev1alpha1.TaskPhaseCancelled {
 				recordScanProgressFailure(&progress, task, r.pipelineTaskSummary(ctx, task, "review stage failed"))
 			}
 		}
@@ -2915,8 +2916,17 @@ func (r *RepositoryScanReconciler) updateStatusWithRetry(ctx context.Context, sc
 		if err := r.Get(ctx, types.NamespacedName{Name: scan.Name, Namespace: scan.Namespace}, current); err != nil {
 			return err
 		}
+		original := current.Status.DeepCopy()
 		mutate(current)
-		return r.Status().Update(ctx, current)
+		if apiequality.Semantic.DeepEqual(*original, current.Status) {
+			scan.Status = *current.Status.DeepCopy()
+			return nil
+		}
+		if err := r.Status().Update(ctx, current); err != nil {
+			return err
+		}
+		scan.Status = *current.Status.DeepCopy()
+		return nil
 	})
 }
 

--- a/internal/controller/repositoryscan_controller_test.go
+++ b/internal/controller/repositoryscan_controller_test.go
@@ -81,6 +81,160 @@ func TestIngestMapperTaskSkipsFailedRun(t *testing.T) {
 	}
 }
 
+func TestRepositoryScanIngestsCancelledPipelineTaskAsTerminalFailure(t *testing.T) {
+	ctx := context.Background()
+	securityStore := setupControllerSQLiteStore(t)
+	scheme := runtime.NewScheme()
+	if err := corev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1.AddToScheme() error = %v", err)
+	}
+
+	const runID = "scan_cancelled"
+	scan := &corev1alpha1.RepositoryScan{
+		ObjectMeta: metav1.ObjectMeta{Name: "cancelled-scan", Namespace: defaultNS},
+		Status: corev1alpha1.RepositoryScanStatus{
+			Phase:      repositoryScanPhaseScanning,
+			LastScanID: runID,
+		},
+	}
+	completed := metav1.Now()
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cancelled-scan-threat-model",
+			Namespace: defaultNS,
+			Labels: map[string]string{
+				labels.LabelSecurityTarget: scan.Name,
+				labels.LabelSecurityScanID: runID,
+				labels.LabelSecurityStage:  security.StageThreatModel,
+			},
+		},
+		Status: corev1alpha1.TaskStatus{
+			Phase:          corev1alpha1.TaskPhaseCancelled,
+			CompletionTime: &completed,
+			Message:        "cancelled by user",
+		},
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&corev1alpha1.RepositoryScan{}).
+		WithObjects(scan, task).
+		Build()
+	reconciler := &RepositoryScanReconciler{Client: cl, Scheme: scheme, SecurityStore: securityStore}
+	if err := securityStore.CreateScanRun(ctx, &storepkg.ScanRun{
+		ID:             runID,
+		Namespace:      defaultNS,
+		RepositoryScan: scan.Name,
+		TaskName:       task.Name,
+		Mode:           "initial",
+		Phase:          scanRunPhaseRunning,
+		StartedAt:      time.Now().Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateScanRun() error = %v", err)
+	}
+
+	if err := reconciler.ingestOwnedTasks(ctx, scan); err != nil {
+		t.Fatalf("ingestOwnedTasks() error = %v", err)
+	}
+
+	run, err := securityStore.GetScanRun(ctx, defaultNS, runID)
+	if err != nil {
+		t.Fatalf("GetScanRun() error = %v", err)
+	}
+	if run.Phase != scanRunPhaseFailed || !strings.Contains(run.ErrorMessage, "cancelled") {
+		t.Fatalf("scan run phase/error = %q/%q, want cancelled terminal failure", run.Phase, run.ErrorMessage)
+	}
+	current := &corev1alpha1.RepositoryScan{}
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(scan), current); err != nil {
+		t.Fatalf("Get(RepositoryScan) error = %v", err)
+	}
+	if current.Status.Phase != repositoryScanPhaseError {
+		t.Fatalf("RepositoryScan phase = %q, want %q", current.Status.Phase, repositoryScanPhaseError)
+	}
+	ready := meta.FindStatusCondition(current.Status.Conditions, "Ready")
+	if ready == nil || ready.Reason != readyReasonScanFailed {
+		t.Fatalf("Ready condition = %#v, want reason %q", ready, readyReasonScanFailed)
+	}
+}
+
+func TestRepositoryScanTaskPhasePredicates(t *testing.T) {
+	for _, tc := range []struct {
+		phase  corev1alpha1.TaskPhase
+		active bool
+	}{
+		{phase: corev1alpha1.TaskPhasePending, active: true},
+		{phase: corev1alpha1.TaskPhaseScheduled, active: true},
+		{phase: corev1alpha1.TaskPhaseRunning, active: true},
+		{phase: corev1alpha1.TaskPhaseFinalizing, active: true},
+		{phase: corev1alpha1.TaskPhaseSucceeded, active: false},
+		{phase: corev1alpha1.TaskPhaseFailed, active: false},
+		{phase: corev1alpha1.TaskPhaseCancelled, active: false},
+	} {
+		t.Run(string(tc.phase), func(t *testing.T) {
+			if got := isActiveTaskPhase(tc.phase); got != tc.active {
+				t.Fatalf("isActiveTaskPhase(%q) = %t, want %t", tc.phase, got, tc.active)
+			}
+		})
+	}
+
+	task := corev1alpha1.Task{Status: corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseCancelled}}
+	if !isTerminalScanTask(task) {
+		t.Fatal("isTerminalScanTask(Cancelled) = false, want true")
+	}
+	if got := taskPhaseToSecurityPhase(corev1alpha1.TaskPhaseCancelled); got != scanRunPhaseFailed {
+		t.Fatalf("taskPhaseToSecurityPhase(Cancelled) = %q, want %q", got, scanRunPhaseFailed)
+	}
+
+	progress := (&RepositoryScanReconciler{}).collectScanRunProgress(context.Background(), []corev1alpha1.Task{{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labels.LabelSecurityStage: security.StageMapper}},
+		Status:     corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseCancelled, Message: "cancelled by user"},
+	}})
+	run := &storepkg.ScanRun{Phase: scanRunPhaseRunning}
+	applyScanRunProgress(run, progress)
+	if run.Phase != scanRunPhaseFailed {
+		t.Fatalf("cancelled pipeline progress phase = %q, want %q", run.Phase, scanRunPhaseFailed)
+	}
+}
+
+func TestRepositoryScanStatusUpdateSkipsNoopAndRetriesConflict(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+	scan := &corev1alpha1.RepositoryScan{
+		ObjectMeta: metav1.ObjectMeta{Name: "status-stable-scan", Namespace: defaultNS},
+		Status:     corev1alpha1.RepositoryScanStatus{Phase: repositoryScanPhasePending},
+	}
+	countingClient := &statusUpdateCountingClient{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(scan).WithObjects(scan).Build(),
+	}
+	reconciler := &RepositoryScanReconciler{Client: countingClient, Scheme: scheme}
+
+	if err := reconciler.updateStatusWithRetry(context.Background(), scan, func(current *corev1alpha1.RepositoryScan) {
+		current.Status.Phase = repositoryScanPhasePending
+	}); err != nil {
+		t.Fatalf("no-op updateStatusWithRetry() error = %v", err)
+	}
+	if countingClient.statusUpdateCount != 0 {
+		t.Fatalf("no-op status update attempts = %d, want 0", countingClient.statusUpdateCount)
+	}
+
+	countingClient.conflictsRemaining = 1
+	if err := reconciler.updateStatusWithRetry(context.Background(), scan, func(current *corev1alpha1.RepositoryScan) {
+		current.Status.Phase = repositoryScanPhaseScanning
+	}); err != nil {
+		t.Fatalf("conflicting updateStatusWithRetry() error = %v", err)
+	}
+	if countingClient.statusUpdateCount != 2 {
+		t.Fatalf("conflicting status update attempts = %d, want 2", countingClient.statusUpdateCount)
+	}
+	if scan.Status.Phase != repositoryScanPhaseScanning {
+		t.Fatalf("RepositoryScan phase = %q, want %q", scan.Status.Phase, repositoryScanPhaseScanning)
+	}
+}
+
 func TestLatestTerminalScanTaskPrefersNewestCompletedScan(t *testing.T) {
 	tasks := []corev1alpha1.Task{
 		{

--- a/internal/controller/status_reconcile_test.go
+++ b/internal/controller/status_reconcile_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type statusUpdateCountingClient struct {
+	client.Client
+	statusUpdateCount  int
+	conflictsRemaining int
+}
+
+func (c *statusUpdateCountingClient) Status() client.SubResourceWriter {
+	return &statusUpdateCountingWriter{
+		SubResourceWriter:  c.Client.Status(),
+		statusUpdateCount:  &c.statusUpdateCount,
+		conflictsRemaining: &c.conflictsRemaining,
+	}
+}
+
+type statusUpdateCountingWriter struct {
+	client.SubResourceWriter
+	statusUpdateCount  *int
+	conflictsRemaining *int
+}
+
+func (w *statusUpdateCountingWriter) Update(
+	ctx context.Context,
+	obj client.Object,
+	opts ...client.SubResourceUpdateOption,
+) error {
+	(*w.statusUpdateCount)++
+	if *w.conflictsRemaining > 0 {
+		(*w.conflictsRemaining)--
+		return apierrors.NewConflict(
+			schema.GroupResource{Group: "core.orka.ai", Resource: "status"},
+			obj.GetName(),
+			errors.New("injected status conflict"),
+		)
+	}
+	return w.SubResourceWriter.Update(ctx, obj, opts...)
+}

--- a/internal/controller/substrate_actor_pool_controller.go
+++ b/internal/controller/substrate_actor_pool_controller.go
@@ -12,10 +12,13 @@ import (
 	"strings"
 	"time"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -210,30 +213,48 @@ func (r *SubstrateActorPoolReconciler) updateSubstrateActorPoolStatus(
 	message string,
 ) (ctrl.Result, error) {
 	now := metav1.Now()
-	pool.Status.Phase = phase
-	pool.Status.ObservedGeneration = pool.Generation
-	pool.Status.WorkerCount = int32(max(density.WorkerCount, 0))
-	pool.Status.ActorCount = int32(max(density.ActorCount, 0))
-	pool.Status.RunningActorCount = int32(max(density.RunningActorCount, 0))
-	pool.Status.SuspendedActorCount = int32(max(density.SuspendedActorCount, 0))
-	pool.Status.ActorsPerWorker = density.ActorsPerWorker
-	pool.Status.Message = sanitizeSubstrateActorPoolMessage(message)
-	condition := metav1.Condition{
-		Type:               "Ready",
-		LastTransitionTime: now,
-		ObservedGeneration: pool.Generation,
-	}
-	if phase == corev1alpha1.SubstrateActorPoolPhaseReady {
-		condition.Status = metav1.ConditionTrue
-		condition.Reason = "PoolReady"
-		condition.Message = "Substrate actor pool is ready"
-	} else {
-		condition.Status = metav1.ConditionFalse
-		condition.Reason = reasonPoolNotReady
-		condition.Message = pool.Status.Message
-	}
-	meta.SetStatusCondition(&pool.Status.Conditions, condition)
-	if err := r.Status().Update(ctx, pool); err != nil {
+	observedGeneration := pool.Generation
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		current := &corev1alpha1.SubstrateActorPool{}
+		if err := r.Get(ctx, types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}, current); err != nil {
+			return err
+		}
+
+		desired := current.Status.DeepCopy()
+		desired.Phase = phase
+		desired.ObservedGeneration = observedGeneration
+		desired.WorkerCount = int32(max(density.WorkerCount, 0))
+		desired.ActorCount = int32(max(density.ActorCount, 0))
+		desired.RunningActorCount = int32(max(density.RunningActorCount, 0))
+		desired.SuspendedActorCount = int32(max(density.SuspendedActorCount, 0))
+		desired.ActorsPerWorker = density.ActorsPerWorker
+		desired.Message = sanitizeSubstrateActorPoolMessage(message)
+		condition := metav1.Condition{
+			Type:               "Ready",
+			LastTransitionTime: now,
+			ObservedGeneration: observedGeneration,
+		}
+		if phase == corev1alpha1.SubstrateActorPoolPhaseReady {
+			condition.Status = metav1.ConditionTrue
+			condition.Reason = "PoolReady"
+			condition.Message = "Substrate actor pool is ready"
+		} else {
+			condition.Status = metav1.ConditionFalse
+			condition.Reason = reasonPoolNotReady
+			condition.Message = desired.Message
+		}
+		meta.SetStatusCondition(&desired.Conditions, condition)
+		if apiequality.Semantic.DeepEqual(current.Status, *desired) {
+			pool.Status = *current.Status.DeepCopy()
+			return nil
+		}
+		current.Status = *desired
+		if err := r.Status().Update(ctx, current); err != nil {
+			return err
+		}
+		pool.Status = *current.Status.DeepCopy()
+		return nil
+	}); err != nil {
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{RequeueAfter: substrateActorPoolRequeue}, nil

--- a/internal/controller/substrate_actor_pool_controller_test.go
+++ b/internal/controller/substrate_actor_pool_controller_test.go
@@ -117,6 +117,74 @@ func TestSubstrateActorPoolReconcilerPrecreatesActorsAndUpdatesDensity(t *testin
 	}
 }
 
+func TestSubstrateActorPoolReconcilerSkipsUnchangedStatusUpdateButKeepsPeriodicRequeue(t *testing.T) {
+	scheme := newSubstrateActorPoolTestScheme(t)
+	pool := &corev1alpha1.SubstrateActorPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "disabled-pool", Namespace: "default"},
+	}
+	countingClient := &statusUpdateCountingClient{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&corev1alpha1.SubstrateActorPool{}).
+			WithObjects(pool).
+			Build(),
+	}
+	reconciler := &SubstrateActorPoolReconciler{Client: countingClient, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}}
+
+	first, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first Reconcile() error = %v", err)
+	}
+	if first.RequeueAfter != substrateActorPoolRequeue {
+		t.Fatalf("first RequeueAfter = %v, want %v", first.RequeueAfter, substrateActorPoolRequeue)
+	}
+	if countingClient.statusUpdateCount != 1 {
+		t.Fatalf("status updates after first reconcile = %d, want 1", countingClient.statusUpdateCount)
+	}
+
+	second, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second Reconcile() error = %v", err)
+	}
+	if second.RequeueAfter != substrateActorPoolRequeue {
+		t.Fatalf("second RequeueAfter = %v, want %v", second.RequeueAfter, substrateActorPoolRequeue)
+	}
+	if countingClient.statusUpdateCount != 1 {
+		t.Fatalf("status updates after second reconcile = %d, want no additional update", countingClient.statusUpdateCount)
+	}
+}
+
+func TestSubstrateActorPoolStatusUpdateRetriesConflict(t *testing.T) {
+	scheme := newSubstrateActorPoolTestScheme(t)
+	pool := &corev1alpha1.SubstrateActorPool{ObjectMeta: metav1.ObjectMeta{Name: "conflict-pool", Namespace: "default"}}
+	countingClient := &statusUpdateCountingClient{
+		Client:             fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(pool).WithObjects(pool).Build(),
+		conflictsRemaining: 1,
+	}
+	reconciler := &SubstrateActorPoolReconciler{Client: countingClient, Scheme: scheme}
+
+	result, err := reconciler.updateSubstrateActorPoolStatus(
+		context.Background(),
+		pool,
+		corev1alpha1.SubstrateActorPoolPhaseReady,
+		workspace.Density{WorkerCount: 1, ActorCount: 2, RunningActorCount: 1, SuspendedActorCount: 1},
+		"pool reconciled",
+	)
+	if err != nil {
+		t.Fatalf("updateSubstrateActorPoolStatus() error = %v", err)
+	}
+	if result.RequeueAfter != substrateActorPoolRequeue {
+		t.Fatalf("RequeueAfter = %v, want %v", result.RequeueAfter, substrateActorPoolRequeue)
+	}
+	if countingClient.statusUpdateCount != 2 {
+		t.Fatalf("status update attempts = %d, want 2", countingClient.statusUpdateCount)
+	}
+	if pool.Status.Phase != corev1alpha1.SubstrateActorPoolPhaseReady || pool.Status.ActorCount != 2 {
+		t.Fatalf("pool status = %#v, want ready density", pool.Status)
+	}
+}
+
 func TestSubstrateActorPoolReconcilerAcceptsMCPOnlyTemplate(t *testing.T) {
 	scheme := newSubstrateActorPoolTestScheme(t)
 	pool := &corev1alpha1.SubstrateActorPool{

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -529,13 +529,7 @@ func (r *TaskReconciler) handleDeletion(ctx context.Context, task *corev1alpha1.
 	// fence. Persist that acknowledgement before later fallible cleanup so retries
 	// never need the runtime endpoint or auth Secret after quiescence is confirmed.
 	if taskHasPlannedHarnessWrapperTurn(task) && !harnessWrapperCancelAcknowledged(task) {
-		legacyAcknowledged := harnessWrapperLegacyCancelAcknowledged(task)
-		if cancelErr := func() error {
-			if legacyAcknowledged {
-				return nil
-			}
-			return r.cancelHarnessWrapperTurn(ctx, task, "task deleted")
-		}(); cancelErr != nil {
+		if cancelErr := r.cancelHarnessWrapperTurn(ctx, task, "task deleted"); cancelErr != nil {
 			if isAgentRuntimeDependencyNotReady(cancelErr) {
 				shouldWait, waitErr := r.waitForHarnessCancelDependency(ctx, task)
 				if waitErr != nil {

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -472,96 +472,117 @@ func executionEventTypeForTaskPhase(phase corev1alpha1.TaskPhase) string {
 func (r *TaskReconciler) handleDeletion(ctx context.Context, task *corev1alpha1.Task) (ctrl.Result, error) { //nolint:unparam // Result is always nil but kept for interface consistency
 	log := logf.FromContext(ctx)
 
-	if controllerutil.ContainsFinalizer(task, labels.TaskFinalizer) {
-		// Clean up result data from store
-		if r.ResultStore != nil {
-			if err := r.ResultStore.DeleteResult(ctx, task.Namespace, task.Name); err != nil {
-				log.Error(err, "failed to delete result from store", "task", task.Name)
-				// Continue with finalizer removal anyway
-			}
-		}
-
-		// Clean up artifacts
-		if r.ArtifactStore != nil {
-			if err := r.ArtifactStore.DeleteArtifacts(ctx, task.Namespace, task.Name); err != nil {
-				log.Error(err, "failed to delete artifacts", "task", task.Name)
-			}
-		}
-
-		// Clean up plan state if any
-		if r.PlanStore != nil {
-			if err := r.PlanStore.DeletePlan(ctx, task.Namespace, task.Name); err != nil {
-				log.Error(err, "failed to delete plan state", "task", task.Name)
-				// Continue with finalizer removal anyway
-			}
-		}
-
-		// Clean up inter-agent messages
-		if r.MessageStore != nil {
-			if err := r.MessageStore.DeleteTaskMessages(ctx, task.Namespace, task.Name); err != nil {
-				log.Error(err, "failed to delete task messages", "task", task.Name)
-			}
-			// If this is a coordinator, clean up all children's messages
-			if err := r.MessageStore.DeleteParentMessages(ctx, task.Namespace, task.Name); err != nil {
-				log.Error(err, "failed to delete parent messages", "task", task.Name)
-			}
-		}
-
-		// Clean up execution timeline events before allowing a future task with the
-		// same namespace/name to expose stale history.
-		if r.ExecutionEventStore != nil {
-			if err := r.ExecutionEventStore.DeleteExecutionEvents(ctx, task.Namespace, store.ExecutionEventStreamTypeTask, task.Name); err != nil {
-				log.Error(err, "failed to delete execution events", "task", task.Name)
-				return ctrl.Result{}, err
-			}
-		}
-
-		if cancelErr := r.cancelHarnessWrapperTurn(ctx, task, "task deleted"); cancelErr != nil {
-			if isAgentRuntimeDependencyNotReady(cancelErr) {
-				if shouldWait, waitErr := r.waitForHarnessCancelDependency(ctx, task); waitErr != nil {
-					return ctrl.Result{}, waitErr
-				} else if shouldWait {
-					log.Info("waiting to cancel deleted harness runtime turn", "error", cancelErr)
-					return ctrl.Result{RequeueAfter: time.Second}, nil
-				}
-			}
-			log.Error(cancelErr, "failed to cancel deleted harness runtime turn")
-		}
-
-		waitingForJob, err := r.cleanupDeletedTaskJob(ctx, task)
-		if err != nil {
-			log.Error(err, "failed to delete Job")
+	if !controllerutil.ContainsFinalizer(task, labels.TaskFinalizer) {
+		if err := r.cleanupTrustedServiceReadBindingsAfterTaskRemoval(ctx, task.Namespace); err != nil {
+			log.Error(err, "failed to clean up trusted Service RBAC after Task removal")
 			return ctrl.Result{}, err
 		}
-		if waitingForJob {
-			return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
-		}
-		releasedPoolLeases, err := r.releaseSubstratePoolActorLeasesAfterTerminalCleanup(ctx, task)
-		if err != nil {
-			log.Error(err, "failed to release substrate pool actor leases")
-			return ctrl.Result{}, err
-		}
-		if !releasedPoolLeases {
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-		}
+		return ctrl.Result{}, nil
+	}
 
-		// Release session lock if held
-		if task.Spec.SessionRef != nil {
-			if err := r.SessionManager.ReleaseLock(ctx, task); err != nil {
-				log.Error(err, "failed to release session lock")
-				// Continue with finalizer removal anyway
-			}
+	var cleanupErrs []error
+	appendCleanupErr := func(operation string, err error) {
+		if err == nil {
+			return
 		}
+		log.Error(err, operation, "task", task.Name)
+		cleanupErrs = append(cleanupErrs, fmt.Errorf("%s: %w", operation, err))
+	}
 
-		// Remove finalizer
-		controllerutil.RemoveFinalizer(task, labels.TaskFinalizer)
-		if err := r.Update(ctx, task); err != nil && !apierrors.IsNotFound(err) {
-			log.Error(err, "failed to remove finalizer")
-			return ctrl.Result{}, err
+	// Durable stores are retried until every cleanup succeeds. Their failures do
+	// not prevent the controller from first revoking execution authority below.
+	if r.ResultStore != nil {
+		appendCleanupErr("deleting result from store", r.ResultStore.DeleteResult(ctx, task.Namespace, task.Name))
+	}
+	if r.ArtifactStore != nil {
+		appendCleanupErr("deleting artifacts", r.ArtifactStore.DeleteArtifacts(ctx, task.Namespace, task.Name))
+	}
+	if r.PlanStore != nil {
+		appendCleanupErr("deleting plan state", r.PlanStore.DeletePlan(ctx, task.Namespace, task.Name))
+	}
+	if r.MessageStore != nil {
+		appendCleanupErr("deleting task messages", r.MessageStore.DeleteTaskMessages(ctx, task.Namespace, task.Name))
+		appendCleanupErr("deleting parent messages", r.MessageStore.DeleteParentMessages(ctx, task.Namespace, task.Name))
+	}
+	if r.ExecutionEventStore != nil {
+		appendCleanupErr(
+			"deleting execution events",
+			r.ExecutionEventStore.DeleteExecutionEvents(ctx, task.Namespace, store.ExecutionEventStreamTypeTask, task.Name),
+		)
+	}
+
+	var requeueAfter time.Duration
+	setRequeueAfter := func(delay time.Duration) {
+		if requeueAfter == 0 || delay < requeueAfter {
+			requeueAfter = delay
 		}
 	}
-	if err := r.cleanupTrustedServiceReadBindingsAfterTaskRemoval(ctx, task.Namespace); err != nil {
-		log.Error(err, "failed to clean up trusted Service RBAC after Task removal")
+	quiescenceBlocked := false
+	runtimeCancellationPending := false
+
+	if cancelErr := r.cancelHarnessWrapperTurn(ctx, task, "task deleted"); cancelErr != nil {
+		if isAgentRuntimeDependencyNotReady(cancelErr) {
+			shouldWait, waitErr := r.waitForHarnessCancelDependency(ctx, task)
+			if waitErr != nil {
+				appendCleanupErr("recording deleted harness runtime cancellation retry", waitErr)
+				quiescenceBlocked = true
+				runtimeCancellationPending = true
+			} else if shouldWait {
+				log.Info("waiting to cancel deleted harness runtime turn", "error", cancelErr)
+				quiescenceBlocked = true
+				runtimeCancellationPending = true
+				setRequeueAfter(time.Second)
+			} else {
+				log.Error(cancelErr, "failed to cancel deleted harness runtime turn after dependency retries")
+			}
+		} else {
+			// Preserve the existing bounded best-effort cancellation policy for the
+			// v1 harness while still deleting the Job and workspace authority.
+			log.Error(cancelErr, "failed to cancel deleted harness runtime turn")
+		}
+	}
+
+	waitingForJob, jobCleanupErr := r.cleanupDeletedTaskJob(ctx, task)
+	if jobCleanupErr != nil {
+		appendCleanupErr("deleting Task Job", jobCleanupErr)
+		quiescenceBlocked = true
+	} else if waitingForJob {
+		quiescenceBlocked = true
+		setRequeueAfter(2 * time.Second)
+	} else if !runtimeCancellationPending {
+		releasedPoolLeases, leaseCleanupErr := r.releaseSubstratePoolActorLeasesAfterTerminalCleanup(ctx, task)
+		if leaseCleanupErr != nil {
+			appendCleanupErr("releasing substrate pool actor leases", leaseCleanupErr)
+			quiescenceBlocked = true
+		} else if !releasedPoolLeases {
+			quiescenceBlocked = true
+			setRequeueAfter(30 * time.Second)
+		}
+	}
+
+	// Do not release session ownership while a runtime, Job, or pooled workspace
+	// may still be active. Once quiesced, lock release is durable cleanup too.
+	if !quiescenceBlocked && task.Spec.SessionRef != nil {
+		appendCleanupErr("releasing session lock", r.SessionManager.ReleaseLock(ctx, task))
+	}
+
+	// Cross-namespace read grants are execution authority. Revoke them before
+	// allowing finalizer removal, and retry any failure while the Task remains.
+	appendCleanupErr(
+		"cleaning up trusted Service RBAC after Task removal",
+		r.cleanupTrustedServiceReadBindingsAfterTaskRemoval(ctx, task.Namespace),
+	)
+
+	if err := errors.Join(cleanupErrs...); err != nil {
+		return ctrl.Result{}, err
+	}
+	if quiescenceBlocked {
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+	}
+
+	controllerutil.RemoveFinalizer(task, labels.TaskFinalizer)
+	if err := r.Update(ctx, task); err != nil && !apierrors.IsNotFound(err) {
+		log.Error(err, "failed to remove finalizer")
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
@@ -3204,13 +3225,18 @@ func (r *TaskReconciler) handleScheduled(ctx context.Context, task *corev1alpha1
 	if now.Sub(scheduledTime) > time.Duration(deadlineSeconds)*time.Second {
 		log.Info("Missed schedule beyond deadline, skipping", "scheduledTime", scheduledTime, "deadline", deadlineSeconds)
 		r.Recorder.Eventf(task, "Warning", "MissedSchedule", "Missed scheduled run at %s (deadline %ds exceeded)", scheduledTime.Format(time.RFC3339), deadlineSeconds)
-		// Advance to next schedule time
+		// Consume the missed occurrence so a later reconcile cannot select it again.
 		next := sched.Next(now)
+		lastSchedule := metav1.NewTime(scheduledTime)
 		nextSchedule := metav1.NewTime(next)
+		lastScheduleCopy := lastSchedule
 		nextScheduleCopy := nextSchedule
-		_ = r.updateStatusWithRetry(ctx, task, func(t *corev1alpha1.Task) {
+		if err := r.updateStatusWithRetry(ctx, task, func(t *corev1alpha1.Task) {
+			t.Status.LastScheduleTime = &lastScheduleCopy
 			t.Status.NextScheduleTime = &nextScheduleCopy
-		})
+		}); err != nil {
+			return ctrl.Result{}, err
+		}
 		return ctrl.Result{RequeueAfter: time.Until(next)}, nil
 	}
 
@@ -3225,12 +3251,18 @@ func (r *TaskReconciler) handleScheduled(ctx context.Context, task *corev1alpha1
 		for i := range childList.Items {
 			if taskPhaseCountsTowardConcurrency(childList.Items[i].Status.Phase) {
 				log.Info("Concurrency policy Forbid: active child task exists, skipping", "activeChild", childList.Items[i].Name)
+				// Consume this occurrence while the earlier child remains active.
 				next := sched.Next(now)
+				lastSchedule := metav1.NewTime(scheduledTime)
 				nextSchedule := metav1.NewTime(next)
+				lastScheduleCopy := lastSchedule
 				nextScheduleCopy := nextSchedule
-				_ = r.updateStatusWithRetry(ctx, task, func(t *corev1alpha1.Task) {
+				if err := r.updateStatusWithRetry(ctx, task, func(t *corev1alpha1.Task) {
+					t.Status.LastScheduleTime = &lastScheduleCopy
 					t.Status.NextScheduleTime = &nextScheduleCopy
-				})
+				}); err != nil {
+					return ctrl.Result{}, err
+				}
 				return ctrl.Result{RequeueAfter: time.Until(next)}, nil
 			}
 		}

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -468,16 +468,6 @@ func executionEventTypeForTaskPhase(phase corev1alpha1.TaskPhase) string {
 	}
 }
 
-func taskHasExternalAgentRuntimeTurn(task *corev1alpha1.Task) bool {
-	if !taskHasPlannedHarnessWrapperTurn(task) {
-		return false
-	}
-	if task.Status.HarnessRuntime != nil && strings.TrimSpace(task.Status.HarnessRuntime.RuntimeRefName) != "" {
-		return true
-	}
-	return strings.TrimSpace(task.Annotations[harnessWrapperRuntimeRefAnno]) != ""
-}
-
 // handleDeletion handles Task cleanup when deleted
 func (r *TaskReconciler) handleDeletion(ctx context.Context, task *corev1alpha1.Task) (ctrl.Result, error) { //nolint:unparam // Result is always nil but kept for interface consistency
 	log := logf.FromContext(ctx)
@@ -534,39 +524,33 @@ func (r *TaskReconciler) handleDeletion(ctx context.Context, task *corev1alpha1.
 		runtimeCancellationPending = true
 		setRequeueAfter(delay)
 	}
-	externalRuntimeTurn := taskHasExternalAgentRuntimeTurn(task)
 
 	// A successful harness-v1 CancelTurn response is the execution-authority
-	// fence: conforming runtimes cancel the turn context before acknowledging it.
-	// Errors leave external-runtime quiescence unconfirmed and must be retried.
-	if cancelErr := r.cancelHarnessWrapperTurn(ctx, task, "task deleted"); cancelErr != nil {
-		if isAgentRuntimeDependencyNotReady(cancelErr) {
-			shouldWait, waitErr := r.waitForHarnessCancelDependency(ctx, task)
-			if waitErr != nil {
-				appendCleanupErr("recording deleted harness runtime cancellation retry", waitErr)
-				markRuntimeCancellationPending(time.Second)
-			} else if shouldWait {
-				log.Info("waiting to cancel deleted harness runtime turn", "error", cancelErr)
-				markRuntimeCancellationPending(time.Second)
-			} else if externalRuntimeTurn {
-				// Remote runtime turns have no local Job to prove quiescence. Keep the
-				// finalizer and retry slowly until cancellation succeeds or the runtime
-				// confirms that the turn is already gone.
-				log.Error(cancelErr, "failed to cancel deleted external runtime turn after dependency retries; retaining finalizer")
-				markRuntimeCancellationPending(30 * time.Second)
+	// fence. Persist that acknowledgement before later fallible cleanup so retries
+	// never need the runtime endpoint or auth Secret after quiescence is confirmed.
+	if taskHasPlannedHarnessWrapperTurn(task) && !harnessWrapperCancelAcknowledged(task) {
+		if cancelErr := r.cancelHarnessWrapperTurn(ctx, task, "task deleted"); cancelErr != nil {
+			if isAgentRuntimeDependencyNotReady(cancelErr) {
+				shouldWait, waitErr := r.waitForHarnessCancelDependency(ctx, task)
+				if waitErr != nil {
+					appendCleanupErr("recording deleted harness runtime cancellation retry", waitErr)
+					markRuntimeCancellationPending(time.Second)
+				} else if shouldWait {
+					log.Info("waiting to cancel deleted harness runtime turn", "error", cancelErr)
+					markRuntimeCancellationPending(time.Second)
+				} else {
+					log.Error(cancelErr, "failed to cancel deleted harness runtime turn after dependency retries; retaining finalizer")
+					markRuntimeCancellationPending(30 * time.Second)
+				}
 			} else {
-				log.Error(cancelErr, "failed to cancel deleted harness runtime turn after dependency retries")
+				// Any unconfirmed started or planned harness turn can remain active,
+				// including built-in runtimes whose wrapper Job is not retained in status.
+				log.Error(cancelErr, "failed to cancel deleted harness runtime turn; retaining finalizer")
+				markRuntimeCancellationPending(30 * time.Second)
 			}
-		} else if externalRuntimeTurn {
-			// Any unconfirmed external-runtime cancellation can leave the remote turn
-			// active, including transport and transient HTTP failures. Fail closed so
-			// session/workspace authority and the Task finalizer remain until retry.
-			log.Error(cancelErr, "failed to cancel deleted external runtime turn; retaining finalizer")
-			markRuntimeCancellationPending(30 * time.Second)
-		} else {
-			// Preserve the existing bounded best-effort cancellation policy for the
-			// local v1 harness while still deleting its Job and workspace authority.
-			log.Error(cancelErr, "failed to cancel deleted harness runtime turn")
+		} else if ackErr := r.patchHarnessWrapperCancelAcknowledged(ctx, task); ackErr != nil {
+			appendCleanupErr("recording deleted harness runtime cancellation acknowledgement", ackErr)
+			markRuntimeCancellationPending(time.Second)
 		}
 	}
 

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -529,7 +529,13 @@ func (r *TaskReconciler) handleDeletion(ctx context.Context, task *corev1alpha1.
 	// fence. Persist that acknowledgement before later fallible cleanup so retries
 	// never need the runtime endpoint or auth Secret after quiescence is confirmed.
 	if taskHasPlannedHarnessWrapperTurn(task) && !harnessWrapperCancelAcknowledged(task) {
-		if cancelErr := r.cancelHarnessWrapperTurn(ctx, task, "task deleted"); cancelErr != nil {
+		legacyAcknowledged := harnessWrapperLegacyCancelAcknowledged(task)
+		if cancelErr := func() error {
+			if legacyAcknowledged {
+				return nil
+			}
+			return r.cancelHarnessWrapperTurn(ctx, task, "task deleted")
+		}(); cancelErr != nil {
 			if isAgentRuntimeDependencyNotReady(cancelErr) {
 				shouldWait, waitErr := r.waitForHarnessCancelDependency(ctx, task)
 				if waitErr != nil {

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -468,6 +468,16 @@ func executionEventTypeForTaskPhase(phase corev1alpha1.TaskPhase) string {
 	}
 }
 
+func taskHasExternalAgentRuntimeTurn(task *corev1alpha1.Task) bool {
+	if !taskHasPlannedHarnessWrapperTurn(task) {
+		return false
+	}
+	if task.Status.HarnessRuntime != nil && strings.TrimSpace(task.Status.HarnessRuntime.RuntimeRefName) != "" {
+		return true
+	}
+	return strings.TrimSpace(task.Annotations[harnessWrapperRuntimeRefAnno]) != ""
+}
+
 // handleDeletion handles Task cleanup when deleted
 func (r *TaskReconciler) handleDeletion(ctx context.Context, task *corev1alpha1.Task) (ctrl.Result, error) { //nolint:unparam // Result is always nil but kept for interface consistency
 	log := logf.FromContext(ctx)
@@ -519,25 +529,43 @@ func (r *TaskReconciler) handleDeletion(ctx context.Context, task *corev1alpha1.
 	}
 	quiescenceBlocked := false
 	runtimeCancellationPending := false
+	markRuntimeCancellationPending := func(delay time.Duration) {
+		quiescenceBlocked = true
+		runtimeCancellationPending = true
+		setRequeueAfter(delay)
+	}
+	externalRuntimeTurn := taskHasExternalAgentRuntimeTurn(task)
 
+	// A successful harness-v1 CancelTurn response is the execution-authority
+	// fence: conforming runtimes cancel the turn context before acknowledging it.
+	// Errors leave external-runtime quiescence unconfirmed and must be retried.
 	if cancelErr := r.cancelHarnessWrapperTurn(ctx, task, "task deleted"); cancelErr != nil {
 		if isAgentRuntimeDependencyNotReady(cancelErr) {
 			shouldWait, waitErr := r.waitForHarnessCancelDependency(ctx, task)
 			if waitErr != nil {
 				appendCleanupErr("recording deleted harness runtime cancellation retry", waitErr)
-				quiescenceBlocked = true
-				runtimeCancellationPending = true
+				markRuntimeCancellationPending(time.Second)
 			} else if shouldWait {
 				log.Info("waiting to cancel deleted harness runtime turn", "error", cancelErr)
-				quiescenceBlocked = true
-				runtimeCancellationPending = true
-				setRequeueAfter(time.Second)
+				markRuntimeCancellationPending(time.Second)
+			} else if externalRuntimeTurn {
+				// Remote runtime turns have no local Job to prove quiescence. Keep the
+				// finalizer and retry slowly until cancellation succeeds or the runtime
+				// confirms that the turn is already gone.
+				log.Error(cancelErr, "failed to cancel deleted external runtime turn after dependency retries; retaining finalizer")
+				markRuntimeCancellationPending(30 * time.Second)
 			} else {
 				log.Error(cancelErr, "failed to cancel deleted harness runtime turn after dependency retries")
 			}
+		} else if externalRuntimeTurn {
+			// Any unconfirmed external-runtime cancellation can leave the remote turn
+			// active, including transport and transient HTTP failures. Fail closed so
+			// session/workspace authority and the Task finalizer remain until retry.
+			log.Error(cancelErr, "failed to cancel deleted external runtime turn; retaining finalizer")
+			markRuntimeCancellationPending(30 * time.Second)
 		} else {
 			// Preserve the existing bounded best-effort cancellation policy for the
-			// v1 harness while still deleting the Job and workspace authority.
+			// local v1 harness while still deleting its Job and workspace authority.
 			log.Error(cancelErr, "failed to cancel deleted harness runtime turn")
 		}
 	}
@@ -751,7 +779,7 @@ func (r *TaskReconciler) handleScheduledTask(ctx context.Context, task *corev1al
 	log := logf.FromContext(ctx)
 
 	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
-	sched, err := parser.Parse(task.Spec.Schedule)
+	sched, err := parseTaskSchedule(parser, task.Spec.Schedule)
 	if err != nil {
 		return r.failTask(ctx, task, fmt.Sprintf("invalid cron expression: %v", err))
 	}
@@ -2193,18 +2221,17 @@ func (r *TaskReconciler) cleanupDeletedTaskJob(ctx context.Context, task *corev1
 		return false, fmt.Errorf("getting deleted task Job %q: %w", task.Status.JobName, err)
 	}
 
-	holdsPoolActor, err := r.taskHasSubstratePoolActorLeases(ctx, task)
-	if err != nil {
-		return false, err
-	}
-	propagationPolicy := metav1.DeletePropagationBackground
-	if holdsPoolActor {
-		propagationPolicy = metav1.DeletePropagationForeground
-	}
-	if err := r.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil && !apierrors.IsNotFound(err) {
+	// Foreground deletion keeps the Job observable until its Pods are gone. The
+	// caller must requeue until a subsequent Get returns NotFound so no worker can
+	// recreate durable Task data after the final cleanup pass.
+	propagationPolicy := metav1.DeletePropagationForeground
+	if err := r.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
 		return false, fmt.Errorf("deleting deleted task Job %q: %w", task.Status.JobName, err)
 	}
-	return holdsPoolActor, nil
+	return true, nil
 }
 
 func (r *TaskReconciler) cleanupTerminalTaskJob(ctx context.Context, task *corev1alpha1.Task) (bool, error) {
@@ -3167,24 +3194,237 @@ func approvalRequiredBuiltInToolSet() map[string]bool {
 	return builtIns
 }
 
+const (
+	maxSkippedScheduleCatchUpSteps    = 1000
+	scheduleSuspendedMarkerAnnotation = "orka.ai/schedule-suspended"
+)
+
+func coalesceOverdueSchedule(
+	sched cron.Schedule,
+	firstDue time.Time,
+	now time.Time,
+) (lastConsumed time.Time, next time.Time) {
+	lastConsumed = firstDue
+	for range maxSkippedScheduleCatchUpSteps {
+		next = sched.Next(lastConsumed)
+		if next.After(now) {
+			return lastConsumed, next
+		}
+		if !next.After(lastConsumed) {
+			break
+		}
+		lastConsumed = next
+	}
+
+	// Bound custom Schedule implementations that cannot be inspected directly.
+	// Parsed cron schedules use mostRecentDueSchedule's constant-time or binary
+	// search paths below and retain an exact scheduled cursor.
+	lastConsumed = now
+	return lastConsumed, sched.Next(lastConsumed)
+}
+
+func mostRecentDueSchedule(sched cron.Schedule, firstDue, now time.Time) (time.Time, time.Time) {
+	switch typed := sched.(type) {
+	case cron.ConstantDelaySchedule:
+		if typed.Delay > 0 {
+			steps := now.Sub(firstDue) / typed.Delay
+			latest := firstDue.Add(steps * typed.Delay)
+			return latest, typed.Next(latest)
+		}
+	case *cron.ConstantDelaySchedule:
+		if typed != nil && typed.Delay > 0 {
+			steps := now.Sub(firstDue) / typed.Delay
+			latest := firstDue.Add(steps * typed.Delay)
+			return latest, typed.Next(latest)
+		}
+	case *cron.SpecSchedule:
+		if typed != nil {
+			latest := firstDue
+			low, high := firstDue, now
+			for range 64 {
+				span := high.Sub(low)
+				if span <= time.Second {
+					break
+				}
+				mid := low.Add(span / 2)
+				candidate := typed.Next(mid)
+				if candidate.IsZero() || candidate.After(now) {
+					high = mid
+					continue
+				}
+				latest = candidate
+				low = mid
+			}
+			next := typed.Next(latest)
+			if !next.IsZero() && !next.After(now) {
+				latest = next
+				next = typed.Next(latest)
+			}
+			return latest, next
+		}
+	}
+	return coalesceOverdueSchedule(sched, firstDue, now)
+}
+
+func (r *TaskReconciler) persistScheduleCursor(
+	ctx context.Context,
+	task *corev1alpha1.Task,
+	lastConsumed time.Time,
+	next time.Time,
+) error {
+	lastSchedule := metav1.NewTime(lastConsumed)
+	nextSchedule := metav1.NewTime(next)
+	return r.updateStatusWithRetry(ctx, task, func(t *corev1alpha1.Task) {
+		t.Status.LastScheduleTime = &lastSchedule
+		t.Status.NextScheduleTime = &nextSchedule
+	})
+}
+
+func (r *TaskReconciler) advanceSkippedSchedule(
+	ctx context.Context,
+	task *corev1alpha1.Task,
+	sched cron.Schedule,
+	firstDue time.Time,
+	now time.Time,
+) (time.Time, error) {
+	lastConsumed, next := mostRecentDueSchedule(sched, firstDue, now)
+	if err := r.persistScheduleCursor(ctx, task, lastConsumed, next); err != nil {
+		return time.Time{}, err
+	}
+	return next, nil
+}
+
+func (r *TaskReconciler) handleSuspendedSchedule(
+	ctx context.Context,
+	task *corev1alpha1.Task,
+	sched cron.Schedule,
+	scheduledTime time.Time,
+	now time.Time,
+) (ctrl.Result, error) {
+	logf.FromContext(ctx).Info("Task is suspended, skipping overdue scheduled runs")
+	if now.Before(scheduledTime) {
+		nextSchedule := metav1.NewTime(scheduledTime)
+		if task.Status.NextScheduleTime == nil || !task.Status.NextScheduleTime.Equal(&nextSchedule) {
+			if err := r.updateStatusWithRetry(ctx, task, func(t *corev1alpha1.Task) {
+				t.Status.NextScheduleTime = &nextSchedule
+			}); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{RequeueAfter: time.Minute}, nil
+	}
+	if _, err := r.advanceSkippedSchedule(ctx, task, sched, scheduledTime, now); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: time.Minute}, nil
+}
+
+func taskHasScheduleSuspensionMarker(task *corev1alpha1.Task) bool {
+	return task != nil && task.Annotations != nil &&
+		task.Annotations[scheduleSuspendedMarkerAnnotation] == scheduledRunLabelValue
+}
+
+func (r *TaskReconciler) ensureScheduleSuspensionMarker(ctx context.Context, task *corev1alpha1.Task) error {
+	if taskHasScheduleSuspensionMarker(task) {
+		return nil
+	}
+	patch := client.MergeFrom(task.DeepCopy())
+	if task.Annotations == nil {
+		task.Annotations = map[string]string{}
+	}
+	task.Annotations[scheduleSuspendedMarkerAnnotation] = scheduledRunLabelValue
+	return r.Patch(ctx, task, patch)
+}
+
+func (r *TaskReconciler) clearScheduleSuspensionMarker(ctx context.Context, task *corev1alpha1.Task) error {
+	if !taskHasScheduleSuspensionMarker(task) {
+		return nil
+	}
+	patch := client.MergeFrom(task.DeepCopy())
+	delete(task.Annotations, scheduleSuspendedMarkerAnnotation)
+	return r.Patch(ctx, task, patch)
+}
+
+func (r *TaskReconciler) finishScheduleResume(
+	ctx context.Context,
+	task *corev1alpha1.Task,
+	sched cron.Schedule,
+	scheduledTime time.Time,
+	now time.Time,
+) (ctrl.Result, bool, error) {
+	if !taskHasScheduleSuspensionMarker(task) {
+		return ctrl.Result{}, false, nil
+	}
+	if now.Before(scheduledTime) {
+		if err := r.clearScheduleSuspensionMarker(ctx, task); err != nil {
+			return ctrl.Result{}, true, err
+		}
+		return ctrl.Result{}, false, nil
+	}
+	next, err := r.advanceSkippedSchedule(ctx, task, sched, scheduledTime, now)
+	if err != nil {
+		return ctrl.Result{}, true, err
+	}
+	if err := r.clearScheduleSuspensionMarker(ctx, task); err != nil {
+		return ctrl.Result{}, true, err
+	}
+	return ctrl.Result{RequeueAfter: time.Until(next)}, true, nil
+}
+
+func (r *TaskReconciler) ensureScheduleSuspensionMarkerIfNeeded(
+	ctx context.Context,
+	task *corev1alpha1.Task,
+	suspended bool,
+) error {
+	if !suspended {
+		return nil
+	}
+	return r.ensureScheduleSuspensionMarker(ctx, task)
+}
+
+func parseTaskSchedule(parser cron.Parser, spec string) (schedule cron.Schedule, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			schedule = nil
+			err = fmt.Errorf("cron parser panic: %v", recovered)
+		}
+	}()
+	return parser.Parse(spec)
+}
+
+func (r *TaskReconciler) parseScheduledTaskSchedule(
+	ctx context.Context,
+	task *corev1alpha1.Task,
+	suspended bool,
+) (cron.Schedule, ctrl.Result, bool) {
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+	sched, err := parseTaskSchedule(parser, task.Spec.Schedule)
+	if err == nil {
+		return sched, ctrl.Result{}, false
+	}
+	if suspended {
+		logf.FromContext(ctx).Info("Task is suspended, deferring invalid schedule validation")
+		return nil, ctrl.Result{RequeueAfter: time.Minute}, true
+	}
+	task.Status.Phase = corev1alpha1.TaskPhaseFailed
+	task.Status.Message = fmt.Sprintf("invalid cron expression: %v", err)
+	_ = r.Status().Update(ctx, task)
+	return nil, ctrl.Result{}, true
+}
+
 // handleScheduled manages the scheduling loop for recurring tasks.
 func (r *TaskReconciler) handleScheduled(ctx context.Context, task *corev1alpha1.Task) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
-
-	// Check if suspended
-	if task.Spec.Suspend != nil && *task.Spec.Suspend {
-		log.Info("Task is suspended, skipping schedule check")
-		return ctrl.Result{RequeueAfter: time.Minute}, nil
+	suspended := task.Spec.Suspend != nil && *task.Spec.Suspend
+	if err := r.ensureScheduleSuspensionMarkerIfNeeded(ctx, task, suspended); err != nil {
+		return ctrl.Result{}, err
 	}
 
-	// Parse schedule
-	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
-	sched, err := parser.Parse(task.Spec.Schedule)
-	if err != nil {
-		task.Status.Phase = corev1alpha1.TaskPhaseFailed
-		task.Status.Message = fmt.Sprintf("invalid cron expression: %v", err)
-		_ = r.Status().Update(ctx, task)
-		return ctrl.Result{}, nil
+	// Parse schedule. Preserve the existing behavior that an invalid suspended
+	// schedule is not failed until the Task is resumed.
+	sched, parseResult, parseHandled := r.parseScheduledTaskSchedule(ctx, task, suspended)
+	if parseHandled {
+		return parseResult, nil
 	}
 
 	// Determine time zone
@@ -3205,14 +3445,22 @@ func (r *TaskReconciler) handleScheduled(ctx context.Context, task *corev1alpha1
 		scheduledTime = sched.Next(task.CreationTimestamp.In(loc))
 	}
 
+	if suspended {
+		return r.handleSuspendedSchedule(ctx, task, sched, scheduledTime, now)
+	}
+	if result, handled, err := r.finishScheduleResume(ctx, task, sched, scheduledTime, now); handled || err != nil {
+		return result, err
+	}
+
 	// Not yet time
 	if now.Before(scheduledTime) {
 		nextSchedule := metav1.NewTime(scheduledTime)
 		if task.Status.NextScheduleTime == nil || !task.Status.NextScheduleTime.Equal(&nextSchedule) {
-			nextScheduleCopy := nextSchedule
-			_ = r.updateStatusWithRetry(ctx, task, func(t *corev1alpha1.Task) {
-				t.Status.NextScheduleTime = &nextScheduleCopy
-			})
+			if err := r.updateStatusWithRetry(ctx, task, func(t *corev1alpha1.Task) {
+				t.Status.NextScheduleTime = &nextSchedule
+			}); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
 		return ctrl.Result{RequeueAfter: time.Until(scheduledTime)}, nil
 	}
@@ -3222,22 +3470,21 @@ func (r *TaskReconciler) handleScheduled(ctx context.Context, task *corev1alpha1
 	if task.Spec.StartingDeadlineSeconds != nil {
 		deadlineSeconds = *task.Spec.StartingDeadlineSeconds
 	}
-	if now.Sub(scheduledTime) > time.Duration(deadlineSeconds)*time.Second {
+	deadline := time.Duration(deadlineSeconds) * time.Second
+	if now.Sub(scheduledTime) > deadline {
 		log.Info("Missed schedule beyond deadline, skipping", "scheduledTime", scheduledTime, "deadline", deadlineSeconds)
 		r.Recorder.Eventf(task, "Warning", "MissedSchedule", "Missed scheduled run at %s (deadline %ds exceeded)", scheduledTime.Format(time.RFC3339), deadlineSeconds)
-		// Consume the missed occurrence so a later reconcile cannot select it again.
-		next := sched.Next(now)
-		lastSchedule := metav1.NewTime(scheduledTime)
-		nextSchedule := metav1.NewTime(next)
-		lastScheduleCopy := lastSchedule
-		nextScheduleCopy := nextSchedule
-		if err := r.updateStatusWithRetry(ctx, task, func(t *corev1alpha1.Task) {
-			t.Status.LastScheduleTime = &lastScheduleCopy
-			t.Status.NextScheduleTime = &nextScheduleCopy
-		}); err != nil {
-			return ctrl.Result{}, err
+		latestDue, next := mostRecentDueSchedule(sched, scheduledTime, now)
+		if now.Sub(latestDue) > deadline {
+			if err := r.persistScheduleCursor(ctx, task, latestDue, next); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{RequeueAfter: time.Until(next)}, nil
 		}
-		return ctrl.Result{RequeueAfter: time.Until(next)}, nil
+		// Retain the most recent occurrence that is still inside the starting
+		// deadline. Older expired ticks are coalesced by the status update after
+		// this occurrence is either created or skipped by ForbidConcurrent.
+		scheduledTime = latestDue
 	}
 
 	// Check concurrency policy
@@ -3251,16 +3498,8 @@ func (r *TaskReconciler) handleScheduled(ctx context.Context, task *corev1alpha1
 		for i := range childList.Items {
 			if taskPhaseCountsTowardConcurrency(childList.Items[i].Status.Phase) {
 				log.Info("Concurrency policy Forbid: active child task exists, skipping", "activeChild", childList.Items[i].Name)
-				// Consume this occurrence while the earlier child remains active.
-				next := sched.Next(now)
-				lastSchedule := metav1.NewTime(scheduledTime)
-				nextSchedule := metav1.NewTime(next)
-				lastScheduleCopy := lastSchedule
-				nextScheduleCopy := nextSchedule
-				if err := r.updateStatusWithRetry(ctx, task, func(t *corev1alpha1.Task) {
-					t.Status.LastScheduleTime = &lastScheduleCopy
-					t.Status.NextScheduleTime = &nextScheduleCopy
-				}); err != nil {
+				next, err := r.advanceSkippedSchedule(ctx, task, sched, scheduledTime, now)
+				if err != nil {
 					return ctrl.Result{}, err
 				}
 				return ctrl.Result{RequeueAfter: time.Until(next)}, nil

--- a/internal/controller/task_controller_test.go
+++ b/internal/controller/task_controller_test.go
@@ -216,14 +216,36 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Delete(ctx, task)).To(Succeed())
 			Expect(k8sClient.Get(ctx, nn, task)).To(Succeed())
 
-			// Reconcile to handle deletion
-			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			// First reconcile starts foreground Job deletion and retains the Task
+			// finalizer until the Job and its worker Pods are actually gone.
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(2 * time.Second))
+			Expect(k8sClient.Get(ctx, nn, task)).To(Succeed())
+			Expect(controllerutil.ContainsFinalizer(task, labels.TaskFinalizer)).To(BeTrue())
 
-			// Job should be deleted
+			// envtest does not run the garbage collector, so emulate completion of
+			// foreground deletion by removing the API-server foreground finalizer.
+			jobKey := types.NamespacedName{Name: taskName + "-job", Namespace: ns}
+			deletingJob := &batchv1.Job{}
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{Name: taskName + "-job", Namespace: ns}, &batchv1.Job{})
-				return errors.IsNotFound(err)
+				if getErr := k8sClient.Get(ctx, jobKey, deletingJob); getErr != nil {
+					return false
+				}
+				return !deletingJob.DeletionTimestamp.IsZero()
+			}, 5*time.Second, 200*time.Millisecond).Should(BeTrue())
+			deletingJob.Finalizers = nil
+			Expect(k8sClient.Update(ctx, deletingJob)).To(Succeed())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, jobKey, &batchv1.Job{}))
+			}, 5*time.Second, 200*time.Millisecond).Should(BeTrue())
+
+			// A later reconcile performs the final durable cleanup pass and only then
+			// removes the Task finalizer.
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, nn, &corev1alpha1.Task{}))
 			}, 5*time.Second, 200*time.Millisecond).Should(BeTrue())
 		})
 

--- a/internal/controller/task_controller_unit_test.go
+++ b/internal/controller/task_controller_unit_test.go
@@ -115,6 +115,71 @@ func (s failingGetSessionStore) GetSession(context.Context, string, string) (*st
 	return nil, s.err
 }
 
+// failOnceTaskCleanupStore injects one durable cleanup failure while delegating
+// every other call to an idempotent backing store.
+type failOnceTaskCleanupStore struct {
+	store.ResultStore
+	store.ArtifactStore
+	store.PlanStore
+	store.MessageStore
+
+	failOperation string
+	failErr       error
+	failed        bool
+}
+
+func (s *failOnceTaskCleanupStore) maybeFail(operation string) error {
+	if !s.failed && s.failOperation == operation {
+		s.failed = true
+		return s.failErr
+	}
+	return nil
+}
+
+func (s *failOnceTaskCleanupStore) DeleteResult(ctx context.Context, namespace, taskName string) error {
+	if err := s.maybeFail("result"); err != nil {
+		return err
+	}
+	return s.ResultStore.DeleteResult(ctx, namespace, taskName)
+}
+
+func (s *failOnceTaskCleanupStore) DeleteArtifacts(ctx context.Context, namespace, taskName string) error {
+	if err := s.maybeFail("artifacts"); err != nil {
+		return err
+	}
+	return s.ArtifactStore.DeleteArtifacts(ctx, namespace, taskName)
+}
+
+func (s *failOnceTaskCleanupStore) DeletePlan(ctx context.Context, namespace, taskName string) error {
+	if err := s.maybeFail("plan"); err != nil {
+		return err
+	}
+	return s.PlanStore.DeletePlan(ctx, namespace, taskName)
+}
+
+func (s *failOnceTaskCleanupStore) DeleteTaskMessages(ctx context.Context, namespace, taskName string) error {
+	if err := s.maybeFail("task messages"); err != nil {
+		return err
+	}
+	return s.MessageStore.DeleteTaskMessages(ctx, namespace, taskName)
+}
+
+func (s *failOnceTaskCleanupStore) DeleteParentMessages(ctx context.Context, namespace, taskName string) error {
+	if err := s.maybeFail("parent messages"); err != nil {
+		return err
+	}
+	return s.MessageStore.DeleteParentMessages(ctx, namespace, taskName)
+}
+
+type failingReleaseLockStore struct {
+	store.SessionStore
+	err error
+}
+
+func (s failingReleaseLockStore) ReleaseLock(context.Context, string, string, string, string) error {
+	return s.err
+}
+
 type recordingTaskWorkspaceExecutor struct {
 	deleteReqs  []workspace.DeleteRequest
 	deleteErr   error
@@ -3223,6 +3288,115 @@ func TestHandleDeletion_WithPersistedResultWithoutResultRef(t *testing.T) {
 	}
 }
 
+func TestHandleDeletionRetainsFinalizerUntilDurableStoreCleanupSucceeds(t *testing.T) {
+	for _, operation := range []string{"result", "artifacts", "plan", "task messages", "parent messages"} {
+		t.Run(operation, func(t *testing.T) {
+			scheme := newTestScheme()
+			taskName := "del-fail-once-" + strings.ReplaceAll(operation, " ", "-")
+			jobName := taskName + "-job"
+			sessionName := taskName + "-session"
+			task := &corev1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       taskName,
+					Namespace:  "default",
+					UID:        types.UID(taskName + "-uid"),
+					Finalizers: []string{labels.TaskFinalizer},
+				},
+				Spec: corev1alpha1.TaskSpec{
+					SessionRef: &corev1alpha1.SessionReference{Name: sessionName, Create: true},
+				},
+				Status: corev1alpha1.TaskStatus{JobName: jobName},
+			}
+			job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: task.Namespace}}
+			r := newUnitReconciler(scheme, task, job)
+			backing := r.ResultStore.(*sqlite.Store)
+			if err := r.SessionManager.AcquireLock(context.Background(), task); err != nil {
+				t.Fatalf("AcquireLock() error = %v", err)
+			}
+			cleanupErr := errors.New("injected durable cleanup failure")
+			cleanupStore := &failOnceTaskCleanupStore{
+				ResultStore:   backing,
+				ArtifactStore: backing,
+				PlanStore:     backing,
+				MessageStore:  backing,
+				failOperation: operation,
+				failErr:       cleanupErr,
+			}
+			r.ResultStore = cleanupStore
+			r.ArtifactStore = cleanupStore
+			r.PlanStore = cleanupStore
+			r.MessageStore = cleanupStore
+			if err := backing.SaveResult(context.Background(), task.Namespace, task.Name, []byte("stale")); err != nil {
+				t.Fatalf("SaveResult() error = %v", err)
+			}
+
+			if _, err := r.handleDeletion(context.Background(), task); !errors.Is(err, cleanupErr) {
+				t.Fatalf("first handleDeletion() error = %v, want %v", err, cleanupErr)
+			}
+			persisted := &corev1alpha1.Task{}
+			key := types.NamespacedName{Namespace: task.Namespace, Name: task.Name}
+			if err := r.Get(context.Background(), key, persisted); err != nil {
+				t.Fatalf("Get Task after cleanup failure: %v", err)
+			}
+			if !controllerutil.ContainsFinalizer(persisted, labels.TaskFinalizer) {
+				t.Fatal("Task finalizer removed after durable cleanup failure")
+			}
+			if err := r.Get(context.Background(), types.NamespacedName{Namespace: job.Namespace, Name: job.Name}, &batchv1.Job{}); !apierrors.IsNotFound(err) {
+				t.Fatalf("Job lookup after durable cleanup failure = %v, want NotFound", err)
+			}
+			session, err := backing.GetSession(context.Background(), task.Namespace, sessionName)
+			if err != nil {
+				t.Fatalf("GetSession() error = %v", err)
+			}
+			if session.ActiveTask != "" || session.ActiveTaskUID != "" {
+				t.Fatalf("session lock after durable cleanup failure = %q/%q, want released", session.ActiveTask, session.ActiveTaskUID)
+			}
+
+			if _, err := r.handleDeletion(context.Background(), persisted); err != nil {
+				t.Fatalf("second handleDeletion() error = %v", err)
+			}
+			if err := r.Get(context.Background(), key, persisted); err != nil {
+				t.Fatalf("Get Task after successful retry: %v", err)
+			}
+			if controllerutil.ContainsFinalizer(persisted, labels.TaskFinalizer) {
+				t.Fatal("Task finalizer retained after durable cleanup succeeded")
+			}
+		})
+	}
+}
+
+func TestHandleDeletionRetainsFinalizerWhenSessionLockReleaseFails(t *testing.T) {
+	scheme := newTestScheme()
+	lockErr := errors.New("injected session lock release failure")
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "del-session-lock-fail",
+			Namespace:  "default",
+			Finalizers: []string{labels.TaskFinalizer},
+		},
+		Spec:   corev1alpha1.TaskSpec{SessionRef: &corev1alpha1.SessionReference{Name: "session"}},
+		Status: corev1alpha1.TaskStatus{JobName: "del-session-lock-fail-job"},
+	}
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: task.Status.JobName, Namespace: task.Namespace}}
+	r := newUnitReconciler(scheme, task, job)
+	backing := r.ResultStore.(*sqlite.Store)
+	r.SessionManager = NewSessionManager(failingReleaseLockStore{SessionStore: backing, err: lockErr})
+
+	if _, err := r.handleDeletion(context.Background(), task); !errors.Is(err, lockErr) {
+		t.Fatalf("handleDeletion() error = %v, want %v", err, lockErr)
+	}
+	persisted := &corev1alpha1.Task{}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(task), persisted); err != nil {
+		t.Fatalf("Get Task: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(persisted, labels.TaskFinalizer) {
+		t.Fatal("Task finalizer removed after session lock release failure")
+	}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(job), &batchv1.Job{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("Job lookup after session lock release failure = %v, want NotFound", err)
+	}
+}
+
 func TestHandleDeletionDeletesExecutionEvents(t *testing.T) {
 	scheme := newTestScheme()
 	task := &corev1alpha1.Task{
@@ -3292,16 +3466,25 @@ func TestHandleDeletionKeepsFinalizerWhenExecutionEventCleanupFails(t *testing.T
 			Namespace:  "default",
 			Finalizers: []string{labels.TaskFinalizer},
 		},
+		Status: corev1alpha1.TaskStatus{JobName: "del-events-fail-job"},
 	}
-	r := newUnitReconciler(scheme, task)
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: task.Status.JobName, Namespace: task.Namespace}}
+	r := newUnitReconciler(scheme, task, job)
 	r.ExecutionEventStore = failingExecutionEventStore{err: errors.New("store unavailable")}
 
 	_, err := r.handleDeletion(context.Background(), task)
 	if err == nil {
 		t.Fatal("handleDeletion() error = nil, want execution event cleanup error")
 	}
-	if !controllerutil.ContainsFinalizer(task, labels.TaskFinalizer) {
-		t.Fatal("task finalizer was removed after execution event cleanup failed")
+	persisted := &corev1alpha1.Task{}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(task), persisted); err != nil {
+		t.Fatalf("Get Task: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(persisted, labels.TaskFinalizer) {
+		t.Fatal("Task finalizer was removed after execution event cleanup failed")
+	}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(job), &batchv1.Job{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("Job lookup after execution event cleanup failure = %v, want NotFound", err)
 	}
 }
 
@@ -3362,6 +3545,60 @@ func TestHandleDeletion_WithJobName(t *testing.T) {
 	_, err := r.handleDeletion(context.Background(), task)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandleDeletionPreservesPoolLeaseWhileRuntimeCancellationIsPending(t *testing.T) {
+	scheme := newTestScheme()
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "del-runtime-cancel-pending",
+			Namespace:  "default",
+			UID:        "del-runtime-cancel-pending-uid",
+			Finalizers: []string{labels.TaskFinalizer},
+		},
+		Status: corev1alpha1.TaskStatus{
+			ExecutionWorkspace: &corev1alpha1.ExecutionWorkspaceStatus{
+				Phase:  corev1alpha1.ExecutionWorkspacePhaseReleased,
+				Reason: corev1alpha1.ExecutionWorkspaceReasonReleased,
+			},
+			HarnessRuntime: &corev1alpha1.HarnessRuntimeStatus{
+				RuntimeRefName: "runtime",
+				Endpoint:       "http://runtime.default.svc",
+				AuthRefName:    "missing-runtime-auth",
+				AuthRefField:   "token",
+			},
+		},
+	}
+	task.Annotations = map[string]string{
+		harnessWrapperTurnIDAnnotation:            string(harnessWrapperTurnID(task, 1)),
+		harnessWrapperRuntimeAnnotation:           "runtime-session",
+		harnessWrapperCorrelationIDAnno:           string(task.UID),
+		harnessWrapperCancelDependencyRetriesAnno: "0",
+	}
+	leaseName := "runtime-cancel-pending-actor"
+	lease := newSubstratePoolActorLease(task, task.Namespace, leaseName, leaseName)
+	r := newUnitReconciler(scheme, task, lease)
+
+	result, err := r.handleDeletion(context.Background(), task)
+	if err != nil {
+		t.Fatalf("handleDeletion() error = %v", err)
+	}
+	if result.RequeueAfter != time.Second {
+		t.Fatalf("RequeueAfter = %v, want 1s while cancellation dependency is pending", result.RequeueAfter)
+	}
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: lease.Namespace, Name: lease.Name}, &coordinationv1.Lease{}); err != nil {
+		t.Fatalf("pool lease while runtime cancellation is pending: %v", err)
+	}
+	persisted := &corev1alpha1.Task{}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(task), persisted); err != nil {
+		t.Fatalf("Get Task: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(persisted, labels.TaskFinalizer) {
+		t.Fatal("Task finalizer removed while runtime cancellation is pending")
+	}
+	if got := persisted.Annotations[harnessWrapperCancelDependencyRetriesAnno]; got != "1" {
+		t.Fatalf("cancellation dependency retries = %q, want 1", got)
 	}
 }
 
@@ -5080,6 +5317,142 @@ func TestHandleScheduled_WithTimeZone(t *testing.T) {
 	}
 	if result.RequeueAfter <= 0 {
 		t.Error("expected positive RequeueAfter")
+	}
+}
+
+func TestHandleScheduledSkippedOccurrenceAdvancesCursor(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		deadline    int64
+		activeChild bool
+	}{
+		{name: "missed deadline", deadline: 1},
+		{name: "forbid concurrent", deadline: 600, activeChild: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			initialCursor := time.Now().UTC().Truncate(time.Minute).Add(-3 * time.Minute)
+			lastSchedule := metav1.NewTime(initialCursor)
+			task := &corev1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "sched-skip-" + strings.ReplaceAll(tc.name, " ", "-"),
+					Namespace:         "default",
+					CreationTimestamp: metav1.NewTime(initialCursor.Add(-time.Hour)),
+				},
+				Spec: corev1alpha1.TaskSpec{
+					Type:                    corev1alpha1.TaskTypeContainer,
+					Schedule:                "* * * * *",
+					ConcurrencyPolicy:       corev1alpha1.ForbidConcurrent,
+					StartingDeadlineSeconds: &tc.deadline,
+				},
+				Status: corev1alpha1.TaskStatus{
+					Phase:            corev1alpha1.TaskPhaseScheduled,
+					LastScheduleTime: &lastSchedule,
+				},
+			}
+			objects := []client.Object{task}
+			if tc.activeChild {
+				objects = append(objects, &corev1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      task.Name + "-active",
+						Namespace: task.Namespace,
+						Labels: map[string]string{
+							labels.LabelParentTask: labels.SelectorValue(task.Name),
+						},
+					},
+					Status: corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseFinalizing},
+				})
+			}
+			r := newUnitReconciler(scheme, objects...)
+			key := types.NamespacedName{Namespace: task.Namespace, Name: task.Name}
+
+			for reconcileNumber := 1; reconcileNumber <= 2; reconcileNumber++ {
+				result, err := r.handleScheduled(context.Background(), task)
+				if err != nil {
+					t.Fatalf("handleScheduled() reconcile %d error = %v", reconcileNumber, err)
+				}
+				if result.RequeueAfter <= 0 {
+					t.Fatalf("handleScheduled() reconcile %d RequeueAfter = %v, want positive", reconcileNumber, result.RequeueAfter)
+				}
+				if err := r.Get(context.Background(), key, task); err != nil {
+					t.Fatalf("Get Task after reconcile %d: %v", reconcileNumber, err)
+				}
+				wantCursor := initialCursor.Add(time.Duration(reconcileNumber) * time.Minute)
+				if task.Status.LastScheduleTime == nil || !task.Status.LastScheduleTime.Time.Equal(wantCursor) {
+					t.Fatalf("LastScheduleTime after reconcile %d = %v, want %s", reconcileNumber, task.Status.LastScheduleTime, wantCursor.Format(time.RFC3339))
+				}
+			}
+		})
+	}
+}
+
+func TestHandleScheduledSkippedOccurrencePropagatesStatusUpdateError(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		deadline    int64
+		activeChild bool
+	}{
+		{name: "missed deadline", deadline: 1},
+		{name: "forbid concurrent", deadline: 600, activeChild: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			initialCursor := time.Now().UTC().Truncate(time.Minute).Add(-3 * time.Minute)
+			lastSchedule := metav1.NewTime(initialCursor)
+			task := &corev1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "sched-status-error-" + strings.ReplaceAll(tc.name, " ", "-"),
+					Namespace:         "default",
+					CreationTimestamp: metav1.NewTime(initialCursor.Add(-time.Hour)),
+				},
+				Spec: corev1alpha1.TaskSpec{
+					Type:                    corev1alpha1.TaskTypeContainer,
+					Schedule:                "* * * * *",
+					ConcurrencyPolicy:       corev1alpha1.ForbidConcurrent,
+					StartingDeadlineSeconds: &tc.deadline,
+				},
+				Status: corev1alpha1.TaskStatus{
+					Phase:            corev1alpha1.TaskPhaseScheduled,
+					LastScheduleTime: &lastSchedule,
+				},
+			}
+			objects := []client.Object{task}
+			if tc.activeChild {
+				objects = append(objects, &corev1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      task.Name + "-active",
+						Namespace: task.Namespace,
+						Labels: map[string]string{
+							labels.LabelParentTask: labels.SelectorValue(task.Name),
+						},
+					},
+					Status: corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseRunning},
+				})
+			}
+			base := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&corev1alpha1.Task{}).
+				WithObjects(objects...).
+				Build()
+			statusErr := errors.New("injected status update failure")
+			fc := interceptor.NewClient(base, interceptor.Funcs{
+				SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+					if subResourceName == "status" {
+						return statusErr
+					}
+					return c.SubResource(subResourceName).Update(ctx, obj, opts...)
+				},
+			})
+			r := &TaskReconciler{
+				Client:   fc,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
+			}
+
+			if _, err := r.handleScheduled(context.Background(), task); !errors.Is(err, statusErr) {
+				t.Fatalf("handleScheduled() error = %v, want %v", err, statusErr)
+			}
+		})
 	}
 }
 

--- a/internal/controller/task_controller_unit_test.go
+++ b/internal/controller/task_controller_unit_test.go
@@ -3744,6 +3744,183 @@ func TestHandleDeletionRetriesExternalRuntimeCancellationFailure(t *testing.T) {
 	if controllerutil.ContainsFinalizer(persisted, labels.TaskFinalizer) {
 		t.Fatal("Task finalizer retained after external runtime cancellation succeeded")
 	}
+	if !harnessWrapperCancelAcknowledged(persisted) {
+		t.Fatal("external runtime cancellation acknowledgement was not persisted")
+	}
+	if got := cancelCalls.Load(); got != 2 {
+		t.Fatalf("CancelTurn calls = %d, want 2", got)
+	}
+}
+
+func TestHandleDeletionPersistsCancellationBeforeLaterCleanupRetry(t *testing.T) {
+	var cancelCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		cancelCalls.Add(1)
+		var request harness.CancelTurnRequest
+		if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			harness.WriteError(w, http.StatusBadRequest, "invalid cancellation request")
+			return
+		}
+		harness.WriteJSON(w, http.StatusAccepted, harness.CancelTurnResponse{
+			Version:          harness.ProtocolVersion,
+			Accepted:         true,
+			RuntimeSessionID: request.RuntimeSessionID,
+			TurnID:           request.TurnID,
+			CorrelationID:    request.CorrelationID,
+		})
+	}))
+	defer server.Close()
+
+	scheme := newTestScheme()
+	runtimeRef, secret := harnessWrapperReadyAgentRuntime("default", server.URL)
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "del-cancel-ack",
+			Namespace:  "default",
+			UID:        "del-cancel-ack-uid",
+			Finalizers: []string{labels.TaskFinalizer},
+		},
+		Status: corev1alpha1.TaskStatus{HarnessRuntime: &corev1alpha1.HarnessRuntimeStatus{
+			RuntimeRefName:         runtimeRef.Name,
+			RuntimeName:            runtimeRef.Name,
+			ContractVersion:        string(runtimeRef.Spec.ContractVersion),
+			Endpoint:               runtimeRef.Spec.Deployment.Endpoint,
+			RuntimeGeneration:      runtimeRef.Generation,
+			AuthRefName:            secret.Name,
+			AuthRefField:           "token",
+			AuthRefResourceVersion: secret.ResourceVersion,
+		}},
+	}
+	task.Annotations = map[string]string{
+		harnessWrapperTurnIDAnnotation:  string(harnessWrapperTurnID(task, 1)),
+		harnessWrapperRuntimeAnnotation: "cancel-ack-runtime-session",
+		harnessWrapperCorrelationIDAnno: string(task.UID),
+		harnessWrapperRuntimeRefAnno:    runtimeRef.Name,
+		harnessWrapperContractAnno:      harness.ProtocolVersion,
+		harnessWrapperStartedAnno:       scheduledRunLabelValue,
+		harnessWrapperLastFrameSeqAnno:  "0",
+	}
+	r := newUnitReconciler(scheme, task, runtimeRef, secret)
+	backing := r.ResultStore.(*sqlite.Store)
+	cleanupErr := errors.New("injected cleanup failure after cancellation")
+	r.ResultStore = &failOnceTaskCleanupStore{
+		ResultStore:   backing,
+		ArtifactStore: backing,
+		PlanStore:     backing,
+		MessageStore:  backing,
+		failOperation: "result",
+		failErr:       cleanupErr,
+	}
+
+	if _, err := r.handleDeletion(context.Background(), task); !errors.Is(err, cleanupErr) {
+		t.Fatalf("first handleDeletion() error = %v, want %v", err, cleanupErr)
+	}
+	persisted := &corev1alpha1.Task{}
+	key := client.ObjectKeyFromObject(task)
+	if err := r.Get(context.Background(), key, persisted); err != nil {
+		t.Fatalf("Get Task after cleanup failure: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(persisted, labels.TaskFinalizer) {
+		t.Fatal("Task finalizer removed after later cleanup failure")
+	}
+	if !harnessWrapperCancelAcknowledged(persisted) {
+		t.Fatal("successful cancellation acknowledgement was not persisted before cleanup returned")
+	}
+
+	if err := r.Delete(context.Background(), runtimeRef); err != nil {
+		t.Fatalf("Delete AgentRuntime: %v", err)
+	}
+	if err := r.Delete(context.Background(), secret); err != nil {
+		t.Fatalf("Delete runtime auth Secret: %v", err)
+	}
+	if _, err := r.handleDeletion(context.Background(), persisted); err != nil {
+		t.Fatalf("second handleDeletion() error = %v", err)
+	}
+	if err := r.Get(context.Background(), key, persisted); err != nil {
+		t.Fatalf("Get Task after cleanup retry: %v", err)
+	}
+	if controllerutil.ContainsFinalizer(persisted, labels.TaskFinalizer) {
+		t.Fatal("Task finalizer retained after acknowledged cancellation and cleanup retry")
+	}
+	if got := cancelCalls.Load(); got != 1 {
+		t.Fatalf("CancelTurn calls = %d, want one durable acknowledgement", got)
+	}
+}
+
+func TestHandleDeletionRetriesBuiltInHarnessCancellationFailure(t *testing.T) {
+	var failCancellation atomic.Bool
+	failCancellation.Store(true)
+	var cancelCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		cancelCalls.Add(1)
+		var request harness.CancelTurnRequest
+		if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			harness.WriteError(w, http.StatusBadRequest, "invalid cancellation request")
+			return
+		}
+		if failCancellation.Load() {
+			harness.WriteError(w, http.StatusServiceUnavailable, "wrapper temporarily unavailable")
+			return
+		}
+		harness.WriteJSON(w, http.StatusAccepted, harness.CancelTurnResponse{
+			Version:          harness.ProtocolVersion,
+			Accepted:         true,
+			RuntimeSessionID: request.RuntimeSessionID,
+			TurnID:           request.TurnID,
+			CorrelationID:    request.CorrelationID,
+		})
+	}))
+	defer server.Close()
+	t.Setenv(harnessWrapperEndpointEnv, server.URL)
+	t.Setenv(harnessWrapperAuthValueEnv, "test-wrapper-token")
+	t.Setenv(harnessWrapperAuthValueFileEnv, "")
+
+	scheme := newTestScheme()
+	task := &corev1alpha1.Task{ObjectMeta: metav1.ObjectMeta{
+		Name:       "del-built-in-runtime",
+		Namespace:  "default",
+		UID:        "del-built-in-runtime-uid",
+		Finalizers: []string{labels.TaskFinalizer},
+	}}
+	task.Annotations = map[string]string{
+		harnessWrapperTurnIDAnnotation:  string(harnessWrapperTurnID(task, 1)),
+		harnessWrapperRuntimeAnnotation: "built-in-runtime-session",
+		harnessWrapperCorrelationIDAnno: string(task.UID),
+		harnessWrapperContractAnno:      harness.ProtocolVersion,
+		harnessWrapperStartedAnno:       scheduledRunLabelValue,
+		harnessWrapperLastFrameSeqAnno:  "0",
+	}
+	r := newUnitReconciler(scheme, task)
+
+	result, err := r.handleDeletion(context.Background(), task)
+	if err != nil {
+		t.Fatalf("handleDeletion() cancellation failure error = %v", err)
+	}
+	if result.RequeueAfter != 30*time.Second {
+		t.Fatalf("RequeueAfter = %v, want 30s after built-in cancellation failure", result.RequeueAfter)
+	}
+	persisted := &corev1alpha1.Task{}
+	key := client.ObjectKeyFromObject(task)
+	if err := r.Get(context.Background(), key, persisted); err != nil {
+		t.Fatalf("Get Task after cancellation failure: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(persisted, labels.TaskFinalizer) {
+		t.Fatal("Task finalizer removed after built-in harness cancellation failure")
+	}
+
+	failCancellation.Store(false)
+	if _, err := r.handleDeletion(context.Background(), persisted); err != nil {
+		t.Fatalf("handleDeletion() cancellation retry error = %v", err)
+	}
+	if err := r.Get(context.Background(), key, persisted); err != nil {
+		t.Fatalf("Get Task after cancellation success: %v", err)
+	}
+	if controllerutil.ContainsFinalizer(persisted, labels.TaskFinalizer) {
+		t.Fatal("Task finalizer retained after built-in harness cancellation succeeded")
+	}
+	if !harnessWrapperCancelAcknowledged(persisted) {
+		t.Fatal("built-in harness cancellation acknowledgement was not persisted")
+	}
 	if got := cancelCalls.Load(); got != 2 {
 		t.Fatalf("CancelTurn calls = %d, want 2", got)
 	}

--- a/internal/controller/task_controller_unit_test.go
+++ b/internal/controller/task_controller_unit_test.go
@@ -19,6 +19,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -45,6 +46,7 @@ import (
 
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
 	"github.com/orka-agents/orka/internal/events"
+	"github.com/orka-agents/orka/internal/harness"
 	"github.com/orka-agents/orka/internal/labels"
 	"github.com/orka-agents/orka/internal/outboundaccess"
 	"github.com/orka-agents/orka/internal/store"
@@ -3348,8 +3350,8 @@ func TestHandleDeletionRetainsFinalizerUntilDurableStoreCleanupSucceeds(t *testi
 			if err != nil {
 				t.Fatalf("GetSession() error = %v", err)
 			}
-			if session.ActiveTask != "" || session.ActiveTaskUID != "" {
-				t.Fatalf("session lock after durable cleanup failure = %q/%q, want released", session.ActiveTask, session.ActiveTaskUID)
+			if session.ActiveTask != task.Name || session.ActiveTaskUID != string(task.UID) {
+				t.Fatalf("session lock after pending Job deletion = %q/%q, want %q/%q", session.ActiveTask, session.ActiveTaskUID, task.Name, task.UID)
 			}
 
 			if _, err := r.handleDeletion(context.Background(), persisted); err != nil {
@@ -3360,6 +3362,13 @@ func TestHandleDeletionRetainsFinalizerUntilDurableStoreCleanupSucceeds(t *testi
 			}
 			if controllerutil.ContainsFinalizer(persisted, labels.TaskFinalizer) {
 				t.Fatal("Task finalizer retained after durable cleanup succeeded")
+			}
+			session, err = backing.GetSession(context.Background(), task.Namespace, sessionName)
+			if err != nil {
+				t.Fatalf("GetSession() after Job deletion error = %v", err)
+			}
+			if session.ActiveTask != "" || session.ActiveTaskUID != "" {
+				t.Fatalf("session lock after Job deletion = %q/%q, want released", session.ActiveTask, session.ActiveTaskUID)
 			}
 		})
 	}
@@ -3382,12 +3391,22 @@ func TestHandleDeletionRetainsFinalizerWhenSessionLockReleaseFails(t *testing.T)
 	backing := r.ResultStore.(*sqlite.Store)
 	r.SessionManager = NewSessionManager(failingReleaseLockStore{SessionStore: backing, err: lockErr})
 
-	if _, err := r.handleDeletion(context.Background(), task); !errors.Is(err, lockErr) {
-		t.Fatalf("handleDeletion() error = %v, want %v", err, lockErr)
+	result, err := r.handleDeletion(context.Background(), task)
+	if err != nil {
+		t.Fatalf("first handleDeletion() error = %v", err)
+	}
+	if result.RequeueAfter != 2*time.Second {
+		t.Fatalf("first handleDeletion() RequeueAfter = %v, want 2s while Job deletion settles", result.RequeueAfter)
 	}
 	persisted := &corev1alpha1.Task{}
 	if err := r.Get(context.Background(), client.ObjectKeyFromObject(task), persisted); err != nil {
-		t.Fatalf("Get Task: %v", err)
+		t.Fatalf("Get Task after Job deletion: %v", err)
+	}
+	if _, err := r.handleDeletion(context.Background(), persisted); !errors.Is(err, lockErr) {
+		t.Fatalf("second handleDeletion() error = %v, want %v", err, lockErr)
+	}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(task), persisted); err != nil {
+		t.Fatalf("Get Task after session lock failure: %v", err)
 	}
 	if !controllerutil.ContainsFinalizer(persisted, labels.TaskFinalizer) {
 		t.Fatal("Task finalizer removed after session lock release failure")
@@ -3545,6 +3564,188 @@ func TestHandleDeletion_WithJobName(t *testing.T) {
 	_, err := r.handleDeletion(context.Background(), task)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandleDeletionWaitsForOrdinaryJobDisappearance(t *testing.T) {
+	scheme := newTestScheme()
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "del-ordinary-job",
+			Namespace:  "default",
+			UID:        "del-ordinary-job-uid",
+			Finalizers: []string{labels.TaskFinalizer},
+		},
+		Status: corev1alpha1.TaskStatus{JobName: "del-ordinary-job-worker"},
+	}
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: task.Status.JobName, Namespace: task.Namespace}}
+	r := newUnitReconciler(scheme, task, job)
+	base, ok := r.Client.(client.WithWatch)
+	if !ok {
+		t.Fatalf("test client = %T, want client.WithWatch", r.Client)
+	}
+	var deleteCalls int
+	var propagationPolicies []metav1.DeletionPropagation
+	r.Client = interceptor.NewClient(base, interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if _, ok := obj.(*batchv1.Job); !ok {
+				return c.Delete(ctx, obj, opts...)
+			}
+			deleteOptions := (&client.DeleteOptions{}).ApplyOptions(opts)
+			if deleteOptions.PropagationPolicy != nil {
+				propagationPolicies = append(propagationPolicies, *deleteOptions.PropagationPolicy)
+			}
+			deleteCalls++
+			if deleteCalls == 1 {
+				// Model foreground deletion while a dependent worker Pod still exists.
+				return nil
+			}
+			return c.Delete(ctx, obj, opts...)
+		},
+	})
+
+	if err := r.ResultStore.SaveResult(context.Background(), task.Namespace, task.Name, []byte("initial")); err != nil {
+		t.Fatalf("SaveResult() error = %v", err)
+	}
+	key := client.ObjectKeyFromObject(task)
+	for reconcileNumber := 1; reconcileNumber <= 2; reconcileNumber++ {
+		result, err := r.handleDeletion(context.Background(), task)
+		if err != nil {
+			t.Fatalf("handleDeletion() reconcile %d error = %v", reconcileNumber, err)
+		}
+		if result.RequeueAfter != 2*time.Second {
+			t.Fatalf("handleDeletion() reconcile %d RequeueAfter = %v, want 2s", reconcileNumber, result.RequeueAfter)
+		}
+		if err := r.Get(context.Background(), key, task); err != nil {
+			t.Fatalf("Get Task after reconcile %d: %v", reconcileNumber, err)
+		}
+		if !controllerutil.ContainsFinalizer(task, labels.TaskFinalizer) {
+			t.Fatalf("Task finalizer removed before Job disappearance on reconcile %d", reconcileNumber)
+		}
+		if reconcileNumber == 1 {
+			if err := r.ResultStore.SaveResult(context.Background(), task.Namespace, task.Name, []byte("late worker result")); err != nil {
+				t.Fatalf("SaveResult() after first cleanup error = %v", err)
+			}
+		}
+	}
+
+	result, err := r.handleDeletion(context.Background(), task)
+	if err != nil {
+		t.Fatalf("handleDeletion() after Job disappeared error = %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Fatalf("handleDeletion() after Job disappeared RequeueAfter = %v, want zero", result.RequeueAfter)
+	}
+	if err := r.Get(context.Background(), key, task); err != nil {
+		t.Fatalf("Get Task after final cleanup: %v", err)
+	}
+	if controllerutil.ContainsFinalizer(task, labels.TaskFinalizer) {
+		t.Fatal("Task finalizer retained after Job disappearance and final durable cleanup")
+	}
+	if _, err := r.ResultStore.GetResult(context.Background(), task.Namespace, task.Name); err == nil {
+		t.Fatal("late worker result survived the final cleanup pass")
+	}
+	if deleteCalls != 2 {
+		t.Fatalf("Job delete calls = %d, want 2", deleteCalls)
+	}
+	for i, policy := range propagationPolicies {
+		if policy != metav1.DeletePropagationForeground {
+			t.Fatalf("Job delete propagation policy %d = %q, want Foreground", i+1, policy)
+		}
+	}
+}
+
+func TestHandleDeletionRetriesExternalRuntimeCancellationFailure(t *testing.T) {
+	var failCancellation atomic.Bool
+	failCancellation.Store(true)
+	var cancelCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		cancelCalls.Add(1)
+		var request harness.CancelTurnRequest
+		if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			harness.WriteError(w, http.StatusBadRequest, "invalid cancellation request")
+			return
+		}
+		if failCancellation.Load() {
+			harness.WriteError(w, http.StatusServiceUnavailable, "runtime temporarily unavailable")
+			return
+		}
+		harness.WriteJSON(w, http.StatusAccepted, harness.CancelTurnResponse{
+			Version:          harness.ProtocolVersion,
+			Accepted:         true,
+			RuntimeSessionID: request.RuntimeSessionID,
+			TurnID:           request.TurnID,
+			CorrelationID:    request.CorrelationID,
+		})
+	}))
+	defer server.Close()
+
+	scheme := newTestScheme()
+	runtimeRef, secret := harnessWrapperReadyAgentRuntime("default", server.URL)
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "del-external-runtime",
+			Namespace:  "default",
+			UID:        "del-external-runtime-uid",
+			Finalizers: []string{labels.TaskFinalizer},
+		},
+		Status: corev1alpha1.TaskStatus{
+			HarnessRuntime: &corev1alpha1.HarnessRuntimeStatus{
+				RuntimeRefName:         runtimeRef.Name,
+				RuntimeName:            runtimeRef.Name,
+				ContractVersion:        string(runtimeRef.Spec.ContractVersion),
+				Endpoint:               runtimeRef.Spec.Deployment.Endpoint,
+				RuntimeGeneration:      runtimeRef.Generation,
+				AuthRefName:            secret.Name,
+				AuthRefField:           "token",
+				AuthRefResourceVersion: secret.ResourceVersion,
+			},
+		},
+	}
+	task.Annotations = map[string]string{
+		harnessWrapperTurnIDAnnotation:       string(harnessWrapperTurnID(task, 1)),
+		harnessWrapperRuntimeAnnotation:      "external-runtime-session",
+		harnessWrapperCorrelationIDAnno:      string(task.UID),
+		harnessWrapperRuntimeRefAnno:         runtimeRef.Name,
+		harnessWrapperContractAnno:           harness.ProtocolVersion,
+		harnessWrapperStartedAnno:            scheduledRunLabelValue,
+		harnessWrapperLastFrameSeqAnno:       "0",
+		harnessWrapperOutputFetchRetriesAnno: "0",
+	}
+	r := newUnitReconciler(scheme, task, runtimeRef, secret)
+
+	result, err := r.handleDeletion(context.Background(), task)
+	if err != nil {
+		t.Fatalf("handleDeletion() transport failure error = %v", err)
+	}
+	if result.RequeueAfter != 30*time.Second {
+		t.Fatalf("RequeueAfter = %v, want 30s after external cancellation failure", result.RequeueAfter)
+	}
+	persisted := &corev1alpha1.Task{}
+	key := client.ObjectKeyFromObject(task)
+	if err := r.Get(context.Background(), key, persisted); err != nil {
+		t.Fatalf("Get Task after cancellation failure: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(persisted, labels.TaskFinalizer) {
+		t.Fatal("Task finalizer removed after unconfirmed external runtime cancellation")
+	}
+
+	failCancellation.Store(false)
+	result, err = r.handleDeletion(context.Background(), persisted)
+	if err != nil {
+		t.Fatalf("handleDeletion() cancellation retry error = %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Fatalf("RequeueAfter = %v, want zero after cancellation succeeds", result.RequeueAfter)
+	}
+	if err := r.Get(context.Background(), key, persisted); err != nil {
+		t.Fatalf("Get Task after cancellation success: %v", err)
+	}
+	if controllerutil.ContainsFinalizer(persisted, labels.TaskFinalizer) {
+		t.Fatal("Task finalizer retained after external runtime cancellation succeeded")
+	}
+	if got := cancelCalls.Load(); got != 2 {
+		t.Fatalf("CancelTurn calls = %d, want 2", got)
 	}
 }
 
@@ -5320,18 +5521,48 @@ func TestHandleScheduled_WithTimeZone(t *testing.T) {
 	}
 }
 
-func TestHandleScheduledSkippedOccurrenceAdvancesCursor(t *testing.T) {
+type countingIntervalSchedule struct {
+	interval time.Duration
+	calls    int
+}
+
+func (s *countingIntervalSchedule) Next(t time.Time) time.Time {
+	s.calls++
+	return t.Add(s.interval)
+}
+
+func TestCoalesceOverdueScheduleBoundsCatchUp(t *testing.T) {
+	now := time.Now().UTC()
+	schedule := &countingIntervalSchedule{interval: time.Minute}
+	firstDue := now.Add(-time.Duration(maxSkippedScheduleCatchUpSteps+100) * time.Minute)
+
+	lastConsumed, next := coalesceOverdueSchedule(schedule, firstDue, now)
+
+	if !lastConsumed.Equal(now) {
+		t.Fatalf("last consumed = %s, want bounded cursor %s", lastConsumed, now)
+	}
+	if !next.Equal(now.Add(time.Minute)) {
+		t.Fatalf("next = %s, want %s", next, now.Add(time.Minute))
+	}
+	if schedule.calls != maxSkippedScheduleCatchUpSteps+1 {
+		t.Fatalf("schedule.Next calls = %d, want bounded %d", schedule.calls, maxSkippedScheduleCatchUpSteps+1)
+	}
+}
+
+func TestHandleScheduledSkippedOccurrenceCoalescesBacklog(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		deadline    int64
 		activeChild bool
+		suspended   bool
 	}{
-		{name: "missed deadline", deadline: 1},
+		{name: "missed deadline", deadline: 0},
 		{name: "forbid concurrent", deadline: 600, activeChild: true},
+		{name: "suspended", deadline: 600, suspended: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := newTestScheme()
-			initialCursor := time.Now().UTC().Truncate(time.Minute).Add(-3 * time.Minute)
+			initialCursor := time.Now().UTC().Truncate(time.Minute).Add(-48 * time.Hour)
 			lastSchedule := metav1.NewTime(initialCursor)
 			task := &corev1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
@@ -5350,6 +5581,9 @@ func TestHandleScheduledSkippedOccurrenceAdvancesCursor(t *testing.T) {
 					LastScheduleTime: &lastSchedule,
 				},
 			}
+			if tc.suspended {
+				task.Spec.Suspend = new(true)
+			}
 			objects := []client.Object{task}
 			if tc.activeChild {
 				objects = append(objects, &corev1alpha1.Task{
@@ -5365,22 +5599,209 @@ func TestHandleScheduledSkippedOccurrenceAdvancesCursor(t *testing.T) {
 			}
 			r := newUnitReconciler(scheme, objects...)
 			key := types.NamespacedName{Namespace: task.Namespace, Name: task.Name}
+			before := time.Now().UTC()
 
-			for reconcileNumber := 1; reconcileNumber <= 2; reconcileNumber++ {
-				result, err := r.handleScheduled(context.Background(), task)
-				if err != nil {
-					t.Fatalf("handleScheduled() reconcile %d error = %v", reconcileNumber, err)
-				}
-				if result.RequeueAfter <= 0 {
-					t.Fatalf("handleScheduled() reconcile %d RequeueAfter = %v, want positive", reconcileNumber, result.RequeueAfter)
-				}
-				if err := r.Get(context.Background(), key, task); err != nil {
-					t.Fatalf("Get Task after reconcile %d: %v", reconcileNumber, err)
-				}
-				wantCursor := initialCursor.Add(time.Duration(reconcileNumber) * time.Minute)
-				if task.Status.LastScheduleTime == nil || !task.Status.LastScheduleTime.Time.Equal(wantCursor) {
-					t.Fatalf("LastScheduleTime after reconcile %d = %v, want %s", reconcileNumber, task.Status.LastScheduleTime, wantCursor.Format(time.RFC3339))
-				}
+			result, err := r.handleScheduled(context.Background(), task)
+			if err != nil {
+				t.Fatalf("handleScheduled() error = %v", err)
+			}
+			if result.RequeueAfter <= 0 {
+				t.Fatalf("handleScheduled() RequeueAfter = %v, want positive", result.RequeueAfter)
+			}
+			if err := r.Get(context.Background(), key, task); err != nil {
+				t.Fatalf("Get Task after backlog coalescing: %v", err)
+			}
+			if task.Status.LastScheduleTime == nil || task.Status.NextScheduleTime == nil {
+				t.Fatalf("schedule status = last %v next %v, want both set", task.Status.LastScheduleTime, task.Status.NextScheduleTime)
+			}
+			if age := before.Sub(task.Status.LastScheduleTime.Time); age < -time.Second || age > time.Minute+time.Second {
+				t.Fatalf("LastScheduleTime age = %v at %s, want latest minutely occurrence near %s", age, task.Status.LastScheduleTime.Time, before)
+			}
+			parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+			schedule, err := parser.Parse(task.Spec.Schedule)
+			if err != nil {
+				t.Fatalf("parse schedule: %v", err)
+			}
+			wantNext := schedule.Next(task.Status.LastScheduleTime.Time)
+			if !task.Status.NextScheduleTime.Time.Equal(wantNext) {
+				t.Fatalf("NextScheduleTime = %s, want %s from coalesced cursor", task.Status.NextScheduleTime.Time, wantNext)
+			}
+			coalescedCursor := task.Status.LastScheduleTime.DeepCopy()
+			if tc.suspended && !taskHasScheduleSuspensionMarker(task) {
+				t.Fatal("suspended Task did not persist the schedule suspension marker")
+			}
+
+			if _, err := r.handleScheduled(context.Background(), task); err != nil {
+				t.Fatalf("second handleScheduled() error = %v", err)
+			}
+			if err := r.Get(context.Background(), key, task); err != nil {
+				t.Fatalf("Get Task after second reconcile: %v", err)
+			}
+			if task.Status.LastScheduleTime == nil || !task.Status.LastScheduleTime.Equal(coalescedCursor) {
+				t.Fatalf("LastScheduleTime after immediate second reconcile = %v, want unchanged %v", task.Status.LastScheduleTime, coalescedCursor)
+			}
+		})
+	}
+}
+
+func TestHandleScheduledResumeCoalescesTicksThatBecameDueWhileSuspended(t *testing.T) {
+	scheme := newTestScheme()
+	initialCursor := time.Now().UTC().Truncate(time.Minute).Add(-2 * time.Minute)
+	lastSchedule := metav1.NewTime(initialCursor)
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "sched-resume-coalesce",
+			Namespace:         "default",
+			UID:               "sched-resume-coalesce-uid",
+			CreationTimestamp: metav1.NewTime(initialCursor.Add(-time.Hour)),
+			Annotations: map[string]string{
+				scheduleSuspendedMarkerAnnotation: scheduledRunLabelValue,
+			},
+		},
+		Spec: corev1alpha1.TaskSpec{
+			Type:                    corev1alpha1.TaskTypeContainer,
+			Image:                   "busybox:latest",
+			Schedule:                "* * * * *",
+			StartingDeadlineSeconds: new(int64(600)),
+		},
+		Status: corev1alpha1.TaskStatus{
+			Phase:            corev1alpha1.TaskPhaseScheduled,
+			LastScheduleTime: &lastSchedule,
+		},
+	}
+	r := newUnitReconciler(scheme, task)
+	before := time.Now().UTC()
+
+	result, err := r.handleScheduled(context.Background(), task)
+	if err != nil {
+		t.Fatalf("handleScheduled() error = %v", err)
+	}
+	if result.RequeueAfter <= 0 {
+		t.Fatalf("RequeueAfter = %v, want positive after resumed backlog coalescing", result.RequeueAfter)
+	}
+	key := client.ObjectKeyFromObject(task)
+	if err := r.Get(context.Background(), key, task); err != nil {
+		t.Fatalf("Get resumed Task: %v", err)
+	}
+	if taskHasScheduleSuspensionMarker(task) {
+		t.Fatal("schedule suspension marker remained after resumed backlog was consumed")
+	}
+	if task.Status.LastScheduleTime == nil || task.Status.NextScheduleTime == nil {
+		t.Fatalf("schedule status = last %v next %v, want resumed cursor and future schedule", task.Status.LastScheduleTime, task.Status.NextScheduleTime)
+	}
+	if age := before.Sub(task.Status.LastScheduleTime.Time); age < -time.Second || age > time.Minute+time.Second {
+		t.Fatalf("resumed LastScheduleTime age = %v, want latest occurrence consumed", age)
+	}
+	children := &corev1alpha1.TaskList{}
+	if err := r.List(context.Background(), children,
+		client.InNamespace(task.Namespace),
+		client.MatchingLabels{labels.LabelParentTask: labels.SelectorValue(task.Name)},
+	); err != nil {
+		t.Fatalf("list scheduled children: %v", err)
+	}
+	if len(children.Items) != 0 {
+		t.Fatalf("scheduled children after resume = %d, want no replay of suspended ticks", len(children.Items))
+	}
+}
+
+func TestHandleScheduledMissedDeadlineRunsMostRecentEligibleOccurrence(t *testing.T) {
+	scheme := newTestScheme()
+	deadlineSeconds := int64(120)
+	initialCursor := time.Now().UTC().Truncate(time.Minute).Add(-10 * time.Minute)
+	lastSchedule := metav1.NewTime(initialCursor)
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "sched-latest-eligible",
+			Namespace:         "default",
+			UID:               "sched-latest-eligible-uid",
+			CreationTimestamp: metav1.NewTime(initialCursor.Add(-time.Hour)),
+		},
+		Spec: corev1alpha1.TaskSpec{
+			Type:                    corev1alpha1.TaskTypeContainer,
+			Image:                   "busybox:latest",
+			Schedule:                "* * * * *",
+			StartingDeadlineSeconds: &deadlineSeconds,
+		},
+		Status: corev1alpha1.TaskStatus{
+			Phase:            corev1alpha1.TaskPhaseScheduled,
+			LastScheduleTime: &lastSchedule,
+		},
+	}
+	r := newUnitReconciler(scheme, task)
+	before := time.Now().UTC()
+
+	result, err := r.handleScheduled(context.Background(), task)
+	if err != nil {
+		t.Fatalf("handleScheduled() error = %v", err)
+	}
+	if result.RequeueAfter <= 0 {
+		t.Fatalf("RequeueAfter = %v, want positive", result.RequeueAfter)
+	}
+	if task.Status.LastScheduleTime == nil {
+		t.Fatal("LastScheduleTime = nil, want most recent eligible occurrence")
+	}
+	if age := before.Sub(task.Status.LastScheduleTime.Time); age < -time.Minute || age > time.Duration(deadlineSeconds)*time.Second {
+		t.Fatalf("selected occurrence age = %v, want within %ds starting deadline", age, deadlineSeconds)
+	}
+	if !task.Status.LastScheduleTime.After(initialCursor.Add(time.Minute)) {
+		t.Fatalf("LastScheduleTime = %s, want backlog coalesced beyond first expired occurrence", task.Status.LastScheduleTime.Time)
+	}
+
+	children := &corev1alpha1.TaskList{}
+	if err := r.List(context.Background(), children,
+		client.InNamespace(task.Namespace),
+		client.MatchingLabels{labels.LabelParentTask: labels.SelectorValue(task.Name)},
+	); err != nil {
+		t.Fatalf("list scheduled children: %v", err)
+	}
+	if len(children.Items) != 1 {
+		t.Fatalf("scheduled children = %d, want one most recent eligible run", len(children.Items))
+	}
+	wantChildName := fmt.Sprintf("%s-%d", task.Name, task.Status.LastScheduleTime.Unix())
+	if children.Items[0].Name != wantChildName {
+		t.Fatalf("scheduled child = %q, want %q", children.Items[0].Name, wantChildName)
+	}
+}
+
+func TestHandleScheduledSuspendedInvalidScheduleMetadataDoesNotFail(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		schedule string
+		timeZone *string
+	}{
+		{name: "invalid spec timezone", schedule: "* * * * *", timeZone: new("Invalid/TimeZone")},
+		{name: "malformed inline timezone", schedule: "TZ=UTC"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			task := &corev1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "sched-suspended-invalid-" + strings.ReplaceAll(tc.name, " ", "-"),
+					Namespace:         "default",
+					CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Hour)),
+				},
+				Spec: corev1alpha1.TaskSpec{
+					Type:     corev1alpha1.TaskTypeContainer,
+					Schedule: tc.schedule,
+					TimeZone: tc.timeZone,
+					Suspend:  new(true),
+				},
+				Status: corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseScheduled},
+			}
+			r := newUnitReconciler(scheme, task)
+
+			result, err := r.handleScheduled(context.Background(), task)
+			if err != nil {
+				t.Fatalf("handleScheduled() error = %v", err)
+			}
+			if result.RequeueAfter != time.Minute {
+				t.Fatalf("RequeueAfter = %v, want 1m while suspended", result.RequeueAfter)
+			}
+			if task.Status.Phase != corev1alpha1.TaskPhaseScheduled {
+				t.Fatalf("phase = %s, want Scheduled while suspended", task.Status.Phase)
+			}
+			if !taskHasScheduleSuspensionMarker(task) {
+				t.Fatal("suspended Task did not retain its schedule suspension marker")
 			}
 		})
 	}
@@ -5391,9 +5812,11 @@ func TestHandleScheduledSkippedOccurrencePropagatesStatusUpdateError(t *testing.
 		name        string
 		deadline    int64
 		activeChild bool
+		suspended   bool
 	}{
 		{name: "missed deadline", deadline: 1},
 		{name: "forbid concurrent", deadline: 600, activeChild: true},
+		{name: "suspended", deadline: 600, suspended: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := newTestScheme()
@@ -5415,6 +5838,9 @@ func TestHandleScheduledSkippedOccurrencePropagatesStatusUpdateError(t *testing.
 					Phase:            corev1alpha1.TaskPhaseScheduled,
 					LastScheduleTime: &lastSchedule,
 				},
+			}
+			if tc.suspended {
+				task.Spec.Suspend = new(true)
 			}
 			objects := []client.Object{task}
 			if tc.activeChild {


### PR DESCRIPTION
## Summary

Focused salvage from #280, rebuilt on current `main` and kept separate from #297 execution-outcome work.

- Keep Task finalizers until durable result, artifact, plan, message, event, session-lock, Job, workspace, and delegated-runtime cleanup has either completed or is safely retryable.
- Revoke execution authority and quiesce active work before removing finalizers.
- Retry status updates against fresh objects across Task, Agent, Provider, RepositoryScan, and Substrate pool reconciliation.

## Scope

This PR changes controller cleanup and status durability only. It does not redefine terminal Task outcomes, worker result semantics, or ACP v2 transport behavior.

## Verification

- `go test ./internal/controller -count=1`
- `make lint-fix && make test`
- Full required CI