### PR TITLE
fix(chat): make session turns durable and gateway-safe

### DIFF
--- a/internal/api/chat.go
+++ b/internal/api/chat.go
@@ -928,8 +928,15 @@ func (ch *ChatHandler) saveChatSession(
 	if ch.sessionTurnCommitter == nil {
 		return fmt.Errorf("session store does not support atomic chat turns")
 	}
+
+	// The provider and tool loop remain bound to the request/turn context, but
+	// once a final response exists its atomic persistence owns the durability
+	// handoff. Detach cancellation here and bound the commit to the same grace
+	// window added to the chat-turn lease.
+	durabilityCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), chatDurabilityTimeout)
+	defer cancel()
 	return ch.sessionTurnCommitter.CommitSessionTurn(
-		ctx,
+		durabilityCtx,
 		&store.SessionRecord{
 			Namespace:   namespace,
 			Name:        sessionID,

--- a/internal/api/chat.go
+++ b/internal/api/chat.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
@@ -45,6 +47,12 @@ var chatLog = logf.Log.WithName("chat-handler")
 const (
 	defaultNamespace      = "default"
 	chatDurabilityTimeout = 10 * time.Second
+)
+
+const (
+	chatStreamUnclaimed uint32 = iota
+	chatStreamOwned
+	chatStreamFinalized
 )
 
 // ChatConfig holds configuration for the chat handler.
@@ -123,6 +131,41 @@ type ChatHandler struct {
 	contextTokenAuthorization ContextTokenAuthorizationConfig
 	cooldownTracker           *llm.CooldownTracker
 	resolver                  *ProviderResolver
+	activeChatTurnsMu         sync.Mutex
+	activeChatTurns           map[chatTurnKey]*activeChatTurn
+}
+
+type chatTurnKey struct {
+	namespace string
+	sessionID string
+}
+
+type activeChatTurn struct {
+	turnID     string
+	cancel     context.CancelFunc
+	done       chan struct{}
+	expiresAt  time.Time
+	cancellers int
+}
+
+type chatStreamRequest struct {
+	parentCtx      context.Context
+	turnCancelCtx  context.Context
+	turnDeadline   time.Time
+	finalizeTurn   func()
+	provider       llm.Provider
+	messages       []llm.Message
+	systemPrompt   string
+	tools          []llm.Tool
+	executor       *ToolExecutor
+	sessionID      string
+	namespace      string
+	model          string
+	temperature    float64
+	maxTokens      int
+	persistedCount int
+	turnID         string
+	span           trace.Span
 }
 
 // NewChatHandler creates a new ChatHandler.
@@ -144,6 +187,7 @@ func NewChatHandler(c client.Client, sm *controller.SessionManager, config ChatC
 		resultStore:               rs,
 		cooldownTracker:           llm.NewCooldownTracker(),
 		resolver:                  resolver,
+		activeChatTurns:           make(map[chatTurnKey]*activeChatTurn),
 	}
 	if committer, ok := ss.(store.SessionTurnCommitter); ok {
 		handler.sessionTurnCommitter = committer
@@ -263,13 +307,19 @@ func (ch *ChatHandler) HandleChat(c fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, "failed to build system prompt")
 	}
 
-	turnID, turnDeadline, err := ch.reserveChatTurn(ctx, namespace, sessionID)
+	turnID, turnDeadline, sessionCreated, turnCancelCtx, err := ch.beginChatTurn(ctx, namespace, sessionID)
 	if err != nil {
 		return err
 	}
+	stopTurnCancellation := context.AfterFunc(turnCancelCtx, cancel)
+	defer stopTurnCancellation()
+	finalizeTurn := sync.OnceFunc(func() {
+		ch.releaseChatTurn(namespace, sessionID, turnID, sessionCreated)
+		ch.finishActiveChatTurn(namespace, sessionID, turnID)
+	})
 	defer func() {
 		if !sseMode {
-			ch.releaseChatTurn(namespace, sessionID, turnID)
+			finalizeTurn()
 		}
 	}()
 
@@ -383,49 +433,87 @@ func (ch *ChatHandler) HandleChat(c fiber.Ctx) error {
 		})
 	}
 
-	// SSE mode
+	streamErr := ch.sendChatStream(c, chatStreamRequest{
+		parentCtx:      ctx,
+		turnCancelCtx:  turnCancelCtx,
+		turnDeadline:   turnDeadline,
+		finalizeTurn:   finalizeTurn,
+		provider:       provider,
+		messages:       messages,
+		systemPrompt:   systemPrompt,
+		tools:          tools,
+		executor:       executor,
+		sessionID:      sessionID,
+		namespace:      namespace,
+		model:          model,
+		temperature:    temperature,
+		maxTokens:      maxTokens,
+		persistedCount: persistedCount,
+		turnID:         turnID,
+		span:           span,
+	})
+	if streamErr == nil {
+		sseMode = true
+	}
+	return streamErr
+}
+
+func (ch *ChatHandler) sendChatStream(c fiber.Ctx, req chatStreamRequest) error {
 	c.Set("Content-Type", "text/event-stream")
 	c.Set("Cache-Control", "no-cache")
 	c.Set("Connection", "keep-alive")
 	c.Set("X-Accel-Buffering", "no")
 
-	// Capture values for the streaming closure (ctx from outer scope is cancelled
-	// when HandleChat returns, so we create a new context inside the callback)
-	sseProvider := provider
-	sseMessages := messages
-	sseSystemPrompt := systemPrompt
-	sseTools := tools
-	sseExecutor := executor
+	// SendStreamWriter outlives the handler, so capture only trace and baggage
+	// state from the recyclable Fiber request context.
 	sseParentCtx := baggage.ContextWithBaggage(
-		trace.ContextWithSpanContext(context.Background(), span.SpanContext()),
-		baggage.FromContext(ctx),
+		trace.ContextWithSpanContext(context.Background(), req.span.SpanContext()),
+		baggage.FromContext(req.parentCtx),
 	)
+	var streamOwnership atomic.Uint32
+	finalizeStream := sync.OnceFunc(func() {
+		req.finalizeTurn()
+		req.span.End()
+		<-ch.semaphore
+	})
+	stopUnclaimedCancellation := context.AfterFunc(req.turnCancelCtx, func() {
+		if streamOwnership.CompareAndSwap(chatStreamUnclaimed, chatStreamFinalized) {
+			finalizeStream()
+		}
+	})
+	streamWatchdog := time.AfterFunc(max(time.Until(req.turnDeadline), time.Duration(0)), func() {
+		if streamOwnership.CompareAndSwap(chatStreamUnclaimed, chatStreamFinalized) {
+			finalizeStream()
+		}
+	})
 
 	streamErr := c.SendStreamWriter(func(w *bufio.Writer) {
-		defer span.End()
-		defer func() { <-ch.semaphore }()
-		defer ch.releaseChatTurn(namespace, sessionID, turnID)
-		// SendStreamWriter outlives the handler, so use a background context
-		// seeded with the originating chat span context rather than Fiber's
-		// recycled request context.
-		sseCtx, sseCancel := context.WithDeadline(sseParentCtx, turnDeadline)
+		if !streamOwnership.CompareAndSwap(chatStreamUnclaimed, chatStreamOwned) {
+			return
+		}
+		stopUnclaimedCancellation()
+		streamWatchdog.Stop()
+		defer finalizeStream()
+
+		sseCtx, sseCancel := context.WithDeadline(sseParentCtx, req.turnDeadline)
+		stopSSECancellation := context.AfterFunc(req.turnCancelCtx, sseCancel)
+		defer stopSSECancellation()
 		defer sseCancel()
 
 		emitSSE := func(event, data string) {
 			_ = writeSSE(w, event, data)
 		}
-
-		// Emit status event
 		statusData, _ := json.Marshal(map[string]string{
-			"sessionId": sessionID,
-			"provider":  sseProvider.Name(),
-			"model":     model,
+			"sessionId": req.sessionID,
+			"provider":  req.provider.Name(),
+			"model":     req.model,
 		})
 		emitSSE("status", string(statusData))
 
 		content, usage, _, err := ch.runToolLoop(
-			sseCtx, sseProvider, sseMessages, sseSystemPrompt, sseTools, sseExecutor,
-			sessionID, namespace, model, temperature, maxTokens, persistedCount, emitSSE, turnID,
+			sseCtx, req.provider, req.messages, req.systemPrompt, req.tools, req.executor,
+			req.sessionID, req.namespace, req.model, req.temperature, req.maxTokens,
+			req.persistedCount, emitSSE, req.turnID,
 		)
 		if err != nil {
 			errData, _ := json.Marshal(map[string]string{"error": err.Error()})
@@ -434,23 +522,55 @@ func (ch *ChatHandler) HandleChat(c fiber.Ctx) error {
 		}
 
 		_ = content // content already emitted via SSE
-
-		// Emit done event
 		doneData, _ := json.Marshal(map[string]any{"usage": usage})
 		emitSSE("done", string(doneData))
 	})
-	if streamErr == nil {
-		sseMode = true
+	if streamErr != nil {
+		stopUnclaimedCancellation()
+		streamWatchdog.Stop()
 	}
 	return streamErr
+}
+
+func (ch *ChatHandler) beginChatTurn(
+	ctx context.Context,
+	namespace, sessionID string,
+) (string, time.Time, bool, context.Context, error) {
+	key := chatTurnKey{namespace: namespace, sessionID: sessionID}
+	ch.activeChatTurnsMu.Lock()
+	defer ch.activeChatTurnsMu.Unlock()
+	if ch.activeChatTurns == nil {
+		ch.activeChatTurns = make(map[chatTurnKey]*activeChatTurn)
+	}
+	if active := ch.activeChatTurns[key]; active != nil {
+		if active.turnID == "" || active.cancellers > 0 || active.expiresAt.After(time.Now().UTC()) {
+			return "", time.Time{}, false, nil, fiber.NewError(fiber.StatusConflict, "chat session is busy")
+		}
+		delete(ch.activeChatTurns, key)
+		active.cancel()
+		close(active.done)
+	}
+
+	turnID, turnDeadline, sessionCreated, err := ch.reserveChatTurn(ctx, namespace, sessionID)
+	if err != nil {
+		return "", time.Time{}, false, nil, err
+	}
+	turnCancelCtx, cancel := context.WithCancel(context.Background())
+	ch.activeChatTurns[key] = &activeChatTurn{
+		turnID:    turnID,
+		cancel:    cancel,
+		done:      make(chan struct{}),
+		expiresAt: turnDeadline.Add(chatDurabilityTimeout),
+	}
+	return turnID, turnDeadline, sessionCreated, turnCancelCtx, nil
 }
 
 func (ch *ChatHandler) reserveChatTurn(
 	ctx context.Context,
 	namespace, sessionID string,
-) (string, time.Time, error) {
+) (string, time.Time, bool, error) {
 	if ch.sessionTurnCommitter == nil {
-		return "", time.Time{}, fiber.NewError(
+		return "", time.Time{}, false, fiber.NewError(
 			fiber.StatusInternalServerError,
 			"session store does not support atomic chat turns",
 		)
@@ -463,36 +583,104 @@ func (ch *ChatHandler) reserveChatTurn(
 	turnID := fmt.Sprintf("chat-turn-%s", generateChatID())
 	now := time.Now().UTC()
 	turnDeadline := now.Add(turnLifetime)
-	err := ch.sessionTurnCommitter.AcquireChatTurn(ctx, &store.SessionRecord{
+	created, err := ch.sessionTurnCommitter.AcquireChatTurn(ctx, &store.SessionRecord{
 		Namespace:   namespace,
 		Name:        sessionID,
-		SessionType: "chat",
+		SessionType: store.SessionTypeChat,
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}, turnID, turnDeadline.Add(chatDurabilityTimeout))
 	if errors.Is(err, store.ErrGatewayOwnedSession) {
-		return "", time.Time{}, fiber.NewError(fiber.StatusNotFound, "chat session not found")
+		return "", time.Time{}, false, fiber.NewError(fiber.StatusNotFound, "chat session not found")
 	}
 	if errors.Is(err, store.ErrConflict) {
-		return "", time.Time{}, fiber.NewError(fiber.StatusConflict, "chat session is busy")
+		return "", time.Time{}, false, fiber.NewError(fiber.StatusConflict, "chat session is busy")
 	}
 	if err != nil {
-		return "", time.Time{}, fiber.NewError(
+		return "", time.Time{}, false, fiber.NewError(
 			fiber.StatusInternalServerError,
 			fmt.Sprintf("failed to reserve chat session: %v", err),
 		)
 	}
-	return turnID, turnDeadline, nil
+	return turnID, turnDeadline, created, nil
 }
 
-func (ch *ChatHandler) releaseChatTurn(namespace, sessionID, turnID string) {
+func (ch *ChatHandler) releaseChatTurn(namespace, sessionID, turnID string, deleteEmptyCreatedSession bool) {
 	if ch.sessionTurnCommitter == nil || turnID == "" {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), chatDurabilityTimeout)
 	defer cancel()
-	if err := ch.sessionTurnCommitter.ReleaseChatTurn(ctx, namespace, sessionID, turnID); err != nil {
+	if err := ch.sessionTurnCommitter.ReleaseChatTurn(
+		ctx,
+		namespace,
+		sessionID,
+		turnID,
+		deleteEmptyCreatedSession,
+	); err != nil {
 		chatLog.Error(err, "failed to release chat turn", "namespace", namespace, "sessionId", sessionID)
+	}
+}
+
+func (ch *ChatHandler) finishActiveChatTurn(namespace, sessionID, turnID string) {
+	key := chatTurnKey{namespace: namespace, sessionID: sessionID}
+
+	ch.activeChatTurnsMu.Lock()
+	active := ch.activeChatTurns[key]
+	if active == nil || active.turnID != turnID {
+		ch.activeChatTurnsMu.Unlock()
+		return
+	}
+	cancel := active.cancel
+	done := active.done
+	if active.cancellers > 0 {
+		active.turnID = ""
+		active.cancel = nil
+		active.done = nil
+	} else {
+		delete(ch.activeChatTurns, key)
+	}
+	ch.activeChatTurnsMu.Unlock()
+
+	cancel()
+	close(done)
+}
+
+func (ch *ChatHandler) startSessionCancellation(namespace, sessionID string) (<-chan struct{}, bool) {
+	key := chatTurnKey{namespace: namespace, sessionID: sessionID}
+
+	ch.activeChatTurnsMu.Lock()
+	if ch.activeChatTurns == nil {
+		ch.activeChatTurns = make(map[chatTurnKey]*activeChatTurn)
+	}
+	active := ch.activeChatTurns[key]
+	if active == nil {
+		active = &activeChatTurn{}
+		ch.activeChatTurns[key] = active
+	}
+	active.cancellers++
+	cancel := active.cancel
+	done := active.done
+	hasActiveTurn := active.turnID != ""
+	ch.activeChatTurnsMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	return done, hasActiveTurn
+}
+
+func (ch *ChatHandler) finishSessionCancellation(namespace, sessionID string) {
+	key := chatTurnKey{namespace: namespace, sessionID: sessionID}
+
+	ch.activeChatTurnsMu.Lock()
+	defer ch.activeChatTurnsMu.Unlock()
+	active := ch.activeChatTurns[key]
+	if active == nil || active.cancellers == 0 {
+		return
+	}
+	active.cancellers--
+	if active.cancellers == 0 && active.turnID == "" {
+		delete(ch.activeChatTurns, key)
 	}
 }
 
@@ -993,6 +1181,17 @@ func (ch *ChatHandler) HandleCancelChat(c fiber.Ctx) error {
 	}
 	if sessionType == store.SessionTypeGateway {
 		return fiber.NewError(fiber.StatusNotFound, "chat session not found")
+	}
+	done, active := ch.startSessionCancellation(namespace, sessionID)
+	defer ch.finishSessionCancellation(namespace, sessionID)
+	if active {
+		waitCtx, waitCancel := context.WithTimeout(c.Context(), chatDurabilityTimeout)
+		defer waitCancel()
+		select {
+		case <-done:
+		case <-waitCtx.Done():
+			return fiber.NewError(fiber.StatusGatewayTimeout, "timed out waiting for active chat turn to stop")
+		}
 	}
 
 	// Delete the session to cancel it

--- a/internal/api/chat.go
+++ b/internal/api/chat.go
@@ -42,7 +42,10 @@ import (
 
 var chatLog = logf.Log.WithName("chat-handler")
 
-const defaultNamespace = "default"
+const (
+	defaultNamespace      = "default"
+	chatDurabilityTimeout = 10 * time.Second
+)
 
 // ChatConfig holds configuration for the chat handler.
 type ChatConfig struct {
@@ -115,6 +118,7 @@ type ChatHandler struct {
 	watchNamespace            string
 	enforceNamespaceIsolation bool
 	sessionStore              store.SessionStore
+	sessionTurnCommitter      store.SessionTurnCommitter
 	resultStore               store.ResultStore
 	contextTokenAuthorization ContextTokenAuthorizationConfig
 	cooldownTracker           *llm.CooldownTracker
@@ -128,7 +132,7 @@ func NewChatHandler(c client.Client, sm *controller.SessionManager, config ChatC
 		kubeClient = kubeClientOpt[0]
 	}
 
-	return &ChatHandler{
+	handler := &ChatHandler{
 		client:                    c,
 		kubeClient:                kubeClient,
 		sessionManager:            sm,
@@ -141,6 +145,10 @@ func NewChatHandler(c client.Client, sm *controller.SessionManager, config ChatC
 		cooldownTracker:           llm.NewCooldownTracker(),
 		resolver:                  resolver,
 	}
+	if committer, ok := ss.(store.SessionTurnCommitter); ok {
+		handler.sessionTurnCommitter = committer
+	}
+	return handler
 }
 
 // blockedNamespaces that cannot be targeted by chat requests.
@@ -255,14 +263,20 @@ func (ch *ChatHandler) HandleChat(c fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, "failed to build system prompt")
 	}
 
-	// Load session history
-	messages, err := ch.loadChatSession(ctx, namespace, sessionID)
+	turnID, turnDeadline, err := ch.reserveChatTurn(ctx, namespace, sessionID)
 	if err != nil {
-		if errors.Is(err, store.ErrGatewayOwnedSession) {
-			return fiber.NewError(fiber.StatusNotFound, "chat session not found")
+		return err
+	}
+	defer func() {
+		if !sseMode {
+			ch.releaseChatTurn(namespace, sessionID, turnID)
 		}
-		chatLog.Info("no existing session, starting fresh", "sessionId", sessionID, "error", err)
-		messages = []llm.Message{}
+	}()
+
+	// Load session history only after reserving its observed revision.
+	messages, err := ch.loadReservedChatSession(ctx, namespace, sessionID)
+	if err != nil {
+		return err
 	}
 	persistedCount := len(messages)
 
@@ -350,7 +364,10 @@ func (ch *ChatHandler) HandleChat(c fiber.Ctx) error {
 	accept := c.Get("Accept")
 	if accept == "application/json" {
 		// JSON mode: run tool loop, collect all content, return JSON
-		content, usage, toolCalls, err := ch.runToolLoop(ctx, provider, messages, systemPrompt, tools, executor, sessionID, namespace, model, temperature, maxTokens, persistedCount, nil)
+		content, usage, toolCalls, err := ch.runToolLoop(
+			ctx, provider, messages, systemPrompt, tools, executor,
+			sessionID, namespace, model, temperature, maxTokens, persistedCount, nil, turnID,
+		)
 		if err != nil {
 			chatLog.Error(err, "tool loop error")
 			span.RecordError(err)
@@ -384,14 +401,14 @@ func (ch *ChatHandler) HandleChat(c fiber.Ctx) error {
 		baggage.FromContext(ctx),
 	)
 
-	sseMode = true
-	return c.SendStreamWriter(func(w *bufio.Writer) {
+	streamErr := c.SendStreamWriter(func(w *bufio.Writer) {
 		defer span.End()
 		defer func() { <-ch.semaphore }()
+		defer ch.releaseChatTurn(namespace, sessionID, turnID)
 		// SendStreamWriter outlives the handler, so use a background context
 		// seeded with the originating chat span context rather than Fiber's
 		// recycled request context.
-		sseCtx, sseCancel := context.WithTimeout(sseParentCtx, ch.config.MaxDuration)
+		sseCtx, sseCancel := context.WithDeadline(sseParentCtx, turnDeadline)
 		defer sseCancel()
 
 		emitSSE := func(event, data string) {
@@ -406,10 +423,14 @@ func (ch *ChatHandler) HandleChat(c fiber.Ctx) error {
 		})
 		emitSSE("status", string(statusData))
 
-		content, usage, _, err := ch.runToolLoop(sseCtx, sseProvider, sseMessages, sseSystemPrompt, sseTools, sseExecutor, sessionID, namespace, model, temperature, maxTokens, persistedCount, emitSSE)
+		content, usage, _, err := ch.runToolLoop(
+			sseCtx, sseProvider, sseMessages, sseSystemPrompt, sseTools, sseExecutor,
+			sessionID, namespace, model, temperature, maxTokens, persistedCount, emitSSE, turnID,
+		)
 		if err != nil {
 			errData, _ := json.Marshal(map[string]string{"error": err.Error()})
 			emitSSE("error", string(errData))
+			return
 		}
 
 		_ = content // content already emitted via SSE
@@ -418,6 +439,78 @@ func (ch *ChatHandler) HandleChat(c fiber.Ctx) error {
 		doneData, _ := json.Marshal(map[string]any{"usage": usage})
 		emitSSE("done", string(doneData))
 	})
+	if streamErr == nil {
+		sseMode = true
+	}
+	return streamErr
+}
+
+func (ch *ChatHandler) reserveChatTurn(
+	ctx context.Context,
+	namespace, sessionID string,
+) (string, time.Time, error) {
+	if ch.sessionTurnCommitter == nil {
+		return "", time.Time{}, fiber.NewError(
+			fiber.StatusInternalServerError,
+			"session store does not support atomic chat turns",
+		)
+	}
+
+	turnLifetime := ch.config.MaxDuration
+	if turnLifetime <= 0 {
+		turnLifetime = 5 * time.Minute
+	}
+	turnID := fmt.Sprintf("chat-turn-%s", generateChatID())
+	now := time.Now().UTC()
+	turnDeadline := now.Add(turnLifetime)
+	err := ch.sessionTurnCommitter.AcquireChatTurn(ctx, &store.SessionRecord{
+		Namespace:   namespace,
+		Name:        sessionID,
+		SessionType: "chat",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}, turnID, turnDeadline.Add(chatDurabilityTimeout))
+	if errors.Is(err, store.ErrGatewayOwnedSession) {
+		return "", time.Time{}, fiber.NewError(fiber.StatusNotFound, "chat session not found")
+	}
+	if errors.Is(err, store.ErrConflict) {
+		return "", time.Time{}, fiber.NewError(fiber.StatusConflict, "chat session is busy")
+	}
+	if err != nil {
+		return "", time.Time{}, fiber.NewError(
+			fiber.StatusInternalServerError,
+			fmt.Sprintf("failed to reserve chat session: %v", err),
+		)
+	}
+	return turnID, turnDeadline, nil
+}
+
+func (ch *ChatHandler) releaseChatTurn(namespace, sessionID, turnID string) {
+	if ch.sessionTurnCommitter == nil || turnID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), chatDurabilityTimeout)
+	defer cancel()
+	if err := ch.sessionTurnCommitter.ReleaseChatTurn(ctx, namespace, sessionID, turnID); err != nil {
+		chatLog.Error(err, "failed to release chat turn", "namespace", namespace, "sessionId", sessionID)
+	}
+}
+
+func (ch *ChatHandler) loadReservedChatSession(
+	ctx context.Context,
+	namespace, sessionID string,
+) ([]llm.Message, error) {
+	messages, err := ch.loadChatSession(ctx, namespace, sessionID)
+	if errors.Is(err, store.ErrGatewayOwnedSession) {
+		return nil, fiber.NewError(fiber.StatusNotFound, "chat session not found")
+	}
+	if err != nil {
+		return nil, fiber.NewError(
+			fiber.StatusInternalServerError,
+			fmt.Sprintf("failed to load chat session: %v", err),
+		)
+	}
+	return messages, nil
 }
 
 // runToolLoop executes the agentic tool loop until the LLM produces a final text response.
@@ -433,6 +526,7 @@ func (ch *ChatHandler) runToolLoop(
 	maxTokens int,
 	persistedCount int,
 	emitSSE func(event, data string),
+	turnID string,
 ) (string, ChatUsage, []ToolCallInfo, error) {
 	var usage ChatUsage
 	var allToolCalls []ToolCallInfo
@@ -452,15 +546,25 @@ func (ch *ChatHandler) runToolLoop(
 		select {
 		case <-iterCtx.Done():
 			usage.Duration = time.Since(start).Round(time.Millisecond).String()
+			err := fmt.Errorf("chat turn interrupted: %w", iterCtx.Err())
+			iterSpan.RecordError(err)
+			iterSpan.SetStatus(codes.Error, err.Error())
 			iterSpan.End()
-			return "I ran out of time. Here's what I accomplished so far.", usage, allToolCalls, nil
+			return "", usage, allToolCalls, err
 		default:
 		}
 
-		if content, hit := ch.handleIterationLimit(iterCtx, iteration, provider, messages, systemPrompt, model, namespace, sessionID, maxTokens, persistedCount, temperature, emitSSE, executor, &usage, start); hit {
+		if content, hit, err := ch.handleIterationLimit(
+			iterCtx, iteration, provider, messages, systemPrompt, model, namespace, sessionID,
+			maxTokens, persistedCount, temperature, emitSSE, executor, &usage, turnID, start,
+		); hit {
 			setUsageSpanAttributes(iterSpan, usage)
+			if err != nil {
+				iterSpan.RecordError(err)
+				iterSpan.SetStatus(codes.Error, err.Error())
+			}
 			iterSpan.End()
-			return content, usage, allToolCalls, nil
+			return content, usage, allToolCalls, err
 		}
 
 		if iteration > 0 && iteration%5 == 0 {
@@ -504,10 +608,17 @@ func (ch *ChatHandler) runToolLoop(
 				iterSpan.End()
 				continue
 			}
-			content := ch.handleFinalResponse(iterCtx, resp.Content, messages, namespace, sessionID, persistedCount, emitSSE, executor, &usage, start)
+			content, err := ch.handleFinalResponse(
+				iterCtx, resp.Content, messages, namespace, sessionID, persistedCount,
+				emitSSE, executor, &usage, turnID, start,
+			)
 			setUsageSpanAttributes(iterSpan, usage)
+			if err != nil {
+				iterSpan.RecordError(err)
+				iterSpan.SetStatus(codes.Error, err.Error())
+			}
 			iterSpan.End()
-			return content, usage, allToolCalls, nil
+			return content, usage, allToolCalls, err
 		}
 
 		var newToolCalls []ToolCallInfo
@@ -533,10 +644,11 @@ func (ch *ChatHandler) handleIterationLimit(
 	emitSSE func(event, data string),
 	executor *ToolExecutor,
 	usage *ChatUsage,
+	turnID string,
 	start time.Time,
-) (string, bool) {
+) (string, bool, error) {
 	if iteration < ch.config.MaxIterations {
-		return "", false
+		return "", false, nil
 	}
 
 	messages = append(messages, llm.Message{
@@ -553,26 +665,27 @@ func (ch *ChatHandler) handleIterationLimit(
 	})
 	if err != nil {
 		usage.Duration = time.Since(start).Round(time.Millisecond).String()
-		return "Reached iteration limit.", true
+		return "", true, fmt.Errorf("final LLM completion after iteration limit failed: %w", err)
 	}
 	usage.LLMCalls++
 	usage.InputTokens += resp.InputTokens
 	usage.OutputTokens += resp.OutputTokens
+
+	finalMessages := append(messages, llm.Message{Role: "assistant", Content: resp.Content})
+	usage.Duration = time.Since(start).Round(time.Millisecond).String()
+	usage.TasksCreated = executor.tasksCreated
+	if err := ch.saveChatSession(
+		ctx, namespace, sessionID, finalMessages, persistedCount, *usage, turnID,
+	); err != nil {
+		return "", true, fmt.Errorf("failed to commit chat turn: %w", err)
+	}
 
 	if emitSSE != nil && resp.Content != "" {
 		msgData, _ := json.Marshal(map[string]string{"content": resp.Content})
 		emitSSE("message", string(msgData))
 	}
 
-	finalMessages := append(messages, llm.Message{Role: "assistant", Content: resp.Content})
-	usage.Duration = time.Since(start).Round(time.Millisecond).String()
-	usage.TasksCreated = executor.tasksCreated
-	_ = ch.saveChatSession(ctx, namespace, sessionID, finalMessages, persistedCount, *usage)
-	if err := ch.sessionStore.UpdateTokenCounts(ctx, namespace, sessionID, usage.InputTokens, usage.OutputTokens); err != nil {
-		chatLog.Error(err, "failed to update token counts")
-	}
-
-	return resp.Content, true
+	return resp.Content, true, nil
 }
 
 // callLLMWithRetry calls the LLM provider and retries once with truncated messages
@@ -706,22 +819,24 @@ func (ch *ChatHandler) handleFinalResponse(
 	emitSSE func(event, data string),
 	executor *ToolExecutor,
 	usage *ChatUsage,
+	turnID string,
 	start time.Time,
-) string {
+) (string, error) {
+	finalMessages := append(messages, llm.Message{Role: "assistant", Content: content})
+	usage.Duration = time.Since(start).Round(time.Millisecond).String()
+	usage.TasksCreated = executor.tasksCreated
+	if err := ch.saveChatSession(
+		ctx, namespace, sessionID, finalMessages, persistedCount, *usage, turnID,
+	); err != nil {
+		return "", fmt.Errorf("failed to commit chat turn: %w", err)
+	}
+
 	if emitSSE != nil && content != "" {
 		msgData, _ := json.Marshal(map[string]string{"content": content})
 		emitSSE("message", string(msgData))
 	}
 
-	finalMessages := append(messages, llm.Message{Role: "assistant", Content: content})
-	usage.Duration = time.Since(start).Round(time.Millisecond).String()
-	usage.TasksCreated = executor.tasksCreated
-	_ = ch.saveChatSession(ctx, namespace, sessionID, finalMessages, persistedCount, *usage)
-	if err := ch.sessionStore.UpdateTokenCounts(ctx, namespace, sessionID, usage.InputTokens, usage.OutputTokens); err != nil {
-		chatLog.Error(err, "failed to update token counts")
-	}
-
-	return content
+	return content, nil
 }
 
 func setUsageSpanAttributes(span trace.Span, usage ChatUsage) {
@@ -773,37 +888,29 @@ func (ch *ChatHandler) loadChatSession(ctx context.Context, namespace, sessionID
 	return llmMessages, nil
 }
 
-// saveChatSession saves chat session messages to the session store.
-func (ch *ChatHandler) saveChatSession(ctx context.Context, namespace, sessionID string, messages []llm.Message, persistedCount int, _ ChatUsage) error {
-	// Check if session exists
-	_, err := ch.sessionStore.GetSession(ctx, namespace, sessionID)
-	if err != nil {
-		if !errors.Is(err, store.ErrNotFound) {
-			return fmt.Errorf("failed to get session: %w", err)
-		}
-		// Create new session
-		now := time.Now()
-		session := &store.SessionRecord{
-			Namespace:   namespace,
-			Name:        sessionID,
-			SessionType: "chat",
-			CreatedAt:   now,
-			UpdatedAt:   now,
-		}
-		if err := ch.sessionStore.CreateSession(ctx, session); err != nil {
-			return fmt.Errorf("failed to create session: %w", err)
-		}
+// saveChatSession atomically commits new transcript messages and their usage.
+func (ch *ChatHandler) saveChatSession(
+	ctx context.Context,
+	namespace, sessionID string,
+	messages []llm.Message,
+	persistedCount int,
+	usage ChatUsage,
+	turnID string,
+) error {
+	if persistedCount < 0 || persistedCount > len(messages) {
+		return fmt.Errorf("invalid persisted message count %d for %d messages", persistedCount, len(messages))
 	}
 
-	// Only append messages that haven't been persisted yet
 	newMessages := messages[persistedCount:]
 	if len(newMessages) == 0 {
+		if usage.InputTokens != 0 || usage.OutputTokens != 0 {
+			return fmt.Errorf("cannot commit token usage without new transcript messages")
+		}
 		return nil
 	}
 
-	// Convert llm.Message to store.SessionMessage
 	storeMessages := make([]store.SessionMessage, 0, len(newMessages))
-	now := time.Now()
+	now := time.Now().UTC()
 	for _, msg := range newMessages {
 		sm := store.SessionMessage{
 			Role:       msg.Role,
@@ -818,7 +925,24 @@ func (ch *ChatHandler) saveChatSession(ctx context.Context, namespace, sessionID
 		storeMessages = append(storeMessages, sm)
 	}
 
-	return ch.sessionStore.AppendMessages(ctx, namespace, sessionID, storeMessages)
+	if ch.sessionTurnCommitter == nil {
+		return fmt.Errorf("session store does not support atomic chat turns")
+	}
+	return ch.sessionTurnCommitter.CommitSessionTurn(
+		ctx,
+		&store.SessionRecord{
+			Namespace:   namespace,
+			Name:        sessionID,
+			SessionType: "chat",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		},
+		turnID,
+		persistedCount,
+		storeMessages,
+		usage.InputTokens,
+		usage.OutputTokens,
+	)
 }
 
 // HandleChatConfig handles GET /api/v1/chat/config.

--- a/internal/api/chat_test.go
+++ b/internal/api/chat_test.go
@@ -47,6 +47,59 @@ type chatMockProvider struct {
 	streamErr    error
 }
 
+type cancellableChatProvider struct {
+	name     string
+	started  chan struct{}
+	stopped  chan error
+	response *llm.CompletionResponse
+}
+
+func (p *cancellableChatProvider) Complete(ctx context.Context, _ *llm.CompletionRequest) (*llm.CompletionResponse, error) {
+	err := p.waitForCancellation(ctx)
+	return p.response, err
+}
+
+func (p *cancellableChatProvider) waitForCancellation(ctx context.Context) error {
+	select {
+	case p.started <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	select {
+	case p.stopped <- ctx.Err():
+	default:
+	}
+	return ctx.Err()
+}
+
+func (p *cancellableChatProvider) Stream(ctx context.Context, _ *llm.CompletionRequest) (<-chan llm.StreamChunk, error) {
+	chunks := make(chan llm.StreamChunk, 1)
+	go func() {
+		defer close(chunks)
+		chunks <- llm.StreamChunk{Error: p.waitForCancellation(ctx)}
+	}()
+	return chunks, nil
+}
+
+func (p *cancellableChatProvider) Name() string { return p.name }
+
+type blockingDeleteSessionStore struct {
+	store.SessionStore
+	store.SessionTurnCommitter
+	deleteStarted chan struct{}
+	allowDelete   chan struct{}
+}
+
+func (s *blockingDeleteSessionStore) DeleteSession(ctx context.Context, namespace, name string) error {
+	close(s.deleteStarted)
+	select {
+	case <-s.allowDelete:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return s.SessionStore.DeleteSession(ctx, namespace, name)
+}
+
 func (m *chatMockProvider) Complete(_ context.Context, _ *llm.CompletionRequest) (*llm.CompletionResponse, error) {
 	if m.err != nil {
 		return nil, m.err
@@ -91,11 +144,11 @@ type observingChatTurnCommitter struct {
 
 func (*observingChatTurnCommitter) AcquireChatTurn(
 	context.Context, *store.SessionRecord, string, time.Time,
-) error {
-	return nil
+) (bool, error) {
+	return false, nil
 }
 
-func (*observingChatTurnCommitter) ReleaseChatTurn(context.Context, string, string, string) error {
+func (*observingChatTurnCommitter) ReleaseChatTurn(context.Context, string, string, string, bool) error {
 	return nil
 }
 
@@ -174,9 +227,9 @@ func newTestChatHandler(t *testing.T, c client.Client, ss store.SessionStore, rs
 
 func reserveTestChatTurn(t *testing.T, ch *ChatHandler, sessionID string) string {
 	t.Helper()
-	turnID, _, err := ch.reserveChatTurn(context.Background(), defaultNamespace, sessionID)
+	turnID, _, created, err := ch.reserveChatTurn(context.Background(), defaultNamespace, sessionID)
 	require.NoError(t, err)
-	t.Cleanup(func() { ch.releaseChatTurn(defaultNamespace, sessionID, turnID) })
+	t.Cleanup(func() { ch.releaseChatTurn(defaultNamespace, sessionID, turnID, created) })
 	return turnID
 }
 
@@ -393,6 +446,168 @@ func TestHandleCancelChat(t *testing.T) {
 		_, err = ss.GetSession(ctx, "default", "test-session")
 		assert.True(t, errors.Is(err, store.ErrNotFound))
 	})
+}
+
+func TestHandleCancelChatStopsActiveSSETurnBeforeSuccess(t *testing.T) {
+	const (
+		providerType = "cancel-active-sse-provider"
+		sessionID    = "cancel-active-sse"
+	)
+	provider := &cancellableChatProvider{
+		name:    providerType,
+		started: make(chan struct{}, 1),
+		stopped: make(chan error, 1),
+	}
+	llm.RegisterProvider(providerType, func(llm.ProviderConfig) (llm.Provider, error) {
+		return provider, nil
+	})
+	objects := providerCRD(defaultNamespace, defaultNamespace, providerType, "test-model")
+	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithRuntimeObjects(objects...).Build()
+	baseSessionStore := newTestSessionStore(t)
+	committer, ok := baseSessionStore.(store.SessionTurnCommitter)
+	require.True(t, ok)
+	ss := &blockingDeleteSessionStore{
+		SessionStore:         baseSessionStore,
+		SessionTurnCommitter: committer,
+		deleteStarted:        make(chan struct{}),
+		allowDelete:          make(chan struct{}),
+	}
+	rs := newTestResultStore(t)
+	cfg := DefaultChatConfig()
+	cfg.Provider = defaultNamespace
+	ch := newTestChatHandler(t, fakeClient, ss, rs, cfg)
+
+	app := fiber.New(fiber.Config{ErrorHandler: customErrorHandler})
+	app.Post("/api/v1/chat", ch.HandleChat)
+	app.Delete("/api/v1/chat/:sessionId", ch.HandleCancelChat)
+
+	type postResult struct {
+		resp *http.Response
+		err  error
+	}
+	postDone := make(chan postResult, 1)
+	deleteDone := make(chan postResult, 1)
+	body, err := json.Marshal(ChatRequest{
+		Message: "wait until cancelled", SessionID: sessionID, Namespace: defaultNamespace,
+	})
+	require.NoError(t, err)
+	go func() {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/chat", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "text/event-stream")
+		resp, testErr := app.Test(req)
+		postDone <- postResult{resp: resp, err: testErr}
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-ss.allowDelete:
+		default:
+			close(ss.allowDelete)
+		}
+		done, active := ch.startSessionCancellation(defaultNamespace, sessionID)
+		defer ch.finishSessionCancellation(defaultNamespace, sessionID)
+		if active {
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+			}
+		}
+	})
+
+	select {
+	case <-provider.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("provider did not start the SSE turn")
+	}
+
+	go func() {
+		resp, testErr := app.Test(httptest.NewRequest(http.MethodDelete, "/api/v1/chat/"+sessionID, nil))
+		deleteDone <- postResult{resp: resp, err: testErr}
+	}()
+
+	select {
+	case stoppedErr := <-provider.stopped:
+		require.ErrorIs(t, stoppedErr, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("DELETE did not cancel the provider context")
+	}
+	select {
+	case <-ss.deleteStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("DELETE did not reach durable session deletion")
+	}
+
+	replacementReq := httptest.NewRequest(http.MethodPost, "/api/v1/chat", bytes.NewReader(body))
+	replacementReq.Header.Set("Content-Type", "application/json")
+	replacementReq.Header.Set("Accept", "application/json")
+	replacementResp, err := app.Test(replacementReq)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusConflict, replacementResp.StatusCode)
+	select {
+	case <-provider.started:
+		t.Fatal("replacement provider work started while session deletion was in progress")
+	default:
+	}
+	close(ss.allowDelete)
+
+	select {
+	case result := <-deleteDone:
+		require.NoError(t, result.err)
+		require.Equal(t, http.StatusNoContent, result.resp.StatusCode)
+	case <-time.After(5 * time.Second):
+		t.Fatal("DELETE did not finish after session deletion was released")
+	}
+
+	select {
+	case result := <-postDone:
+		require.NoError(t, result.err)
+		require.Equal(t, http.StatusOK, result.resp.StatusCode)
+	case <-time.After(5 * time.Second):
+		t.Fatal("SSE request did not stop after session cancellation")
+	}
+	_, err = baseSessionStore.GetSession(context.Background(), defaultNamespace, sessionID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestHandleChatRemovesNewEmptySessionAfterProviderFailure(t *testing.T) {
+	const (
+		providerType = "failed-new-session-provider"
+		sessionID    = "failed-new-session"
+	)
+	provider := &chatMockProvider{name: providerType, err: &llm.ProviderError{
+		Provider: providerType, Message: "invalid provider request", StatusCode: http.StatusBadRequest,
+	}}
+	llm.RegisterProvider(providerType, func(llm.ProviderConfig) (llm.Provider, error) {
+		return provider, nil
+	})
+	objects := providerCRD(defaultNamespace, defaultNamespace, providerType, "test-model")
+	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithRuntimeObjects(objects...).Build()
+	ss := newTestSessionStore(t)
+	rs := newTestResultStore(t)
+	cfg := DefaultChatConfig()
+	cfg.Provider = defaultNamespace
+	ch := newTestChatHandler(t, fakeClient, ss, rs, cfg)
+	app := fiber.New(fiber.Config{ErrorHandler: customErrorHandler})
+	app.Post("/api/v1/chat", ch.HandleChat)
+
+	body, err := json.Marshal(ChatRequest{
+		Message: "this provider will fail", SessionID: sessionID, Namespace: defaultNamespace,
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	_, err = ss.GetSession(context.Background(), defaultNamespace, sessionID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+	sessions, err := ss.ListSessions(context.Background(), defaultNamespace)
+	require.NoError(t, err)
+	for _, session := range sessions {
+		assert.NotEqual(t, sessionID, session.Name, "failed new turn remained visible in session inventory")
+	}
 }
 
 // --- loadChatSession ---
@@ -1511,11 +1726,12 @@ func TestHandleChatRejectsConcurrentSessionTurnBeforeProviderInvocation(t *testi
 	committer, ok := ss.(store.SessionTurnCommitter)
 	require.True(t, ok)
 	now := time.Now().UTC()
-	require.NoError(t, committer.AcquireChatTurn(context.Background(), &store.SessionRecord{
+	_, err := committer.AcquireChatTurn(context.Background(), &store.SessionRecord{
 		Namespace: testDefaultNamespace, Name: "busy-chat", SessionType: "chat", CreatedAt: now, UpdatedAt: now,
-	}, "held-turn", now.Add(time.Minute)))
+	}, "held-turn", now.Add(time.Minute))
+	require.NoError(t, err)
 	t.Cleanup(func() {
-		_ = committer.ReleaseChatTurn(context.Background(), testDefaultNamespace, "busy-chat", "held-turn")
+		_ = committer.ReleaseChatTurn(context.Background(), testDefaultNamespace, "busy-chat", "held-turn", false)
 	})
 
 	rs := newTestResultStore(t)

--- a/internal/api/chat_test.go
+++ b/internal/api/chat_test.go
@@ -38,12 +38,13 @@ import (
 
 // chatMockProvider implements llm.Provider for testing.
 type chatMockProvider struct {
-	name      string
-	responses []*llm.CompletionResponse
-	callCount int
-	err       error
-	streamCh  chan llm.StreamChunk
-	streamErr error
+	name         string
+	responses    []*llm.CompletionResponse
+	callCount    int
+	err          error
+	beforeReturn func()
+	streamCh     chan llm.StreamChunk
+	streamErr    error
 }
 
 func (m *chatMockProvider) Complete(_ context.Context, _ *llm.CompletionRequest) (*llm.CompletionResponse, error) {
@@ -52,10 +53,14 @@ func (m *chatMockProvider) Complete(_ context.Context, _ *llm.CompletionRequest)
 	}
 	idx := m.callCount
 	m.callCount++
+	resp := &llm.CompletionResponse{Content: "default response"}
 	if idx < len(m.responses) {
-		return m.responses[idx], nil
+		resp = m.responses[idx]
 	}
-	return &llm.CompletionResponse{Content: "default response"}, nil
+	if m.beforeReturn != nil {
+		m.beforeReturn()
+	}
+	return resp, nil
 }
 
 func (m *chatMockProvider) Stream(_ context.Context, _ *llm.CompletionRequest) (<-chan llm.StreamChunk, error) {
@@ -70,6 +75,39 @@ func (m *chatMockProvider) Name() string {
 		return m.name
 	}
 	return "mock-provider"
+}
+
+type observingChatTurnCommitter struct {
+	commit func(
+		context.Context,
+		*store.SessionRecord,
+		string,
+		int,
+		[]store.SessionMessage,
+		int,
+		int,
+	) error
+}
+
+func (*observingChatTurnCommitter) AcquireChatTurn(
+	context.Context, *store.SessionRecord, string, time.Time,
+) error {
+	return nil
+}
+
+func (*observingChatTurnCommitter) ReleaseChatTurn(context.Context, string, string, string) error {
+	return nil
+}
+
+func (c *observingChatTurnCommitter) CommitSessionTurn(
+	ctx context.Context,
+	session *store.SessionRecord,
+	turnID string,
+	expectedMessageCount int,
+	messages []store.SessionMessage,
+	inputTokens, outputTokens int,
+) error {
+	return c.commit(ctx, session, turnID, expectedMessageCount, messages, inputTokens, outputTokens)
 }
 
 func newTestScheme() *runtime.Scheme {
@@ -496,6 +534,61 @@ func TestSaveChatSession(t *testing.T) {
 		}
 		err := ch.saveChatSession(ctx, "default", "noop-session", messages, 1, ChatUsage{}, turnID)
 		require.NoError(t, err)
+	})
+
+	t.Run("uses a detached bounded context for the atomic commit", func(t *testing.T) {
+		type durabilityContextKey struct{}
+		const contextValue = "chat-trace-value"
+
+		for _, tt := range []struct {
+			name       string
+			newContext func(context.Context) (context.Context, context.CancelFunc)
+			wantErr    error
+		}{
+			{
+				name: "parent canceled",
+				newContext: func(parent context.Context) (context.Context, context.CancelFunc) {
+					ctx, cancel := context.WithCancel(parent)
+					cancel()
+					return ctx, cancel
+				},
+				wantErr: context.Canceled,
+			},
+			{
+				name: "parent deadline expired",
+				newContext: func(parent context.Context) (context.Context, context.CancelFunc) {
+					return context.WithDeadline(parent, time.Now().Add(-time.Second))
+				},
+				wantErr: context.DeadlineExceeded,
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				parent, parentCancel := tt.newContext(context.WithValue(
+					context.Background(), durabilityContextKey{}, contextValue,
+				))
+				defer parentCancel()
+				require.ErrorIs(t, parent.Err(), tt.wantErr)
+
+				started := time.Now()
+				committer := &observingChatTurnCommitter{
+					commit: func(commitCtx context.Context, _ *store.SessionRecord, _ string, _ int, _ []store.SessionMessage, _, _ int) error {
+						require.NoError(t, commitCtx.Err())
+						require.Equal(t, contextValue, commitCtx.Value(durabilityContextKey{}))
+						deadline, ok := commitCtx.Deadline()
+						require.True(t, ok)
+						assert.WithinDuration(t, started.Add(chatDurabilityTimeout), deadline, time.Second)
+						return nil
+					},
+				}
+				testHandler := &ChatHandler{sessionTurnCommitter: committer}
+				err := testHandler.saveChatSession(
+					parent, "default", "durable-session",
+					[]llm.Message{{Role: "assistant", Content: "completed"}},
+					0, ChatUsage{InputTokens: 3, OutputTokens: 5}, "durable-turn",
+				)
+				require.NoError(t, err)
+			})
+		}
 	})
 }
 
@@ -945,6 +1038,44 @@ func TestRunToolLoop(t *testing.T) {
 		)
 		require.ErrorIs(t, err, context.Canceled)
 		assert.Empty(t, content)
+		assert.Zero(t, provider.callCount)
+		stored, loadErr := ss.LoadTranscript(context.Background(), "default", "test-sess3", 0)
+		require.NoError(t, loadErr)
+		assert.Empty(t, stored)
+	})
+
+	t.Run("commits a completed response when cancellation races the final handoff", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		ss := newTestSessionStore(t)
+		rs := newTestResultStore(t)
+		ch := newTestChatHandler(t, fakeClient, ss, rs, DefaultChatConfig())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		provider := &chatMockProvider{
+			responses: []*llm.CompletionResponse{
+				{Content: "completed near deadline", InputTokens: 8, OutputTokens: 13},
+			},
+			beforeReturn: cancel,
+		}
+
+		messages := []llm.Message{{Role: "user", Content: "finish this turn"}}
+		turnID := reserveTestChatTurn(t, ch, "durability-handoff-session")
+		content, usage, _, err := ch.runToolLoop(
+			ctx, provider, messages, "system prompt",
+			nil, NewToolExecutor(fakeClient, nil, "default", "durability-handoff-session", "", false, 5, 60*time.Second, rs),
+			"durability-handoff-session", "default", "test-model", 0.7, 4096, 0, nil, turnID,
+		)
+		require.ErrorIs(t, ctx.Err(), context.Canceled)
+		require.NoError(t, err)
+		assert.Equal(t, "completed near deadline", content)
+		assert.Equal(t, 8, usage.InputTokens)
+		assert.Equal(t, 13, usage.OutputTokens)
+
+		stored, loadErr := ss.LoadTranscript(context.Background(), "default", "durability-handoff-session", 0)
+		require.NoError(t, loadErr)
+		require.Len(t, stored, 2)
+		assert.Equal(t, "finish this turn", stored[0].Content)
+		assert.Equal(t, "completed near deadline", stored[1].Content)
 	})
 
 	t.Run("respects max iterations", func(t *testing.T) {

--- a/internal/api/chat_test.go
+++ b/internal/api/chat_test.go
@@ -134,6 +134,14 @@ func newTestChatHandler(t *testing.T, c client.Client, ss store.SessionStore, rs
 	return NewChatHandler(c, nil, cfg, "", false, ss, rs, resolver)
 }
 
+func reserveTestChatTurn(t *testing.T, ch *ChatHandler, sessionID string) string {
+	t.Helper()
+	turnID, _, err := ch.reserveChatTurn(context.Background(), defaultNamespace, sessionID)
+	require.NoError(t, err)
+	t.Cleanup(func() { ch.releaseChatTurn(defaultNamespace, sessionID, turnID) })
+	return turnID
+}
+
 // providerCRD creates a Provider CRD + matching Secret for tests.
 func providerCRD(name, namespace, providerType, model string) []runtime.Object { //nolint:unparam
 	return []runtime.Object{
@@ -423,22 +431,31 @@ func TestSaveChatSession(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("creates session if not exists and appends messages", func(t *testing.T) {
+		turnID := reserveTestChatTurn(t, ch, "new-session")
 		messages := []llm.Message{
 			{Role: "user", Content: "hello"},
 			{Role: "assistant", Content: "hi"},
 		}
-		err := ch.saveChatSession(ctx, "default", "new-session", messages, 0, ChatUsage{})
+		err := ch.saveChatSession(ctx, "default", "new-session", messages, 0, ChatUsage{
+			InputTokens: 10, OutputTokens: 20,
+		}, turnID)
 		require.NoError(t, err)
 
 		// Verify session was created
 		sess, err := ss.GetSession(ctx, "default", "new-session")
 		require.NoError(t, err)
 		assert.Equal(t, "chat", sess.SessionType)
+		assert.Equal(t, 10, sess.InputTokens)
+		assert.Equal(t, 20, sess.OutputTokens)
 
 		// Verify messages were stored
 		stored, err := ss.LoadTranscript(ctx, "default", "new-session", 0)
 		require.NoError(t, err)
 		assert.Len(t, stored, 2)
+		assert.NotEmpty(t, stored[0].ID)
+		assert.NotEmpty(t, stored[1].ID)
+		assert.Equal(t, int64(2), stored[0].Order)
+		assert.Equal(t, int64(4), stored[1].Order)
 	})
 
 	t.Run("only appends new messages (skips persisted)", func(t *testing.T) {
@@ -457,13 +474,14 @@ func TestSaveChatSession(t *testing.T) {
 			{Role: "user", Content: "old message", Timestamp: now},
 		})
 		require.NoError(t, err)
+		turnID := reserveTestChatTurn(t, ch, "partial-session")
 
 		messages := []llm.Message{
 			{Role: "user", Content: "old message"},
 			{Role: "assistant", Content: "new response"},
 		}
 		// persistedCount=1 means skip first message
-		err = ch.saveChatSession(ctx, "default", "partial-session", messages, 1, ChatUsage{})
+		err = ch.saveChatSession(ctx, "default", "partial-session", messages, 1, ChatUsage{}, turnID)
 		require.NoError(t, err)
 
 		stored, err := ss.LoadTranscript(ctx, "default", "partial-session", 0)
@@ -472,10 +490,11 @@ func TestSaveChatSession(t *testing.T) {
 	})
 
 	t.Run("no new messages is a no-op", func(t *testing.T) {
+		turnID := reserveTestChatTurn(t, ch, "noop-session")
 		messages := []llm.Message{
 			{Role: "user", Content: "already saved"},
 		}
-		err := ch.saveChatSession(ctx, "default", "noop-session", messages, 1, ChatUsage{})
+		err := ch.saveChatSession(ctx, "default", "noop-session", messages, 1, ChatUsage{}, turnID)
 		require.NoError(t, err)
 	})
 }
@@ -849,10 +868,11 @@ func TestRunToolLoop(t *testing.T) {
 		}
 
 		messages := []llm.Message{{Role: "user", Content: "hello"}}
+		turnID := reserveTestChatTurn(t, ch, "test-sess")
 		content, usage, toolCalls, err := ch.runToolLoop(
 			context.Background(), provider, messages, "system prompt",
 			nil, NewToolExecutor(fakeClient, nil, "default", "test-sess", "", false, 5, 60*time.Second, rs),
-			"test-sess", "default", "test-model", 0.7, 4096, 0, nil,
+			"test-sess", "default", "test-model", 0.7, 4096, 0, nil, turnID,
 		)
 		require.NoError(t, err)
 		assert.Equal(t, "Hello, I'm here to help!", content)
@@ -888,10 +908,11 @@ func TestRunToolLoop(t *testing.T) {
 
 		messages := []llm.Message{{Role: "user", Content: "list tasks"}}
 		exec := NewToolExecutor(fakeClient, nil, "default", "test-sess2", "", false, 5, 60*time.Second, rs)
+		turnID := reserveTestChatTurn(t, ch, "test-sess2")
 		content, usage, toolCalls, err := ch.runToolLoop(
 			context.Background(), provider, messages, "system prompt",
 			exec.registry.ToLLMTools(chattools.ChatToolNames()), exec,
-			"test-sess2", "default", "test-model", 0.7, 4096, 0, nil,
+			"test-sess2", "default", "test-model", 0.7, 4096, 0, nil, turnID,
 		)
 		require.NoError(t, err)
 		assert.Equal(t, "Done!", content)
@@ -916,13 +937,14 @@ func TestRunToolLoop(t *testing.T) {
 		}
 
 		messages := []llm.Message{{Role: "user", Content: "hello"}}
+		turnID := reserveTestChatTurn(t, ch, "test-sess3")
 		content, _, _, err := ch.runToolLoop(
 			ctx, provider, messages, "system prompt",
 			nil, NewToolExecutor(fakeClient, nil, "default", "test-sess3", "", false, 5, 60*time.Second, rs),
-			"test-sess3", "default", "test-model", 0.7, 4096, 0, nil,
+			"test-sess3", "default", "test-model", 0.7, 4096, 0, nil, turnID,
 		)
-		require.NoError(t, err)
-		assert.Contains(t, content, "ran out of time")
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Empty(t, content)
 	})
 
 	t.Run("respects max iterations", func(t *testing.T) {
@@ -947,10 +969,11 @@ func TestRunToolLoop(t *testing.T) {
 
 		messages := []llm.Message{{Role: "user", Content: "do things"}}
 		exec2 := NewToolExecutor(fakeClient, nil, "default", "max-iter-sess", "", false, 5, 60*time.Second, rs)
+		turnID := reserveTestChatTurn(t, ch, "max-iter-sess")
 		content, usage, _, err := ch.runToolLoop(
 			context.Background(), provider, messages, "system prompt",
 			exec2.registry.ToLLMTools(chattools.ChatToolNames()), exec2,
-			"max-iter-sess", "default", "test-model", 0.7, 4096, 0, nil,
+			"max-iter-sess", "default", "test-model", 0.7, 4096, 0, nil, turnID,
 		)
 		require.NoError(t, err)
 		assert.NotEmpty(t, content)
@@ -968,10 +991,11 @@ func TestRunToolLoop(t *testing.T) {
 		}
 
 		messages := []llm.Message{{Role: "user", Content: "hello"}}
+		turnID := reserveTestChatTurn(t, ch, "err-sess")
 		_, _, _, err := ch.runToolLoop(
 			context.Background(), provider, messages, "system prompt",
 			nil, NewToolExecutor(fakeClient, nil, "default", "err-sess", "", false, 5, 60*time.Second, rs),
-			"err-sess", "default", "test-model", 0.7, 4096, 0, nil,
+			"err-sess", "default", "test-model", 0.7, 4096, 0, nil, turnID,
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "LLM completion failed")
@@ -1001,10 +1025,11 @@ func TestRunToolLoop(t *testing.T) {
 
 		messages := []llm.Message{{Role: "user", Content: "do it"}}
 		exec3 := NewToolExecutor(fakeClient, nil, "default", "sse-sess", "", false, 5, 60*time.Second, rs)
+		turnID := reserveTestChatTurn(t, ch, "sse-sess")
 		content, _, _, err := ch.runToolLoop(
 			context.Background(), provider, messages, "system prompt",
 			exec3.registry.ToLLMTools(chattools.ChatToolNames()), exec3,
-			"sse-sess", "default", "test-model", 0.7, 4096, 0, emitSSE,
+			"sse-sess", "default", "test-model", 0.7, 4096, 0, emitSSE, turnID,
 		)
 		require.NoError(t, err)
 		assert.Equal(t, "All done!", content)
@@ -1157,6 +1182,15 @@ func TestHandleChat(t *testing.T) {
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&chatResp))
 		assert.NotEmpty(t, chatResp.SessionID)
 		assert.NotEmpty(t, chatResp.Message)
+		session, err := ss.GetSession(context.Background(), "default", chatResp.SessionID)
+		require.NoError(t, err)
+		require.Len(t, session.Messages, 2)
+		assert.Equal(t, 10, session.InputTokens)
+		assert.Equal(t, 20, session.OutputTokens)
+		assert.NotEmpty(t, session.Messages[0].ID)
+		assert.NotEmpty(t, session.Messages[1].ID)
+		assert.Equal(t, int64(2), session.Messages[0].Order)
+		assert.Equal(t, int64(4), session.Messages[1].Order)
 	})
 
 	t.Run("SSE mode returns event stream", func(t *testing.T) {
@@ -1232,6 +1266,18 @@ func TestHandleChat(t *testing.T) {
 		var chatResp ChatResponse
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&chatResp))
 		assert.Equal(t, "my-session-123", chatResp.SessionID)
+
+		secondBody, _ := json.Marshal(ChatRequest{Message: "again", SessionID: "my-session-123"})
+		secondReq := httptest.NewRequest(http.MethodPost, "/api/v1/chat", bytes.NewReader(secondBody))
+		secondReq.Header.Set("Content-Type", "application/json")
+		secondReq.Header.Set("Accept", "application/json")
+		secondResp, err := app.Test(secondReq)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, secondResp.StatusCode)
+		session, err := ss.GetSession(context.Background(), "default", "my-session-123")
+		require.NoError(t, err)
+		require.Len(t, session.Messages, 4)
+		assert.Equal(t, int64(8), session.Messages[3].Order)
 	})
 
 	t.Run("SSE streaming mode", func(t *testing.T) {
@@ -1319,6 +1365,44 @@ func TestHandleChatHidesGatewaySessionBeforeProviderInvocation(t *testing.T) {
 	resp, err := app.Test(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	require.Zero(t, mock.callCount)
+}
+
+func TestHandleChatRejectsConcurrentSessionTurnBeforeProviderInvocation(t *testing.T) {
+	const providerType = "chat-turn-reservation-test"
+	mock := &chatMockProvider{name: providerType}
+	llm.RegisterProvider(providerType, func(llm.ProviderConfig) (llm.Provider, error) {
+		return mock, nil
+	})
+	objects := providerCRD(testDefaultNamespace, testDefaultNamespace, providerType, "test-model")
+	fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithRuntimeObjects(objects...).Build()
+	ss := newTestSessionStore(t)
+	committer, ok := ss.(store.SessionTurnCommitter)
+	require.True(t, ok)
+	now := time.Now().UTC()
+	require.NoError(t, committer.AcquireChatTurn(context.Background(), &store.SessionRecord{
+		Namespace: testDefaultNamespace, Name: "busy-chat", SessionType: "chat", CreatedAt: now, UpdatedAt: now,
+	}, "held-turn", now.Add(time.Minute)))
+	t.Cleanup(func() {
+		_ = committer.ReleaseChatTurn(context.Background(), testDefaultNamespace, "busy-chat", "held-turn")
+	})
+
+	rs := newTestResultStore(t)
+	cfg := DefaultChatConfig()
+	cfg.Provider = testDefaultNamespace
+	ch := newTestChatHandler(t, fakeClient, ss, rs, cfg)
+	app := fiber.New(fiber.Config{ErrorHandler: customErrorHandler})
+	app.Post("/api/v1/chat", ch.HandleChat)
+	body, err := json.Marshal(ChatRequest{
+		Message: "second turn", SessionID: "busy-chat", Namespace: testDefaultNamespace,
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusConflict, resp.StatusCode)
 	require.Zero(t, mock.callCount)
 }
 

--- a/internal/api/chat_tool_executor.go
+++ b/internal/api/chat_tool_executor.go
@@ -152,6 +152,13 @@ func (e *ToolExecutor) Execute(ctx context.Context, toolCall llm.ToolCall) (stri
 		recordRejectedToolCall(ctx, toolCall, resultStr)
 		return resultStr, marshalErr
 	}
+	if sessionRef, _ := args["sessionRef"].(string); strings.TrimSpace(sessionRef) != "" &&
+		strings.TrimSpace(sessionRef) == strings.TrimSpace(e.sessionID) {
+		result := toolError("invalid_arguments", "child task sessionRef cannot reuse the active chat session", "Use a different session name or omit sessionRef")
+		resultStr, err := marshalResult(result)
+		recordRejectedToolCall(ctx, toolCall, resultStr)
+		return resultStr, err
+	}
 
 	toolCtx, cancel := context.WithTimeout(ctx, e.toolTimeout)
 	defer cancel()

--- a/internal/controller/session_manager.go
+++ b/internal/controller/session_manager.go
@@ -94,10 +94,14 @@ func (m *SessionManager) AcquireLock(ctx context.Context, task *corev1alpha1.Tas
 
 // ReleaseLock releases the session lock for a task.
 func (m *SessionManager) ReleaseLock(ctx context.Context, task *corev1alpha1.Task) error {
-	if event, ok, err := m.gatewayEventForTask(ctx, task); err != nil {
+	if _, ok, err := m.gatewayEventForTask(ctx, task); err != nil {
 		return err
 	} else if ok {
-		return m.store.ReleaseLock(ctx, event.Namespace, event.SessionName, task.Name, string(task.UID))
+		// Gateway terminal projection owns lock release atomically with its
+		// canonical assistant message and delivery outbox row. Generic Task
+		// finalization must remain a no-op even when a malformed session policy
+		// caused the admitted Gateway Task to fail.
+		return nil
 	}
 	if task.Spec.SessionRef == nil {
 		return nil
@@ -172,6 +176,14 @@ func (m *SessionManager) createSession(ctx context.Context, task *corev1alpha1.T
 // AppendMessages appends messages from a completed task to the session.
 // The resultStore is used to fetch the task result for the assistant message.
 func (m *SessionManager) AppendMessages(ctx context.Context, task *corev1alpha1.Task, resultStore store.ResultStore) error {
+	if _, ok, err := m.gatewayEventForTask(ctx, task); err != nil {
+		return err
+	} else if ok {
+		// Gateway terminal projection is the only writer for the canonical
+		// assistant message. Do not inspect a potentially modified SessionRef or
+		// read the Task result from generic finalization.
+		return nil
+	}
 	if task.Spec.SessionRef == nil || !task.Spec.SessionRef.Append {
 		return nil
 	}

--- a/internal/controller/session_manager_test.go
+++ b/internal/controller/session_manager_test.go
@@ -18,7 +18,27 @@ import (
 	"github.com/orka-agents/orka/internal/store/sqlite"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
+
+const sessionRoleUser = "user"
+
+type countingSessionResultStore struct {
+	reads int
+}
+
+func (s *countingSessionResultStore) SaveResult(context.Context, string, string, []byte) error {
+	return nil
+}
+
+func (s *countingSessionResultStore) GetResult(context.Context, string, string) ([]byte, error) {
+	s.reads++
+	return []byte("generic finalization must not project this result"), nil
+}
+
+func (s *countingSessionResultStore) DeleteResult(context.Context, string, string) error {
+	return nil
+}
 
 func setupSessionManager() (*SessionManager, *sqlite.Store) {
 	db, err := sqlite.NewDB(":memory:")
@@ -390,7 +410,7 @@ func TestSessionManager_LoadTranscript_WithMessages(t *testing.T) {
 		SessionType: "task",
 	}))
 	require.NoError(t, ss.AppendMessages(ctx, "default", "test-session", []store.SessionMessage{
-		{Role: "user", Content: "hello"},
+		{Role: sessionRoleUser, Content: "hello"},
 		{Role: "assistant", Content: "hi"},
 	}))
 
@@ -426,11 +446,11 @@ func TestSessionManager_LoadTranscript_MaxMessages(t *testing.T) {
 		SessionType: "task",
 	}))
 	require.NoError(t, ss.AppendMessages(ctx, "default", "test-session", []store.SessionMessage{
-		{Role: "user", Content: "msg1"},
+		{Role: sessionRoleUser, Content: "msg1"},
 		{Role: "assistant", Content: "msg2"},
-		{Role: "user", Content: "msg3"},
+		{Role: sessionRoleUser, Content: "msg3"},
 		{Role: "assistant", Content: "msg4"},
-		{Role: "user", Content: "msg5"},
+		{Role: sessionRoleUser, Content: "msg5"},
 	}))
 
 	task := &corev1alpha1.Task{
@@ -619,7 +639,7 @@ func TestSessionManager_AppendMessages_WithPromptAndResult(t *testing.T) {
 	if len(msgs) != 2 {
 		t.Fatalf("expected 2 messages, got %d", len(msgs))
 	}
-	if msgs[0].Role != "user" || msgs[0].Content != "What is the answer?" {
+	if msgs[0].Role != sessionRoleUser || msgs[0].Content != "What is the answer?" {
 		t.Errorf("user message = %v, want user/What is the answer?", msgs[0])
 	}
 	if msgs[1].Role != "assistant" || msgs[1].Content != "Here is the answer" {
@@ -634,7 +654,7 @@ func TestSessionManager_AppendMessages_PromptIncludedSkipsDuplicateUserMessage(t
 		Namespace: "default", Name: "prompt-included-session", SessionType: "task",
 	}))
 	require.NoError(t, ss.AppendMessages(ctx, "default", "prompt-included-session", []store.SessionMessage{{
-		Role: "user", Content: "canonical transcript prompt", Timestamp: time.Now(),
+		Role: sessionRoleUser, Content: "canonical transcript prompt", Timestamp: time.Now(),
 	}}))
 	require.NoError(t, ss.SaveResult(ctx, defaultNS, testTask, []byte("assistant result")))
 	task := &corev1alpha1.Task{
@@ -702,7 +722,7 @@ func TestSessionManager_AppendMessages_NilResultStore(t *testing.T) {
 	if len(msgs) != 1 {
 		t.Fatalf("expected only the user message to be appended, got %d messages", len(msgs))
 	}
-	if msgs[0].Role != "user" || msgs[0].Content != "What is the answer?" {
+	if msgs[0].Role != sessionRoleUser || msgs[0].Content != "What is the answer?" {
 		t.Errorf("user message = %v, want user/What is the answer?", msgs[0])
 	}
 }
@@ -770,10 +790,10 @@ func TestSessionManagerLoadsTranscriptThroughStableMessageID(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := ss.AppendMessages(ctx, "default", "cutoff-session", []store.SessionMessage{
-		{ID: "prior-user", Order: 2, Role: "user", Content: "first"},
+		{ID: "prior-user", Order: 2, Role: sessionRoleUser, Content: "first"},
 		{ID: "prior-assistant", Order: 3, Role: "assistant", Content: "reply"},
-		{ID: store.GatewayUserMessageID("gateway-event"), Order: 4, Role: "user", Content: "current"},
-		{ID: "future-user", Order: 6, Role: "user", Content: "future"},
+		{ID: store.GatewayUserMessageID("gateway-event"), Order: 4, Role: sessionRoleUser, Content: "current"},
+		{ID: "future-user", Order: 6, Role: sessionRoleUser, Content: "future"},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -791,5 +811,78 @@ func TestSessionManagerLoadsTranscriptThroughStableMessageID(t *testing.T) {
 	}
 	if len(messages) != 3 || messages[0].Content != "first" || messages[1].Content != "reply" || messages[2].Content != "current" {
 		t.Fatalf("cutoff transcript = %#v", messages)
+	}
+}
+
+func TestSessionManagerDefersGatewayTranscriptAndLockFinalization(t *testing.T) {
+	db, err := sqlite.NewDB(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	ss := sqlite.NewStore(db, ":memory:")
+	ctx := context.Background()
+	now := time.Now().UTC()
+	event := store.GatewayEvent{
+		ID: "gateway-finalize-event", Namespace: "default", NamespaceUID: "namespace-uid",
+		GatewayUID: "gateway-uid", GatewayGeneration: 1, GatewayName: "chat",
+		BindingName: "room", BindingUID: "binding-uid", ExternalEventID: "gateway-finalize-external",
+		ProtocolVersion: "orka.gateway.v1", EventType: "text", AccountID: "acct", ContextID: "room",
+		SenderID: "sender", Text: "current", ReplyTarget: "room", SessionName: "gateway-finalize-session",
+		TaskName: "gateway-finalize-task", ReceivedAt: now, NextAttemptAt: now,
+		ExpiresAt: now.Add(time.Hour), CreatedAt: now, UpdatedAt: now,
+	}
+	if _, _, err := ss.AdmitGatewayEvent(ctx, store.GatewayEventAdmission{
+		Event: event, AppendUserMessage: true, PendingLimit: 100,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	claimed, err := ss.ClaimNextGatewayEvent(ctx, event.Namespace, "dispatcher", now, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const taskUID = "gateway-finalize-task-uid"
+	if err := ss.MarkGatewayEventTaskCreated(
+		ctx, event.Namespace, event.ID, claimed.TaskName, taskUID, "dispatcher", now,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	manager := NewSessionManager(ss)
+	manager.SetGatewayEventStore(ss)
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: claimed.TaskName, Namespace: event.Namespace, UID: types.UID(taskUID),
+		},
+		// Use an admitted but malformed policy to prove generic finalization does
+		// not revalidate the policy before deferring to Gateway projection.
+		Spec: corev1alpha1.TaskSpec{SessionRef: &corev1alpha1.SessionReference{
+			Name: event.SessionName, Create: true, Append: true, MaxMessages: 1,
+		}},
+		Status: corev1alpha1.TaskStatus{ResultRef: &corev1alpha1.ResultReference{Available: true}},
+	}
+	results := &countingSessionResultStore{}
+	if err := manager.AppendMessages(ctx, task, results); err != nil {
+		t.Fatalf("AppendMessages() error = %v", err)
+	}
+	if err := manager.ReleaseLock(ctx, task); err != nil {
+		t.Fatalf("ReleaseLock() error = %v", err)
+	}
+	if results.reads != 0 {
+		t.Fatalf("generic finalization read the Gateway result %d times", results.reads)
+	}
+
+	session, err := ss.GetSession(ctx, event.Namespace, event.SessionName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.ActiveTask != task.Name || session.ActiveTaskUID != string(task.UID) {
+		t.Fatalf(
+			"gateway session lock = (%q, %q), want (%q, %q)",
+			session.ActiveTask, session.ActiveTaskUID, task.Name, task.UID,
+		)
+	}
+	if len(session.Messages) != 1 || session.Messages[0].Role != sessionRoleUser {
+		t.Fatalf("gateway transcript was generically finalized: %#v", session.Messages)
 	}
 }

--- a/internal/gateway/service_test.go
+++ b/internal/gateway/service_test.go
@@ -816,6 +816,70 @@ func TestNamespaceTaskCapacityAvailableCountsFinalizingButNotTerminalTasks(t *te
 	}
 }
 
+func TestProjectTerminalsLeavesFinalizingTaskOwnedByGateway(t *testing.T) {
+	service, sqliteStore, _ := newGatewayServiceFixture(t)
+	ctx := context.Background()
+	accepted, err := service.AdmitEvent(
+		ctx,
+		"default",
+		"chat",
+		"Bearer inbound-token",
+		gatewayEventBody(t, "finalizing-task", "user-1"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := service.DispatchOnce(ctx); err != nil {
+		t.Fatal(err)
+	}
+	event, err := sqliteStore.GetGatewayEvent(ctx, "default", accepted.EventID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	task := &corev1alpha1.Task{}
+	key := client.ObjectKey{Namespace: event.Namespace, Name: event.TaskName}
+	if err := service.freshReader().Get(ctx, key, task); err != nil {
+		t.Fatal(err)
+	}
+	task.Status.Phase = corev1alpha1.TaskPhaseFinalizing
+	if err := service.Client.Status().Update(ctx, task); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := service.ProjectTerminals(ctx); err != nil {
+		t.Fatal(err)
+	}
+	event, err = sqliteStore.GetGatewayEvent(ctx, "default", accepted.EventID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.State != store.GatewayEventTaskCreated {
+		t.Fatalf("Finalizing event state = %s, want TaskCreated", event.State)
+	}
+	session, err := sqliteStore.GetSession(ctx, event.Namespace, event.SessionName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.ActiveTask != task.Name || session.ActiveTaskUID != string(task.UID) {
+		t.Fatalf(
+			"Finalizing session lock = (%q, %q), want (%q, %q)",
+			session.ActiveTask, session.ActiveTaskUID, task.Name, task.UID,
+		)
+	}
+	if len(session.Messages) != 1 || session.Messages[0].Role != "user" {
+		t.Fatalf("Finalizing session transcript = %#v, want only admitted user message", session.Messages)
+	}
+	deliveries, err := sqliteStore.ListGatewayDeliveries(ctx, store.GatewayDeliveryFilter{
+		Namespace: event.Namespace, EventID: event.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deliveries) != 0 {
+		t.Fatalf("Finalizing Task created terminal deliveries: %#v", deliveries)
+	}
+}
+
 func TestDispatchOnceCountsFinalizingTaskTowardNamespaceLimitAcrossSessions(t *testing.T) {
 	service, sqliteStore, _ := newGatewayServiceFixture(t)
 	service.Config.MaxTasksPerNamespace = 1

--- a/internal/store/sqlite/chat_turn_test.go
+++ b/internal/store/sqlite/chat_turn_test.go
@@ -54,12 +54,16 @@ func TestChatTurnMigrationPreservesExistingSession(t *testing.T) {
 	t.Cleanup(func() { _ = db.Close() })
 	s := NewStore(db, dbPath)
 	now := time.Now().UTC()
-	if err := s.AcquireChatTurn(context.Background(), &store.SessionRecord{
+	created, err := s.AcquireChatTurn(context.Background(), &store.SessionRecord{
 		Namespace: "default", Name: "legacy-chat", SessionType: "chat",
-	}, "turn-migrated", now.Add(time.Minute)); err != nil {
+	}, "turn-migrated", now.Add(time.Minute))
+	if err != nil {
 		t.Fatalf("AcquireChatTurn() after migration error = %v", err)
 	}
-	if err := s.ReleaseChatTurn(context.Background(), "default", "legacy-chat", "turn-migrated"); err != nil {
+	if created {
+		t.Fatal("AcquireChatTurn() reported an existing migrated session as newly created")
+	}
+	if err := s.ReleaseChatTurn(context.Background(), "default", "legacy-chat", "turn-migrated", created); err != nil {
 		t.Fatalf("ReleaseChatTurn() after migration error = %v", err)
 	}
 	session, err := s.GetSession(context.Background(), "default", "legacy-chat")
@@ -78,27 +82,50 @@ func TestAcquireChatTurnFencesConcurrentAndRecoveredTurns(t *testing.T) {
 	session := &store.SessionRecord{
 		Namespace: "default", Name: "chat-session", SessionType: "chat", CreatedAt: now, UpdatedAt: now,
 	}
-	if err := s.AcquireChatTurn(ctx, session, "turn-a", now.Add(time.Minute)); err != nil {
+	created, err := s.AcquireChatTurn(ctx, session, "turn-a", now.Add(time.Minute))
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.AcquireChatTurn(ctx, session, "turn-b", now.Add(time.Minute)); !errors.Is(err, store.ErrConflict) {
+	if !created {
+		t.Fatal("AcquireChatTurn() did not report a newly created session")
+	}
+	if _, err := s.AcquireChatTurn(ctx, session, "turn-b", now.Add(time.Minute)); !errors.Is(err, store.ErrConflict) {
 		t.Fatalf("concurrent AcquireChatTurn() error = %v, want ErrConflict", err)
 	}
 
-	// Chat reservations and Task locks are separate domains. A child Task may
-	// run while the chat turn waits, but another chat turn still cannot start.
-	if err := s.AcquireLock(ctx, "default", "chat-session", "task-a", "task-uid"); err != nil {
-		t.Fatalf("AcquireLock() during chat turn error = %v", err)
-	}
-	if err := s.ReleaseLock(ctx, "default", "chat-session", "task-a", "task-uid"); err != nil {
+	locked, err := s.IsLocked(ctx, "default", "chat-session", "task-a", "task-uid")
+	if err != nil {
 		t.Fatal(err)
+	}
+	if !locked {
+		t.Fatal("IsLocked() did not report the active chat turn")
+	}
+	if err := s.AcquireLock(ctx, "default", "chat-session", "task-a", "task-uid"); err == nil {
+		t.Fatal("AcquireLock() acquired the same session during an active chat turn")
+	}
+	if err := s.CreateSession(ctx, &store.SessionRecord{
+		Namespace: "default", Name: "child-session", SessionType: "task", CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AcquireLock(ctx, "default", "child-session", "child-task", "child-task-uid"); err != nil {
+		t.Fatalf("AcquireLock() rejected a Task using a different session: %v", err)
 	}
 
 	if _, err := s.db.Exec(`UPDATE sessions SET chat_turn_expires_at = ?
 		WHERE namespace = ? AND name = ?`, now.Add(-time.Second), "default", "chat-session"); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.AcquireChatTurn(ctx, session, "turn-b", now.Add(time.Minute)); err != nil {
+	if err := s.AcquireLock(ctx, "default", "chat-session", "task-a", "task-uid"); err != nil {
+		t.Fatalf("AcquireLock() did not reclaim an expired chat turn: %v", err)
+	}
+	if _, err := s.AcquireChatTurn(ctx, session, "turn-b", now.Add(time.Minute)); !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("AcquireChatTurn() stole an active Task lock: %v", err)
+	}
+	if err := s.ReleaseLock(ctx, "default", "chat-session", "task-a", "task-uid"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.AcquireChatTurn(ctx, session, "turn-b", now.Add(time.Minute)); err != nil {
 		t.Fatalf("AcquireChatTurn() did not recover expired reservation: %v", err)
 	}
 	if err := s.CommitSessionTurn(ctx, session, "turn-a", 0, []store.SessionMessage{{
@@ -107,13 +134,13 @@ func TestAcquireChatTurnFencesConcurrentAndRecoveredTurns(t *testing.T) {
 		t.Fatalf("recovered owner accepted stale commit: %v", err)
 	}
 
-	if err := s.ReleaseChatTurn(ctx, "default", "chat-session", "turn-b"); err != nil {
+	if err := s.ReleaseChatTurn(ctx, "default", "chat-session", "turn-b", false); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.AcquireLock(ctx, "default", "chat-session", "task-b", "task-b-uid"); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.AcquireChatTurn(ctx, session, "turn-c", now.Add(time.Minute)); !errors.Is(err, store.ErrConflict) {
+	if _, err := s.AcquireChatTurn(ctx, session, "turn-c", now.Add(time.Minute)); !errors.Is(err, store.ErrConflict) {
 		t.Fatalf("AcquireChatTurn() stole active Task lock: %v", err)
 	}
 
@@ -124,9 +151,117 @@ func TestAcquireChatTurnFencesConcurrentAndRecoveredTurns(t *testing.T) {
 	if err := s.CreateSession(ctx, gateway); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.AcquireChatTurn(ctx, gateway, "turn-gateway", now.Add(time.Minute)); !errors.Is(err, store.ErrGatewayOwnedSession) {
+	if _, err := s.AcquireChatTurn(ctx, gateway, "turn-gateway", now.Add(time.Minute)); !errors.Is(err, store.ErrGatewayOwnedSession) {
 		t.Fatalf("AcquireChatTurn() gateway error = %v, want ErrGatewayOwnedSession", err)
 	}
+}
+
+func TestCommitSessionTurnRejectsActiveTaskFence(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	session := &store.SessionRecord{
+		Namespace: "default", Name: "task-fenced-chat", SessionType: store.SessionTypeChat,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if _, err := s.AcquireChatTurn(ctx, session, "turn-fenced", now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE sessions SET active_task = ?, active_task_uid = ?
+		WHERE namespace = ? AND name = ?`, "interleaved-task", "task-uid", "default", "task-fenced-chat"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := s.CommitSessionTurn(ctx, session, "turn-fenced", 0, []store.SessionMessage{
+		{Role: "user", Content: "must not commit"},
+		{Role: "assistant", Content: "also fenced"},
+	}, 8, 5)
+	if !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("CommitSessionTurn() active Task error = %v, want ErrConflict", err)
+	}
+	got, err := s.GetSession(ctx, "default", "task-fenced-chat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MessageCount != 0 || got.InputTokens != 0 || got.OutputTokens != 0 || len(got.Messages) != 0 {
+		t.Fatalf("active Task fence allowed a partial chat commit: %+v", got)
+	}
+}
+
+func TestReleaseChatTurnDeletesOnlyCreatedEmptySession(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	t.Run("new failed turn is removed", func(t *testing.T) {
+		session := &store.SessionRecord{
+			Namespace: "default", Name: "new-empty-chat", SessionType: store.SessionTypeChat,
+			CreatedAt: now, UpdatedAt: now,
+		}
+		created, err := s.AcquireChatTurn(ctx, session, "turn-new-empty", now.Add(time.Minute))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !created {
+			t.Fatal("AcquireChatTurn() did not report a new Session")
+		}
+		if err := s.ReleaseChatTurn(ctx, "default", "new-empty-chat", "turn-new-empty", created); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.GetSession(ctx, "default", "new-empty-chat"); !errors.Is(err, store.ErrNotFound) {
+			t.Fatalf("GetSession() after failed new turn error = %v, want ErrNotFound", err)
+		}
+	})
+
+	t.Run("preexisting empty session is retained", func(t *testing.T) {
+		session := &store.SessionRecord{
+			Namespace: "default", Name: "existing-empty-chat", SessionType: store.SessionTypeChat,
+			CreatedAt: now, UpdatedAt: now,
+		}
+		if err := s.CreateSession(ctx, session); err != nil {
+			t.Fatal(err)
+		}
+		created, err := s.AcquireChatTurn(ctx, session, "turn-existing-empty", now.Add(time.Minute))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if created {
+			t.Fatal("AcquireChatTurn() reported a preexisting Session as new")
+		}
+		if err := s.ReleaseChatTurn(ctx, "default", "existing-empty-chat", "turn-existing-empty", created); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.GetSession(ctx, "default", "existing-empty-chat"); err != nil {
+			t.Fatalf("GetSession() after releasing preexisting Session error = %v", err)
+		}
+	})
+
+	t.Run("committed new session is retained", func(t *testing.T) {
+		session := &store.SessionRecord{
+			Namespace: "default", Name: "new-committed-chat", SessionType: store.SessionTypeChat,
+			CreatedAt: now, UpdatedAt: now,
+		}
+		created, err := s.AcquireChatTurn(ctx, session, "turn-new-committed", now.Add(time.Minute))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.CommitSessionTurn(ctx, session, "turn-new-committed", 0, []store.SessionMessage{
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: "hi"},
+		}, 4, 2); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.ReleaseChatTurn(ctx, "default", "new-committed-chat", "turn-new-committed", created); err != nil {
+			t.Fatal(err)
+		}
+		got, err := s.GetSession(ctx, "default", "new-committed-chat")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.MessageCount != 2 {
+			t.Fatalf("committed Session message count = %d, want 2", got.MessageCount)
+		}
+	})
 }
 
 func TestCommitSessionTurnPreservesStableMessageOrderingAndUsage(t *testing.T) {
@@ -136,7 +271,7 @@ func TestCommitSessionTurnPreservesStableMessageOrderingAndUsage(t *testing.T) {
 	session := &store.SessionRecord{
 		Namespace: "default", Name: "atomic-chat", SessionType: "chat", CreatedAt: now, UpdatedAt: now,
 	}
-	if err := s.AcquireChatTurn(ctx, session, "turn-one", now.Add(time.Minute)); err != nil {
+	if _, err := s.AcquireChatTurn(ctx, session, "turn-one", now.Add(time.Minute)); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.CommitSessionTurn(ctx, session, "turn-one", 0, []store.SessionMessage{
@@ -145,7 +280,7 @@ func TestCommitSessionTurnPreservesStableMessageOrderingAndUsage(t *testing.T) {
 	}, 13, 8); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.ReleaseChatTurn(ctx, "default", "atomic-chat", "turn-one"); err != nil {
+	if err := s.ReleaseChatTurn(ctx, "default", "atomic-chat", "turn-one", false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -163,7 +298,7 @@ func TestCommitSessionTurnPreservesStableMessageOrderingAndUsage(t *testing.T) {
 		t.Fatalf("logical message orders = (%d, %d), want (2, 4)", got.Messages[0].Order, got.Messages[1].Order)
 	}
 
-	if err := s.AcquireChatTurn(ctx, session, "turn-two", now.Add(time.Minute)); err != nil {
+	if _, err := s.AcquireChatTurn(ctx, session, "turn-two", now.Add(time.Minute)); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.CommitSessionTurn(ctx, session, "turn-two", 2, []store.SessionMessage{{
@@ -187,7 +322,7 @@ func TestCommitSessionTurnRollsBackMessagesAndUsageTogether(t *testing.T) {
 	session := &store.SessionRecord{
 		Namespace: "default", Name: "rollback-chat", SessionType: "chat", CreatedAt: now, UpdatedAt: now,
 	}
-	if err := s.AcquireChatTurn(ctx, session, "turn-rollback", now.Add(time.Minute)); err != nil {
+	if _, err := s.AcquireChatTurn(ctx, session, "turn-rollback", now.Add(time.Minute)); err != nil {
 		t.Fatal(err)
 	}
 	err := s.CommitSessionTurn(ctx, session, "turn-rollback", 0, []store.SessionMessage{
@@ -213,7 +348,7 @@ func TestCommitSessionTurnRejectsInterleavedTranscriptRevision(t *testing.T) {
 	session := &store.SessionRecord{
 		Namespace: "default", Name: "interleaved-chat", SessionType: "chat", CreatedAt: now, UpdatedAt: now,
 	}
-	if err := s.AcquireChatTurn(ctx, session, "turn-interleaved", now.Add(time.Minute)); err != nil {
+	if _, err := s.AcquireChatTurn(ctx, session, "turn-interleaved", now.Add(time.Minute)); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.AppendMessages(ctx, "default", "interleaved-chat", []store.SessionMessage{{

--- a/internal/store/sqlite/chat_turn_test.go
+++ b/internal/store/sqlite/chat_turn_test.go
@@ -1,0 +1,239 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/orka-agents/orka/internal/store"
+)
+
+func TestChatTurnMigrationPreservesExistingSession(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "legacy-sessions.db")
+	legacyDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = legacyDB.Exec(`CREATE TABLE sessions (
+		namespace TEXT NOT NULL,
+		name TEXT NOT NULL,
+		session_type TEXT NOT NULL DEFAULT 'task',
+		owner_type TEXT NOT NULL DEFAULT '',
+		owner_ref TEXT NOT NULL DEFAULT '',
+		active_task TEXT NOT NULL DEFAULT '',
+		active_task_uid TEXT NOT NULL DEFAULT '',
+		message_count INTEGER NOT NULL DEFAULT 0,
+		input_tokens INTEGER NOT NULL DEFAULT 0,
+		output_tokens INTEGER NOT NULL DEFAULT 0,
+		cancelled BOOLEAN NOT NULL DEFAULT FALSE,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY (namespace, name)
+	)`)
+	if err != nil {
+		_ = legacyDB.Close()
+		t.Fatal(err)
+	}
+	if _, err := legacyDB.Exec(`INSERT INTO sessions
+		(namespace, name, session_type, message_count, input_tokens, output_tokens)
+		VALUES ('default', 'legacy-chat', 'chat', 3, 11, 7)`); err != nil {
+		_ = legacyDB.Close()
+		t.Fatal(err)
+	}
+	if err := legacyDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := NewDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	s := NewStore(db, dbPath)
+	now := time.Now().UTC()
+	if err := s.AcquireChatTurn(context.Background(), &store.SessionRecord{
+		Namespace: "default", Name: "legacy-chat", SessionType: "chat",
+	}, "turn-migrated", now.Add(time.Minute)); err != nil {
+		t.Fatalf("AcquireChatTurn() after migration error = %v", err)
+	}
+	if err := s.ReleaseChatTurn(context.Background(), "default", "legacy-chat", "turn-migrated"); err != nil {
+		t.Fatalf("ReleaseChatTurn() after migration error = %v", err)
+	}
+	session, err := s.GetSession(context.Background(), "default", "legacy-chat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.SessionType != "chat" || session.MessageCount != 3 || session.InputTokens != 11 || session.OutputTokens != 7 {
+		t.Fatalf("session changed during migration: %+v", session)
+	}
+}
+
+func TestAcquireChatTurnFencesConcurrentAndRecoveredTurns(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	session := &store.SessionRecord{
+		Namespace: "default", Name: "chat-session", SessionType: "chat", CreatedAt: now, UpdatedAt: now,
+	}
+	if err := s.AcquireChatTurn(ctx, session, "turn-a", now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AcquireChatTurn(ctx, session, "turn-b", now.Add(time.Minute)); !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("concurrent AcquireChatTurn() error = %v, want ErrConflict", err)
+	}
+
+	// Chat reservations and Task locks are separate domains. A child Task may
+	// run while the chat turn waits, but another chat turn still cannot start.
+	if err := s.AcquireLock(ctx, "default", "chat-session", "task-a", "task-uid"); err != nil {
+		t.Fatalf("AcquireLock() during chat turn error = %v", err)
+	}
+	if err := s.ReleaseLock(ctx, "default", "chat-session", "task-a", "task-uid"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.db.Exec(`UPDATE sessions SET chat_turn_expires_at = ?
+		WHERE namespace = ? AND name = ?`, now.Add(-time.Second), "default", "chat-session"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AcquireChatTurn(ctx, session, "turn-b", now.Add(time.Minute)); err != nil {
+		t.Fatalf("AcquireChatTurn() did not recover expired reservation: %v", err)
+	}
+	if err := s.CommitSessionTurn(ctx, session, "turn-a", 0, []store.SessionMessage{{
+		Role: "user", Content: "stale",
+	}}, 1, 1); !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("recovered owner accepted stale commit: %v", err)
+	}
+
+	if err := s.ReleaseChatTurn(ctx, "default", "chat-session", "turn-b"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AcquireLock(ctx, "default", "chat-session", "task-b", "task-b-uid"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AcquireChatTurn(ctx, session, "turn-c", now.Add(time.Minute)); !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("AcquireChatTurn() stole active Task lock: %v", err)
+	}
+
+	gateway := &store.SessionRecord{
+		Namespace: "default", Name: "gateway-session", SessionType: store.SessionTypeGateway,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := s.CreateSession(ctx, gateway); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AcquireChatTurn(ctx, gateway, "turn-gateway", now.Add(time.Minute)); !errors.Is(err, store.ErrGatewayOwnedSession) {
+		t.Fatalf("AcquireChatTurn() gateway error = %v, want ErrGatewayOwnedSession", err)
+	}
+}
+
+func TestCommitSessionTurnPreservesStableMessageOrderingAndUsage(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	session := &store.SessionRecord{
+		Namespace: "default", Name: "atomic-chat", SessionType: "chat", CreatedAt: now, UpdatedAt: now,
+	}
+	if err := s.AcquireChatTurn(ctx, session, "turn-one", now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CommitSessionTurn(ctx, session, "turn-one", 0, []store.SessionMessage{
+		{Role: "user", Content: "hello", Timestamp: now},
+		{Role: "assistant", Content: "hi", Timestamp: now},
+	}, 13, 8); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ReleaseChatTurn(ctx, "default", "atomic-chat", "turn-one"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetSession(ctx, "default", "atomic-chat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MessageCount != 2 || got.InputTokens != 13 || got.OutputTokens != 8 || len(got.Messages) != 2 {
+		t.Fatalf("first atomic turn = %+v", got)
+	}
+	if got.Messages[0].ID == "" || got.Messages[1].ID == "" || got.Messages[0].ID == got.Messages[1].ID {
+		t.Fatalf("stable message IDs = (%q, %q)", got.Messages[0].ID, got.Messages[1].ID)
+	}
+	if got.Messages[0].Order != 2 || got.Messages[1].Order != 4 {
+		t.Fatalf("logical message orders = (%d, %d), want (2, 4)", got.Messages[0].Order, got.Messages[1].Order)
+	}
+
+	if err := s.AcquireChatTurn(ctx, session, "turn-two", now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CommitSessionTurn(ctx, session, "turn-two", 2, []store.SessionMessage{{
+		Role: "user", Content: "again", Timestamp: now.Add(time.Second),
+	}}, 5, 3); err != nil {
+		t.Fatal(err)
+	}
+	got, err = s.GetSession(ctx, "default", "atomic-chat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MessageCount != 3 || got.InputTokens != 18 || got.OutputTokens != 11 || got.Messages[2].Order != 6 {
+		t.Fatalf("second atomic turn = %+v", got)
+	}
+}
+
+func TestCommitSessionTurnRollsBackMessagesAndUsageTogether(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	session := &store.SessionRecord{
+		Namespace: "default", Name: "rollback-chat", SessionType: "chat", CreatedAt: now, UpdatedAt: now,
+	}
+	if err := s.AcquireChatTurn(ctx, session, "turn-rollback", now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	err := s.CommitSessionTurn(ctx, session, "turn-rollback", 0, []store.SessionMessage{
+		{Role: "user", Content: "first"},
+		{Role: "assistant", Content: "invalid", Input: map[string]any{"bad": make(chan int)}},
+	}, 21, 34)
+	if err == nil {
+		t.Fatal("CommitSessionTurn() succeeded with an unencodable message")
+	}
+	got, getErr := s.GetSession(ctx, "default", "rollback-chat")
+	if getErr != nil {
+		t.Fatal(getErr)
+	}
+	if got.MessageCount != 0 || got.InputTokens != 0 || got.OutputTokens != 0 || len(got.Messages) != 0 {
+		t.Fatalf("failed turn was partially committed: %+v", got)
+	}
+}
+
+func TestCommitSessionTurnRejectsInterleavedTranscriptRevision(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	session := &store.SessionRecord{
+		Namespace: "default", Name: "interleaved-chat", SessionType: "chat", CreatedAt: now, UpdatedAt: now,
+	}
+	if err := s.AcquireChatTurn(ctx, session, "turn-interleaved", now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendMessages(ctx, "default", "interleaved-chat", []store.SessionMessage{{
+		ID: "task:result", Role: "assistant", Content: "concurrent task result", Timestamp: now,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CommitSessionTurn(ctx, session, "turn-interleaved", 0, []store.SessionMessage{{
+		Role: "user", Content: "chat message", Timestamp: now,
+	}}, 9, 4); !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("CommitSessionTurn() interleaved error = %v, want ErrConflict", err)
+	}
+	got, err := s.GetSession(ctx, "default", "interleaved-chat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MessageCount != 1 || len(got.Messages) != 1 || got.Messages[0].ID != "task:result" {
+		t.Fatalf("interleaved transcript changed unexpectedly: %+v", got)
+	}
+	if got.InputTokens != 0 || got.OutputTokens != 0 {
+		t.Fatalf("interleaved commit updated tokens: (%d, %d)", got.InputTokens, got.OutputTokens)
+	}
+}

--- a/internal/store/sqlite/session_store.go
+++ b/internal/store/sqlite/session_store.go
@@ -13,6 +13,11 @@ import (
 	"github.com/orka-agents/orka/internal/store"
 )
 
+var (
+	_ store.SessionStore         = (*Store)(nil)
+	_ store.SessionTurnCommitter = (*Store)(nil)
+)
+
 // CreateSession inserts a new session record.
 func (s *Store) CreateSession(ctx context.Context, session *store.SessionRecord) error {
 	_, err := s.db.ExecContext(ctx,
@@ -220,6 +225,193 @@ func (s *Store) AcquireLock(ctx context.Context, namespace, name, taskName, task
 	return nil
 }
 
+// AcquireChatTurn creates a chat Session when needed and reserves its current
+// transcript revision for one turn. Expired reservations may be reclaimed, but
+// Task locks and Gateway-owned Sessions are never taken over by chat.
+func (s *Store) AcquireChatTurn(
+	ctx context.Context,
+	session *store.SessionRecord,
+	turnID string,
+	expiresAt time.Time,
+) error {
+	if session == nil {
+		return store.ValidationErrorf("session is required")
+	}
+	if session.Namespace == "" || session.Name == "" || session.SessionType == "" || turnID == "" {
+		return store.ValidationErrorf("session namespace, name, type, and turn ID are required")
+	}
+	now := time.Now().UTC()
+	expiresAt = expiresAt.UTC()
+	if !expiresAt.After(now) {
+		return store.ValidationErrorf("chat turn expiration must be in the future")
+	}
+	createdAt := session.CreatedAt.UTC()
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO sessions
+		 (namespace, name, session_type, active_task, active_task_uid, message_count, input_tokens, output_tokens, cancelled, created_at, updated_at)
+		 VALUES (?, ?, ?, '', '', 0, 0, 0, ?, ?, ?)
+		 ON CONFLICT(namespace, name) DO NOTHING`,
+		session.Namespace, session.Name, session.SessionType, session.Cancelled, createdAt, now,
+	); err != nil {
+		return err
+	}
+
+	var sessionType, ownerType, activeTask, activeTurn string
+	var activeTurnExpiresAt sql.NullTime
+	if err := tx.QueryRowContext(ctx,
+		`SELECT session_type, owner_type, active_task, chat_turn_id, chat_turn_expires_at
+		 FROM sessions WHERE namespace = ? AND name = ?`,
+		session.Namespace, session.Name,
+	).Scan(&sessionType, &ownerType, &activeTask, &activeTurn, &activeTurnExpiresAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return store.ErrNotFound
+		}
+		return err
+	}
+	if sessionType == store.SessionTypeGateway || ownerType == gatewaySessionOwnerType {
+		return store.ErrGatewayOwnedSession
+	}
+	if activeTask != "" {
+		return fmt.Errorf("%w: chat session %s/%s has an active Task", store.ErrConflict, session.Namespace, session.Name)
+	}
+	if activeTurn != "" && activeTurnExpiresAt.Valid && activeTurnExpiresAt.Time.After(now) {
+		return fmt.Errorf("%w: chat session %s/%s already has an active turn", store.ErrConflict, session.Namespace, session.Name)
+	}
+
+	result, err := tx.ExecContext(ctx,
+		`UPDATE sessions SET chat_turn_id = ?, chat_turn_expires_at = ?, updated_at = ?
+		 WHERE namespace = ? AND name = ? AND active_task = ''
+		 AND session_type <> ? AND owner_type <> ?
+		 AND (chat_turn_id = '' OR chat_turn_expires_at IS NULL OR chat_turn_expires_at <= ?)`,
+		turnID, expiresAt, now, session.Namespace, session.Name,
+		store.SessionTypeGateway, gatewaySessionOwnerType, now,
+	)
+	if err != nil {
+		return err
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if updated != 1 {
+		return fmt.Errorf("%w: chat session %s/%s already has an active turn", store.ErrConflict, session.Namespace, session.Name)
+	}
+	return tx.Commit()
+}
+
+// ReleaseChatTurn clears a reservation only when it is still owned by turnID.
+func (s *Store) ReleaseChatTurn(ctx context.Context, namespace, name, turnID string) error {
+	if turnID == "" {
+		return nil
+	}
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE sessions SET chat_turn_id = '', chat_turn_expires_at = NULL
+		 WHERE namespace = ? AND name = ? AND chat_turn_id = ?`,
+		namespace, name, turnID,
+	)
+	return err
+}
+
+// CommitSessionTurn atomically appends one chat turn's messages and token
+// usage. The reservation owner, lease, and observed message count fence the
+// commit against concurrent or recovered turns.
+func (s *Store) CommitSessionTurn(
+	ctx context.Context,
+	session *store.SessionRecord,
+	turnID string,
+	expectedMessageCount int,
+	messages []store.SessionMessage,
+	inputTokens, outputTokens int,
+) error {
+	if session == nil {
+		return store.ValidationErrorf("session is required")
+	}
+	if session.Namespace == "" || session.Name == "" || turnID == "" {
+		return store.ValidationErrorf("session namespace, name, and turn ID are required")
+	}
+	if expectedMessageCount < 0 {
+		return store.ValidationErrorf("expected message count must not be negative")
+	}
+	if inputTokens < 0 || outputTokens < 0 {
+		return store.ValidationErrorf("token increments must not be negative")
+	}
+	if len(messages) == 0 && (inputTokens != 0 || outputTokens != 0) {
+		return store.ValidationErrorf("token increments require transcript messages")
+	}
+
+	now := time.Now().UTC()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var sessionType, ownerType, activeTurn string
+	var activeTurnExpiresAt sql.NullTime
+	var currentMessageCount int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT session_type, owner_type, message_count, chat_turn_id, chat_turn_expires_at
+		 FROM sessions WHERE namespace = ? AND name = ?`,
+		session.Namespace, session.Name,
+	).Scan(&sessionType, &ownerType, &currentMessageCount, &activeTurn, &activeTurnExpiresAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return store.ErrNotFound
+		}
+		return err
+	}
+	if sessionType == store.SessionTypeGateway || ownerType == gatewaySessionOwnerType {
+		return store.ErrGatewayOwnedSession
+	}
+	if activeTurn != turnID {
+		return fmt.Errorf("%w: chat turn no longer owns session", store.ErrConflict)
+	}
+	if !activeTurnExpiresAt.Valid || !activeTurnExpiresAt.Time.After(now) {
+		return fmt.Errorf("%w: chat turn reservation expired", store.ErrConflict)
+	}
+	if currentMessageCount != expectedMessageCount {
+		return fmt.Errorf(
+			"%w: session message count is %d, expected %d",
+			store.ErrConflict, currentMessageCount, expectedMessageCount,
+		)
+	}
+
+	inserted, err := insertSessionMessagesTx(ctx, tx, session.Namespace, session.Name, messages)
+	if err != nil {
+		return err
+	}
+	if inserted != len(messages) {
+		return fmt.Errorf("%w: chat turn messages were already present", store.ErrConflict)
+	}
+	result, err := tx.ExecContext(ctx,
+		`UPDATE sessions
+		 SET message_count = message_count + ?, input_tokens = input_tokens + ?, output_tokens = output_tokens + ?, updated_at = ?
+		 WHERE namespace = ? AND name = ? AND message_count = ? AND chat_turn_id = ? AND chat_turn_expires_at > ?`,
+		inserted, inputTokens, outputTokens, now,
+		session.Namespace, session.Name, expectedMessageCount, turnID, now,
+	)
+	if err != nil {
+		return err
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if updated != 1 {
+		return fmt.Errorf("%w: session changed while committing turn", store.ErrConflict)
+	}
+	return tx.Commit()
+}
+
 // ReleaseLock clears the lock only for the exact Task incarnation.
 func (s *Store) ReleaseLock(ctx context.Context, namespace, name, taskName, taskUID string) error {
 	_, err := s.db.ExecContext(ctx,
@@ -271,67 +463,10 @@ func (s *Store) AppendMessages(ctx context.Context, namespace, name string, mess
 		return store.ErrConflict
 	}
 
-	stmt, err := tx.PrepareContext(ctx,
-		`INSERT INTO session_messages
-		 (namespace, session_name, message_id, sort_order, role, content, name, input, tool_calls, tool_call_id,
-		  source_type, source_ref, metadata_json, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		 ON CONFLICT(namespace, session_name, message_id) WHERE message_id <> '' DO NOTHING`,
-	)
+	inserted, err := insertSessionMessagesTx(ctx, tx, namespace, name, messages)
 	if err != nil {
 		return err
 	}
-	defer stmt.Close() //nolint:errcheck
-
-	inserted := 0
-	for _, msg := range messages {
-		inputJSON, toolCallsJSON, metadataJSON, err := encodeSessionMessagePayload(msg)
-		if err != nil {
-			return err
-		}
-		ts := msg.Timestamp
-		if ts.IsZero() {
-			ts = time.Now().UTC()
-		}
-		messageID := msg.ID
-		if messageID == "" {
-			messageID, err = newSessionMessageID()
-			if err != nil {
-				return err
-			}
-		}
-		logicalOrder := msg.Order
-		if logicalOrder <= 0 {
-			logicalOrder, err = nextSessionMessageOrderTx(ctx, tx, namespace, name)
-			if err != nil {
-				return err
-			}
-		}
-		result, err := stmt.ExecContext(ctx,
-			namespace, name, messageID, logicalOrder, msg.Role, msg.Content, nilIfEmpty(msg.Name), inputJSON,
-			toolCallsJSON, nilIfEmpty(msg.ToolCallID), msg.SourceType, msg.SourceRef, metadataJSON, ts,
-		)
-		if err != nil {
-			return err
-		}
-		rows, err := result.RowsAffected()
-		if err != nil {
-			return err
-		}
-		if rows == 0 {
-			matches, matchErr := sessionMessageMatchesTx(
-				ctx, tx, namespace, name, messageID, logicalOrder, msg.Order > 0, msg, inputJSON, toolCallsJSON, metadataJSON,
-			)
-			if matchErr != nil {
-				return matchErr
-			}
-			if !matches {
-				return store.ErrDuplicateMismatch
-			}
-		}
-		inserted += int(rows)
-	}
-
 	if inserted > 0 {
 		if _, err := tx.ExecContext(ctx,
 			`UPDATE sessions SET message_count = message_count + ?, updated_at = CURRENT_TIMESTAMP WHERE namespace = ? AND name = ?`,
@@ -341,6 +476,75 @@ func (s *Store) AppendMessages(ctx context.Context, namespace, name string, mess
 		}
 	}
 	return tx.Commit()
+}
+
+func insertSessionMessagesTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	namespace, name string,
+	messages []store.SessionMessage,
+) (int, error) {
+	stmt, err := tx.PrepareContext(ctx,
+		`INSERT INTO session_messages
+		 (namespace, session_name, message_id, sort_order, role, content, name, input, tool_calls, tool_call_id,
+		  source_type, source_ref, metadata_json, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(namespace, session_name, message_id) WHERE message_id <> '' DO NOTHING`,
+	)
+	if err != nil {
+		return 0, err
+	}
+	defer stmt.Close() //nolint:errcheck
+
+	inserted := 0
+	for _, msg := range messages {
+		inputJSON, toolCallsJSON, metadataJSON, err := encodeSessionMessagePayload(msg)
+		if err != nil {
+			return 0, err
+		}
+		ts := msg.Timestamp
+		if ts.IsZero() {
+			ts = time.Now().UTC()
+		}
+		messageID := msg.ID
+		if messageID == "" {
+			messageID, err = newSessionMessageID()
+			if err != nil {
+				return 0, err
+			}
+		}
+		logicalOrder := msg.Order
+		if logicalOrder <= 0 {
+			logicalOrder, err = nextSessionMessageOrderTx(ctx, tx, namespace, name)
+			if err != nil {
+				return 0, err
+			}
+		}
+		result, err := stmt.ExecContext(ctx,
+			namespace, name, messageID, logicalOrder, msg.Role, msg.Content, nilIfEmpty(msg.Name), inputJSON,
+			toolCallsJSON, nilIfEmpty(msg.ToolCallID), msg.SourceType, msg.SourceRef, metadataJSON, ts,
+		)
+		if err != nil {
+			return 0, err
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return 0, err
+		}
+		if rows == 0 {
+			matches, matchErr := sessionMessageMatchesTx(
+				ctx, tx, namespace, name, messageID, logicalOrder, msg.Order > 0, msg, inputJSON, toolCallsJSON, metadataJSON,
+			)
+			if matchErr != nil {
+				return 0, matchErr
+			}
+			if !matches {
+				return 0, store.ErrDuplicateMismatch
+			}
+		}
+		inserted += int(rows)
+	}
+	return inserted, nil
 }
 
 // LoadTranscript retrieves messages in logical conversation order.

--- a/internal/store/sqlite/session_store.go
+++ b/internal/store/sqlite/session_store.go
@@ -101,12 +101,15 @@ func (s *Store) DeleteSession(ctx context.Context, namespace, name string) error
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
-	var sessionType string
+	var sessionType, chatTurnID string
 	if err := tx.QueryRowContext(ctx,
-		`SELECT session_type FROM sessions WHERE namespace = ? AND name = ?`,
+		`SELECT session_type, chat_turn_id FROM sessions WHERE namespace = ? AND name = ?`,
 		namespace, name,
-	).Scan(&sessionType); err != nil && !errors.Is(err, sql.ErrNoRows) {
+	).Scan(&sessionType, &chatTurnID); err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return err
+	}
+	if chatTurnID != "" {
+		return store.ErrConflict
 	}
 	var pendingGatewayEvents int
 	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM gateway_events

--- a/internal/store/sqlite/session_store.go
+++ b/internal/store/sqlite/session_store.go
@@ -204,12 +204,24 @@ func (s *Store) AcquireLock(ctx context.Context, namespace, name, taskName, task
 	}
 
 	// Try to acquire the exact Task incarnation. Empty stored UIDs are adopted only for
-	// compatibility with locks created before the fencing column existed.
+	// compatibility with locks created before the fencing column existed. A live chat
+	// turn owns the same transcript boundary and therefore excludes Task locks; an
+	// expired chat lease is cleared as part of the successful lock acquisition.
+	now := time.Now().UTC()
 	result, err := s.db.ExecContext(ctx,
-		`UPDATE sessions SET active_task = ?, active_task_uid = ?
+		`UPDATE sessions SET active_task = ?, active_task_uid = ?,
+		   chat_turn_id = CASE
+		     WHEN chat_turn_id <> '' AND (chat_turn_expires_at IS NULL OR chat_turn_expires_at <= ?) THEN ''
+		     ELSE chat_turn_id
+		   END,
+		   chat_turn_expires_at = CASE
+		     WHEN chat_turn_id <> '' AND (chat_turn_expires_at IS NULL OR chat_turn_expires_at <= ?) THEN NULL
+		     ELSE chat_turn_expires_at
+		   END
 		 WHERE namespace = ? AND name = ? AND (active_task = '' OR
-		   (active_task = ? AND (active_task_uid = '' OR active_task_uid = ?)))`,
-		taskName, taskUID, namespace, name, taskName, taskUID,
+		   (active_task = ? AND (active_task_uid = '' OR active_task_uid = ?)))
+		 AND (chat_turn_id = '' OR chat_turn_expires_at IS NULL OR chat_turn_expires_at <= ?)`,
+		taskName, taskUID, now, now, namespace, name, taskName, taskUID, now,
 	)
 	if err != nil {
 		return err
@@ -220,7 +232,7 @@ func (s *Store) AcquireLock(ctx context.Context, namespace, name, taskName, task
 		return err
 	}
 	if rows == 0 {
-		return fmt.Errorf("session %s/%s is already locked", namespace, name)
+		return fmt.Errorf("session %s/%s is already locked or has an active chat turn", namespace, name)
 	}
 	return nil
 }
@@ -233,17 +245,17 @@ func (s *Store) AcquireChatTurn(
 	session *store.SessionRecord,
 	turnID string,
 	expiresAt time.Time,
-) error {
+) (bool, error) {
 	if session == nil {
-		return store.ValidationErrorf("session is required")
+		return false, store.ValidationErrorf("session is required")
 	}
 	if session.Namespace == "" || session.Name == "" || session.SessionType == "" || turnID == "" {
-		return store.ValidationErrorf("session namespace, name, type, and turn ID are required")
+		return false, store.ValidationErrorf("session namespace, name, type, and turn ID are required")
 	}
 	now := time.Now().UTC()
 	expiresAt = expiresAt.UTC()
 	if !expiresAt.After(now) {
-		return store.ValidationErrorf("chat turn expiration must be in the future")
+		return false, store.ValidationErrorf("chat turn expiration must be in the future")
 	}
 	createdAt := session.CreatedAt.UTC()
 	if createdAt.IsZero() {
@@ -252,19 +264,25 @@ func (s *Store) AcquireChatTurn(
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	if _, err := tx.ExecContext(ctx,
+	insertResult, err := tx.ExecContext(ctx,
 		`INSERT INTO sessions
 		 (namespace, name, session_type, active_task, active_task_uid, message_count, input_tokens, output_tokens, cancelled, created_at, updated_at)
 		 VALUES (?, ?, ?, '', '', 0, 0, 0, ?, ?, ?)
 		 ON CONFLICT(namespace, name) DO NOTHING`,
 		session.Namespace, session.Name, session.SessionType, session.Cancelled, createdAt, now,
-	); err != nil {
-		return err
+	)
+	if err != nil {
+		return false, err
 	}
+	createdRows, err := insertResult.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	created := createdRows == 1
 
 	var sessionType, ownerType, activeTask, activeTurn string
 	var activeTurnExpiresAt sql.NullTime
@@ -274,18 +292,18 @@ func (s *Store) AcquireChatTurn(
 		session.Namespace, session.Name,
 	).Scan(&sessionType, &ownerType, &activeTask, &activeTurn, &activeTurnExpiresAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return store.ErrNotFound
+			return false, store.ErrNotFound
 		}
-		return err
+		return false, err
 	}
 	if sessionType == store.SessionTypeGateway || ownerType == gatewaySessionOwnerType {
-		return store.ErrGatewayOwnedSession
+		return false, store.ErrGatewayOwnedSession
 	}
 	if activeTask != "" {
-		return fmt.Errorf("%w: chat session %s/%s has an active Task", store.ErrConflict, session.Namespace, session.Name)
+		return false, fmt.Errorf("%w: chat session %s/%s has an active Task", store.ErrConflict, session.Namespace, session.Name)
 	}
 	if activeTurn != "" && activeTurnExpiresAt.Valid && activeTurnExpiresAt.Time.After(now) {
-		return fmt.Errorf("%w: chat session %s/%s already has an active turn", store.ErrConflict, session.Namespace, session.Name)
+		return false, fmt.Errorf("%w: chat session %s/%s already has an active turn", store.ErrConflict, session.Namespace, session.Name)
 	}
 
 	result, err := tx.ExecContext(ctx,
@@ -297,22 +315,54 @@ func (s *Store) AcquireChatTurn(
 		store.SessionTypeGateway, gatewaySessionOwnerType, now,
 	)
 	if err != nil {
-		return err
+		return false, err
 	}
 	updated, err := result.RowsAffected()
 	if err != nil {
-		return err
+		return false, err
 	}
 	if updated != 1 {
-		return fmt.Errorf("%w: chat session %s/%s already has an active turn", store.ErrConflict, session.Namespace, session.Name)
+		return false, fmt.Errorf("%w: chat session %s/%s already has an active turn", store.ErrConflict, session.Namespace, session.Name)
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return created, nil
 }
 
 // ReleaseChatTurn clears a reservation only when it is still owned by turnID.
-func (s *Store) ReleaseChatTurn(ctx context.Context, namespace, name, turnID string) error {
+// If this reservation created the Session, failed turns remove that row only
+// while it is still empty and otherwise untouched.
+func (s *Store) ReleaseChatTurn(
+	ctx context.Context,
+	namespace, name, turnID string,
+	deleteEmptyCreatedSession bool,
+) error {
 	if turnID == "" {
 		return nil
+	}
+	if deleteEmptyCreatedSession {
+		result, err := s.db.ExecContext(ctx,
+			`DELETE FROM sessions
+			 WHERE namespace = ? AND name = ? AND chat_turn_id = ?
+			   AND session_type = ? AND owner_type <> ? AND active_task = ''
+			   AND message_count = 0 AND input_tokens = 0 AND output_tokens = 0
+			   AND NOT EXISTS (
+			     SELECT 1 FROM session_messages
+			     WHERE namespace = ? AND session_name = ?
+			   )`,
+			namespace, name, turnID, store.SessionTypeChat, gatewaySessionOwnerType, namespace, name,
+		)
+		if err != nil {
+			return err
+		}
+		deleted, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if deleted == 1 {
+			return nil
+		}
 	}
 	_, err := s.db.ExecContext(ctx,
 		`UPDATE sessions SET chat_turn_id = '', chat_turn_expires_at = NULL
@@ -356,14 +406,14 @@ func (s *Store) CommitSessionTurn(
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	var sessionType, ownerType, activeTurn string
+	var sessionType, ownerType, activeTask, activeTurn string
 	var activeTurnExpiresAt sql.NullTime
 	var currentMessageCount int
 	if err := tx.QueryRowContext(ctx,
-		`SELECT session_type, owner_type, message_count, chat_turn_id, chat_turn_expires_at
+		`SELECT session_type, owner_type, active_task, message_count, chat_turn_id, chat_turn_expires_at
 		 FROM sessions WHERE namespace = ? AND name = ?`,
 		session.Namespace, session.Name,
-	).Scan(&sessionType, &ownerType, &currentMessageCount, &activeTurn, &activeTurnExpiresAt); err != nil {
+	).Scan(&sessionType, &ownerType, &activeTask, &currentMessageCount, &activeTurn, &activeTurnExpiresAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return store.ErrNotFound
 		}
@@ -371,6 +421,9 @@ func (s *Store) CommitSessionTurn(
 	}
 	if sessionType == store.SessionTypeGateway || ownerType == gatewaySessionOwnerType {
 		return store.ErrGatewayOwnedSession
+	}
+	if activeTask != "" {
+		return fmt.Errorf("%w: chat session has an active Task", store.ErrConflict)
 	}
 	if activeTurn != turnID {
 		return fmt.Errorf("%w: chat turn no longer owns session", store.ErrConflict)
@@ -395,7 +448,8 @@ func (s *Store) CommitSessionTurn(
 	result, err := tx.ExecContext(ctx,
 		`UPDATE sessions
 		 SET message_count = message_count + ?, input_tokens = input_tokens + ?, output_tokens = output_tokens + ?, updated_at = ?
-		 WHERE namespace = ? AND name = ? AND message_count = ? AND chat_turn_id = ? AND chat_turn_expires_at > ?`,
+		 WHERE namespace = ? AND name = ? AND active_task = ''
+		   AND message_count = ? AND chat_turn_id = ? AND chat_turn_expires_at > ?`,
 		inserted, inputTokens, outputTokens, now,
 		session.Namespace, session.Name, expectedMessageCount, turnID, now,
 	)
@@ -425,16 +479,21 @@ func (s *Store) ReleaseLock(ctx context.Context, namespace, name, taskName, task
 
 // IsLocked returns true if the session is locked by another Task incarnation.
 func (s *Store) IsLocked(ctx context.Context, namespace, name, currentTask, currentTaskUID string) (bool, error) {
-	var activeTask, activeTaskUID string
+	var activeTask, activeTaskUID, activeTurn string
+	var activeTurnExpiresAt sql.NullTime
 	err := s.db.QueryRowContext(ctx,
-		`SELECT active_task, active_task_uid FROM sessions WHERE namespace = ? AND name = ?`,
+		`SELECT active_task, active_task_uid, chat_turn_id, chat_turn_expires_at
+		 FROM sessions WHERE namespace = ? AND name = ?`,
 		namespace, name,
-	).Scan(&activeTask, &activeTaskUID)
+	).Scan(&activeTask, &activeTaskUID, &activeTurn, &activeTurnExpiresAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, store.ErrNotFound
 	}
 	if err != nil {
 		return false, err
+	}
+	if activeTurn != "" && activeTurnExpiresAt.Valid && activeTurnExpiresAt.Time.After(time.Now().UTC()) {
+		return true, nil
 	}
 	if activeTask == "" {
 		return false, nil

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -82,9 +82,11 @@ func migrate(db *sql.DB) error {
 			session_type  TEXT NOT NULL DEFAULT 'task',
 			owner_type    TEXT NOT NULL DEFAULT '',
 			owner_ref     TEXT NOT NULL DEFAULT '',
-			active_task     TEXT NOT NULL DEFAULT '',
-			active_task_uid TEXT NOT NULL DEFAULT '',
-			message_count   INTEGER NOT NULL DEFAULT 0,
+			active_task          TEXT NOT NULL DEFAULT '',
+			active_task_uid      TEXT NOT NULL DEFAULT '',
+			chat_turn_id         TEXT NOT NULL DEFAULT '',
+			chat_turn_expires_at TIMESTAMP,
+			message_count        INTEGER NOT NULL DEFAULT 0,
 			input_tokens  INTEGER NOT NULL DEFAULT 0,
 			output_tokens INTEGER NOT NULL DEFAULT 0,
 			cancelled     BOOLEAN NOT NULL DEFAULT FALSE,
@@ -834,6 +836,8 @@ func migrate(db *sql.DB) error {
 		{Name: "owner_type", Definition: "owner_type TEXT NOT NULL DEFAULT ''"},
 		{Name: "owner_ref", Definition: "owner_ref TEXT NOT NULL DEFAULT ''"},
 		{Name: "active_task_uid", Definition: "active_task_uid TEXT NOT NULL DEFAULT ''"},
+		{Name: "chat_turn_id", Definition: "chat_turn_id TEXT NOT NULL DEFAULT ''"},
+		{Name: "chat_turn_expires_at", Definition: "chat_turn_expires_at TIMESTAMP"},
 	}); err != nil {
 		return err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -85,8 +85,8 @@ type SessionStore interface {
 // transcript messages with token usage. The expected message count fences the
 // session revision observed after acquiring the turn lease.
 type SessionTurnCommitter interface {
-	AcquireChatTurn(ctx context.Context, session *SessionRecord, turnID string, expiresAt time.Time) error
-	ReleaseChatTurn(ctx context.Context, namespace, name, turnID string) error
+	AcquireChatTurn(ctx context.Context, session *SessionRecord, turnID string, expiresAt time.Time) (created bool, err error)
+	ReleaseChatTurn(ctx context.Context, namespace, name, turnID string, deleteEmptyCreatedSession bool) error
 	CommitSessionTurn(
 		ctx context.Context,
 		session *SessionRecord,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -81,6 +81,22 @@ type SessionStore interface {
 	UpdateTokenCounts(ctx context.Context, namespace, name string, inputTokens, outputTokens int) error
 }
 
+// SessionTurnCommitter reserves chat turns and atomically commits their
+// transcript messages with token usage. The expected message count fences the
+// session revision observed after acquiring the turn lease.
+type SessionTurnCommitter interface {
+	AcquireChatTurn(ctx context.Context, session *SessionRecord, turnID string, expiresAt time.Time) error
+	ReleaseChatTurn(ctx context.Context, namespace, name, turnID string) error
+	CommitSessionTurn(
+		ctx context.Context,
+		session *SessionRecord,
+		turnID string,
+		expectedMessageCount int,
+		messages []SessionMessage,
+		inputTokens, outputTokens int,
+	) error
+}
+
 // GatewayEventStore handles durable normalized ingress records and atomic Session projection.
 type GatewayEventStore interface {
 	AdmitGatewayEvent(ctx context.Context, admission GatewayEventAdmission) (*GatewayEvent, bool, error)

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -2,8 +2,12 @@ package store
 
 import "time"
 
-// SessionTypeGateway identifies canonical Sessions exclusively owned by gateway admission/projection.
-const SessionTypeGateway = "gateway"
+const (
+	// SessionTypeChat identifies Sessions owned by the interactive chat API.
+	SessionTypeChat = "chat"
+	// SessionTypeGateway identifies canonical Sessions exclusively owned by gateway admission/projection.
+	SessionTypeGateway = "gateway"
+)
 
 // SessionRecord represents a full session.
 type SessionRecord struct {


### PR DESCRIPTION
## Summary

Focused salvage from #280, rebuilt on current `main`.

- Reserve chat turns with expiring leases and fence them against the transcript revision they observed.
- Atomically commit assistant messages and token usage before exposing a successful response.
- Keep Gateway-owned session projection and lock release under the Gateway terminal path instead of generic Task finalization.

## Scope

This PR is limited to chat-session turn durability and Gateway/session ownership boundaries. It does not change generic Task completion semantics or external AgentRuntime transport.

## Verification

- `go test ./internal/api ./internal/controller ./internal/gateway ./internal/store/sqlite -count=1`
- `make lint-fix && make test`
- Full required CI