### PR TITLE
fix(api): repair Kubernetes inventory pagination

### DIFF
--- a/internal/api/context_token_authorization.go
+++ b/internal/api/context_token_authorization.go
@@ -598,11 +598,17 @@ func (h *Handlers) authorizeContextTokenLoadedTaskWithIdentity(c fiber.Ctx, acti
 	return h.handleContextTokenAuthorizationFailures(ui.ContextToken, action, failures)
 }
 
-func (h *Handlers) contextTokenAllowsLoadedTask(c fiber.Ctx, action string, task *corev1alpha1.Task) (bool, error) {
-	return h.contextTokenAllowsLoadedTaskWithIdentity(c, action, task, true)
+func (h *Handlers) contextTokenAllowsLoadedTaskWithIdentity(c fiber.Ctx, action string, task *corev1alpha1.Task, includeTaskIdentity bool) (bool, error) {
+	return h.contextTokenAllowsLoadedTaskWithReader(c, action, task, includeTaskIdentity, h.client)
 }
 
-func (h *Handlers) contextTokenAllowsLoadedTaskWithIdentity(c fiber.Ctx, action string, task *corev1alpha1.Task, includeTaskIdentity bool) (bool, error) {
+func (h *Handlers) contextTokenAllowsLoadedTaskWithReader(
+	c fiber.Ctx,
+	action string,
+	task *corev1alpha1.Task,
+	includeTaskIdentity bool,
+	k8sReader client.Reader,
+) (bool, error) {
 	if !h.contextTokenAuthorization.Enabled() {
 		return true, nil
 	}
@@ -611,7 +617,7 @@ func (h *Handlers) contextTokenAllowsLoadedTaskWithIdentity(c fiber.Ctx, action 
 		return true, nil
 	}
 
-	failures, err := h.contextTokenLoadedTaskContextFailures(c.Context(), ui.ContextToken, task, includeTaskIdentity)
+	failures, err := contextTokenLoadedTaskContextFailures(c.Context(), k8sReader, ui.ContextToken, task, includeTaskIdentity)
 	if err != nil {
 		return false, err
 	}
@@ -628,7 +634,7 @@ func (h *Handlers) contextTokenLoadedTaskContextFailures(ctx context.Context, to
 	return contextTokenLoadedTaskContextFailures(ctx, h.client, token, task, includeTaskIdentity)
 }
 
-func contextTokenLoadedTaskContextFailures(ctx context.Context, k8sClient client.Client, token *ContextToken, task *corev1alpha1.Task, includeTaskIdentity bool) ([]string, error) {
+func contextTokenLoadedTaskContextFailures(ctx context.Context, k8sClient client.Reader, token *ContextToken, task *corev1alpha1.Task, includeTaskIdentity bool) ([]string, error) {
 	if token == nil || task == nil {
 		return nil, nil
 	}
@@ -1109,7 +1115,7 @@ func (h *Handlers) resolveContextTokenTaskCreateAuthorizationContext(ctx context
 	return resolveContextTokenTaskCreateAuthorizationContext(ctx, h.client, req, namespace)
 }
 
-func resolveContextTokenTaskCreateAuthorizationContext(ctx context.Context, c client.Client, req CreateTaskRequest, namespace string) (contextTokenTaskCreateAuthorizationContext, error) {
+func resolveContextTokenTaskCreateAuthorizationContext(ctx context.Context, c client.Reader, req CreateTaskRequest, namespace string) (contextTokenTaskCreateAuthorizationContext, error) {
 	authzCtx := contextTokenTaskCreateAuthorizationContext{
 		Request:   req,
 		Namespace: namespace,
@@ -1164,7 +1170,7 @@ func resolveContextTokenTaskCreateAuthorizationContext(ctx context.Context, c cl
 	return authzCtx, nil
 }
 
-func contextTokenTaskCreateFallbackProviderModels(ctx context.Context, c client.Client, namespace string, agent *corev1alpha1.Agent) []contextTokenProviderModel {
+func contextTokenTaskCreateFallbackProviderModels(ctx context.Context, c client.Reader, namespace string, agent *corev1alpha1.Agent) []contextTokenProviderModel {
 	if c == nil || agent == nil || agent.Spec.Model == nil || len(agent.Spec.Model.Fallbacks) == 0 {
 		return nil
 	}
@@ -1314,7 +1320,7 @@ func contextTokenTaskCreateEffectiveRuntimeAllowBash(req CreateTaskRequest, agen
 
 func contextTokenTaskToolCredentialFailures(
 	ctx context.Context,
-	k8sClient client.Client,
+	k8sClient client.Reader,
 	token *ContextToken,
 	cfg ContextTokenAuthorizationConfig,
 	authzCtx contextTokenTaskCreateAuthorizationContext,

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -589,7 +589,7 @@ func (h *Handlers) ListTasks(c fiber.Ctx) error {
 		task := &taskList.Items[i]
 		allowed := true
 		if h.contextTokenAuthorization.Enabled() {
-			allowed, err = h.contextTokenAllowsLoadedTask(c, "listTasks", task)
+			allowed, err = h.contextTokenAllowsLoadedTaskWithReader(c, "listTasks", task, true, listReader)
 			if err != nil {
 				return err
 			}
@@ -994,10 +994,9 @@ func (h *Handlers) ListTools(c fiber.Ctx) error {
 		return err
 	}
 
-	pagination, err := ParsePagination(c.Query("limit", "100"), c.Query("continue", ""))
-	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	}
+	limit := c.Query("limit", "100")
+	continueToken := c.Query("continue", "")
+	paginationRequested := queryArgumentPresent(c, "limit") || continueToken != ""
 
 	builtins, err := h.allowedBuiltinTools(c)
 	if err != nil {
@@ -1005,14 +1004,30 @@ func (h *Handlers) ListTools(c fiber.Ctx) error {
 	}
 	filteredNames, filteredMode := h.filteredCustomToolNames(c)
 	if filteredMode {
-		if c.Query("continue", "") != "" {
+		if continueToken != "" {
 			return fiber.NewError(fiber.StatusBadRequest, "continue is not supported for filtered tool lists; restart without a cursor")
+		}
+		if paginationRequested {
+			if _, err := ParsePagination(limit, ""); err != nil {
+				return fiber.NewError(fiber.StatusBadRequest, err.Error())
+			}
 		}
 		response, err := h.filteredToolListAll(c, namespace, builtins, filteredNames)
 		if err != nil {
 			return err
 		}
 		return c.JSON(response)
+	}
+	if !paginationRequested {
+		response, err := h.unpaginatedToolListAll(c, namespace, builtins)
+		if err != nil {
+			return err
+		}
+		return c.JSON(response)
+	}
+	pagination, err := ParsePagination(limit, continueToken)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
 
 	cursor, err := decodeToolListCursor(pagination.Continue, namespace, len(builtins))
@@ -1074,6 +1089,7 @@ func (h *Handlers) ListAgents(c fiber.Ctx) error {
 	}
 	limit := c.Query("limit", "100")
 	continueToken := c.Query("continue", "")
+	paginationRequested := queryArgumentPresent(c, "limit") || continueToken != ""
 
 	opts := &client.ListOptions{Namespace: namespace}
 	filteredContextList := h.contextTokenAuthorization.enforcing() && isContextTokenRequest(c)
@@ -1084,7 +1100,7 @@ func (h *Handlers) ListAgents(c fiber.Ctx) error {
 		if _, err := ParsePagination(limit, ""); err != nil {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
-	} else {
+	} else if paginationRequested {
 		pagination, err := ParsePagination(limit, continueToken)
 		if err != nil {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
@@ -1315,13 +1331,14 @@ func (h *Handlers) ListSkills(c fiber.Ctx) error {
 	continueToken := c.Query("continue", "")
 
 	opts := &client.ListOptions{Namespace: namespace}
-
-	pagination, err := ParsePagination(limit, continueToken)
-	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	if queryArgumentPresent(c, "limit") || continueToken != "" {
+		pagination, err := ParsePagination(limit, continueToken)
+		if err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		}
+		opts.Limit = pagination.Limit
+		opts.Continue = pagination.Continue
 	}
-	opts.Limit = pagination.Limit
-	opts.Continue = pagination.Continue
 
 	skillList := &corev1alpha1.SkillList{}
 	ctx := c.Context()

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -553,8 +553,15 @@ func (h *Handlers) ListTasks(c fiber.Ctx) error {
 	}
 
 	filteredContextList := h.contextTokenAuthorization.enforcing() && isContextTokenRequest(c)
-	logicalPagination := paginationRequested && !filteredContextList &&
-		(h.contextTokenAuthorization.Enabled() || h.gatewayEventStore != nil || h.clientset != nil)
+	broadGatewayRead := false
+	logicalPagination := false
+	if paginationRequested && !filteredContextList {
+		broadGatewayRead, err = h.taskAccess().hasBroadGatewayRead(c, "listTasks", namespace)
+		if err != nil {
+			return err
+		}
+		logicalPagination = !broadGatewayRead
+	}
 
 	// Raw Kubernetes continuations describe the unfiltered inventory. Callers
 	// whose context or gateway authorization can hide Tasks receive one complete
@@ -590,7 +597,7 @@ func (h *Handlers) ListTasks(c fiber.Ctx) error {
 	}
 
 	gatewayAuthorizations := map[gatewayTaskAuthorizationKey]bool{}
-	filtered, filteredList, err := h.filterTaskList(c, taskList.Items, listReader, gatewayAuthorizations)
+	filtered, filteredList, err := h.filterTaskList(c, taskList.Items, listReader, gatewayAuthorizations, broadGatewayRead)
 	if err != nil {
 		return err
 	}
@@ -600,7 +607,11 @@ func (h *Handlers) ListTasks(c fiber.Ctx) error {
 		if err != nil {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
-		returnPage, err := logicalTaskListPage(namespace, pagination.Limit, continueToken, filtered)
+		pageSize, err := paginationLimitInt(pagination.Limit)
+		if err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		}
+		returnPage, err := logicalTaskListPage(namespace, pageSize, continueToken, filtered)
 		if err != nil {
 			return err
 		}
@@ -624,6 +635,7 @@ func (h *Handlers) filterTaskList(
 	tasks []corev1alpha1.Task,
 	listReader client.Reader,
 	gatewayAuthorizations map[gatewayTaskAuthorizationKey]bool,
+	skipGatewayAuthorization bool,
 ) ([]corev1alpha1.Task, bool, error) {
 	filtered := make([]corev1alpha1.Task, 0, len(tasks))
 	for i := range tasks {
@@ -636,7 +648,7 @@ func (h *Handlers) filterTaskList(
 				return nil, false, err
 			}
 		}
-		if allowed {
+		if allowed && !skipGatewayAuthorization {
 			allowed, err = h.taskAccess().gatewayTaskReadableCached(c, "listTasks", task, gatewayAuthorizations)
 			if err != nil {
 				return nil, false, err
@@ -1058,8 +1070,12 @@ func (h *Handlers) ListTools(c fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
 
+	pageSize, err := paginationLimitInt(pagination.Limit)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
 	response, err := h.logicalToolListPage(
-		c, namespace, pagination.Limit, builtins, pagination.Continue,
+		c, namespace, pageSize, builtins, pagination.Continue,
 	)
 	if err != nil {
 		return err

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1020,7 +1020,7 @@ func (h *Handlers) ListTools(c fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
 	response, err := h.kubernetesToolListPage(
-		c, namespace, int(pagination.Limit), builtins, cursor, nil,
+		c, namespace, pagination.Limit, builtins, cursor, nil,
 	)
 	if err != nil {
 		return err

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -535,47 +535,52 @@ func (h *Handlers) authorizeTaskCreate(ctx context.Context, c fiber.Ctx, task *c
 // ListTasks lists tasks
 func (h *Handlers) ListTasks(c fiber.Ctx) error {
 	explicitNS := c.Query("namespace", "")
-	limit := c.Query("limit", "100")
-	continueToken := c.Query("continue", "")
+	paginationParams, err := parseTaskPaginationParams(c)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+	limit := paginationParams.limit
+	continueToken := paginationParams.continueID
+	paginationRequested := paginationParams.requested
 
-	opts := &client.ListOptions{}
-	listReader := h.apiReader
-
-	// Apply namespace filter with smart defaults
+	// Apply namespace filter with smart defaults.
 	namespace, err := h.resolveNamespace(c, explicitNS)
 	if err != nil {
 		return err
 	}
-	opts.Namespace = namespace
 	if err := h.authorizeContextTokenAction(c, "listTasks", h.contextTokenAuthorization.TaskListScopes); err != nil {
 		return err
 	}
 
 	filteredContextList := h.contextTokenAuthorization.enforcing() && isContextTokenRequest(c)
-	// Raw Kubernetes continuations describe the unfiltered inventory. For an
-	// enforcing context-token caller, scan the complete authorized logical list
-	// in one response instead of exposing hidden pagination structure.
-	if filteredContextList {
-		if continueToken != "" {
-			return fiber.NewError(fiber.StatusBadRequest, "continue is not supported for filtered task lists; restart without a cursor")
-		}
-		if limit != "0" {
-			if _, err := ParsePagination(limit, ""); err != nil {
-				return fiber.NewError(fiber.StatusBadRequest, err.Error())
-			}
-		}
-	} else if limit == "0" {
-		if continueToken != "" {
-			return fiber.NewError(fiber.StatusBadRequest, "continue cannot be used with limit=0")
-		}
+	logicalPagination := paginationRequested && !filteredContextList &&
+		(h.contextTokenAuthorization.Enabled() || h.gatewayEventStore != nil || h.clientset != nil)
+
+	// Raw Kubernetes continuations describe the unfiltered inventory. Callers
+	// whose context or gateway authorization can hide Tasks receive one complete
+	// logical list instead of raw continuation or remaining-count metadata.
+	if filteredContextList && continueToken != "" {
+		return fiber.NewError(fiber.StatusBadRequest, "continue is not supported for filtered task lists; restart without a cursor")
+	}
+
+	opts := &client.ListOptions{Namespace: namespace}
+	listReader := h.apiReader
+	switch {
+	case filteredContextList || logicalPagination:
+		// Scan the authoritative inventory so filtering cannot omit later visible
+		// Tasks merely because a hidden Task occupied an earlier Kubernetes page.
+	case limit == "0":
 		listReader = h.client
-	} else {
+	case paginationRequested:
 		pagination, err := ParsePagination(limit, continueToken)
 		if err != nil {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 		opts.Limit = pagination.Limit
 		opts.Continue = pagination.Continue
+	default:
+		// Positive limit-only requests predate reliable Kubernetes pagination.
+		// Keep them complete until all first-page consumers explicitly opt in.
 	}
 
 	taskList := &corev1alpha1.TaskList{}
@@ -583,42 +588,65 @@ func (h *Handlers) ListTasks(c fiber.Ctx) error {
 	if err := listReader.List(ctx, taskList, opts); err != nil {
 		return paginationListError("tasks", err)
 	}
-	filtered := taskList.Items[:0]
+
 	gatewayAuthorizations := map[gatewayTaskAuthorizationKey]bool{}
-	for i := range taskList.Items {
-		task := &taskList.Items[i]
+	filtered, filteredList, err := h.filterTaskList(c, taskList.Items, listReader, gatewayAuthorizations)
+	if err != nil {
+		return err
+	}
+
+	if logicalPagination {
+		pagination, err := ParsePagination(limit, continueToken)
+		if err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		}
+		returnPage, err := logicalTaskListPage(namespace, pagination.Limit, continueToken, filtered)
+		if err != nil {
+			return err
+		}
+		return c.JSON(returnPage)
+	}
+
+	// If an otherwise-unfiltered raw page unexpectedly loses an item, suppress
+	// raw metadata and return the visible page rather than leaking hidden structure.
+	taskList.Items = filtered
+	metadata := ListMeta{}
+	if paginationRequested && !filteredContextList && !filteredList {
+		metadata.Continue = taskList.Continue
+		metadata.RemainingItemCount = taskList.RemainingItemCount
+	}
+	return c.JSON(ListResponse{Items: taskList.Items, Metadata: metadata})
+
+}
+
+func (h *Handlers) filterTaskList(
+	c fiber.Ctx,
+	tasks []corev1alpha1.Task,
+	listReader client.Reader,
+	gatewayAuthorizations map[gatewayTaskAuthorizationKey]bool,
+) ([]corev1alpha1.Task, bool, error) {
+	filtered := make([]corev1alpha1.Task, 0, len(tasks))
+	for i := range tasks {
+		task := &tasks[i]
 		allowed := true
+		var err error
 		if h.contextTokenAuthorization.Enabled() {
 			allowed, err = h.contextTokenAllowsLoadedTaskWithReader(c, "listTasks", task, true, listReader)
 			if err != nil {
-				return err
+				return nil, false, err
 			}
 		}
 		if allowed {
 			allowed, err = h.taskAccess().gatewayTaskReadableCached(c, "listTasks", task, gatewayAuthorizations)
 			if err != nil {
-				return err
+				return nil, false, err
 			}
 		}
 		if allowed {
 			filtered = append(filtered, *task)
 		}
 	}
-	filteredList := len(filtered) != len(taskList.Items)
-	taskList.Items = filtered
-	remainingItemCount := taskList.RemainingItemCount
-	if filteredList {
-		remainingItemCount = nil
-	}
-
-	metadata := ListMeta{}
-	if !filteredContextList {
-		metadata.Continue = taskList.Continue
-		metadata.RemainingItemCount = remainingItemCount
-	}
-	response := ListResponse{Items: taskList.Items, Metadata: metadata}
-
-	return c.JSON(response)
+	return filtered, len(filtered) != len(tasks), nil
 }
 
 // GetTask gets a task by ID
@@ -1030,12 +1058,8 @@ func (h *Handlers) ListTools(c fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
 
-	cursor, err := decodeToolListCursor(pagination.Continue, namespace, len(builtins))
-	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	}
-	response, err := h.kubernetesToolListPage(
-		c, namespace, pagination.Limit, builtins, cursor, nil,
+	response, err := h.logicalToolListPage(
+		c, namespace, pagination.Limit, builtins, pagination.Continue,
 	)
 	if err != nil {
 		return err

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -130,9 +130,13 @@ type HandlersConfig struct {
 
 // NewHandlers creates a new Handlers instance
 func NewHandlers(cfg HandlersConfig) *Handlers {
+	apiReader := cfg.APIReader
+	if apiReader == nil {
+		apiReader = cfg.Client
+	}
 	return &Handlers{
 		client:                    cfg.Client,
-		apiReader:                 cfg.APIReader,
+		apiReader:                 apiReader,
 		clientset:                 cfg.KubeClient,
 		watchNamespace:            cfg.WatchNamespace,
 		enforceNamespaceIsolation: cfg.EnforceNamespaceIsolation,
@@ -535,6 +539,7 @@ func (h *Handlers) ListTasks(c fiber.Ctx) error {
 	continueToken := c.Query("continue", "")
 
 	opts := &client.ListOptions{}
+	listReader := h.apiReader
 
 	// Apply namespace filter with smart defaults
 	namespace, err := h.resolveNamespace(c, explicitNS)
@@ -546,12 +551,24 @@ func (h *Handlers) ListTasks(c fiber.Ctx) error {
 		return err
 	}
 
-	// Apply pagination. A limit of 0 is an explicit unpaginated list request for
-	// cache-backed client-side filtered scans; omitted limits keep the default page size.
-	if limit == "0" {
+	filteredContextList := h.contextTokenAuthorization.enforcing() && isContextTokenRequest(c)
+	// Raw Kubernetes continuations describe the unfiltered inventory. For an
+	// enforcing context-token caller, scan the complete authorized logical list
+	// in one response instead of exposing hidden pagination structure.
+	if filteredContextList {
+		if continueToken != "" {
+			return fiber.NewError(fiber.StatusBadRequest, "continue is not supported for filtered task lists; restart without a cursor")
+		}
+		if limit != "0" {
+			if _, err := ParsePagination(limit, ""); err != nil {
+				return fiber.NewError(fiber.StatusBadRequest, err.Error())
+			}
+		}
+	} else if limit == "0" {
 		if continueToken != "" {
 			return fiber.NewError(fiber.StatusBadRequest, "continue cannot be used with limit=0")
 		}
+		listReader = h.client
 	} else {
 		pagination, err := ParsePagination(limit, continueToken)
 		if err != nil {
@@ -563,8 +580,8 @@ func (h *Handlers) ListTasks(c fiber.Ctx) error {
 
 	taskList := &corev1alpha1.TaskList{}
 	ctx := c.Context()
-	if err := h.client.List(ctx, taskList, opts); err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to list tasks: %v", err))
+	if err := listReader.List(ctx, taskList, opts); err != nil {
+		return paginationListError("tasks", err)
 	}
 	filtered := taskList.Items[:0]
 	gatewayAuthorizations := map[gatewayTaskAuthorizationKey]bool{}
@@ -594,13 +611,12 @@ func (h *Handlers) ListTasks(c fiber.Ctx) error {
 		remainingItemCount = nil
 	}
 
-	response := ListResponse{
-		Items: taskList.Items,
-		Metadata: ListMeta{
-			Continue:           taskList.Continue,
-			RemainingItemCount: remainingItemCount,
-		},
+	metadata := ListMeta{}
+	if !filteredContextList {
+		metadata.Continue = taskList.Continue
+		metadata.RemainingItemCount = remainingItemCount
 	}
+	response := ListResponse{Items: taskList.Items, Metadata: metadata}
 
 	return c.JSON(response)
 }
@@ -977,64 +993,38 @@ func (h *Handlers) ListTools(c fiber.Ctx) error {
 	if err := h.authorizeContextTokenAction(c, "listTools", h.contextTokenAuthorization.ToolReadScopes); err != nil {
 		return err
 	}
-	limit := c.Query("limit", "100")
-	continueToken := c.Query("continue", "")
 
-	opts := &client.ListOptions{Namespace: namespace}
-
-	// Apply pagination
-	pagination, err := ParsePagination(limit, continueToken)
+	pagination, err := ParsePagination(c.Query("limit", "100"), c.Query("continue", ""))
 	if err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
-	opts.Limit = pagination.Limit
-	opts.Continue = pagination.Continue
 
-	toolList := &corev1alpha1.ToolList{}
-	ctx := c.Context()
-	if err := h.client.List(ctx, toolList, opts); err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to list tools: %v", err))
+	builtins, err := h.allowedBuiltinTools(c)
+	if err != nil {
+		return err
 	}
-
-	// Add built-in tools to the response
-	toolItems := make([]fiber.Map, 0, len(toolList.Items)+len(builtinToolsList))
-	for _, tool := range builtinToolsList {
-		name, _ := tool["name"].(string)
-		allowed, err := contextTokenAllowsToolMetadata(c, h.contextTokenAuthorization, "listTools", name)
+	filteredNames, filteredMode := h.filteredCustomToolNames(c)
+	if filteredMode {
+		if c.Query("continue", "") != "" {
+			return fiber.NewError(fiber.StatusBadRequest, "continue is not supported for filtered tool lists; restart without a cursor")
+		}
+		response, err := h.filteredToolListAll(c, namespace, builtins, filteredNames)
 		if err != nil {
 			return err
 		}
-		if allowed {
-			toolItems = append(toolItems, tool)
-		}
+		return c.JSON(response)
 	}
 
-	for _, tool := range toolList.Items {
-		allowed, err := contextTokenAllowsToolMetadata(c, h.contextTokenAuthorization, "listTools", tool.Name)
-		if err != nil {
-			return err
-		}
-		if !allowed {
-			continue
-		}
-		toolItems = append(toolItems, fiber.Map{
-			"name":        tool.Name,
-			"namespace":   tool.Namespace,
-			"builtin":     false,
-			"description": tool.Spec.Description,
-			"available":   tool.Status.Available,
-			"url":         toolSpecHTTPURL(&tool),
-		})
+	cursor, err := decodeToolListCursor(pagination.Continue, namespace, len(builtins))
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
-
-	response := ListResponse{
-		Items: toolItems,
-		Metadata: ListMeta{
-			Continue:           toolList.Continue,
-			RemainingItemCount: toolList.RemainingItemCount,
-		},
+	response, err := h.kubernetesToolListPage(
+		c, namespace, int(pagination.Limit), builtins, cursor, nil,
+	)
+	if err != nil {
+		return err
 	}
-
 	return c.JSON(response)
 }
 
@@ -1086,19 +1076,27 @@ func (h *Handlers) ListAgents(c fiber.Ctx) error {
 	continueToken := c.Query("continue", "")
 
 	opts := &client.ListOptions{Namespace: namespace}
-
-	// Apply pagination
-	pagination, err := ParsePagination(limit, continueToken)
-	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	filteredContextList := h.contextTokenAuthorization.enforcing() && isContextTokenRequest(c)
+	if filteredContextList {
+		if continueToken != "" {
+			return fiber.NewError(fiber.StatusBadRequest, "continue is not supported for filtered agent lists; restart without a cursor")
+		}
+		if _, err := ParsePagination(limit, ""); err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		}
+	} else {
+		pagination, err := ParsePagination(limit, continueToken)
+		if err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		}
+		opts.Limit = pagination.Limit
+		opts.Continue = pagination.Continue
 	}
-	opts.Limit = pagination.Limit
-	opts.Continue = pagination.Continue
 
 	agentList := &corev1alpha1.AgentList{}
 	ctx := c.Context()
-	if err := h.client.List(ctx, agentList, opts); err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to list agents: %v", err))
+	if err := h.apiReader.List(ctx, agentList, opts); err != nil {
+		return paginationListError("agents", err)
 	}
 	if h.contextTokenAuthorization.Enabled() {
 		filtered := agentList.Items[:0]
@@ -1115,13 +1113,12 @@ func (h *Handlers) ListAgents(c fiber.Ctx) error {
 		agentList.Items = filtered
 	}
 
-	response := ListResponse{
-		Items: agentList.Items,
-		Metadata: ListMeta{
-			Continue:           agentList.Continue,
-			RemainingItemCount: agentList.RemainingItemCount,
-		},
+	metadata := ListMeta{}
+	if !filteredContextList {
+		metadata.Continue = agentList.Continue
+		metadata.RemainingItemCount = agentList.RemainingItemCount
 	}
+	response := ListResponse{Items: agentList.Items, Metadata: metadata}
 
 	return c.JSON(response)
 }
@@ -1328,8 +1325,8 @@ func (h *Handlers) ListSkills(c fiber.Ctx) error {
 
 	skillList := &corev1alpha1.SkillList{}
 	ctx := c.Context()
-	if err := h.client.List(ctx, skillList, opts); err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to list skills: %v", err))
+	if err := h.apiReader.List(ctx, skillList, opts); err != nil {
+		return paginationListError("skills", err)
 	}
 
 	skills := make([]fiber.Map, 0, len(skillList.Items))

--- a/internal/api/handlers_pagination_envtest_test.go
+++ b/internal/api/handlers_pagination_envtest_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package api
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+)
+
+func TestHandlers_ListTasks_UsesManagerAPIReaderForRealKubernetesContinuation(t *testing.T) {
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: apiEnvtestBinaryDirectory(t),
+	}
+	cfg, err := testEnv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, testEnv.Stop())
+	})
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1alpha1.AddToScheme(scheme))
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+		PprofBindAddress:       "0",
+		WebhookServer:          webhook.NewServer(webhook.Options{Port: 0}),
+	})
+	require.NoError(t, err)
+
+	managerCtx, cancelManager := context.WithCancel(context.Background())
+	managerDone := make(chan error, 1)
+	go func() {
+		managerDone <- mgr.Start(managerCtx)
+	}()
+	t.Cleanup(func() {
+		cancelManager()
+		select {
+		case managerErr := <-managerDone:
+			require.NoError(t, managerErr)
+		case <-time.After(10 * time.Second):
+			t.Error("manager did not stop within 10 seconds")
+		}
+	})
+
+	directClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	require.NoError(t, err)
+	for _, name := range []string{"real-task-1", "real-task-2"} {
+		task := &corev1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: corev1alpha1.TaskSpec{
+				Type:  corev1alpha1.TaskTypeContainer,
+				Image: "busybox:1.36",
+			},
+		}
+		require.NoError(t, directClient.Create(context.Background(), task))
+	}
+
+	cachedPage := &corev1alpha1.TaskList{}
+	require.Eventually(t, func() bool {
+		cachedPage = &corev1alpha1.TaskList{}
+		return mgr.GetClient().List(
+			context.Background(),
+			cachedPage,
+			client.InNamespace("default"),
+			client.Limit(1),
+		) == nil && len(cachedPage.Items) > 0
+	}, 10*time.Second, 50*time.Millisecond)
+	require.Equal(t, cacheUnsupportedContinue, cachedPage.Continue)
+
+	handlers := NewHandlers(HandlersConfig{
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+	})
+	app := newListTestApp(handlers)
+
+	first, status := listPage[corev1alpha1.Task](t, app, "/tasks?limit=1")
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, first.Items, 1)
+	require.NotEmpty(t, first.Metadata.Continue)
+	require.NotEqual(t, cacheUnsupportedContinue, first.Metadata.Continue)
+
+	second, status := listPage[corev1alpha1.Task](t, app, pathWithContinue("/tasks?limit=1", first.Metadata.Continue))
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, second.Items, 1)
+	require.NotEqual(t, first.Items[0].Name, second.Items[0].Name)
+	require.Empty(t, second.Metadata.Continue)
+
+	createEnvtestTool(t, directClient, "snapshot-tool-1")
+	toolPath := "/tools?limit=1"
+	toolPage, status := listPage[toolListTestItem](t, app, toolPath)
+	require.Equal(t, http.StatusOK, status)
+	require.NotEmpty(t, toolPage.Metadata.Continue)
+	createEnvtestTool(t, directClient, "snapshot-tool-2")
+
+	toolNames := make([]string, 0, len(builtinToolsList)+1)
+	for pageNumber := 1; pageNumber <= 20; pageNumber++ {
+		for _, tool := range toolPage.Items {
+			toolNames = append(toolNames, tool.Name)
+		}
+		if toolPage.Metadata.Continue == "" {
+			break
+		}
+		toolPath = pathWithContinue("/tools?limit=1", toolPage.Metadata.Continue)
+		toolPage, status = listPage[toolListTestItem](t, app, toolPath)
+		require.Equal(t, http.StatusOK, status)
+	}
+	wantToolNames := make([]string, 0, len(builtinToolsList)+1)
+	for _, tool := range builtinToolsList {
+		wantToolNames = append(wantToolNames, tool["name"].(string))
+	}
+	wantToolNames = append(wantToolNames, "snapshot-tool-1")
+	require.Equal(t, wantToolNames, toolNames)
+}
+
+func createEnvtestTool(t *testing.T, c client.Client, name string) {
+	t.Helper()
+	tool := &corev1alpha1.Tool{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: corev1alpha1.ToolSpec{
+			Description: "snapshot test tool",
+			HTTP:        &corev1alpha1.HTTPExecution{URL: "https://example.com/tool"},
+		},
+	}
+	require.NoError(t, c.Create(context.Background(), tool))
+}
+
+func apiEnvtestBinaryDirectory(t *testing.T) string {
+	t.Helper()
+	if configured := os.Getenv("KUBEBUILDER_ASSETS"); configured != "" {
+		return configured
+	}
+
+	base := filepath.Join("..", "..", "bin", "k8s")
+	entries, err := os.ReadDir(base)
+	require.NoError(t, err, "run make setup-envtest before running API pagination tests")
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(base, entry.Name())
+		}
+	}
+	t.Fatalf("no envtest binaries found under %s; run make setup-envtest", base)
+	return ""
+}

--- a/internal/api/handlers_pagination_envtest_test.go
+++ b/internal/api/handlers_pagination_envtest_test.go
@@ -96,43 +96,62 @@ func TestHandlers_ListTasks_UsesManagerAPIReaderForRealKubernetesContinuation(t 
 	})
 	app := newListTestApp(handlers)
 
-	first, status := listPage[corev1alpha1.Task](t, app, "/tasks?limit=1")
+	first, status := listPage[corev1alpha1.Task](t, app, "/tasks?limit=1&paginate=true")
 	require.Equal(t, http.StatusOK, status)
 	require.Len(t, first.Items, 1)
 	require.NotEmpty(t, first.Metadata.Continue)
 	require.NotEqual(t, cacheUnsupportedContinue, first.Metadata.Continue)
 
-	second, status := listPage[corev1alpha1.Task](t, app, pathWithContinue("/tasks?limit=1", first.Metadata.Continue))
+	second, status := listPage[corev1alpha1.Task](t, app, pathWithContinue("/tasks?limit=1&paginate=true", first.Metadata.Continue))
 	require.Equal(t, http.StatusOK, status)
 	require.Len(t, second.Items, 1)
 	require.NotEqual(t, first.Items[0].Name, second.Items[0].Name)
 	require.Empty(t, second.Metadata.Continue)
 
+	const toolPagePath = "/tools?limit=1"
 	createEnvtestTool(t, directClient, "snapshot-tool-1")
-	toolPath := "/tools?limit=1"
+	createEnvtestTool(t, directClient, "snapshot-tool-2")
+	toolPath := toolPagePath
 	toolPage, status := listPage[toolListTestItem](t, app, toolPath)
 	require.Equal(t, http.StatusOK, status)
-	require.NotEmpty(t, toolPage.Metadata.Continue)
-	createEnvtestTool(t, directClient, "snapshot-tool-2")
+	for {
+		customPage := false
+		for _, tool := range toolPage.Items {
+			customPage = customPage || !tool.Builtin
+		}
+		if customPage && toolPage.Metadata.Continue != "" {
+			break
+		}
+		require.NotEmpty(t, toolPage.Metadata.Continue)
+		toolPath = pathWithContinue(toolPagePath, toolPage.Metadata.Continue)
+		toolPage, status = listPage[toolListTestItem](t, app, toolPath)
+		require.Equal(t, http.StatusOK, status)
+	}
 
-	toolNames := make([]string, 0, len(builtinToolsList)+1)
-	for pageNumber := 1; pageNumber <= 20; pageNumber++ {
+	createEnvtestTool(t, directClient, "snapshot-tool-3")
+	_, status = listPage[toolListTestItem](t, app, pathWithContinue(toolPagePath, toolPage.Metadata.Continue))
+	require.Equal(t, http.StatusGone, status)
+
+	toolPath = toolPagePath
+	toolNames := make([]string, 0, len(builtinToolsList)+3)
+	for pageNumber := 0; pageNumber < len(builtinToolsList)+4; pageNumber++ {
+		toolPage, status = listPage[toolListTestItem](t, app, toolPath)
+		require.Equal(t, http.StatusOK, status)
 		for _, tool := range toolPage.Items {
 			toolNames = append(toolNames, tool.Name)
 		}
 		if toolPage.Metadata.Continue == "" {
 			break
 		}
-		toolPath = pathWithContinue("/tools?limit=1", toolPage.Metadata.Continue)
-		toolPage, status = listPage[toolListTestItem](t, app, toolPath)
-		require.Equal(t, http.StatusOK, status)
+		toolPath = pathWithContinue(toolPagePath, toolPage.Metadata.Continue)
 	}
-	wantToolNames := make([]string, 0, len(builtinToolsList)+1)
+	wantToolNames := make([]string, 0, len(builtinToolsList)+3)
 	for _, tool := range builtinToolsList {
 		wantToolNames = append(wantToolNames, tool["name"].(string))
 	}
-	wantToolNames = append(wantToolNames, "snapshot-tool-1")
+	wantToolNames = append(wantToolNames, "snapshot-tool-1", "snapshot-tool-2", "snapshot-tool-3")
 	require.Equal(t, wantToolNames, toolNames)
+
 }
 
 func createEnvtestTool(t *testing.T, c client.Client, name string) {

--- a/internal/api/handlers_pagination_test.go
+++ b/internal/api/handlers_pagination_test.go
@@ -372,17 +372,36 @@ func TestHandlers_ListAgents_APIReaderExposesCLI101stAgent(t *testing.T) {
 	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader})
 	app := newListTestApp(handlers)
 
-	first, status := listPage[corev1alpha1.Agent](t, app, "/agents")
+	first, status := listPage[corev1alpha1.Agent](t, app, "/agents?limit=100")
 	require.Equal(t, http.StatusOK, status)
 	require.Len(t, first.Items, 100)
 	require.NotEmpty(t, first.Metadata.Continue)
 
-	second, status := listPage[corev1alpha1.Agent](t, app, pathWithContinue("/agents", first.Metadata.Continue))
+	second, status := listPage[corev1alpha1.Agent](t, app, pathWithContinue("/agents?limit=100", first.Metadata.Continue))
 	require.Equal(t, http.StatusOK, status)
 	require.Len(t, second.Items, 1)
 	require.Equal(t, "agent-101", second.Items[0].Name)
 	require.Empty(t, cacheCalls.snapshot())
 	require.Len(t, apiReader.snapshotCalls(), 2)
+}
+
+func TestHandlers_ListAgents_OmittedPaginationReturnsCompleteInventory(t *testing.T) {
+	agents := make([]corev1alpha1.Agent, 101)
+	objects := make([]client.Object, 0, len(agents))
+	for i := range agents {
+		agents[i].ObjectMeta = metav1.ObjectMeta{Name: fmt.Sprintf("agent-%03d", i+1), Namespace: "default"}
+		objects = append(objects, &agents[i])
+	}
+	cacheClient, cacheCalls := newCachePaginationClient(t, objects...)
+	apiReader := &paginatedAPIReader{agents: agents}
+	app := newListTestApp(NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader}))
+
+	page, status := listPage[corev1alpha1.Agent](t, app, "/agents")
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, page.Items, 101)
+	require.Empty(t, page.Metadata.Continue)
+	require.Empty(t, cacheCalls.snapshot())
+	require.Equal(t, []recordedListCall{{Kind: "agents", Namespace: "default"}}, apiReader.snapshotCalls())
 }
 
 type skillListTestItem struct {
@@ -413,9 +432,47 @@ func TestHandlers_ListSkills_UsesAPIReaderContinuation(t *testing.T) {
 	require.Len(t, apiReader.snapshotCalls(), 2)
 }
 
+func TestHandlers_ListSkills_OmittedPaginationReturnsCompleteInventory(t *testing.T) {
+	skills := make([]corev1alpha1.Skill, 101)
+	objects := make([]client.Object, 0, len(skills))
+	for i := range skills {
+		skills[i].ObjectMeta = metav1.ObjectMeta{Name: fmt.Sprintf("skill-%03d", i+1), Namespace: "default"}
+		objects = append(objects, &skills[i])
+	}
+	cacheClient, cacheCalls := newCachePaginationClient(t, objects...)
+	apiReader := &paginatedAPIReader{skills: skills}
+	app := newListTestApp(NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader}))
+
+	page, status := listPage[skillListTestItem](t, app, "/skills")
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, page.Items, 101)
+	require.Empty(t, page.Metadata.Continue)
+	require.Empty(t, cacheCalls.snapshot())
+	require.Equal(t, []recordedListCall{{Kind: "skills", Namespace: "default"}}, apiReader.snapshotCalls())
+}
+
 type toolListTestItem struct {
 	Name    string `json:"name"`
 	Builtin bool   `json:"builtin"`
+}
+
+func TestHandlers_ListTools_OmittedPaginationReturnsCompleteInventory(t *testing.T) {
+	customTools := make([]corev1alpha1.Tool, 101)
+	objects := make([]client.Object, 0, len(customTools))
+	for i := range customTools {
+		customTools[i].ObjectMeta = metav1.ObjectMeta{Name: fmt.Sprintf("custom-%03d", i+1), Namespace: "default"}
+		objects = append(objects, &customTools[i])
+	}
+	cacheClient, cacheCalls := newCachePaginationClient(t, objects...)
+	apiReader := &paginatedAPIReader{tools: customTools}
+	app := newListTestApp(NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader}))
+
+	page, status := listPage[toolListTestItem](t, app, "/tools")
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, page.Items, len(builtinToolsList)+len(customTools))
+	require.Empty(t, page.Metadata.Continue)
+	require.Empty(t, cacheCalls.snapshot())
+	require.Equal(t, []recordedListCall{{Kind: "tools", Namespace: "default"}}, apiReader.snapshotCalls())
 }
 
 func TestHandlers_ListTools_CombinedPaginationHonorsLimitAndAllContinuations(t *testing.T) {
@@ -737,6 +794,42 @@ func TestHandlers_ListTools_StopsCombinedContinuationCycle(t *testing.T) {
 
 	_, status = listPage[toolListTestItem](t, app, pathWithContinue(path, third.Metadata.Continue))
 	require.Equal(t, http.StatusInternalServerError, status)
+}
+
+func TestHandlers_ListTasks_ContextTokenUsesAuthoritativeReaderForDependencies(t *testing.T) {
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent-task", Namespace: "default"},
+		Spec: corev1alpha1.TaskSpec{
+			Type:     corev1alpha1.TaskTypeAI,
+			AgentRef: &corev1alpha1.AgentReference{Name: "current-agent"},
+		},
+	}
+	agent := &corev1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "current-agent", Namespace: "default"},
+		Spec:       corev1alpha1.AgentSpec{Tools: []corev1alpha1.ToolReference{{Name: "web_search"}}},
+	}
+	cacheClient, _ := newCachePaginationClient(t, task)
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1alpha1.AddToScheme(scheme))
+	apiReader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(task, agent).Build()
+	authz, err := NewContextTokenAuthorizationConfig(ContextTokenAuthorizationConfigOptions{Mode: ContextTokenAuthorizationModeEnforce})
+	require.NoError(t, err)
+	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader, ContextTokenAuthorization: authz})
+	app := fiber.New(fiber.Config{ErrorHandler: customErrorHandler})
+	app.Use(func(c fiber.Ctx) error {
+		userInfo := contextScopedTestUser(ContextTokenScopeTaskList)
+		userInfo.ContextToken.TransactionContext = map[string]any{
+			"allowedAgents": []string{"current-agent"},
+			"allowedTools":  []string{"recall_memory", "remember", "propose_memory", "search_transcript"},
+		}
+		c.Locals(UserInfoContextKey, userInfo)
+		return c.Next()
+	})
+	app.Get("/tasks", handlers.ListTasks)
+
+	page, status := listPage[corev1alpha1.Task](t, app, "/tasks?limit=1")
+	require.Equal(t, http.StatusOK, status)
+	require.Empty(t, page.Items, "authoritative Agent tools must remain part of authorization")
 }
 
 func TestHandlers_ListTasks_ContextTokenReturnsCompleteAuthorizedLogicalList(t *testing.T) {

--- a/internal/api/handlers_pagination_test.go
+++ b/internal/api/handlers_pagination_test.go
@@ -1,0 +1,853 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+)
+
+const cacheUnsupportedContinue = "continue-not-supported"
+
+const (
+	testToolCursorA         = "cursor-a"
+	testToolCursorB         = "cursor-b"
+	testToolResourceVersion = "cycle-resource-version"
+)
+
+type recordedListCall struct {
+	Kind            string
+	Namespace       string
+	Limit           int64
+	Continue        string
+	ResourceVersion string
+}
+
+type listCallRecorder struct {
+	mu    sync.Mutex
+	calls []recordedListCall
+}
+
+func (r *listCallRecorder) record(kind string, opts client.ListOptions) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, recordedListCall{
+		Kind:            kind,
+		Namespace:       opts.Namespace,
+		Limit:           opts.Limit,
+		Continue:        opts.Continue,
+		ResourceVersion: listResourceVersion(opts),
+	})
+}
+
+func (r *listCallRecorder) snapshot() []recordedListCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]recordedListCall(nil), r.calls...)
+}
+
+func newCachePaginationClient(t *testing.T, objects ...client.Object) (client.Client, *listCallRecorder) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1alpha1.AddToScheme(scheme))
+	recorder := &listCallRecorder{}
+	cacheClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, underlying client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				listOpts := client.ListOptions{}
+				listOpts.ApplyOptions(opts)
+				recorder.record(listKind(list), listOpts)
+				if listOpts.Continue != "" {
+					return fmt.Errorf("cache continuation is unsupported")
+				}
+				if err := underlying.List(ctx, list, opts...); err != nil {
+					return err
+				}
+				if listOpts.Limit > 0 {
+					list.SetContinue(cacheUnsupportedContinue)
+				}
+				return nil
+			},
+		}).
+		Build()
+	return cacheClient, recorder
+}
+
+type paginationTestCursor struct {
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace"`
+	Offset    int    `json:"offset"`
+}
+
+type paginatedAPIReader struct {
+	mu     sync.Mutex
+	tasks  []corev1alpha1.Task
+	agents []corev1alpha1.Agent
+	skills []corev1alpha1.Skill
+	tools  []corev1alpha1.Tool
+	calls  []recordedListCall
+}
+
+func (r *paginatedAPIReader) Get(_ context.Context, key client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	return apierrors.NewNotFound(schema.GroupResource{Group: corev1alpha1.GroupVersion.Group, Resource: "test"}, key.Name)
+}
+
+func (r *paginatedAPIReader) List(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+	kind := listKind(list)
+
+	r.mu.Lock()
+	r.calls = append(r.calls, recordedListCall{
+		Kind:            kind,
+		Namespace:       listOpts.Namespace,
+		Limit:           listOpts.Limit,
+		Continue:        listOpts.Continue,
+		ResourceVersion: listResourceVersion(listOpts),
+	})
+	r.mu.Unlock()
+
+	switch typed := list.(type) {
+	case *corev1alpha1.TaskList:
+		items, meta, err := paginateTestItems(r.tasks, kind, listOpts)
+		if err != nil {
+			return err
+		}
+		typed.Items = items
+		typed.ListMeta = meta
+	case *corev1alpha1.AgentList:
+		items, meta, err := paginateTestItems(r.agents, kind, listOpts)
+		if err != nil {
+			return err
+		}
+		typed.Items = items
+		typed.ListMeta = meta
+	case *corev1alpha1.SkillList:
+		items, meta, err := paginateTestItems(r.skills, kind, listOpts)
+		if err != nil {
+			return err
+		}
+		typed.Items = items
+		typed.ListMeta = meta
+	case *corev1alpha1.ToolList:
+		items, meta, err := paginateTestItems(r.tools, kind, listOpts)
+		if err != nil {
+			return err
+		}
+		typed.Items = items
+		typed.ListMeta = meta
+	default:
+		return fmt.Errorf("unsupported list type %T", list)
+	}
+	return nil
+}
+
+func (r *paginatedAPIReader) snapshotCalls() []recordedListCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]recordedListCall(nil), r.calls...)
+}
+
+func paginateTestItems[T any](items []T, kind string, opts client.ListOptions) ([]T, metav1.ListMeta, error) {
+	const resourceVersion = "test-resource-version"
+	if requested := listResourceVersion(opts); requested != "" && requested != resourceVersion {
+		return nil, metav1.ListMeta{}, fmt.Errorf("resourceVersion = %q, want %q", requested, resourceVersion)
+	}
+	start := 0
+	if opts.Continue != "" {
+		cursor, err := decodePaginationTestCursor(opts.Continue)
+		if err != nil {
+			return nil, metav1.ListMeta{}, err
+		}
+		if cursor.Kind != kind || cursor.Namespace != opts.Namespace || cursor.Offset < 0 || cursor.Offset > len(items) {
+			return nil, metav1.ListMeta{}, fmt.Errorf("invalid test continuation")
+		}
+		start = cursor.Offset
+	}
+
+	end := len(items)
+	if opts.Limit > 0 && int64(end-start) > opts.Limit {
+		end = start + int(opts.Limit)
+	}
+	page := append([]T(nil), items[start:end]...)
+	meta := metav1.ListMeta{ResourceVersion: resourceVersion}
+	if end < len(items) {
+		meta.Continue = encodePaginationTestCursor(paginationTestCursor{
+			Kind:      kind,
+			Namespace: opts.Namespace,
+			Offset:    end,
+		})
+		remaining := int64(len(items) - end)
+		meta.RemainingItemCount = &remaining
+	}
+	return page, meta, nil
+}
+
+func listResourceVersion(opts client.ListOptions) string {
+	if opts.Raw == nil {
+		return ""
+	}
+	return opts.Raw.ResourceVersion
+}
+
+func encodePaginationTestCursor(cursor paginationTestCursor) string {
+	data, err := json.Marshal(cursor)
+	if err != nil {
+		panic(err)
+	}
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func decodePaginationTestCursor(raw string) (paginationTestCursor, error) {
+	data, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return paginationTestCursor{}, fmt.Errorf("decode test continuation: %w", err)
+	}
+	var cursor paginationTestCursor
+	if err := json.Unmarshal(data, &cursor); err != nil {
+		return paginationTestCursor{}, fmt.Errorf("unmarshal test continuation: %w", err)
+	}
+	return cursor, nil
+}
+
+func listKind(list client.ObjectList) string {
+	switch list.(type) {
+	case *corev1alpha1.TaskList:
+		return "tasks"
+	case *corev1alpha1.AgentList:
+		return "agents"
+	case *corev1alpha1.SkillList:
+		return "skills"
+	case *corev1alpha1.ToolList:
+		return "tools"
+	default:
+		return fmt.Sprintf("%T", list)
+	}
+}
+
+type paginationListResponse[T any] struct {
+	Items    []T      `json:"items"`
+	Metadata ListMeta `json:"metadata"`
+}
+
+func listPage[T any](t *testing.T, app *fiber.App, path string) (paginationListResponse[T], int) {
+	t.Helper()
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, path, nil))
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	var body paginationListResponse[T]
+	if resp.StatusCode == http.StatusOK {
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	}
+	return body, resp.StatusCode
+}
+
+func pathWithContinue(path, continuation string) string {
+	parsed, err := url.Parse(path)
+	if err != nil {
+		panic(err)
+	}
+	query := parsed.Query()
+	query.Set("continue", continuation)
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}
+
+func newListTestApp(handlers *Handlers) *fiber.App {
+	app := fiber.New(fiber.Config{ErrorHandler: customErrorHandler})
+	app.Get("/tasks", handlers.ListTasks)
+	app.Get("/agents", handlers.ListAgents)
+	app.Get("/skills", handlers.ListSkills)
+	app.Get("/tools", handlers.ListTools)
+	return app
+}
+
+func TestHandlers_ListTasks_CachePaginationReproducesUnsupportedContinuation(t *testing.T) {
+	cacheClient, _ := newCachePaginationClient(t, &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-1", Namespace: "default"},
+	})
+	handlers := NewHandlers(HandlersConfig{Client: cacheClient})
+	app := newListTestApp(handlers)
+
+	first, status := listPage[corev1alpha1.Task](t, app, "/tasks?limit=1")
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, cacheUnsupportedContinue, first.Metadata.Continue)
+
+	_, status = listPage[corev1alpha1.Task](t, app, pathWithContinue("/tasks?limit=1", first.Metadata.Continue))
+	require.Equal(t, http.StatusInternalServerError, status)
+}
+
+func TestHandlers_ListTasks_APIReaderExposesUISecondPage(t *testing.T) {
+	tasks := make([]corev1alpha1.Task, 26)
+	objects := make([]client.Object, 0, len(tasks))
+	for i := range tasks {
+		tasks[i].ObjectMeta = metav1.ObjectMeta{
+			Name:      fmt.Sprintf("task-%02d", i+1),
+			Namespace: "default",
+		}
+		objects = append(objects, &tasks[i])
+	}
+	cacheClient, cacheCalls := newCachePaginationClient(t, objects...)
+	apiReader := &paginatedAPIReader{tasks: tasks}
+	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader})
+	app := newListTestApp(handlers)
+
+	first, status := listPage[corev1alpha1.Task](t, app, "/tasks?limit=25")
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, first.Items, 25)
+	require.NotEmpty(t, first.Metadata.Continue)
+	require.NotEqual(t, cacheUnsupportedContinue, first.Metadata.Continue)
+	require.NotNil(t, first.Metadata.RemainingItemCount)
+	require.EqualValues(t, 1, *first.Metadata.RemainingItemCount)
+
+	second, status := listPage[corev1alpha1.Task](t, app, pathWithContinue("/tasks?limit=25", first.Metadata.Continue))
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, second.Items, 1)
+	require.Equal(t, "task-26", second.Items[0].Name)
+	require.Empty(t, second.Metadata.Continue)
+	require.Empty(t, cacheCalls.snapshot())
+	require.Equal(t, []recordedListCall{
+		{Kind: "tasks", Namespace: "default", Limit: 25},
+		{Kind: "tasks", Namespace: "default", Limit: 25, Continue: first.Metadata.Continue},
+	}, apiReader.snapshotCalls())
+}
+
+func TestHandlers_ListTasks_LimitZeroKeepsCachePath(t *testing.T) {
+	tasks := []corev1alpha1.Task{
+		{ObjectMeta: metav1.ObjectMeta{Name: "task-1", Namespace: "default"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "task-2", Namespace: "default"}},
+	}
+	objects := []client.Object{&tasks[0], &tasks[1]}
+	cacheClient, cacheCalls := newCachePaginationClient(t, objects...)
+	apiReader := &paginatedAPIReader{tasks: tasks}
+	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader})
+	app := newListTestApp(handlers)
+
+	page, status := listPage[corev1alpha1.Task](t, app, "/tasks?limit=0")
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, page.Items, 2)
+	require.Empty(t, page.Metadata.Continue)
+	require.Equal(t, []recordedListCall{{Kind: "tasks", Namespace: "default"}}, cacheCalls.snapshot())
+	require.Empty(t, apiReader.snapshotCalls())
+}
+
+func TestHandlers_ListAgents_APIReaderExposesCLI101stAgent(t *testing.T) {
+	agents := make([]corev1alpha1.Agent, 101)
+	objects := make([]client.Object, 0, len(agents))
+	for i := range agents {
+		agents[i].ObjectMeta = metav1.ObjectMeta{
+			Name:      fmt.Sprintf("agent-%03d", i+1),
+			Namespace: "default",
+		}
+		objects = append(objects, &agents[i])
+	}
+	cacheClient, cacheCalls := newCachePaginationClient(t, objects...)
+	apiReader := &paginatedAPIReader{agents: agents}
+	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader})
+	app := newListTestApp(handlers)
+
+	first, status := listPage[corev1alpha1.Agent](t, app, "/agents")
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, first.Items, 100)
+	require.NotEmpty(t, first.Metadata.Continue)
+
+	second, status := listPage[corev1alpha1.Agent](t, app, pathWithContinue("/agents", first.Metadata.Continue))
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, second.Items, 1)
+	require.Equal(t, "agent-101", second.Items[0].Name)
+	require.Empty(t, cacheCalls.snapshot())
+	require.Len(t, apiReader.snapshotCalls(), 2)
+}
+
+type skillListTestItem struct {
+	Name string `json:"name"`
+}
+
+func TestHandlers_ListSkills_UsesAPIReaderContinuation(t *testing.T) {
+	skills := []corev1alpha1.Skill{
+		{ObjectMeta: metav1.ObjectMeta{Name: "skill-1", Namespace: "default"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "skill-2", Namespace: "default"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "skill-3", Namespace: "default"}},
+	}
+	objects := []client.Object{&skills[0], &skills[1], &skills[2]}
+	cacheClient, cacheCalls := newCachePaginationClient(t, objects...)
+	apiReader := &paginatedAPIReader{skills: skills}
+	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader})
+	app := newListTestApp(handlers)
+
+	first, status := listPage[skillListTestItem](t, app, "/skills?limit=2")
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, []skillListTestItem{{Name: "skill-1"}, {Name: "skill-2"}}, first.Items)
+	require.NotEmpty(t, first.Metadata.Continue)
+
+	second, status := listPage[skillListTestItem](t, app, pathWithContinue("/skills?limit=2", first.Metadata.Continue))
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, []skillListTestItem{{Name: "skill-3"}}, second.Items)
+	require.Empty(t, cacheCalls.snapshot())
+	require.Len(t, apiReader.snapshotCalls(), 2)
+}
+
+type toolListTestItem struct {
+	Name    string `json:"name"`
+	Builtin bool   `json:"builtin"`
+}
+
+func TestHandlers_ListTools_CombinedPaginationHonorsLimitAndAllContinuations(t *testing.T) {
+	for _, limit := range []int{1, 2} {
+		t.Run("limit-"+strconv.Itoa(limit), func(t *testing.T) {
+			customTools := []corev1alpha1.Tool{
+				{ObjectMeta: metav1.ObjectMeta{Name: "custom-1", Namespace: "default"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "custom-2", Namespace: "default"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "custom-3", Namespace: "default"}},
+			}
+			objects := []client.Object{&customTools[0], &customTools[1], &customTools[2]}
+			cacheClient, cacheCalls := newCachePaginationClient(t, objects...)
+			apiReader := &paginatedAPIReader{tools: customTools}
+			handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader})
+			app := newListTestApp(handlers)
+
+			path := "/tools?limit=" + strconv.Itoa(limit)
+			seenCursors := map[string]struct{}{}
+			var names []string
+			var builtins int
+			var remainingCounts []int64
+			for pageNumber := 1; pageNumber <= 20; pageNumber++ {
+				page, status := listPage[toolListTestItem](t, app, path)
+				require.Equal(t, http.StatusOK, status)
+				require.LessOrEqual(t, len(page.Items), limit)
+				if page.Metadata.RemainingItemCount != nil {
+					remainingCounts = append(remainingCounts, *page.Metadata.RemainingItemCount)
+				}
+				for _, item := range page.Items {
+					names = append(names, item.Name)
+					if item.Builtin {
+						builtins++
+					}
+				}
+				if page.Metadata.Continue == "" {
+					break
+				}
+				_, duplicate := seenCursors[page.Metadata.Continue]
+				require.False(t, duplicate, "combined cursor repeated on page %d", pageNumber)
+				seenCursors[page.Metadata.Continue] = struct{}{}
+				path = pathWithContinue("/tools?limit="+strconv.Itoa(limit), page.Metadata.Continue)
+			}
+
+			wantNames := make([]string, 0, len(builtinToolsList)+len(customTools))
+			for _, tool := range builtinToolsList {
+				wantNames = append(wantNames, tool["name"].(string))
+			}
+			wantNames = append(wantNames, "custom-1", "custom-2", "custom-3")
+			require.Equal(t, wantNames, names)
+			require.Equal(t, len(builtinToolsList), builtins)
+			require.Contains(t, remainingCounts, int64(1))
+			require.Empty(t, cacheCalls.snapshot())
+
+			calls := apiReader.snapshotCalls()
+			require.NotEmpty(t, calls)
+			for _, call := range calls {
+				require.Equal(t, "tools", call.Kind)
+				require.Equal(t, "default", call.Namespace)
+			}
+			require.EqualValues(t, 1, calls[0].Limit)
+			require.Empty(t, calls[0].Continue)
+			require.Empty(t, calls[0].ResourceVersion)
+			require.EqualValues(t, limit, calls[1].Limit)
+			require.Empty(t, calls[1].Continue)
+			require.Equal(t, "test-resource-version", calls[1].ResourceVersion)
+			for _, call := range calls[2:] {
+				require.EqualValues(t, limit, call.Limit)
+				require.NotEmpty(t, call.Continue)
+				require.Empty(t, call.ResourceVersion)
+			}
+		})
+	}
+}
+
+func TestHandlers_ListTools_RejectsMalformedCombinedCursor(t *testing.T) {
+	cacheClient, _ := newCachePaginationClient(t)
+	apiReader := &paginatedAPIReader{}
+	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader})
+	app := newListTestApp(handlers)
+
+	_, status := listPage[toolListTestItem](t, app, "/tools?limit=1&continue=not-a-combined-cursor")
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Empty(t, apiReader.snapshotCalls())
+}
+
+func TestHandlers_ListTools_RejectsLimitZero(t *testing.T) {
+	cacheClient, _ := newCachePaginationClient(t)
+	apiReader := &paginatedAPIReader{}
+	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader})
+	app := newListTestApp(handlers)
+
+	_, status := listPage[toolListTestItem](t, app, "/tools?limit=0")
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Empty(t, apiReader.snapshotCalls())
+}
+
+func TestHandlers_ListTools_RejectsCombinedCursorFromDifferentNamespace(t *testing.T) {
+	cacheClient, _ := newCachePaginationClient(t)
+	apiReader := &paginatedAPIReader{}
+	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader})
+	app := newListTestApp(handlers)
+
+	first, status := listPage[toolListTestItem](t, app, "/tools?limit=1&namespace=default")
+	require.Equal(t, http.StatusOK, status)
+	require.NotEmpty(t, first.Metadata.Continue)
+
+	path := pathWithContinue("/tools?limit=1&namespace=other", first.Metadata.Continue)
+	_, status = listPage[toolListTestItem](t, app, path)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Len(t, apiReader.snapshotCalls(), 1)
+}
+
+func TestHandlers_ListTools_FiltersBeforePaginationWithoutLeakingHiddenCounts(t *testing.T) {
+	authorized := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{Name: "custom-allowed", Namespace: "default"}}
+	hidden := &corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{Name: "custom-hidden", Namespace: "default"}}
+	cacheClient, cacheCalls := newCachePaginationClient(t, authorized, hidden)
+	authz, err := NewContextTokenAuthorizationConfig(ContextTokenAuthorizationConfigOptions{
+		Mode: ContextTokenAuthorizationModeEnforce,
+	})
+	require.NoError(t, err)
+	handlers := NewHandlers(HandlersConfig{
+		Client:                    cacheClient,
+		APIReader:                 cacheClient,
+		ContextTokenAuthorization: authz,
+	})
+	app := fiber.New(fiber.Config{ErrorHandler: customErrorHandler})
+	app.Use(func(c fiber.Ctx) error {
+		userInfo := contextScopedTestUser(ContextTokenScopeToolsRead)
+		userInfo.ContextToken.TransactionContext = map[string]any{
+			"allowedTools": []string{"file_read", "custom-allowed"},
+		}
+		c.Locals(UserInfoContextKey, userInfo)
+		return c.Next()
+	})
+	app.Get("/tools", handlers.ListTools)
+
+	page, status := listPage[toolListTestItem](t, app, "/tools?limit=1")
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, []toolListTestItem{
+		{Name: "file_read", Builtin: true},
+		{Name: "custom-allowed"},
+	}, page.Items)
+	require.Empty(t, page.Metadata.Continue)
+	require.Nil(t, page.Metadata.RemainingItemCount)
+	require.Empty(t, cacheCalls.snapshot(), "filtered listing must not raw-list hidden tools")
+
+	_, status = listPage[toolListTestItem](t, app, "/tools?limit=1&continue=opaque")
+	require.Equal(t, http.StatusBadRequest, status)
+}
+
+type erroringListReader struct {
+	err error
+}
+
+func (r *erroringListReader) Get(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	return r.err
+}
+
+func (r *erroringListReader) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+	return r.err
+}
+
+func TestHandlers_DirectListContinuationErrorsKeepKubernetesStatus(t *testing.T) {
+	resources := []struct {
+		name string
+		path string
+	}{
+		{name: "tasks", path: "/tasks?limit=1"},
+		{name: "agents", path: "/agents?limit=1"},
+		{name: "skills", path: "/skills?limit=1"},
+	}
+	errors := []struct {
+		name   string
+		err    error
+		status int
+	}{
+		{name: "expired", err: apierrors.NewResourceExpired("expired"), status: http.StatusGone},
+		{name: "malformed", err: apierrors.NewBadRequest("bad continue"), status: http.StatusBadRequest},
+	}
+
+	for _, resource := range resources {
+		for _, failure := range errors {
+			t.Run(resource.name+"/"+failure.name, func(t *testing.T) {
+				cacheClient, cacheCalls := newCachePaginationClient(t)
+				handlers := NewHandlers(HandlersConfig{
+					Client:    cacheClient,
+					APIReader: &erroringListReader{err: failure.err},
+				})
+				app := newListTestApp(handlers)
+
+				resp, err := app.Test(httptest.NewRequest(http.MethodGet, resource.path, nil))
+				require.NoError(t, err)
+				defer resp.Body.Close() //nolint:errcheck
+				require.Equal(t, failure.status, resp.StatusCode)
+				require.Empty(t, cacheCalls.snapshot())
+			})
+		}
+	}
+}
+
+type expiringToolReader struct {
+	calls int
+}
+
+func (r *expiringToolReader) Get(_ context.Context, key client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	return apierrors.NewNotFound(schema.GroupResource{Group: corev1alpha1.GroupVersion.Group, Resource: "tools"}, key.Name)
+}
+
+func (r *expiringToolReader) List(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	r.calls++
+	if r.calls == 2 {
+		return apierrors.NewResourceExpired("expired")
+	}
+	if r.calls != 1 {
+		return fmt.Errorf("unexpected list call %d", r.calls)
+	}
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+	if listOpts.Continue != "" || listResourceVersion(listOpts) != "" {
+		return fmt.Errorf("unexpected probe options: continue=%q resourceVersion=%q", listOpts.Continue, listResourceVersion(listOpts))
+	}
+	toolList := list.(*corev1alpha1.ToolList)
+	toolList.Items = []corev1alpha1.Tool{{ObjectMeta: metav1.ObjectMeta{Name: "custom", Namespace: "default"}}}
+	toolList.ResourceVersion = "expiring-resource-version"
+	return nil
+}
+
+func TestHandlers_ListTools_ReturnsGoneForExpiredKubernetesContinuation(t *testing.T) {
+	cacheClient, _ := newCachePaginationClient(t)
+	handlers := NewHandlers(HandlersConfig{
+		Client:    cacheClient,
+		APIReader: &expiringToolReader{},
+	})
+	app := newListTestApp(handlers)
+
+	first, status := listPage[toolListTestItem](t, app, "/tools?limit=6")
+	require.Equal(t, http.StatusOK, status)
+	require.NotEmpty(t, first.Metadata.Continue)
+
+	_, status = listPage[toolListTestItem](t, app, pathWithContinue("/tools?limit=6", first.Metadata.Continue))
+	require.Equal(t, http.StatusGone, status)
+}
+
+type cyclingToolReader struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (r *cyclingToolReader) Get(_ context.Context, key client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	return apierrors.NewNotFound(schema.GroupResource{Group: corev1alpha1.GroupVersion.Group, Resource: "tools"}, key.Name)
+}
+
+func (r *cyclingToolReader) List(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+	toolList, ok := list.(*corev1alpha1.ToolList)
+	if !ok {
+		return fmt.Errorf("unsupported list type %T", list)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls++
+	var next string
+	switch r.calls {
+	case 1:
+		if listOpts.Continue != "" || listResourceVersion(listOpts) != "" {
+			return fmt.Errorf("unexpected probe options")
+		}
+		toolList.Items = []corev1alpha1.Tool{{
+			ObjectMeta: metav1.ObjectMeta{Name: "probe-tool", Namespace: "default"},
+		}}
+		toolList.ResourceVersion = testToolResourceVersion
+		return nil
+	case 2:
+		if listOpts.Continue != "" || listResourceVersion(listOpts) != testToolResourceVersion {
+			return fmt.Errorf("unexpected snapshot-start options")
+		}
+		next = testToolCursorA
+	case 3:
+		if listOpts.Continue != testToolCursorA {
+			return fmt.Errorf("continue = %q, want cursor-a", listOpts.Continue)
+		}
+		next = testToolCursorB
+	case 4:
+		if listOpts.Continue != testToolCursorB {
+			return fmt.Errorf("continue = %q, want cursor-b", listOpts.Continue)
+		}
+		next = testToolCursorA
+	default:
+		return fmt.Errorf("unexpected list call %d", r.calls)
+	}
+	toolList.Items = []corev1alpha1.Tool{{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("custom-%d", r.calls), Namespace: "default"},
+	}}
+	toolList.Continue = next
+	toolList.ResourceVersion = testToolResourceVersion
+	return nil
+}
+
+func TestHandlers_ListTools_StopsCombinedContinuationCycle(t *testing.T) {
+	cacheClient, _ := newCachePaginationClient(t)
+	apiReader := &cyclingToolReader{}
+	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader})
+	app := newListTestApp(handlers)
+
+	path := "/tools?limit=6"
+	first, status := listPage[toolListTestItem](t, app, path)
+	require.Equal(t, http.StatusOK, status)
+	require.NotEmpty(t, first.Metadata.Continue)
+
+	second, status := listPage[toolListTestItem](t, app, pathWithContinue(path, first.Metadata.Continue))
+	require.Equal(t, http.StatusOK, status)
+	require.NotEmpty(t, second.Metadata.Continue)
+
+	third, status := listPage[toolListTestItem](t, app, pathWithContinue(path, second.Metadata.Continue))
+	require.Equal(t, http.StatusOK, status)
+	require.NotEmpty(t, third.Metadata.Continue)
+
+	_, status = listPage[toolListTestItem](t, app, pathWithContinue(path, third.Metadata.Continue))
+	require.Equal(t, http.StatusInternalServerError, status)
+}
+
+func TestHandlers_ListTasks_ContextTokenReturnsCompleteAuthorizedLogicalList(t *testing.T) {
+	tasks := []corev1alpha1.Task{
+		{ObjectMeta: metav1.ObjectMeta{Name: "allowed-task-1", Namespace: "default"}, Spec: corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeAgent, AgentRef: &corev1alpha1.AgentReference{Name: "allowed-agent"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "hidden-task", Namespace: "default"}, Spec: corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeAgent, AgentRef: &corev1alpha1.AgentReference{Name: "hidden-agent"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "allowed-task-2", Namespace: "default"}, Spec: corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeAgent, AgentRef: &corev1alpha1.AgentReference{Name: "allowed-agent"}}},
+	}
+	cacheClient, _ := newCachePaginationClient(t, &tasks[0], &tasks[1], &tasks[2])
+	apiReader := &paginatedAPIReader{tasks: tasks}
+	authz, err := NewContextTokenAuthorizationConfig(ContextTokenAuthorizationConfigOptions{Mode: ContextTokenAuthorizationModeEnforce})
+	require.NoError(t, err)
+	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader, ContextTokenAuthorization: authz})
+	app := fiber.New(fiber.Config{ErrorHandler: customErrorHandler})
+	app.Use(func(c fiber.Ctx) error {
+		userInfo := contextScopedTestUser(ContextTokenScopeTaskList)
+		userInfo.ContextToken.TransactionContext = map[string]any{"allowedAgents": []string{"allowed-agent"}}
+		c.Locals(UserInfoContextKey, userInfo)
+		return c.Next()
+	})
+	app.Get("/tasks", handlers.ListTasks)
+
+	page, status := listPage[corev1alpha1.Task](t, app, "/tasks?limit=1")
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, []string{"allowed-task-1", "allowed-task-2"}, []string{page.Items[0].Name, page.Items[1].Name})
+	require.Empty(t, page.Metadata.Continue)
+	require.Nil(t, page.Metadata.RemainingItemCount)
+	require.Equal(t, []recordedListCall{{Kind: "tasks", Namespace: "default"}}, apiReader.snapshotCalls())
+
+	_, status = listPage[corev1alpha1.Task](t, app, "/tasks?limit=1&continue=opaque")
+	require.Equal(t, http.StatusBadRequest, status)
+}
+
+func TestHandlers_ListAgents_ContextTokenReturnsCompleteAuthorizedLogicalList(t *testing.T) {
+	agents := []corev1alpha1.Agent{
+		{ObjectMeta: metav1.ObjectMeta{Name: "allowed-agent-1", Namespace: "default"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "hidden-agent", Namespace: "default"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "allowed-agent-2", Namespace: "default"}},
+	}
+	cacheClient, _ := newCachePaginationClient(t, &agents[0], &agents[1], &agents[2])
+	apiReader := &paginatedAPIReader{agents: agents}
+	authz, err := NewContextTokenAuthorizationConfig(ContextTokenAuthorizationConfigOptions{Mode: ContextTokenAuthorizationModeEnforce})
+	require.NoError(t, err)
+	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader, ContextTokenAuthorization: authz})
+	app := fiber.New(fiber.Config{ErrorHandler: customErrorHandler})
+	app.Use(func(c fiber.Ctx) error {
+		userInfo := contextScopedTestUser(ContextTokenScopeAgentsRead)
+		userInfo.ContextToken.TransactionContext = map[string]any{
+			"allowedAgents": []string{"allowed-agent-1", "allowed-agent-2"},
+		}
+		c.Locals(UserInfoContextKey, userInfo)
+		return c.Next()
+	})
+	app.Get("/agents", handlers.ListAgents)
+
+	page, status := listPage[corev1alpha1.Agent](t, app, "/agents?limit=1")
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, []string{"allowed-agent-1", "allowed-agent-2"}, []string{page.Items[0].Name, page.Items[1].Name})
+	require.Empty(t, page.Metadata.Continue)
+	require.Nil(t, page.Metadata.RemainingItemCount)
+	require.Equal(t, []recordedListCall{{Kind: "agents", Namespace: "default"}}, apiReader.snapshotCalls())
+
+	_, status = listPage[corev1alpha1.Agent](t, app, "/agents?limit=1&continue=opaque")
+	require.Equal(t, http.StatusBadRequest, status)
+}
+
+func TestHandlers_ListTools_AllowsMoreThanCursorHistoryWindow(t *testing.T) {
+	tools := make([]corev1alpha1.Tool, maxToolCursorHistorySize+2)
+	objects := make([]client.Object, 0, len(tools))
+	for i := range tools {
+		tools[i].ObjectMeta = metav1.ObjectMeta{
+			Name:      fmt.Sprintf("custom-long-%03d", i),
+			Namespace: "default",
+		}
+		objects = append(objects, &tools[i])
+	}
+	cacheClient, _ := newCachePaginationClient(t, objects...)
+	apiReader := &paginatedAPIReader{tools: tools}
+	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader})
+	app := newListTestApp(handlers)
+
+	path := "/tools?limit=1"
+	count := 0
+	for page := 0; page < len(builtinToolsList)+len(tools)+1; page++ {
+		response, status := listPage[toolListTestItem](t, app, path)
+		require.Equal(t, http.StatusOK, status)
+		count += len(response.Items)
+		if response.Metadata.Continue == "" {
+			break
+		}
+		path = pathWithContinue("/tools?limit=1", response.Metadata.Continue)
+	}
+	require.Equal(t, len(builtinToolsList)+len(tools), count)
+}
+
+func TestHandlers_ListTools_FilteredModeStillValidatesLimit(t *testing.T) {
+	cacheClient, _ := newCachePaginationClient(t)
+	authz, err := NewContextTokenAuthorizationConfig(ContextTokenAuthorizationConfigOptions{Mode: ContextTokenAuthorizationModeEnforce})
+	require.NoError(t, err)
+	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: cacheClient, ContextTokenAuthorization: authz})
+	app := fiber.New(fiber.Config{ErrorHandler: customErrorHandler})
+	app.Use(func(c fiber.Ctx) error {
+		userInfo := contextScopedTestUser(ContextTokenScopeToolsRead)
+		userInfo.ContextToken.TransactionContext = map[string]any{"allowedTools": []string{"file_read"}}
+		c.Locals(UserInfoContextKey, userInfo)
+		return c.Next()
+	})
+	app.Get("/tools", handlers.ListTools)
+
+	for _, limit := range []string{"0", "-1", "not-a-number"} {
+		_, status := listPage[toolListTestItem](t, app, "/tools?limit="+url.QueryEscape(limit))
+		require.Equal(t, http.StatusBadRequest, status, "limit %q", limit)
+	}
+}

--- a/internal/api/handlers_pagination_test.go
+++ b/internal/api/handlers_pagination_test.go
@@ -33,12 +33,6 @@ import (
 
 const cacheUnsupportedContinue = "continue-not-supported"
 
-const (
-	testToolCursorA         = "cursor-a"
-	testToolCursorB         = "cursor-b"
-	testToolResourceVersion = "cycle-resource-version"
-)
-
 type recordedListCall struct {
 	Kind            string
 	Namespace       string
@@ -106,15 +100,19 @@ type paginationTestCursor struct {
 }
 
 type paginatedAPIReader struct {
-	mu     sync.Mutex
-	tasks  []corev1alpha1.Task
-	agents []corev1alpha1.Agent
-	skills []corev1alpha1.Skill
-	tools  []corev1alpha1.Tool
-	calls  []recordedListCall
+	mu        sync.Mutex
+	getReader client.Reader
+	tasks     []corev1alpha1.Task
+	agents    []corev1alpha1.Agent
+	skills    []corev1alpha1.Skill
+	tools     []corev1alpha1.Tool
+	calls     []recordedListCall
 }
 
-func (r *paginatedAPIReader) Get(_ context.Context, key client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+func (r *paginatedAPIReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if r.getReader != nil {
+		return r.getReader.Get(ctx, key, obj, opts...)
+	}
 	return apierrors.NewNotFound(schema.GroupResource{Group: corev1alpha1.GroupVersion.Group, Resource: "test"}, key.Name)
 }
 
@@ -295,11 +293,11 @@ func TestHandlers_ListTasks_CachePaginationReproducesUnsupportedContinuation(t *
 	handlers := NewHandlers(HandlersConfig{Client: cacheClient})
 	app := newListTestApp(handlers)
 
-	first, status := listPage[corev1alpha1.Task](t, app, "/tasks?limit=1")
+	first, status := listPage[corev1alpha1.Task](t, app, "/tasks?limit=1&paginate=true")
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, cacheUnsupportedContinue, first.Metadata.Continue)
 
-	_, status = listPage[corev1alpha1.Task](t, app, pathWithContinue("/tasks?limit=1", first.Metadata.Continue))
+	_, status = listPage[corev1alpha1.Task](t, app, pathWithContinue("/tasks?limit=1&paginate=true", first.Metadata.Continue))
 	require.Equal(t, http.StatusInternalServerError, status)
 }
 
@@ -318,7 +316,7 @@ func TestHandlers_ListTasks_APIReaderExposesUISecondPage(t *testing.T) {
 	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader})
 	app := newListTestApp(handlers)
 
-	first, status := listPage[corev1alpha1.Task](t, app, "/tasks?limit=25")
+	first, status := listPage[corev1alpha1.Task](t, app, "/tasks?limit=25&paginate=true")
 	require.Equal(t, http.StatusOK, status)
 	require.Len(t, first.Items, 25)
 	require.NotEmpty(t, first.Metadata.Continue)
@@ -326,7 +324,7 @@ func TestHandlers_ListTasks_APIReaderExposesUISecondPage(t *testing.T) {
 	require.NotNil(t, first.Metadata.RemainingItemCount)
 	require.EqualValues(t, 1, *first.Metadata.RemainingItemCount)
 
-	second, status := listPage[corev1alpha1.Task](t, app, pathWithContinue("/tasks?limit=25", first.Metadata.Continue))
+	second, status := listPage[corev1alpha1.Task](t, app, pathWithContinue("/tasks?limit=25&paginate=true", first.Metadata.Continue))
 	require.Equal(t, http.StatusOK, status)
 	require.Len(t, second.Items, 1)
 	require.Equal(t, "task-26", second.Items[0].Name)
@@ -335,6 +333,88 @@ func TestHandlers_ListTasks_APIReaderExposesUISecondPage(t *testing.T) {
 	require.Equal(t, []recordedListCall{
 		{Kind: "tasks", Namespace: "default", Limit: 25},
 		{Kind: "tasks", Namespace: "default", Limit: 25, Continue: first.Metadata.Continue},
+	}, apiReader.snapshotCalls())
+}
+
+func TestHandlers_ListTasks_LimitOnlyReturnsCompleteInventory(t *testing.T) {
+	tasks := make([]corev1alpha1.Task, 26)
+	objects := make([]client.Object, 0, len(tasks))
+	for i := range tasks {
+		tasks[i].ObjectMeta = metav1.ObjectMeta{
+			Name:      fmt.Sprintf("task-%02d", i+1),
+			Namespace: "default",
+		}
+		objects = append(objects, &tasks[i])
+	}
+	cacheClient, cacheCalls := newCachePaginationClient(t, objects...)
+	apiReader := &paginatedAPIReader{tasks: tasks}
+	app := newListTestApp(NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader}))
+
+	page, status := listPage[corev1alpha1.Task](t, app, "/tasks?limit=25")
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, page.Items, 26)
+	require.Empty(t, page.Metadata.Continue)
+	require.Nil(t, page.Metadata.RemainingItemCount)
+	require.Empty(t, cacheCalls.snapshot())
+	require.Equal(t, []recordedListCall{{Kind: "tasks", Namespace: "default"}}, apiReader.snapshotCalls())
+}
+
+func TestHandlers_ListTasks_RequiresExplicitPaginationOptIn(t *testing.T) {
+	cacheClient, cacheCalls := newCachePaginationClient(t)
+	apiReader := &paginatedAPIReader{}
+	app := newListTestApp(NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader}))
+
+	for _, path := range []string{
+		"/tasks?limit=1&continue=opaque",
+		"/tasks?limit=1&paginate=maybe",
+		"/tasks?limit=0&paginate=true",
+	} {
+		_, status := listPage[corev1alpha1.Task](t, app, path)
+		require.Equal(t, http.StatusBadRequest, status, "path %q", path)
+	}
+	require.Empty(t, cacheCalls.snapshot())
+	require.Empty(t, apiReader.snapshotCalls())
+}
+
+func TestHandlers_ListTasks_GatewayFilteredCallerReceivesCompleteLogicalList(t *testing.T) {
+	hiddenGatewayTask := gatewayTaskAccessFixture()
+	visibleTasks := []corev1alpha1.Task{
+		{ObjectMeta: metav1.ObjectMeta{Name: "visible-task-1", Namespace: "default"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "visible-task-2", Namespace: "default"}},
+	}
+	tasks := []corev1alpha1.Task{*hiddenGatewayTask, visibleTasks[0], visibleTasks[1]}
+	objects := []client.Object{hiddenGatewayTask, &visibleTasks[0], &visibleTasks[1]}
+	cacheClient, cacheCalls := newCachePaginationClient(t, objects...)
+	apiReader := &paginatedAPIReader{
+		getReader: newGatewayIdentityClient(t, "namespace-uid", "gateway-uid"),
+		tasks:     tasks,
+	}
+	handlers := NewHandlers(HandlersConfig{
+		Client:     cacheClient,
+		APIReader:  apiReader,
+		KubeClient: denyingSubjectAccessReviewClient(t, nil, nil),
+	})
+	app := fiber.New(fiber.Config{ErrorHandler: customErrorHandler})
+	app.Use(tokenReviewUserMiddleware(limitedTokenReviewUser("default")))
+	app.Get("/tasks", handlers.ListTasks)
+
+	path := "/tasks?namespace=default&limit=1&paginate=true"
+	page, status := listPage[corev1alpha1.Task](t, app, path)
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, []string{"visible-task-1"}, []string{page.Items[0].Name})
+	require.NotEmpty(t, page.Metadata.Continue)
+	require.NotNil(t, page.Metadata.RemainingItemCount)
+	require.EqualValues(t, 1, *page.Metadata.RemainingItemCount)
+
+	second, status := listPage[corev1alpha1.Task](t, app, pathWithContinue(path, page.Metadata.Continue))
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, []string{"visible-task-2"}, []string{second.Items[0].Name})
+	require.Empty(t, second.Metadata.Continue)
+	require.Nil(t, second.Metadata.RemainingItemCount)
+	require.Empty(t, cacheCalls.snapshot())
+	require.Equal(t, []recordedListCall{
+		{Kind: "tasks", Namespace: "default"},
+		{Kind: "tasks", Namespace: "default"},
 	}, apiReader.snapshotCalls())
 }
 
@@ -531,18 +611,11 @@ func TestHandlers_ListTools_CombinedPaginationHonorsLimitAndAllContinuations(t *
 			for _, call := range calls {
 				require.Equal(t, "tools", call.Kind)
 				require.Equal(t, "default", call.Namespace)
-			}
-			require.EqualValues(t, 1, calls[0].Limit)
-			require.Empty(t, calls[0].Continue)
-			require.Empty(t, calls[0].ResourceVersion)
-			require.EqualValues(t, limit, calls[1].Limit)
-			require.Empty(t, calls[1].Continue)
-			require.Equal(t, "test-resource-version", calls[1].ResourceVersion)
-			for _, call := range calls[2:] {
-				require.EqualValues(t, limit, call.Limit)
-				require.NotEmpty(t, call.Continue)
+				require.Zero(t, call.Limit)
+				require.Empty(t, call.Continue)
 				require.Empty(t, call.ResourceVersion)
 			}
+
 		})
 	}
 }
@@ -554,6 +627,21 @@ func TestHandlers_ListTools_RejectsMalformedCombinedCursor(t *testing.T) {
 	app := newListTestApp(handlers)
 
 	_, status := listPage[toolListTestItem](t, app, "/tools?limit=1&continue=not-a-combined-cursor")
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Empty(t, apiReader.snapshotCalls())
+}
+
+func TestHandlers_ListTools_RejectsCallerControlledResourceVersion(t *testing.T) {
+	cacheClient, _ := newCachePaginationClient(t)
+	apiReader := &paginatedAPIReader{}
+	app := newListTestApp(NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader}))
+	forged := base64.RawURLEncoding.EncodeToString(fmt.Appendf(nil,
+		`{"v":%d,"n":"default","b":%d,"r":"caller-selected"}`,
+		toolListCursorVersion,
+		len(builtinToolsList),
+	))
+
+	_, status := listPage[toolListTestItem](t, app, pathWithContinue("/tools?limit=1", forged))
 	require.Equal(t, http.StatusBadRequest, status)
 	require.Empty(t, apiReader.snapshotCalls())
 }
@@ -640,7 +728,7 @@ func TestHandlers_DirectListContinuationErrorsKeepKubernetesStatus(t *testing.T)
 		name string
 		path string
 	}{
-		{name: "tasks", path: "/tasks?limit=1"},
+		{name: "tasks", path: "/tasks?limit=1&paginate=true"},
 		{name: "agents", path: "/agents?limit=1"},
 		{name: "skills", path: "/skills?limit=1"},
 	}
@@ -673,127 +761,37 @@ func TestHandlers_DirectListContinuationErrorsKeepKubernetesStatus(t *testing.T)
 	}
 }
 
-type expiringToolReader struct {
-	calls int
-}
-
-func (r *expiringToolReader) Get(_ context.Context, key client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
-	return apierrors.NewNotFound(schema.GroupResource{Group: corev1alpha1.GroupVersion.Group, Resource: "tools"}, key.Name)
-}
-
-func (r *expiringToolReader) List(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
-	r.calls++
-	if r.calls == 2 {
-		return apierrors.NewResourceExpired("expired")
-	}
-	if r.calls != 1 {
-		return fmt.Errorf("unexpected list call %d", r.calls)
-	}
-	listOpts := client.ListOptions{}
-	listOpts.ApplyOptions(opts)
-	if listOpts.Continue != "" || listResourceVersion(listOpts) != "" {
-		return fmt.Errorf("unexpected probe options: continue=%q resourceVersion=%q", listOpts.Continue, listResourceVersion(listOpts))
-	}
-	toolList := list.(*corev1alpha1.ToolList)
-	toolList.Items = []corev1alpha1.Tool{{ObjectMeta: metav1.ObjectMeta{Name: "custom", Namespace: "default"}}}
-	toolList.ResourceVersion = "expiring-resource-version"
-	return nil
-}
-
-func TestHandlers_ListTools_ReturnsGoneForExpiredKubernetesContinuation(t *testing.T) {
+func TestHandlers_ListTools_ReturnsGoneWhenSnapshotChanges(t *testing.T) {
 	cacheClient, _ := newCachePaginationClient(t)
-	handlers := NewHandlers(HandlersConfig{
-		Client:    cacheClient,
-		APIReader: &expiringToolReader{},
-	})
+	apiReader := &paginatedAPIReader{tools: []corev1alpha1.Tool{{
+		ObjectMeta: metav1.ObjectMeta{Name: "custom-1", Namespace: "default"},
+	}}}
+	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader})
 	app := newListTestApp(handlers)
 
 	first, status := listPage[toolListTestItem](t, app, "/tools?limit=6")
 	require.Equal(t, http.StatusOK, status)
 	require.NotEmpty(t, first.Metadata.Continue)
-
+	apiReader.mu.Lock()
+	apiReader.tools = append(apiReader.tools, corev1alpha1.Tool{ObjectMeta: metav1.ObjectMeta{Name: "custom-2", Namespace: "default"}})
+	apiReader.mu.Unlock()
 	_, status = listPage[toolListTestItem](t, app, pathWithContinue("/tools?limit=6", first.Metadata.Continue))
 	require.Equal(t, http.StatusGone, status)
 }
 
-type cyclingToolReader struct {
-	mu    sync.Mutex
-	calls int
-}
-
-func (r *cyclingToolReader) Get(_ context.Context, key client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
-	return apierrors.NewNotFound(schema.GroupResource{Group: corev1alpha1.GroupVersion.Group, Resource: "tools"}, key.Name)
-}
-
-func (r *cyclingToolReader) List(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
-	listOpts := client.ListOptions{}
-	listOpts.ApplyOptions(opts)
-	toolList, ok := list.(*corev1alpha1.ToolList)
-	if !ok {
-		return fmt.Errorf("unsupported list type %T", list)
-	}
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.calls++
-	var next string
-	switch r.calls {
-	case 1:
-		if listOpts.Continue != "" || listResourceVersion(listOpts) != "" {
-			return fmt.Errorf("unexpected probe options")
-		}
-		toolList.Items = []corev1alpha1.Tool{{
-			ObjectMeta: metav1.ObjectMeta{Name: "probe-tool", Namespace: "default"},
-		}}
-		toolList.ResourceVersion = testToolResourceVersion
-		return nil
-	case 2:
-		if listOpts.Continue != "" || listResourceVersion(listOpts) != testToolResourceVersion {
-			return fmt.Errorf("unexpected snapshot-start options")
-		}
-		next = testToolCursorA
-	case 3:
-		if listOpts.Continue != testToolCursorA {
-			return fmt.Errorf("continue = %q, want cursor-a", listOpts.Continue)
-		}
-		next = testToolCursorB
-	case 4:
-		if listOpts.Continue != testToolCursorB {
-			return fmt.Errorf("continue = %q, want cursor-b", listOpts.Continue)
-		}
-		next = testToolCursorA
-	default:
-		return fmt.Errorf("unexpected list call %d", r.calls)
-	}
-	toolList.Items = []corev1alpha1.Tool{{
-		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("custom-%d", r.calls), Namespace: "default"},
-	}}
-	toolList.Continue = next
-	toolList.ResourceVersion = testToolResourceVersion
-	return nil
-}
-
-func TestHandlers_ListTools_StopsCombinedContinuationCycle(t *testing.T) {
+func TestHandlers_ListTools_AllowsRetryingTheSameCursor(t *testing.T) {
 	cacheClient, _ := newCachePaginationClient(t)
-	apiReader := &cyclingToolReader{}
+	apiReader := &paginatedAPIReader{tools: []corev1alpha1.Tool{{ObjectMeta: metav1.ObjectMeta{Name: "custom", Namespace: "default"}}}}
 	handlers := NewHandlers(HandlersConfig{Client: cacheClient, APIReader: apiReader})
 	app := newListTestApp(handlers)
-
-	path := "/tools?limit=6"
-	first, status := listPage[toolListTestItem](t, app, path)
+	first, status := listPage[toolListTestItem](t, app, "/tools?limit=1")
 	require.Equal(t, http.StatusOK, status)
-	require.NotEmpty(t, first.Metadata.Continue)
-
-	second, status := listPage[toolListTestItem](t, app, pathWithContinue(path, first.Metadata.Continue))
+	path := pathWithContinue("/tools?limit=1", first.Metadata.Continue)
+	second, status := listPage[toolListTestItem](t, app, path)
 	require.Equal(t, http.StatusOK, status)
-	require.NotEmpty(t, second.Metadata.Continue)
-
-	third, status := listPage[toolListTestItem](t, app, pathWithContinue(path, second.Metadata.Continue))
+	retried, status := listPage[toolListTestItem](t, app, path)
 	require.Equal(t, http.StatusOK, status)
-	require.NotEmpty(t, third.Metadata.Continue)
-
-	_, status = listPage[toolListTestItem](t, app, pathWithContinue(path, third.Metadata.Continue))
-	require.Equal(t, http.StatusInternalServerError, status)
+	require.Equal(t, second, retried)
 }
 
 func TestHandlers_ListTasks_ContextTokenUsesAuthoritativeReaderForDependencies(t *testing.T) {
@@ -859,7 +857,7 @@ func TestHandlers_ListTasks_ContextTokenReturnsCompleteAuthorizedLogicalList(t *
 	require.Nil(t, page.Metadata.RemainingItemCount)
 	require.Equal(t, []recordedListCall{{Kind: "tasks", Namespace: "default"}}, apiReader.snapshotCalls())
 
-	_, status = listPage[corev1alpha1.Task](t, app, "/tasks?limit=1&continue=opaque")
+	_, status = listPage[corev1alpha1.Task](t, app, "/tasks?limit=1&paginate=true&continue=opaque")
 	require.Equal(t, http.StatusBadRequest, status)
 }
 
@@ -913,9 +911,16 @@ func TestHandlers_ListTools_AllowsMoreThanCursorHistoryWindow(t *testing.T) {
 
 	path := "/tools?limit=1"
 	count := 0
+	seenNames := map[string]struct{}{}
 	for page := 0; page < len(builtinToolsList)+len(tools)+1; page++ {
 		response, status := listPage[toolListTestItem](t, app, path)
 		require.Equal(t, http.StatusOK, status)
+		for _, item := range response.Items {
+			if _, duplicate := seenNames[item.Name]; duplicate {
+				t.Fatalf("duplicate tool %q on page %d", item.Name, page)
+			}
+			seenNames[item.Name] = struct{}{}
+		}
 		count += len(response.Items)
 		if response.Metadata.Continue == "" {
 			break

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2406,13 +2406,17 @@ func TestParseDuration(t *testing.T) {
 func TestNewHandlers(t *testing.T) {
 	scheme := runtime.NewScheme()
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	apiReader := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	handlers := NewHandlers(HandlersConfig{Client: fakeClient, WatchNamespace: "test-ns"})
+	handlers := NewHandlers(HandlersConfig{Client: fakeClient, APIReader: apiReader, WatchNamespace: "test-ns"})
 	if handlers == nil {
 		t.Fatal("NewHandlers returned nil")
 	}
 	if handlers.watchNamespace != "test-ns" {
 		t.Errorf("watchNamespace = %s, want test-ns", handlers.watchNamespace)
+	}
+	if handlers.apiReader != apiReader {
+		t.Error("apiReader was not configured")
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1970,11 +1970,11 @@ func TestHandlers_ListTasks(t *testing.T) {
 	}
 }
 
-func TestHandlers_ListTasks_WithPagination(t *testing.T) {
+func TestHandlers_ListTasks_WithExplicitPagination(t *testing.T) {
 	handlers, app := setupTestHandlers()
 	app.Get("/tasks", handlers.ListTasks)
 
-	req := httptest.NewRequest(http.MethodGet, "/tasks?limit=10", nil)
+	req := httptest.NewRequest(http.MethodGet, "/tasks?limit=10&paginate=true", nil)
 	resp, err := app.Test(req)
 	if err != nil {
 		t.Fatalf("Test request failed: %v", err)

--- a/internal/api/pagination.go
+++ b/internal/api/pagination.go
@@ -9,6 +9,9 @@ package api
 import (
 	"fmt"
 	"strconv"
+
+	"github.com/gofiber/fiber/v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
@@ -47,4 +50,14 @@ func ParsePagination(limitStr, continueToken string) (*Pagination, error) {
 	}
 
 	return p, nil
+}
+
+func paginationListError(resource string, err error) error {
+	if apierrors.IsResourceExpired(err) {
+		return fiber.NewError(fiber.StatusGone, fmt.Sprintf("%s continue cursor expired; restart the list", resource))
+	}
+	if apierrors.IsBadRequest(err) {
+		return fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("invalid %s continue cursor", resource))
+	}
+	return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to list %s: %v", resource, err))
 }

--- a/internal/api/pagination.go
+++ b/internal/api/pagination.go
@@ -105,7 +105,14 @@ func parseTaskPaginationParams(c fiber.Ctx) (taskPaginationParams, error) {
 	return params, nil
 }
 
-const taskListCursorVersion = 1
+func paginationLimitInt(limit int64) (int, error) {
+	if limit < 1 || limit > int64(MaxLimit) {
+		return 0, fmt.Errorf("pagination limit %d is out of range", limit)
+	}
+	return int(limit), nil
+}
+
+const taskListCursorVersion = 2
 
 type taskListCursor struct {
 	Version   int    `json:"v"`
@@ -146,7 +153,23 @@ func decodeTaskListCursor(raw, namespace string) (taskListCursor, error) {
 }
 
 func taskListSnapshot(tasks []corev1alpha1.Task) (string, error) {
-	data, err := json.Marshal(tasks)
+	type stableTask struct {
+		Namespace   string                `json:"namespace"`
+		Name        string                `json:"name"`
+		UID         string                `json:"uid"`
+		Generation  int64                 `json:"generation"`
+		Labels      map[string]string     `json:"labels,omitempty"`
+		Annotations map[string]string     `json:"annotations,omitempty"`
+		Spec        corev1alpha1.TaskSpec `json:"spec"`
+	}
+	stable := make([]stableTask, 0, len(tasks))
+	for i := range tasks {
+		stable = append(stable, stableTask{
+			Namespace: tasks[i].Namespace, Name: tasks[i].Name, UID: string(tasks[i].UID),
+			Generation: tasks[i].Generation, Labels: tasks[i].Labels, Annotations: tasks[i].Annotations, Spec: tasks[i].Spec,
+		})
+	}
+	data, err := json.Marshal(stable)
 	if err != nil {
 		return "", fmt.Errorf("encode task list snapshot: %w", err)
 	}
@@ -154,7 +177,7 @@ func taskListSnapshot(tasks []corev1alpha1.Task) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(sum[:]), nil
 }
 
-func logicalTaskListPage(namespace string, pageSize int64, rawCursor string, tasks []corev1alpha1.Task) (ListResponse, error) {
+func logicalTaskListPage(namespace string, pageSize int, rawCursor string, tasks []corev1alpha1.Task) (ListResponse, error) {
 	tasks = append([]corev1alpha1.Task(nil), tasks...)
 	sort.Slice(tasks, func(i, j int) bool {
 		if tasks[i].Namespace == tasks[j].Namespace {
@@ -181,7 +204,7 @@ func logicalTaskListPage(namespace string, pageSize int64, rawCursor string, tas
 	if cursor.Offset > len(tasks) {
 		return ListResponse{}, fiber.NewError(fiber.StatusBadRequest, "invalid tasks continue cursor: cursor does not match this request")
 	}
-	end := min(len(tasks), cursor.Offset+int(pageSize))
+	end := min(len(tasks), cursor.Offset+pageSize)
 	items := append(make([]corev1alpha1.Task, 0, end-cursor.Offset), tasks[cursor.Offset:end]...)
 	metadata := ListMeta{}
 	if end < len(tasks) {

--- a/internal/api/pagination.go
+++ b/internal/api/pagination.go
@@ -52,6 +52,10 @@ func ParsePagination(limitStr, continueToken string) (*Pagination, error) {
 	return p, nil
 }
 
+func queryArgumentPresent(c fiber.Ctx, name string) bool {
+	return c.Request().URI().QueryArgs().Has(name)
+}
+
 func paginationListError(resource string, err error) error {
 	if apierrors.IsResourceExpired(err) {
 		return fiber.NewError(fiber.StatusGone, fmt.Sprintf("%s continue cursor expired; restart the list", resource))

--- a/internal/api/pagination.go
+++ b/internal/api/pagination.go
@@ -7,11 +7,19 @@ MIT License - see LICENSE file for details.
 package api
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
+	"sort"
 	"strconv"
 
 	"github.com/gofiber/fiber/v3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
 )
 
 const (
@@ -54,6 +62,139 @@ func ParsePagination(limitStr, continueToken string) (*Pagination, error) {
 
 func queryArgumentPresent(c fiber.Ctx, name string) bool {
 	return c.Request().URI().QueryArgs().Has(name)
+}
+
+func taskPaginationRequested(c fiber.Ctx) (bool, error) {
+	if !queryArgumentPresent(c, "paginate") {
+		return false, nil
+	}
+	paginate, err := strconv.ParseBool(c.Query("paginate", ""))
+	if err != nil {
+		return false, fmt.Errorf("invalid paginate parameter: must be true or false")
+	}
+	return paginate, nil
+}
+
+type taskPaginationParams struct {
+	limit      string
+	continueID string
+	requested  bool
+}
+
+func parseTaskPaginationParams(c fiber.Ctx) (taskPaginationParams, error) {
+	params := taskPaginationParams{
+		limit:      c.Query("limit", "100"),
+		continueID: c.Query("continue", ""),
+	}
+	requested, err := taskPaginationRequested(c)
+	if err != nil {
+		return taskPaginationParams{}, err
+	}
+	params.requested = requested
+	if params.continueID != "" && !params.requested {
+		return taskPaginationParams{}, fmt.Errorf("continue requires paginate=true")
+	}
+	if params.limit == "0" && params.requested {
+		return taskPaginationParams{}, fmt.Errorf("paginate=true cannot be used with limit=0")
+	}
+	if params.limit != "0" {
+		if _, err := ParsePagination(params.limit, ""); err != nil {
+			return taskPaginationParams{}, err
+		}
+	}
+	return params, nil
+}
+
+const taskListCursorVersion = 1
+
+type taskListCursor struct {
+	Version   int    `json:"v"`
+	Namespace string `json:"n"`
+	Offset    int    `json:"o"`
+	Snapshot  string `json:"s"`
+}
+
+func encodeTaskListCursor(cursor taskListCursor) (string, error) {
+	data, err := json.Marshal(cursor)
+	if err != nil {
+		return "", fmt.Errorf("encode tasks continue cursor: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func decodeTaskListCursor(raw, namespace string) (taskListCursor, error) {
+	cursor := taskListCursor{Version: taskListCursorVersion, Namespace: namespace}
+	if raw == "" {
+		return cursor, nil
+	}
+	data, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return taskListCursor{}, fmt.Errorf("invalid tasks continue cursor: malformed encoding")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&cursor); err != nil {
+		return taskListCursor{}, fmt.Errorf("invalid tasks continue cursor: malformed payload")
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return taskListCursor{}, fmt.Errorf("invalid tasks continue cursor: trailing payload")
+	}
+	if cursor.Version != taskListCursorVersion || cursor.Namespace != namespace || cursor.Offset < 0 || cursor.Snapshot == "" {
+		return taskListCursor{}, fmt.Errorf("invalid tasks continue cursor: cursor does not match this request")
+	}
+	return cursor, nil
+}
+
+func taskListSnapshot(tasks []corev1alpha1.Task) (string, error) {
+	data, err := json.Marshal(tasks)
+	if err != nil {
+		return "", fmt.Errorf("encode task list snapshot: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return base64.RawURLEncoding.EncodeToString(sum[:]), nil
+}
+
+func logicalTaskListPage(namespace string, pageSize int64, rawCursor string, tasks []corev1alpha1.Task) (ListResponse, error) {
+	tasks = append([]corev1alpha1.Task(nil), tasks...)
+	sort.Slice(tasks, func(i, j int) bool {
+		if tasks[i].Namespace == tasks[j].Namespace {
+			if tasks[i].Name == tasks[j].Name {
+				return string(tasks[i].UID) < string(tasks[j].UID)
+			}
+			return tasks[i].Name < tasks[j].Name
+		}
+		return tasks[i].Namespace < tasks[j].Namespace
+	})
+	cursor, err := decodeTaskListCursor(rawCursor, namespace)
+	if err != nil {
+		return ListResponse{}, fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+	snapshot, err := taskListSnapshot(tasks)
+	if err != nil {
+		return ListResponse{}, fiber.NewError(fiber.StatusInternalServerError, err.Error())
+	}
+	if rawCursor == "" {
+		cursor.Snapshot = snapshot
+	} else if cursor.Snapshot != snapshot {
+		return ListResponse{}, fiber.NewError(fiber.StatusGone, "tasks continue cursor expired; restart the list")
+	}
+	if cursor.Offset > len(tasks) {
+		return ListResponse{}, fiber.NewError(fiber.StatusBadRequest, "invalid tasks continue cursor: cursor does not match this request")
+	}
+	end := min(len(tasks), cursor.Offset+int(pageSize))
+	items := append(make([]corev1alpha1.Task, 0, end-cursor.Offset), tasks[cursor.Offset:end]...)
+	metadata := ListMeta{}
+	if end < len(tasks) {
+		metadata.Continue, err = encodeTaskListCursor(taskListCursor{
+			Version: taskListCursorVersion, Namespace: namespace, Offset: end, Snapshot: snapshot,
+		})
+		if err != nil {
+			return ListResponse{}, fiber.NewError(fiber.StatusInternalServerError, err.Error())
+		}
+		remaining := int64(len(tasks) - end)
+		metadata.RemainingItemCount = &remaining
+	}
+	return ListResponse{Items: items, Metadata: metadata}, nil
 }
 
 func paginationListError(resource string, err error) error {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -31,10 +31,12 @@ func TestNewServer(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1alpha1.AddToScheme(scheme)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	apiReader := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	config := ServerConfig{
 		Port:           8080,
 		MetricsPort:    9090,
+		APIReader:      apiReader,
 		WatchNamespace: "default",
 	}
 
@@ -48,6 +50,9 @@ func TestNewServer(t *testing.T) {
 	}
 	if server.handlers == nil {
 		t.Error("handlers is nil")
+	}
+	if server.handlers.apiReader != apiReader {
+		t.Error("APIReader was not wired to handlers")
 	}
 	if server.config.Port != 8080 {
 		t.Errorf("Port = %d, want 8080", server.config.Port)

--- a/internal/api/task_access.go
+++ b/internal/api/task_access.go
@@ -111,6 +111,30 @@ type gatewayTaskAuthorizationKey struct {
 	GatewayUID       string
 }
 
+func (a taskAccess) hasBroadGatewayRead(c fiber.Ctx, action, namespace string) (bool, error) {
+	if err := a.h.authorizeContextTokenAction(c, action+"GatewayRead", a.h.contextTokenAuthorization.GatewayReadScopes); err != nil {
+		if isGatewayTaskFilterDenial(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if a.h.clientset == nil {
+		return true, nil
+	}
+	if err := a.h.authorizeGatewayKubernetes(c, gatewayVerbList, "gateways", namespace, ""); err != nil {
+		if isGatewayTaskFilterDenial(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func isGatewayTaskFilterDenial(err error) bool {
+	var fiberErr *fiber.Error
+	return errors.As(err, &fiberErr) && (fiberErr.Code == fiber.StatusForbidden || fiberErr.Code == fiber.StatusNotFound)
+}
+
 func (a taskAccess) gatewayTaskReadableCached(
 	c fiber.Ctx, action string, task *corev1alpha1.Task, cache map[gatewayTaskAuthorizationKey]bool,
 ) (bool, error) {
@@ -137,8 +161,7 @@ func (a taskAccess) gatewayTaskReadableCached(
 		}
 		return true, nil
 	}
-	var fiberErr *fiber.Error
-	if errors.As(err, &fiberErr) && (fiberErr.Code == fiber.StatusForbidden || fiberErr.Code == fiber.StatusNotFound) {
+	if isGatewayTaskFilterDenial(err) {
 		if cache != nil {
 			cache[key] = false
 		}

--- a/internal/api/tool_pagination.go
+++ b/internal/api/tool_pagination.go
@@ -126,6 +126,23 @@ func (h *Handlers) filteredToolListAll(
 	return ListResponse{Items: items, Metadata: ListMeta{}}, nil
 }
 
+func (h *Handlers) unpaginatedToolListAll(
+	c fiber.Ctx,
+	namespace string,
+	builtins []fiber.Map,
+) (ListResponse, error) {
+	toolList := &corev1alpha1.ToolList{}
+	if err := h.apiReader.List(c.Context(), toolList, &client.ListOptions{Namespace: namespace}); err != nil {
+		return ListResponse{}, paginationListError("tools", err)
+	}
+	customItems, _, err := customToolListItems(c, h.contextTokenAuthorization, toolList.Items)
+	if err != nil {
+		return ListResponse{}, err
+	}
+	items := append(append([]fiber.Map(nil), builtins...), customItems...)
+	return ListResponse{Items: items, Metadata: ListMeta{}}, nil
+}
+
 func decodeToolListCursor(raw, namespace string, builtinCount int) (toolListCursor, error) {
 	cursor := toolListCursor{Version: toolListCursorVersion, Namespace: namespace}
 	if raw == "" {

--- a/internal/api/tool_pagination.go
+++ b/internal/api/tool_pagination.go
@@ -1,0 +1,321 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package api
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+	"sort"
+
+	"github.com/gofiber/fiber/v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+)
+
+const (
+	toolListCursorVersion    = 1
+	maxToolListCursorLength  = 16 * 1024
+	maxToolCursorHistorySize = 64
+)
+
+// toolListCursor is traversal state, not an authorization credential. Every
+// request resolves its namespace and re-applies item authorization before data
+// is returned. The cursor only combines the built-in offset with Kubernetes'
+// opaque continuation token and detects non-progress/cycles.
+type toolListCursor struct {
+	Version         int      `json:"v"`
+	Namespace       string   `json:"n"`
+	BuiltinOffset   int      `json:"b"`
+	Continue        string   `json:"c,omitempty"`
+	History         []string `json:"h,omitempty"`
+	ResourceVersion string   `json:"r,omitempty"`
+	CustomAvailable bool     `json:"a,omitempty"`
+}
+
+func (h *Handlers) allowedBuiltinTools(c fiber.Ctx) ([]fiber.Map, error) {
+	allowedTools := make([]fiber.Map, 0, len(builtinToolsList))
+	for _, tool := range builtinToolsList {
+		name, _ := tool["name"].(string)
+		allowed, err := contextTokenAllowsToolMetadata(c, h.contextTokenAuthorization, "listTools", name)
+		if err != nil {
+			return nil, err
+		}
+		if allowed {
+			allowedTools = append(allowedTools, tool)
+		}
+	}
+	return allowedTools, nil
+}
+
+func (h *Handlers) filteredCustomToolNames(c fiber.Ctx) ([]string, bool) {
+	if !h.contextTokenAuthorization.enforcing() || !isContextTokenRequest(c) {
+		return nil, false
+	}
+	ui := GetUserInfo(c)
+	if ui == nil || ui.ContextToken == nil {
+		return nil, false
+	}
+	allowedTools, ok := contextStringList(ui.ContextToken.TransactionContext, "allowedTools")
+	if !ok {
+		return nil, false
+	}
+
+	unique := make(map[string]struct{}, len(allowedTools))
+	for _, name := range allowedTools {
+		if name != "" {
+			unique[name] = struct{}{}
+		}
+	}
+	names := make([]string, 0, len(unique))
+	for name := range unique {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, true
+}
+
+// filteredToolListAll resolves only names already authorized by the token. It
+// intentionally returns one complete logical page: exposing a raw Kubernetes
+// continuation after filtering would reveal hidden inventory structure, while
+// the signed token already bounds the candidate name set.
+func (h *Handlers) filteredToolListAll(
+	c fiber.Ctx,
+	namespace string,
+	builtins []fiber.Map,
+	allowedNames []string,
+) (ListResponse, error) {
+	items := append([]fiber.Map(nil), builtins...)
+	builtinNames := make(map[string]struct{}, len(builtins))
+	for _, builtin := range builtins {
+		if name, _ := builtin["name"].(string); name != "" {
+			builtinNames[name] = struct{}{}
+		}
+	}
+	for _, name := range allowedNames {
+		if _, builtin := builtinNames[name]; builtin {
+			continue
+		}
+		tool := &corev1alpha1.Tool{}
+		if err := h.apiReader.Get(c.Context(), client.ObjectKey{Namespace: namespace, Name: name}, tool); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return ListResponse{}, fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to get tool %q: %v", name, err))
+		}
+		allowed, err := contextTokenAllowsToolMetadata(c, h.contextTokenAuthorization, "listTools", tool.Name)
+		if err != nil {
+			return ListResponse{}, err
+		}
+		if allowed {
+			items = append(items, customToolListItem(tool))
+		}
+	}
+	return ListResponse{Items: items, Metadata: ListMeta{}}, nil
+}
+
+func decodeToolListCursor(raw, namespace string, builtinCount int) (toolListCursor, error) {
+	cursor := toolListCursor{Version: toolListCursorVersion, Namespace: namespace}
+	if raw == "" {
+		return cursor, nil
+	}
+	if len(raw) > maxToolListCursorLength {
+		return toolListCursor{}, fmt.Errorf("invalid tools continue cursor: cursor is too large")
+	}
+	data, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return toolListCursor{}, fmt.Errorf("invalid tools continue cursor: malformed encoding")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&cursor); err != nil {
+		return toolListCursor{}, fmt.Errorf("invalid tools continue cursor: malformed payload")
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return toolListCursor{}, fmt.Errorf("invalid tools continue cursor: trailing payload")
+	}
+	if cursor.Version != toolListCursorVersion || cursor.Namespace != namespace ||
+		cursor.BuiltinOffset < 0 || cursor.BuiltinOffset > builtinCount ||
+		len(cursor.History) > maxToolCursorHistorySize ||
+		(cursor.Continue != "" && (cursor.BuiltinOffset != builtinCount || cursor.ResourceVersion == "" || !cursor.CustomAvailable)) {
+		return toolListCursor{}, fmt.Errorf("invalid tools continue cursor: cursor does not match this request")
+	}
+	return cursor, nil
+}
+
+func encodeToolListCursor(cursor toolListCursor) (string, error) {
+	data, err := json.Marshal(cursor)
+	if err != nil {
+		return "", fmt.Errorf("encode tools continue cursor: %w", err)
+	}
+	if len(data) > maxToolListCursorLength {
+		return "", fmt.Errorf("encode tools continue cursor: cursor is too large")
+	}
+	return base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func advanceToolListCursor(cursor toolListCursor, nextContinue string) (toolListCursor, error) {
+	if nextContinue == "" {
+		cursor.Continue = ""
+		return cursor, nil
+	}
+	if nextContinue == cursor.Continue {
+		return toolListCursor{}, fmt.Errorf("tools continue cursor did not advance")
+	}
+	digest := hashToolContinuation(nextContinue)
+	if slices.Contains(cursor.History, digest) {
+		return toolListCursor{}, fmt.Errorf("tools continue cursor cycle detected")
+	}
+	if len(cursor.History) >= maxToolCursorHistorySize {
+		cursor.History = append(cursor.History[1:], digest)
+	} else {
+		cursor.History = append(cursor.History, digest)
+	}
+	cursor.Continue = nextContinue
+	return cursor, nil
+}
+
+func hashToolContinuation(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return base64.RawURLEncoding.EncodeToString(sum[:16])
+}
+
+func (h *Handlers) kubernetesToolListPage(
+	c fiber.Ctx,
+	namespace string,
+	pageSize int,
+	builtins []fiber.Map,
+	cursor toolListCursor,
+	items []fiber.Map,
+) (ListResponse, error) {
+	for cursor.BuiltinOffset < len(builtins) && len(items) < pageSize {
+		items = append(items, builtins[cursor.BuiltinOffset])
+		cursor.BuiltinOffset++
+	}
+
+	if len(items) == pageSize {
+		if cursor.ResourceVersion == "" {
+			resourceVersion, available, err := h.probeCustomToolSnapshot(c.Context(), namespace)
+			if err != nil {
+				return ListResponse{}, err
+			}
+			cursor.ResourceVersion = resourceVersion
+			cursor.CustomAvailable = available
+		}
+		if cursor.BuiltinOffset >= len(builtins) && !cursor.CustomAvailable {
+			return ListResponse{Items: items, Metadata: ListMeta{}}, nil
+		}
+		continuation, err := encodeToolListCursor(cursor)
+		if err != nil {
+			return ListResponse{}, fiber.NewError(fiber.StatusInternalServerError, err.Error())
+		}
+		return ListResponse{Items: items, Metadata: ListMeta{Continue: continuation}}, nil
+	}
+	if cursor.ResourceVersion != "" && !cursor.CustomAvailable {
+		return ListResponse{Items: items, Metadata: ListMeta{}}, nil
+	}
+
+	toolList := &corev1alpha1.ToolList{}
+	opts := &client.ListOptions{
+		Namespace: namespace,
+		Limit:     int64(pageSize - len(items)),
+		Continue:  cursor.Continue,
+	}
+	if cursor.Continue == "" && cursor.ResourceVersion != "" {
+		opts.Raw = &metav1.ListOptions{
+			ResourceVersion:      cursor.ResourceVersion,
+			ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+		}
+	}
+	if err := h.apiReader.List(c.Context(), toolList, opts); err != nil {
+		return ListResponse{}, paginationListError("tools", err)
+	}
+	customItems, filtered, err := customToolListItems(c, h.contextTokenAuthorization, toolList.Items)
+	if err != nil {
+		return ListResponse{}, err
+	}
+	items = append(items, customItems...)
+	metadata := ListMeta{}
+	if !filtered {
+		remaining := int64(len(builtins) - cursor.BuiltinOffset)
+		if toolList.RemainingItemCount != nil {
+			remaining += *toolList.RemainingItemCount
+			metadata.RemainingItemCount = &remaining
+		}
+	}
+	if toolList.Continue == "" {
+		return ListResponse{Items: items, Metadata: metadata}, nil
+	}
+	if toolList.ResourceVersion == "" {
+		return ListResponse{}, fiber.NewError(fiber.StatusInternalServerError, "tool list response omitted resourceVersion")
+	}
+
+	cursor.BuiltinOffset = len(builtins)
+	cursor.ResourceVersion = toolList.ResourceVersion
+	cursor.CustomAvailable = true
+	cursor, err = advanceToolListCursor(cursor, toolList.Continue)
+	if err != nil {
+		return ListResponse{}, fiber.NewError(fiber.StatusInternalServerError, err.Error())
+	}
+	metadata.Continue, err = encodeToolListCursor(cursor)
+	if err != nil {
+		return ListResponse{}, fiber.NewError(fiber.StatusInternalServerError, err.Error())
+	}
+	return ListResponse{Items: items, Metadata: metadata}, nil
+}
+
+func (h *Handlers) probeCustomToolSnapshot(ctx context.Context, namespace string) (string, bool, error) {
+	probe := &corev1alpha1.ToolList{}
+	if err := h.apiReader.List(ctx, probe, &client.ListOptions{Namespace: namespace, Limit: 1}); err != nil {
+		return "", false, paginationListError("tools", err)
+	}
+	if probe.ResourceVersion == "" {
+		return "", false, fiber.NewError(fiber.StatusInternalServerError, "tool list response omitted resourceVersion")
+	}
+	return probe.ResourceVersion, len(probe.Items) > 0 || probe.Continue != "", nil
+}
+
+func customToolListItems(
+	c fiber.Ctx,
+	authz ContextTokenAuthorizationConfig,
+	tools []corev1alpha1.Tool,
+) ([]fiber.Map, bool, error) {
+	items := make([]fiber.Map, 0, len(tools))
+	filtered := false
+	for i := range tools {
+		tool := &tools[i]
+		allowed, err := contextTokenAllowsToolMetadata(c, authz, "listTools", tool.Name)
+		if err != nil {
+			return nil, false, err
+		}
+		if !allowed {
+			filtered = true
+			continue
+		}
+		items = append(items, customToolListItem(tool))
+	}
+	return items, filtered, nil
+}
+
+func customToolListItem(tool *corev1alpha1.Tool) fiber.Map {
+	return fiber.Map{
+		"name":        tool.Name,
+		"namespace":   tool.Namespace,
+		"builtin":     false,
+		"description": tool.Spec.Description,
+		"available":   tool.Status.Available,
+		"url":         toolSpecHTTPURL(tool),
+	}
+}

--- a/internal/api/tool_pagination.go
+++ b/internal/api/tool_pagination.go
@@ -8,18 +8,15 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
-	"slices"
 	"sort"
 
 	"github.com/gofiber/fiber/v3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
@@ -31,18 +28,14 @@ const (
 	maxToolCursorHistorySize = 64
 )
 
-// toolListCursor is traversal state, not an authorization credential. Every
-// request resolves its namespace and re-applies item authorization before data
-// is returned. The cursor only combines the built-in offset with Kubernetes'
-// opaque continuation token and detects non-progress/cycles.
+// toolListCursor contains only logical current-inventory traversal state.
+// It never carries a Kubernetes resourceVersion or continuation token, so
+// callers cannot use it to select historical API-server snapshots.
 type toolListCursor struct {
-	Version         int      `json:"v"`
-	Namespace       string   `json:"n"`
-	BuiltinOffset   int      `json:"b"`
-	Continue        string   `json:"c,omitempty"`
-	History         []string `json:"h,omitempty"`
-	ResourceVersion string   `json:"r,omitempty"`
-	CustomAvailable bool     `json:"a,omitempty"`
+	Version   int    `json:"v"`
+	Namespace string `json:"n"`
+	Offset    int    `json:"o"`
+	Snapshot  string `json:"s"`
 }
 
 func (h *Handlers) allowedBuiltinTools(c fiber.Ctx) ([]fiber.Map, error) {
@@ -135,7 +128,7 @@ func (h *Handlers) unpaginatedToolListAll(
 	if err := h.apiReader.List(c.Context(), toolList, &client.ListOptions{Namespace: namespace}); err != nil {
 		return ListResponse{}, paginationListError("tools", err)
 	}
-	customItems, _, err := customToolListItems(c, h.contextTokenAuthorization, toolList.Items)
+	customItems, err := customToolListItems(c, h.contextTokenAuthorization, toolList.Items)
 	if err != nil {
 		return ListResponse{}, err
 	}
@@ -143,7 +136,7 @@ func (h *Handlers) unpaginatedToolListAll(
 	return ListResponse{Items: items, Metadata: ListMeta{}}, nil
 }
 
-func decodeToolListCursor(raw, namespace string, builtinCount int) (toolListCursor, error) {
+func decodeToolListCursor(raw, namespace string, itemCount int) (toolListCursor, error) {
 	cursor := toolListCursor{Version: toolListCursorVersion, Namespace: namespace}
 	if raw == "" {
 		return cursor, nil
@@ -164,9 +157,7 @@ func decodeToolListCursor(raw, namespace string, builtinCount int) (toolListCurs
 		return toolListCursor{}, fmt.Errorf("invalid tools continue cursor: trailing payload")
 	}
 	if cursor.Version != toolListCursorVersion || cursor.Namespace != namespace ||
-		cursor.BuiltinOffset < 0 || cursor.BuiltinOffset > builtinCount ||
-		len(cursor.History) > maxToolCursorHistorySize ||
-		(cursor.Continue != "" && (cursor.BuiltinOffset != builtinCount || cursor.ResourceVersion == "" || !cursor.CustomAvailable)) {
+		cursor.Offset < 0 || (itemCount >= 0 && cursor.Offset > itemCount) || cursor.Snapshot == "" {
 		return toolListCursor{}, fmt.Errorf("invalid tools continue cursor: cursor does not match this request")
 	}
 	return cursor, nil
@@ -183,147 +174,84 @@ func encodeToolListCursor(cursor toolListCursor) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(data), nil
 }
 
-func advanceToolListCursor(cursor toolListCursor, nextContinue string) (toolListCursor, error) {
-	if nextContinue == "" {
-		cursor.Continue = ""
-		return cursor, nil
+func toolListSnapshot(items []fiber.Map) (string, error) {
+	payload, err := json.Marshal(items)
+	if err != nil {
+		return "", fmt.Errorf("encode tool list snapshot: %w", err)
 	}
-	if nextContinue == cursor.Continue {
-		return toolListCursor{}, fmt.Errorf("tools continue cursor did not advance")
-	}
-	digest := hashToolContinuation(nextContinue)
-	if slices.Contains(cursor.History, digest) {
-		return toolListCursor{}, fmt.Errorf("tools continue cursor cycle detected")
-	}
-	if len(cursor.History) >= maxToolCursorHistorySize {
-		cursor.History = append(cursor.History[1:], digest)
-	} else {
-		cursor.History = append(cursor.History, digest)
-	}
-	cursor.Continue = nextContinue
-	return cursor, nil
+	sum := sha256.Sum256(payload)
+	return base64.RawURLEncoding.EncodeToString(sum[:]), nil
 }
 
-func hashToolContinuation(value string) string {
-	sum := sha256.Sum256([]byte(value))
-	return base64.RawURLEncoding.EncodeToString(sum[:16])
-}
-
-func (h *Handlers) kubernetesToolListPage(
+func (h *Handlers) logicalToolListPage(
 	c fiber.Ctx,
 	namespace string,
 	pageSize int64,
 	builtins []fiber.Map,
-	cursor toolListCursor,
-	items []fiber.Map,
+	rawCursor string,
 ) (ListResponse, error) {
-	for cursor.BuiltinOffset < len(builtins) && int64(len(items)) < pageSize {
-		items = append(items, builtins[cursor.BuiltinOffset])
-		cursor.BuiltinOffset++
+	cursor, err := decodeToolListCursor(rawCursor, namespace, -1)
+	if err != nil {
+		return ListResponse{}, fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
-
-	if int64(len(items)) == pageSize {
-		if cursor.ResourceVersion == "" {
-			resourceVersion, available, err := h.probeCustomToolSnapshot(c.Context(), namespace)
-			if err != nil {
-				return ListResponse{}, err
-			}
-			cursor.ResourceVersion = resourceVersion
-			cursor.CustomAvailable = available
-		}
-		if cursor.BuiltinOffset >= len(builtins) && !cursor.CustomAvailable {
-			return ListResponse{Items: items, Metadata: ListMeta{}}, nil
-		}
-		continuation, err := encodeToolListCursor(cursor)
-		if err != nil {
-			return ListResponse{}, fiber.NewError(fiber.StatusInternalServerError, err.Error())
-		}
-		return ListResponse{Items: items, Metadata: ListMeta{Continue: continuation}}, nil
-	}
-	if cursor.ResourceVersion != "" && !cursor.CustomAvailable {
-		return ListResponse{Items: items, Metadata: ListMeta{}}, nil
-	}
-
 	toolList := &corev1alpha1.ToolList{}
-	opts := &client.ListOptions{
-		Namespace: namespace,
-		Limit:     pageSize - int64(len(items)),
-		Continue:  cursor.Continue,
-	}
-	if cursor.Continue == "" && cursor.ResourceVersion != "" {
-		opts.Raw = &metav1.ListOptions{
-			ResourceVersion:      cursor.ResourceVersion,
-			ResourceVersionMatch: metav1.ResourceVersionMatchExact,
-		}
-	}
-	if err := h.apiReader.List(c.Context(), toolList, opts); err != nil {
+	if err := h.apiReader.List(c.Context(), toolList, &client.ListOptions{Namespace: namespace}); err != nil {
 		return ListResponse{}, paginationListError("tools", err)
 	}
-	customItems, filtered, err := customToolListItems(c, h.contextTokenAuthorization, toolList.Items)
+	sort.Slice(toolList.Items, func(i, j int) bool { return toolList.Items[i].Name < toolList.Items[j].Name })
+	customItems, err := customToolListItems(c, h.contextTokenAuthorization, toolList.Items)
 	if err != nil {
 		return ListResponse{}, err
 	}
-	items = append(items, customItems...)
+	items := append(append([]fiber.Map(nil), builtins...), customItems...)
+	snapshot, err := toolListSnapshot(items)
+	if err != nil {
+		return ListResponse{}, fiber.NewError(fiber.StatusInternalServerError, err.Error())
+	}
+	if rawCursor == "" {
+		cursor.Snapshot = snapshot
+	} else if cursor.Snapshot != snapshot {
+		return ListResponse{}, fiber.NewError(fiber.StatusGone, "tools continue cursor expired; restart the list")
+	}
+	if cursor.Offset > len(items) {
+		return ListResponse{}, fiber.NewError(fiber.StatusBadRequest, "invalid tools continue cursor: cursor does not match this request")
+	}
+
+	end := min(len(items), cursor.Offset+int(pageSize))
+	pageItems := append(make([]fiber.Map, 0, end-cursor.Offset), items[cursor.Offset:end]...)
 	metadata := ListMeta{}
-	if !filtered {
-		remaining := int64(len(builtins) - cursor.BuiltinOffset)
-		if toolList.RemainingItemCount != nil {
-			remaining += *toolList.RemainingItemCount
-			metadata.RemainingItemCount = &remaining
+	if end < len(items) {
+		next := toolListCursor{
+			Version: toolListCursorVersion, Namespace: namespace, Offset: end, Snapshot: snapshot,
 		}
+		metadata.Continue, err = encodeToolListCursor(next)
+		if err != nil {
+			return ListResponse{}, fiber.NewError(fiber.StatusInternalServerError, err.Error())
+		}
+		remaining := int64(len(items) - end)
+		metadata.RemainingItemCount = &remaining
 	}
-	if toolList.Continue == "" {
-		return ListResponse{Items: items, Metadata: metadata}, nil
-	}
-	if toolList.ResourceVersion == "" {
-		return ListResponse{}, fiber.NewError(fiber.StatusInternalServerError, "tool list response omitted resourceVersion")
-	}
-
-	cursor.BuiltinOffset = len(builtins)
-	cursor.ResourceVersion = toolList.ResourceVersion
-	cursor.CustomAvailable = true
-	cursor, err = advanceToolListCursor(cursor, toolList.Continue)
-	if err != nil {
-		return ListResponse{}, fiber.NewError(fiber.StatusInternalServerError, err.Error())
-	}
-	metadata.Continue, err = encodeToolListCursor(cursor)
-	if err != nil {
-		return ListResponse{}, fiber.NewError(fiber.StatusInternalServerError, err.Error())
-	}
-	return ListResponse{Items: items, Metadata: metadata}, nil
-}
-
-func (h *Handlers) probeCustomToolSnapshot(ctx context.Context, namespace string) (string, bool, error) {
-	probe := &corev1alpha1.ToolList{}
-	if err := h.apiReader.List(ctx, probe, &client.ListOptions{Namespace: namespace, Limit: 1}); err != nil {
-		return "", false, paginationListError("tools", err)
-	}
-	if probe.ResourceVersion == "" {
-		return "", false, fiber.NewError(fiber.StatusInternalServerError, "tool list response omitted resourceVersion")
-	}
-	return probe.ResourceVersion, len(probe.Items) > 0 || probe.Continue != "", nil
+	return ListResponse{Items: pageItems, Metadata: metadata}, nil
 }
 
 func customToolListItems(
 	c fiber.Ctx,
 	authz ContextTokenAuthorizationConfig,
 	tools []corev1alpha1.Tool,
-) ([]fiber.Map, bool, error) {
+) ([]fiber.Map, error) {
 	items := make([]fiber.Map, 0, len(tools))
-	filtered := false
 	for i := range tools {
 		tool := &tools[i]
 		allowed, err := contextTokenAllowsToolMetadata(c, authz, "listTools", tool.Name)
 		if err != nil {
-			return nil, false, err
+			return nil, err
 		}
 		if !allowed {
-			filtered = true
 			continue
 		}
 		items = append(items, customToolListItem(tool))
 	}
-	return items, filtered, nil
+	return items, nil
 }
 
 func customToolListItem(tool *corev1alpha1.Tool) fiber.Map {

--- a/internal/api/tool_pagination.go
+++ b/internal/api/tool_pagination.go
@@ -195,17 +195,17 @@ func hashToolContinuation(value string) string {
 func (h *Handlers) kubernetesToolListPage(
 	c fiber.Ctx,
 	namespace string,
-	pageSize int,
+	pageSize int64,
 	builtins []fiber.Map,
 	cursor toolListCursor,
 	items []fiber.Map,
 ) (ListResponse, error) {
-	for cursor.BuiltinOffset < len(builtins) && len(items) < pageSize {
+	for cursor.BuiltinOffset < len(builtins) && int64(len(items)) < pageSize {
 		items = append(items, builtins[cursor.BuiltinOffset])
 		cursor.BuiltinOffset++
 	}
 
-	if len(items) == pageSize {
+	if int64(len(items)) == pageSize {
 		if cursor.ResourceVersion == "" {
 			resourceVersion, available, err := h.probeCustomToolSnapshot(c.Context(), namespace)
 			if err != nil {
@@ -230,7 +230,7 @@ func (h *Handlers) kubernetesToolListPage(
 	toolList := &corev1alpha1.ToolList{}
 	opts := &client.ListOptions{
 		Namespace: namespace,
-		Limit:     int64(pageSize - len(items)),
+		Limit:     pageSize - int64(len(items)),
 		Continue:  cursor.Continue,
 	}
 	if cursor.Continue == "" && cursor.ResourceVersion != "" {

--- a/internal/api/tool_pagination.go
+++ b/internal/api/tool_pagination.go
@@ -186,7 +186,7 @@ func toolListSnapshot(items []fiber.Map) (string, error) {
 func (h *Handlers) logicalToolListPage(
 	c fiber.Ctx,
 	namespace string,
-	pageSize int64,
+	pageSize int,
 	builtins []fiber.Map,
 	rawCursor string,
 ) (ListResponse, error) {
@@ -217,7 +217,7 @@ func (h *Handlers) logicalToolListPage(
 		return ListResponse{}, fiber.NewError(fiber.StatusBadRequest, "invalid tools continue cursor: cursor does not match this request")
 	}
 
-	end := min(len(items), cursor.Offset+int(pageSize))
+	end := min(len(items), cursor.Offset+pageSize)
 	pageItems := append(make([]fiber.Map, 0, end-cursor.Offset), items[cursor.Offset:end]...)
 	metadata := ListMeta{}
 	if end < len(items) {


### PR DESCRIPTION
## Summary

Focused salvage from #280, rebuilt on current `main`.

- Use the authoritative Kubernetes API reader for paginated Task, Agent, and Skill lists while preserving the unpaginated cache path.
- Combine built-in and custom Tool inventory with namespace-bound, snapshot-aware cursors and continuation-cycle protection.
- Map malformed or expired continuations correctly and prevent filtered context-token callers from receiving hidden cursor/count metadata.

## Scope

This PR defines backend inventory pagination only. It does not change CLI traversal or task-log streaming; those are separate stacked follow-ups.

## Verification

- `go test ./internal/api -run 'Pagination|ListTools|Handlers' -count=1`
- `make lint-fix && make test`
- Full required CI