### PR TITLE
fix(auth): cache OIDC signing metadata safely

### DIFF
--- a/internal/aitools/resolver.go
+++ b/internal/aitools/resolver.go
@@ -1,0 +1,177 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+// Package aitools resolves the effective built-in and configured tool set exposed
+// to AI workers and brokered agent runtimes. It is deliberately pure so
+// authorization, child transaction checks, and runtime injection share the
+// exact same decision.
+package aitools
+
+import (
+	"slices"
+	"strings"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+	"github.com/orka-agents/orka/internal/labels"
+)
+
+var memoryToolNames = []string{
+	"recall_memory",
+	"remember",
+	"propose_memory",
+	"search_transcript",
+}
+
+var registeredCoordinationToolNames = []string{
+	"delegate_task",
+	"wait_for_tasks",
+	"create_container_task",
+	"cancel_task",
+	"send_message",
+	"check_messages",
+	"create_pull_request",
+	"check_pull_request_ci",
+	"merge_pull_request",
+	"auto_merge_pull_request",
+	"review_pull_request",
+	"post_review_comment",
+	"check_pr_review_marker",
+	"list_issues",
+	"list_pull_requests",
+	"get_issue",
+	"comment_on_issue",
+	"create_agent",
+	"delete_agent",
+	"update_plan",
+	"recall_memory",
+	"remember",
+	"propose_memory",
+	"search_transcript",
+}
+
+var implicitCoordinationToolNames = []string{
+	"delegate_task",
+	"wait_for_tasks",
+	"create_container_task",
+	"cancel_task",
+	"send_message",
+	"check_messages",
+	"recall_memory",
+	"remember",
+	"propose_memory",
+	"search_transcript",
+	"create_pull_request",
+	"list_pull_requests",
+	"check_pr_review_marker",
+	"check_pull_request_ci",
+	"merge_pull_request",
+	"auto_merge_pull_request",
+	"review_pull_request",
+	"post_review_comment",
+	"create_agent",
+	"delete_agent",
+	"update_plan",
+}
+
+var childMessagingToolNames = []string{
+	"send_message",
+	"check_messages",
+}
+
+// MemoryToolNames returns the AI worker's always-on memory tool names.
+func MemoryToolNames() []string {
+	return append([]string(nil), memoryToolNames...)
+}
+
+// CoordinationToolNames returns the tools registered for coordinator workers.
+func CoordinationToolNames() []string {
+	return append([]string(nil), registeredCoordinationToolNames...)
+}
+
+// IsImplicitTool reports whether name is injected by Orka rather than selected
+// explicitly by an Agent or Task. Authorization uses it to distinguish platform
+// tools from Tool CR references without broadening implicit capabilities.
+func IsImplicitTool(task *corev1alpha1.Task, agent *corev1alpha1.Agent, name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" || (task != nil && task.Spec.Type == corev1alpha1.TaskTypeContainer) {
+		return false
+	}
+	disableImplicitTools := task != nil && task.Annotations[labels.AnnotationDisableCoordinationToolInject] == "true"
+	if !disableImplicitTools {
+		if agent != nil && agent.Spec.Coordination != nil && agent.Spec.Coordination.Enabled {
+			if containsTool(implicitCoordinationToolNames, name) || (agent.Spec.Coordination.Autonomous && name == "request_approval") {
+				return true
+			}
+		}
+		if task != nil && labels.ParentTaskName(task.Labels, task.Annotations) != "" && containsTool(childMessagingToolNames, name) {
+			return true
+		}
+	}
+	return task != nil && task.Spec.Type == corev1alpha1.TaskTypeAI && containsTool(memoryToolNames, name)
+}
+
+func containsTool(tools []string, name string) bool {
+	return slices.Contains(tools, name)
+}
+
+// Resolve returns the ordered, de-duplicated configured and implicit tool set
+// exposed for task. Container tasks do not expose AI tools. Agent tasks retain
+// configured/brokered tools, while the in-process AI worker additionally gets
+// its always-on memory tools.
+func Resolve(task *corev1alpha1.Task, agent *corev1alpha1.Agent) []string {
+	if task != nil && task.Spec.Type == corev1alpha1.TaskTypeContainer {
+		return nil
+	}
+
+	tools := make([]string, 0)
+	seen := make(map[string]struct{})
+	appendTool := func(raw string) {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		tools = append(tools, name)
+	}
+	appendTools := func(names []string) {
+		for _, name := range names {
+			appendTool(name)
+		}
+	}
+
+	if agent != nil {
+		for _, tool := range agent.Spec.Tools {
+			if tool.Enabled != nil && !*tool.Enabled {
+				continue
+			}
+			appendTool(tool.Name)
+		}
+	}
+	if task != nil && task.Spec.AI != nil {
+		appendTools(task.Spec.AI.Tools)
+	}
+
+	disableImplicitTools := task != nil && task.Annotations[labels.AnnotationDisableCoordinationToolInject] == "true"
+	if agent != nil && agent.Spec.Coordination != nil && agent.Spec.Coordination.Enabled && !disableImplicitTools {
+		appendTools(implicitCoordinationToolNames)
+		if agent.Spec.Coordination.Autonomous {
+			appendTool("request_approval")
+		}
+	}
+
+	if task != nil && labels.ParentTaskName(task.Labels, task.Annotations) != "" && !disableImplicitTools {
+		appendTools(childMessagingToolNames)
+	}
+
+	if task != nil && task.Spec.Type == corev1alpha1.TaskTypeAI {
+		appendTools(memoryToolNames)
+	}
+
+	return tools
+}

--- a/internal/aitools/resolver.go
+++ b/internal/aitools/resolver.go
@@ -91,6 +91,20 @@ func CoordinationToolNames() []string {
 	return append([]string(nil), registeredCoordinationToolNames...)
 }
 
+// RegistersCoordinationTools reports whether the AI worker registers Orka's
+// coordination tool implementations for task. Disabling implicit injection only
+// narrows the selected tool list; child identity still enables the registry so
+// explicitly selected coordination tools remain platform-provided.
+func RegistersCoordinationTools(task *corev1alpha1.Task, agent *corev1alpha1.Agent) bool {
+	if task != nil && task.Spec.Type == corev1alpha1.TaskTypeContainer {
+		return false
+	}
+	if agent != nil && agent.Spec.Coordination != nil && agent.Spec.Coordination.Enabled {
+		return true
+	}
+	return task != nil && labels.ParentTaskName(task.Labels, task.Annotations) != ""
+}
+
 // IsImplicitTool reports whether name is injected by Orka rather than selected
 // explicitly by an Agent or Task. Authorization uses it to distinguish platform
 // tools from Tool CR references without broadening implicit capabilities.

--- a/internal/aitools/resolver.go
+++ b/internal/aitools/resolver.go
@@ -93,10 +93,10 @@ func CoordinationToolNames() []string {
 
 // RegistersCoordinationTools reports whether the AI worker registers Orka's
 // coordination tool implementations for task. Disabling implicit injection only
-// narrows the selected tool list; child identity still enables the registry so
-// explicitly selected coordination tools remain platform-provided.
+// narrows the selected tool list; AI child identity still enables the registry
+// so explicitly selected coordination tools remain platform-provided.
 func RegistersCoordinationTools(task *corev1alpha1.Task, agent *corev1alpha1.Agent) bool {
-	if task != nil && task.Spec.Type == corev1alpha1.TaskTypeContainer {
+	if !usesAIWorkerToolRegistry(task) {
 		return false
 	}
 	if agent != nil && agent.Spec.Coordination != nil && agent.Spec.Coordination.Enabled {
@@ -110,7 +110,7 @@ func RegistersCoordinationTools(task *corev1alpha1.Task, agent *corev1alpha1.Age
 // tools from Tool CR references without broadening implicit capabilities.
 func IsImplicitTool(task *corev1alpha1.Task, agent *corev1alpha1.Agent, name string) bool {
 	name = strings.TrimSpace(name)
-	if name == "" || (task != nil && task.Spec.Type == corev1alpha1.TaskTypeContainer) {
+	if name == "" || !usesAIWorkerToolRegistry(task) {
 		return false
 	}
 	disableImplicitTools := task != nil && task.Annotations[labels.AnnotationDisableCoordinationToolInject] == "true"
@@ -129,6 +129,10 @@ func IsImplicitTool(task *corev1alpha1.Task, agent *corev1alpha1.Agent, name str
 
 func containsTool(tools []string, name string) bool {
 	return slices.Contains(tools, name)
+}
+
+func usesAIWorkerToolRegistry(task *corev1alpha1.Task) bool {
+	return task == nil || task.Spec.Type == "" || task.Spec.Type == corev1alpha1.TaskTypeAI
 }
 
 // Resolve returns the ordered, de-duplicated configured and implicit tool set
@@ -172,14 +176,14 @@ func Resolve(task *corev1alpha1.Task, agent *corev1alpha1.Agent) []string {
 	}
 
 	disableImplicitTools := task != nil && task.Annotations[labels.AnnotationDisableCoordinationToolInject] == "true"
-	if agent != nil && agent.Spec.Coordination != nil && agent.Spec.Coordination.Enabled && !disableImplicitTools {
+	if usesAIWorkerToolRegistry(task) && agent != nil && agent.Spec.Coordination != nil && agent.Spec.Coordination.Enabled && !disableImplicitTools {
 		appendTools(implicitCoordinationToolNames)
 		if agent.Spec.Coordination.Autonomous {
 			appendTool("request_approval")
 		}
 	}
 
-	if task != nil && labels.ParentTaskName(task.Labels, task.Annotations) != "" && !disableImplicitTools {
+	if usesAIWorkerToolRegistry(task) && task != nil && labels.ParentTaskName(task.Labels, task.Annotations) != "" && !disableImplicitTools {
 		appendTools(childMessagingToolNames)
 	}
 

--- a/internal/aitools/resolver_test.go
+++ b/internal/aitools/resolver_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package aitools
+
+import (
+	"slices"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+	"github.com/orka-agents/orka/internal/labels"
+)
+
+func TestResolve(t *testing.T) {
+	enabled := true
+	disabled := false
+	tests := []struct {
+		name  string
+		task  *corev1alpha1.Task
+		agent *corev1alpha1.Agent
+		want  []string
+	}{
+		{
+			name: "configured tools and memory are canonicalized",
+			task: aiToolTask(nil, nil, []string{"task_tool", " agent_tool ", ""}),
+			agent: &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{Tools: []corev1alpha1.ToolReference{
+				{Name: " agent_tool ", Enabled: &enabled},
+				{Name: "disabled_tool", Enabled: &disabled},
+			}}},
+			want: []string{"agent_tool", "task_tool", "recall_memory", "remember", "propose_memory", "search_transcript"},
+		},
+		{
+			name: "autonomous coordination adds approval",
+			task: aiToolTask(nil, nil, nil),
+			agent: &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{Coordination: &corev1alpha1.CoordinationConfig{
+				Enabled: true, Autonomous: true,
+			}}},
+			want: append(append([]string{}, implicitCoordinationToolNames...), "request_approval"),
+		},
+		{
+			name: "parent label adds messaging",
+			task: aiToolTask(map[string]string{labels.LabelParentTask: "parent"}, nil, nil),
+			want: []string{"send_message", "check_messages", "recall_memory", "remember", "propose_memory", "search_transcript"},
+		},
+		{
+			name: "parent annotation adds messaging",
+			task: aiToolTask(nil, map[string]string{labels.AnnotationParentTaskName: "long-parent-name"}, nil),
+			want: []string{"send_message", "check_messages", "recall_memory", "remember", "propose_memory", "search_transcript"},
+		},
+		{
+			name:  "agent task retains configured brokered tools without AI memory tools",
+			task:  &corev1alpha1.Task{Spec: corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeAgent, AI: &corev1alpha1.AISpec{Tools: []string{"brokered"}}}},
+			agent: &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{Tools: []corev1alpha1.ToolReference{{Name: "agent_tool"}}}},
+			want:  []string{"agent_tool", "brokered"},
+		},
+		{
+			name: "container task has no AI tools",
+			task: &corev1alpha1.Task{Spec: corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeContainer}},
+			agent: &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{
+				Tools:        []corev1alpha1.ToolReference{{Name: "agent_tool"}},
+				Coordination: &corev1alpha1.CoordinationConfig{Enabled: true, Autonomous: true},
+			}},
+			want: nil,
+		},
+		{
+			name: "disable annotation suppresses implicit tools",
+			task: aiToolTask(
+				map[string]string{labels.LabelParentTask: "parent"},
+				map[string]string{labels.AnnotationDisableCoordinationToolInject: "true"},
+				[]string{"explicit_tool"},
+			),
+			agent: &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{Coordination: &corev1alpha1.CoordinationConfig{
+				Enabled: true, Autonomous: true,
+			}}},
+			want: []string{"explicit_tool", "recall_memory", "remember", "propose_memory", "search_transcript"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Resolve(tt.task, tt.agent)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("Resolve() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsImplicitTool(t *testing.T) {
+	child := aiToolTask(map[string]string{labels.LabelParentTask: "parent"}, nil, nil)
+	if !IsImplicitTool(child, nil, "send_message") {
+		t.Fatal("child messaging tool was not classified as implicit")
+	}
+	child.Annotations = map[string]string{labels.AnnotationDisableCoordinationToolInject: "true"}
+	if IsImplicitTool(child, nil, "send_message") {
+		t.Fatal("disabled child messaging tool was classified as implicit")
+	}
+	if IsImplicitTool(aiToolTask(nil, nil, []string{"list_issues"}), nil, "list_issues") {
+		t.Fatal("explicit issue tool was classified as implicit")
+	}
+}
+
+func TestToolNameAccessorsReturnCopies(t *testing.T) {
+	const changed = "changed"
+	coordination := CoordinationToolNames()
+	memory := MemoryToolNames()
+	coordination[0] = changed
+	memory[0] = changed
+	if CoordinationToolNames()[0] == changed || MemoryToolNames()[0] == changed {
+		t.Fatal("tool name accessor exposed mutable package state")
+	}
+}
+
+func aiToolTask(labelsMap, annotations map[string]string, tools []string) *corev1alpha1.Task {
+	return &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Labels: labelsMap, Annotations: annotations},
+		Spec: corev1alpha1.TaskSpec{
+			Type: corev1alpha1.TaskTypeAI,
+			AI:   &corev1alpha1.AISpec{Tools: tools},
+		},
+	}
+}

--- a/internal/aitools/resolver_test.go
+++ b/internal/aitools/resolver_test.go
@@ -91,6 +91,55 @@ func TestResolve(t *testing.T) {
 	}
 }
 
+func TestRegistersCoordinationTools(t *testing.T) {
+	tests := []struct {
+		name  string
+		task  *corev1alpha1.Task
+		agent *corev1alpha1.Agent
+		want  bool
+	}{
+		{
+			name:  "coordinator agent",
+			task:  aiToolTask(nil, nil, nil),
+			agent: &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{Coordination: &corev1alpha1.CoordinationConfig{Enabled: true}}},
+			want:  true,
+		},
+		{
+			name: "child with implicit injection disabled",
+			task: aiToolTask(
+				map[string]string{labels.LabelParentTask: "parent"},
+				map[string]string{labels.AnnotationDisableCoordinationToolInject: "true"},
+				[]string{"send_message"},
+			),
+			want: true,
+		},
+		{
+			name: "child identified by annotation",
+			task: aiToolTask(nil, map[string]string{
+				labels.AnnotationParentTaskName:                "long-parent-name",
+				labels.AnnotationDisableCoordinationToolInject: "true",
+			}, []string{"list_pull_requests"}),
+			want: true,
+		},
+		{name: "standalone task", task: aiToolTask(nil, nil, []string{"send_message"})},
+		{
+			name: "container child",
+			task: &corev1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labels.LabelParentTask: "parent"}},
+				Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeContainer},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RegistersCoordinationTools(tt.task, tt.agent); got != tt.want {
+				t.Fatalf("RegistersCoordinationTools() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsImplicitTool(t *testing.T) {
 	child := aiToolTask(map[string]string{labels.LabelParentTask: "parent"}, nil, nil)
 	if !IsImplicitTool(child, nil, "send_message") {

--- a/internal/aitools/resolver_test.go
+++ b/internal/aitools/resolver_test.go
@@ -53,10 +53,16 @@ func TestResolve(t *testing.T) {
 			want: []string{"send_message", "check_messages", "recall_memory", "remember", "propose_memory", "search_transcript"},
 		},
 		{
-			name:  "agent task retains configured brokered tools without AI memory tools",
-			task:  &corev1alpha1.Task{Spec: corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeAgent, AI: &corev1alpha1.AISpec{Tools: []string{"brokered"}}}},
-			agent: &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{Tools: []corev1alpha1.ToolReference{{Name: "agent_tool"}}}},
-			want:  []string{"agent_tool", "brokered"},
+			name: "agent child retains configured tools without AI worker implicit tools",
+			task: &corev1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labels.LabelParentTask: "parent"}},
+				Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeAgent, AI: &corev1alpha1.AISpec{Tools: []string{"brokered"}}},
+			},
+			agent: &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{
+				Tools:        []corev1alpha1.ToolReference{{Name: "agent_tool"}},
+				Coordination: &corev1alpha1.CoordinationConfig{Enabled: true, Autonomous: true},
+			}},
+			want: []string{"agent_tool", "brokered"},
 		},
 		{
 			name: "container task has no AI tools",
@@ -122,6 +128,13 @@ func TestRegistersCoordinationTools(t *testing.T) {
 			want: true,
 		},
 		{name: "standalone task", task: aiToolTask(nil, nil, []string{"send_message"})},
+		{
+			name: "agent child",
+			task: &corev1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labels.LabelParentTask: "parent"}},
+				Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeAgent},
+			},
+		},
 		{
 			name: "container child",
 			task: &corev1alpha1.Task{

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -140,6 +140,7 @@ func NewAuthMiddleware(c client.Client, configs ...AuthConfig) fiber.Handler {
 	}
 
 	tokenExtractor := AuthTokenExtractor{Sources: cfg.TokenSources}
+	jwtVerifier := newJWTVerifier()
 
 	return func(ctx fiber.Ctx) error {
 		contextToken, profile, ok, err := extractContextTokenCandidate(ctx, cfg.ContextTokens)
@@ -150,7 +151,7 @@ func NewAuthMiddleware(c client.Client, configs ...AuthConfig) fiber.Handler {
 
 		var userInfo *UserInfo
 		if ok {
-			userInfo, err = authenticateContextToken(ctx.Context(), contextToken, profile)
+			userInfo, err = authenticateContextTokenWithVerifier(ctx.Context(), contextToken, profile, jwtVerifier)
 		} else {
 			bearerContextToken, bearerErr := isUnconfiguredBearerContextToken(ctx, cfg.ContextTokens)
 			if bearerErr != nil {
@@ -174,7 +175,7 @@ func NewAuthMiddleware(c client.Client, configs ...AuthConfig) fiber.Handler {
 				return fiber.NewError(fiber.StatusUnauthorized, "missing authorization header")
 			}
 
-			userInfo, err = authenticateToken(ctx.Context(), c, token, cfg)
+			userInfo, err = authenticateTokenWithVerifier(ctx.Context(), c, token, cfg, jwtVerifier)
 		}
 		if err != nil {
 			log.Error(err, "token validation failed")
@@ -189,13 +190,17 @@ func NewAuthMiddleware(c client.Client, configs ...AuthConfig) fiber.Handler {
 }
 
 func authenticateToken(ctx context.Context, c client.Client, token string, cfg AuthConfig) (*UserInfo, error) {
+	return authenticateTokenWithVerifier(ctx, c, token, cfg, processJWTVerifier)
+}
+
+func authenticateTokenWithVerifier(ctx context.Context, c client.Client, token string, cfg AuthConfig, verifier *jwtVerifier) (*UserInfo, error) {
 	if !cfg.OIDC.Enabled() {
 		return validateToken(ctx, c, token)
 	}
 
 	parsedOIDC, oidcErr := parseOIDCTokenCandidate(token, cfg.OIDC)
 	if oidcErr == nil {
-		userInfo, oidcErr := validateParsedOIDCToken(ctx, parsedOIDC, cfg.OIDC)
+		userInfo, oidcErr := validateParsedOIDCTokenWithVerifier(ctx, parsedOIDC, cfg.OIDC, verifier)
 		if oidcErr == nil {
 			return userInfo, nil
 		}
@@ -215,8 +220,8 @@ func authenticateToken(ctx context.Context, c client.Client, token string, cfg A
 	return nil, fmt.Errorf("OIDC validation skipped: %w; TokenReview validation failed: %v", oidcErr, tokenReviewErr)
 }
 
-func authenticateContextToken(ctx context.Context, token string, profile ContextTokenProfileConfig) (*UserInfo, error) {
-	contextToken, err := validateContextToken(ctx, token, profile)
+func authenticateContextTokenWithVerifier(ctx context.Context, token string, profile ContextTokenProfileConfig, verifier *jwtVerifier) (*UserInfo, error) {
+	contextToken, err := validateContextTokenWithVerifier(ctx, token, profile, verifier)
 	if err != nil {
 		metrics.RecordContextTokenAuth(profile.Name, "failure")
 		return nil, err

--- a/internal/api/context_token.go
+++ b/internal/api/context_token.go
@@ -14,10 +14,12 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/orka-agents/orka/internal/transactiontoken"
+	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 )
 
 const (
@@ -35,6 +37,28 @@ const (
 )
 
 var transactionTokenRequiredClaims = append([]string(nil), transactiontoken.RequiredClaims...)
+
+var contextTokenStringAuthorizationClaims = [...]string{
+	"namespace",
+	"taskType",
+	"taskName",
+	"task",
+	"agent",
+	"repo",
+	"branch",
+	"ref",
+	"configMap",
+	"secret",
+	"provider",
+	"model",
+}
+
+var contextTokenStringListAuthorizationClaims = [...]string{
+	"allowedAgents",
+	"allowedTools",
+	"allowedProviders",
+	"allowedModels",
+}
 
 // TokenHeaderConfig describes one HTTP header location from which a token can be extracted.
 type TokenHeaderConfig struct {
@@ -288,6 +312,9 @@ func validateContextToken(ctx context.Context, token string, profile ContextToke
 	if err != nil {
 		return nil, fmt.Errorf("parse context-token claims map: %w", err)
 	}
+	if err := validateContextTokenAuthorizationClaims(claimsMap); err != nil {
+		return nil, err
+	}
 	if err := validateRequiredContextTokenClaims(claimsMap, profile.RequiredClaims); err != nil {
 		return nil, err
 	}
@@ -321,6 +348,67 @@ func decodeContextTokenClaimsMap(raw json.RawMessage) (map[string]any, error) {
 		return nil, err
 	}
 	return claims, nil
+}
+
+func validateContextTokenAuthorizationClaims(claims map[string]any) error {
+	rawContext, ok := claims["tctx"]
+	if !ok || rawContext == nil {
+		return nil
+	}
+	transactionContext, ok := rawContext.(map[string]any)
+	if !ok {
+		return errors.New(`invalid context-token claim "tctx": expected an object`)
+	}
+
+	for _, name := range contextTokenStringAuthorizationClaims {
+		value, present := transactionContext[name]
+		if !present {
+			continue
+		}
+		stringValue, valid := value.(string)
+		if !valid || strings.TrimSpace(stringValue) == "" {
+			return fmt.Errorf("invalid context-token tctx claim %q: expected a non-empty string", name)
+		}
+	}
+
+	for _, name := range contextTokenStringListAuthorizationClaims {
+		if _, present := transactionContext[name]; !present {
+			continue
+		}
+		if _, valid := contextStringList(transactionContext, name); !valid {
+			return fmt.Errorf("invalid context-token tctx claim %q: expected a non-empty string or a string list", name)
+		}
+	}
+
+	if value, present := transactionContext["maxDepth"]; present {
+		if err := validateContextTokenMaxDepth(value); err != nil {
+			return err
+		}
+	}
+
+	if secret, present := transactionContext["secret"].(string); present {
+		if validationErrors := utilvalidation.IsDNS1123Subdomain(secret); len(validationErrors) > 0 {
+			return fmt.Errorf("invalid context-token tctx claim %q: expected a valid Kubernetes Secret name: %s", "secret", strings.Join(validationErrors, "; "))
+		}
+	}
+	return nil
+}
+
+func validateContextTokenMaxDepth(value any) error {
+	var raw string
+	switch typed := value.(type) {
+	case json.Number:
+		raw = typed.String()
+	case string:
+		raw = strings.TrimSpace(typed)
+	default:
+		return errors.New(`invalid context-token tctx claim "maxDepth": expected a non-negative integer`)
+	}
+	parsed, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || parsed < 0 {
+		return errors.New(`invalid context-token tctx claim "maxDepth": expected a non-negative integer`)
+	}
+	return nil
 }
 
 func validateRequiredContextTokenClaims(claims map[string]any, required []string) error {

--- a/internal/api/context_token.go
+++ b/internal/api/context_token.go
@@ -268,6 +268,10 @@ func extractTokenFromHeaderValue(value string, header TokenHeaderConfig) (string
 }
 
 func validateContextToken(ctx context.Context, token string, profile ContextTokenProfileConfig) (*ContextToken, error) {
+	return validateContextTokenWithVerifier(ctx, token, profile, processJWTVerifier)
+}
+
+func validateContextTokenWithVerifier(ctx context.Context, token string, profile ContextTokenProfileConfig, verifier *jwtVerifier) (*ContextToken, error) {
 	if profile.Name == "" {
 		return nil, errors.New("missing context-token profile name")
 	}
@@ -289,19 +293,10 @@ func validateContextToken(ctx context.Context, token string, profile ContextToke
 		return nil, fmt.Errorf("invalid JWT type %q", parsed.Header.Type)
 	}
 
-	jwksURL := profile.JWKSURL
-	if jwksURL == "" {
-		discovered, err := discoverOIDCJWKSURL(ctx, profile.Issuer)
-		if err != nil {
-			return nil, err
-		}
-		jwksURL = discovered
-	}
-
-	verified, err := verifyParsedJWT(ctx, parsed, jwtVerificationConfig{
+	verified, err := verifier.verifyParsedJWTWithDiscovery(ctx, parsed, jwtVerificationConfig{
 		Issuer:         profile.Issuer,
 		Audience:       profile.Audience,
-		JWKSURL:        jwksURL,
+		JWKSURL:        profile.JWKSURL,
 		RequiredClaims: profile.RequiredClaims,
 	})
 	if err != nil {

--- a/internal/api/context_token_authorization.go
+++ b/internal/api/context_token_authorization.go
@@ -1588,15 +1588,15 @@ func contextTokenTaskToolFailures(token *ContextToken, authzCtx contextTokenTask
 }
 
 func contextTokenPlatformAIToolName(authzCtx contextTokenTaskCreateAuthorizationContext, name string) bool {
+	task := contextTokenTaskCreateAIToolTask(authzCtx.Request)
 	if slices.Contains(aitools.MemoryToolNames(), name) {
 		return true
 	}
-	if aitools.IsImplicitTool(contextTokenTaskCreateAIToolTask(authzCtx.Request), authzCtx.Agent, name) {
+	if aitools.IsImplicitTool(task, authzCtx.Agent, name) {
 		return true
 	}
 	if slices.Contains(toolspkg.CoordinationToolNames(), name) {
-		coordinationEnabled := authzCtx.Agent != nil && authzCtx.Agent.Spec.Coordination != nil && authzCtx.Agent.Spec.Coordination.Enabled
-		return coordinationEnabled || slices.Contains(toolspkg.ChatToolNames(), name)
+		return aitools.RegistersCoordinationTools(task, authzCtx.Agent) || slices.Contains(toolspkg.ChatToolNames(), name)
 	}
 	_, builtin := toolspkg.DefaultRegistry.Get(name)
 	return builtin

--- a/internal/api/context_token_authorization.go
+++ b/internal/api/context_token_authorization.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gofiber/fiber/v3"
 
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
-	"github.com/orka-agents/orka/internal/labels"
+	"github.com/orka-agents/orka/internal/aitools"
 	"github.com/orka-agents/orka/internal/llm"
 	"github.com/orka-agents/orka/internal/metrics"
 	"github.com/orka-agents/orka/internal/redact"
@@ -653,8 +653,14 @@ func createTaskRequestFromTask(task *corev1alpha1.Task) CreateTaskRequest {
 	}
 
 	req := CreateTaskRequest{
-		Name:              task.Name,
-		Namespace:         task.Namespace,
+		Name:      task.Name,
+		Namespace: task.Namespace,
+		Metadata: MetadataRequest{
+			Name:        task.Name,
+			Namespace:   task.Namespace,
+			Labels:      task.Labels,
+			Annotations: task.Annotations,
+		},
 		Annotations:       task.Annotations,
 		Type:              task.Spec.Type,
 		Image:             task.Spec.Image,
@@ -1236,59 +1242,28 @@ func contextTokenTaskCreateEffectiveProviderModel(req CreateTaskRequest, agent *
 }
 
 func contextTokenTaskCreateEffectiveAITools(req CreateTaskRequest, agent *corev1alpha1.Agent) []string {
-	tools := []string{}
-	if agent != nil {
-		for _, tool := range agent.Spec.Tools {
-			if tool.Enabled != nil && !*tool.Enabled {
-				continue
-			}
-			if strings.TrimSpace(tool.Name) != "" {
-				tools = append(tools, tool.Name)
-			}
-		}
-		if agent.Spec.Coordination != nil && agent.Spec.Coordination.Enabled && req.Annotations[labels.AnnotationDisableCoordinationToolInject] != queryTrue {
-			for _, tool := range coordinationToolNames() {
-				if !slices.Contains(tools, tool) {
-					tools = append(tools, tool)
-				}
-			}
-		}
-	}
-	if req.AI != nil {
-		for _, tool := range req.AI.Tools {
-			if strings.TrimSpace(tool) != "" {
-				tools = append(tools, tool)
-			}
-		}
-	}
-	if req.Type == corev1alpha1.TaskTypeAI {
-		for _, tool := range memoryToolNames() {
-			if !slices.Contains(tools, tool) {
-				tools = append(tools, tool)
-			}
-		}
-	}
-	return tools
+	return aitools.Resolve(contextTokenTaskCreateAIToolTask(req), agent)
 }
 
-func memoryToolNames() []string {
-	return []string{
-		"recall_memory",
-		"remember",
-		"propose_memory",
-		"search_transcript",
+func contextTokenTaskCreateAIToolTask(req CreateTaskRequest) *corev1alpha1.Task {
+	taskType := req.Type
+	taskAI := req.AI
+	if req.Spec != nil {
+		if taskType == "" {
+			taskType = req.Spec.Type
+		}
+		if taskAI == nil {
+			taskAI = req.Spec.AI
+		}
 	}
-}
-
-func coordinationToolNames() []string {
-	return []string{
-		"delegate_task", "wait_for_tasks", "create_container_task", "cancel_task",
-		"send_message", "check_messages", "recall_memory", "remember",
-		"propose_memory", "search_transcript", "create_pull_request",
-		"list_pull_requests", "check_pr_review_marker", "check_pull_request_ci",
-		"merge_pull_request", "auto_merge_pull_request", "review_pull_request",
-		"post_review_comment", "create_agent", "delete_agent", "update_plan",
+	annotations := req.Annotations
+	if annotations == nil {
+		annotations = req.Metadata.Annotations
 	}
+	task := &corev1alpha1.Task{Spec: corev1alpha1.TaskSpec{Type: taskType, AI: taskAI}}
+	task.Labels = req.Metadata.Labels
+	task.Annotations = annotations
+	return task
 }
 
 func contextTokenTaskCreateEffectiveRuntimeAllowedTools(req CreateTaskRequest, agent *corev1alpha1.Agent) []string {
@@ -1613,7 +1588,10 @@ func contextTokenTaskToolFailures(token *ContextToken, authzCtx contextTokenTask
 }
 
 func contextTokenPlatformAIToolName(authzCtx contextTokenTaskCreateAuthorizationContext, name string) bool {
-	if slices.Contains(memoryToolNames(), name) {
+	if slices.Contains(aitools.MemoryToolNames(), name) {
+		return true
+	}
+	if aitools.IsImplicitTool(contextTokenTaskCreateAIToolTask(authzCtx.Request), authzCtx.Agent, name) {
 		return true
 	}
 	if slices.Contains(toolspkg.CoordinationToolNames(), name) {

--- a/internal/api/context_token_authorization_test.go
+++ b/internal/api/context_token_authorization_test.go
@@ -1072,6 +1072,20 @@ func TestContextTokenTaskCreateEffectiveAIToolsIncludesChildMessaging(t *testing
 	require.Contains(t, got, "check_messages")
 }
 
+func TestContextTokenTaskCreateEffectiveAIToolsExcludesImplicitAgentCoordination(t *testing.T) {
+	agent := &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{
+		Tools:        []corev1alpha1.ToolReference{{Name: "agent_tool"}},
+		Coordination: &corev1alpha1.CoordinationConfig{Enabled: true, Autonomous: true},
+	}}
+	req := CreateTaskRequest{
+		Type:     corev1alpha1.TaskTypeAgent,
+		Metadata: MetadataRequest{Labels: map[string]string{labels.LabelParentTask: "parent-task"}},
+		AI:       &corev1alpha1.AISpec{Tools: []string{"brokered_tool"}},
+	}
+
+	require.Equal(t, []string{"agent_tool", "brokered_tool"}, contextTokenTaskCreateEffectiveAITools(req, agent))
+}
+
 func TestContextTokenTaskCreateEffectiveAIToolsMatchesSharedResolver(t *testing.T) {
 	agent := &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{
 		Tools:        []corev1alpha1.ToolReference{{Name: "agent_tool"}},

--- a/internal/api/context_token_authorization_test.go
+++ b/internal/api/context_token_authorization_test.go
@@ -145,6 +145,32 @@ func TestContextTokenTaskCreateFailures(t *testing.T) {
 	})
 }
 
+func TestContextTokenTaskToolFailuresKeepsExplicitChildCoordinationFailClosed(t *testing.T) {
+	req := CreateTaskRequest{
+		Type: corev1alpha1.TaskTypeAI,
+		Metadata: MetadataRequest{
+			Labels: map[string]string{labels.LabelParentTask: "parent-task"},
+		},
+		Annotations: map[string]string{labels.AnnotationDisableCoordinationToolInject: queryTrue},
+		AI:          &corev1alpha1.AISpec{Tools: []string{"send_message"}},
+	}
+	authzCtx := contextTokenTaskCreateAuthorizationContext{
+		Request:          req,
+		EffectiveAITools: contextTokenTaskCreateEffectiveAITools(req, nil),
+	}
+	allowedWithoutExplicit := make([]any, 0, len(aitools.MemoryToolNames()))
+	for _, name := range aitools.MemoryToolNames() {
+		allowedWithoutExplicit = append(allowedWithoutExplicit, name)
+	}
+	token := &ContextToken{TransactionContext: map[string]any{"allowedTools": allowedWithoutExplicit}}
+
+	failures := contextTokenTaskToolFailures(token, authzCtx)
+	require.Equal(t, []string{`tool "send_message" is not allowed by token context`}, failures)
+
+	token.TransactionContext["allowedTools"] = append(allowedWithoutExplicit, "send_message")
+	require.Empty(t, contextTokenTaskToolFailures(token, authzCtx))
+}
+
 func TestAuthorizeContextTokenToolAgentCreateRejectsSpecOutsideTokenConstraints(t *testing.T) {
 	cfg := enforceContextTokenAuthorizationConfig()
 	token := &ContextToken{
@@ -981,6 +1007,8 @@ func TestContextTokenTaskToolCredentialFailuresUsesToolProvenance(t *testing.T) 
 		{name: "AI coordination tool is builtin when coordination is enabled", ctx: contextTokenTaskCreateAuthorizationContext{Namespace: "team-a", Agent: &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{Coordination: &corev1alpha1.CoordinationConfig{Enabled: true}}}, EffectiveAITools: []string{"list_issues"}}},
 		{name: "AI coordination name resolves as custom without coordination", ctx: contextTokenTaskCreateAuthorizationContext{Namespace: "team-a", EffectiveAITools: []string{"list_issues"}}, wantFailure: "list_issues"},
 		{name: "implicit child messaging is builtin without agent coordination", ctx: contextTokenTaskCreateAuthorizationContext{Namespace: "team-a", Request: CreateTaskRequest{Type: corev1alpha1.TaskTypeAI, Metadata: MetadataRequest{Labels: map[string]string{labels.LabelParentTask: "parent-task"}}}, EffectiveAITools: []string{"send_message", "check_messages"}}},
+		{name: "explicit child coordination is builtin when injection is disabled", ctx: contextTokenTaskCreateAuthorizationContext{Namespace: "team-a", Request: CreateTaskRequest{Type: corev1alpha1.TaskTypeAI, Metadata: MetadataRequest{Labels: map[string]string{labels.LabelParentTask: "parent-task"}}, Annotations: map[string]string{labels.AnnotationDisableCoordinationToolInject: queryTrue}}, EffectiveAITools: []string{"send_message", "list_pull_requests"}}},
+		{name: "explicit child custom tool still resolves when injection is disabled", ctx: contextTokenTaskCreateAuthorizationContext{Namespace: "team-a", Request: CreateTaskRequest{Type: corev1alpha1.TaskTypeAI, Metadata: MetadataRequest{Labels: map[string]string{labels.LabelParentTask: "parent-task"}}, Annotations: map[string]string{labels.AnnotationDisableCoordinationToolInject: queryTrue}}, EffectiveAITools: []string{"custom-search"}}, wantFailure: "custom-search"},
 		{name: "explicit child messaging name resolves as custom without child identity", ctx: contextTokenTaskCreateAuthorizationContext{Namespace: "team-a", Request: CreateTaskRequest{Type: corev1alpha1.TaskTypeAI}, EffectiveAITools: []string{"send_message"}}, wantFailure: "send_message"},
 		{name: "AI explicit coordination tool remains builtin when injection disabled", ctx: contextTokenTaskCreateAuthorizationContext{Namespace: "team-a", Agent: &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{Coordination: &corev1alpha1.CoordinationConfig{Enabled: true}}}, Request: CreateTaskRequest{Annotations: map[string]string{labels.AnnotationDisableCoordinationToolInject: queryTrue}}, EffectiveAITools: []string{"list_pull_requests"}}},
 		{name: "controller proxy coordination name resolves as custom when coordination disabled", ctx: contextTokenTaskCreateAuthorizationContext{Namespace: "team-a", EffectiveAITools: []string{"create_pull_request"}}, wantFailure: "create_pull_request"},

--- a/internal/api/context_token_authorization_test.go
+++ b/internal/api/context_token_authorization_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+	"github.com/orka-agents/orka/internal/aitools"
 	"github.com/orka-agents/orka/internal/labels"
 )
 
@@ -573,11 +574,12 @@ func testTaskCreateAuthorizationContext() contextTokenTaskCreateAuthorizationCon
 func TestContextTokenTaskCreateEffectiveAIToolsSkipsDisabledCoordinationInjection(t *testing.T) {
 	agent := &corev1alpha1.Agent{
 		Spec: corev1alpha1.AgentSpec{
-			Coordination: &corev1alpha1.CoordinationConfig{Enabled: true},
+			Coordination: &corev1alpha1.CoordinationConfig{Enabled: true, Autonomous: true},
 		},
 	}
 	req := CreateTaskRequest{
 		Type:        corev1alpha1.TaskTypeAI,
+		Metadata:    MetadataRequest{Labels: map[string]string{labels.LabelParentTask: "parent-task"}},
 		Annotations: map[string]string{labels.AnnotationDisableCoordinationToolInject: "true"},
 		AI: &corev1alpha1.AISpec{
 			Tools: []string{"list_pull_requests", "check_pr_review_marker"},
@@ -592,6 +594,9 @@ func TestContextTokenTaskCreateEffectiveAIToolsSkipsDisabledCoordinationInjectio
 	require.Contains(t, got, "propose_memory")
 	require.Contains(t, got, "search_transcript")
 	require.NotContains(t, got, "delegate_task")
+	require.NotContains(t, got, "send_message")
+	require.NotContains(t, got, "check_messages")
+	require.NotContains(t, got, "request_approval")
 	require.NotContains(t, got, "merge_pull_request")
 	require.NotContains(t, got, "auto_merge_pull_request")
 }
@@ -975,6 +980,8 @@ func TestContextTokenTaskToolCredentialFailuresUsesToolProvenance(t *testing.T) 
 		{name: "AI name matching native tool still resolves", ctx: contextTokenTaskCreateAuthorizationContext{Namespace: "team-a", EffectiveAITools: []string{"Read"}}, wantFailure: "Read"},
 		{name: "AI coordination tool is builtin when coordination is enabled", ctx: contextTokenTaskCreateAuthorizationContext{Namespace: "team-a", Agent: &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{Coordination: &corev1alpha1.CoordinationConfig{Enabled: true}}}, EffectiveAITools: []string{"list_issues"}}},
 		{name: "AI coordination name resolves as custom without coordination", ctx: contextTokenTaskCreateAuthorizationContext{Namespace: "team-a", EffectiveAITools: []string{"list_issues"}}, wantFailure: "list_issues"},
+		{name: "implicit child messaging is builtin without agent coordination", ctx: contextTokenTaskCreateAuthorizationContext{Namespace: "team-a", Request: CreateTaskRequest{Type: corev1alpha1.TaskTypeAI, Metadata: MetadataRequest{Labels: map[string]string{labels.LabelParentTask: "parent-task"}}}, EffectiveAITools: []string{"send_message", "check_messages"}}},
+		{name: "explicit child messaging name resolves as custom without child identity", ctx: contextTokenTaskCreateAuthorizationContext{Namespace: "team-a", Request: CreateTaskRequest{Type: corev1alpha1.TaskTypeAI}, EffectiveAITools: []string{"send_message"}}, wantFailure: "send_message"},
 		{name: "AI explicit coordination tool remains builtin when injection disabled", ctx: contextTokenTaskCreateAuthorizationContext{Namespace: "team-a", Agent: &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{Coordination: &corev1alpha1.CoordinationConfig{Enabled: true}}}, Request: CreateTaskRequest{Annotations: map[string]string{labels.AnnotationDisableCoordinationToolInject: queryTrue}}, EffectiveAITools: []string{"list_pull_requests"}}},
 		{name: "controller proxy coordination name resolves as custom when coordination disabled", ctx: contextTokenTaskCreateAuthorizationContext{Namespace: "team-a", EffectiveAITools: []string{"create_pull_request"}}, wantFailure: "create_pull_request"},
 		{name: "dual-registered coordination name remains builtin when coordination disabled", ctx: contextTokenTaskCreateAuthorizationContext{Namespace: "team-a", EffectiveAITools: []string{"cancel_task"}}},
@@ -1013,4 +1020,46 @@ func TestContextTokenTaskToolCredentialFailuresAllowsLowercaseBrokeredBashWithSy
 	failures, err := contextTokenTaskToolCredentialFailures(context.Background(), client, &ContextToken{}, enforceContextTokenAuthorizationConfig(), authzCtx)
 	require.NoError(t, err)
 	require.Empty(t, failures)
+}
+
+func TestContextTokenTaskCreateEffectiveAIToolsIncludesAutonomousApproval(t *testing.T) {
+	agent := &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{
+		Coordination: &corev1alpha1.CoordinationConfig{Enabled: true, Autonomous: true},
+	}}
+
+	got := contextTokenTaskCreateEffectiveAITools(CreateTaskRequest{Type: corev1alpha1.TaskTypeAI}, agent)
+	require.Contains(t, got, "request_approval")
+}
+
+func TestContextTokenTaskCreateEffectiveAIToolsIncludesChildMessaging(t *testing.T) {
+	req := CreateTaskRequest{
+		Type: corev1alpha1.TaskTypeAI,
+		Metadata: MetadataRequest{
+			Labels: map[string]string{labels.LabelParentTask: "parent-task"},
+		},
+	}
+
+	got := contextTokenTaskCreateEffectiveAITools(req, nil)
+	require.Contains(t, got, "send_message")
+	require.Contains(t, got, "check_messages")
+}
+
+func TestContextTokenTaskCreateEffectiveAIToolsMatchesSharedResolver(t *testing.T) {
+	agent := &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{
+		Tools:        []corev1alpha1.ToolReference{{Name: "agent_tool"}},
+		Coordination: &corev1alpha1.CoordinationConfig{Enabled: true, Autonomous: true},
+	}}
+	req := CreateTaskRequest{
+		Type: corev1alpha1.TaskTypeAI,
+		Metadata: MetadataRequest{
+			Labels: map[string]string{labels.LabelParentTask: "parent-task"},
+		},
+		AI: &corev1alpha1.AISpec{Tools: []string{"task_tool"}},
+	}
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Labels: req.Metadata.Labels},
+		Spec:       corev1alpha1.TaskSpec{Type: req.Type, AI: req.AI},
+	}
+
+	require.Equal(t, aitools.Resolve(task, agent), contextTokenTaskCreateEffectiveAITools(req, agent))
 }

--- a/internal/api/context_token_test.go
+++ b/internal/api/context_token_test.go
@@ -301,6 +301,39 @@ func TestValidateContextToken_TransactionToken(t *testing.T) {
 	}
 }
 
+func TestNewAuthMiddleware_ContextTokenRepeatedInvalidSignatureReusesJWKS(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	snapshot := provider.snapshot()
+	cfg := testContextTokenConfig(t, snapshot, "")
+	cfg.Profiles[0].JWKSURL = ""
+	token := tamperJWTSignature(t, issueTestContextToken(t, snapshot, nil, nil))
+
+	app := fiber.New()
+	app.Use(NewAuthMiddleware(nil, AuthConfig{ContextTokens: cfg}))
+	app.Get("/test", func(ctx fiber.Ctx) error {
+		return ctx.SendStatus(http.StatusOK)
+	})
+
+	for i := range 8 {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set(TransactionTokenHeaderName, token)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("request %d failed: %v", i, err)
+		}
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("request %d status = %d, want %d", i, resp.StatusCode, http.StatusUnauthorized)
+		}
+	}
+
+	if got := provider.jwksHits.Load(); got != 1 {
+		t.Fatalf("JWKS fetches = %d, want 1 for repeated invalid context tokens", got)
+	}
+	if got := provider.discoveryHits.Load(); got != 1 {
+		t.Fatalf("OIDC discovery fetches = %d, want 1 for repeated invalid context tokens", got)
+	}
+}
+
 func TestValidateContextToken_TransactionAuthorizationClaimCompatibility(t *testing.T) {
 	provider := newTestOIDCProvider(t)
 	profile := testContextTokenConfig(t, provider, "").Profiles[0]

--- a/internal/api/context_token_test.go
+++ b/internal/api/context_token_test.go
@@ -301,6 +301,122 @@ func TestValidateContextToken_TransactionToken(t *testing.T) {
 	}
 }
 
+func TestValidateContextToken_TransactionAuthorizationClaimCompatibility(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+	profile := testContextTokenConfig(t, provider, "").Profiles[0]
+
+	tests := []struct {
+		name string
+		tctx map[string]any
+	}{
+		{
+			name: "string list and numeric forms",
+			tctx: map[string]any{
+				"namespace":        "team-a",
+				"taskType":         "agent",
+				"taskName":         "task-1",
+				"task":             "team-a/task-1",
+				"agent":            "team-a/coder",
+				"repo":             "https://github.com/orka-agents/orka",
+				"branch":           "main",
+				"ref":              "refs/heads/main",
+				"configMap":        "agent-policy",
+				"provider":         "openai",
+				"model":            "gpt-5.4",
+				"maxDepth":         3,
+				"allowedAgents":    "team-a/coder,team-a/reviewer",
+				"allowedTools":     []any{"file_read", "web_search"},
+				"allowedProviders": "openai,anthropic",
+				"allowedModels":    []any{"gpt-5.4", "claude-sonnet-4"},
+			},
+		},
+		{
+			name: "empty deny-all lists and unknown extensions",
+			tctx: map[string]any{
+				"allowedAgents":    []any{},
+				"allowedTools":     []any{},
+				"allowedProviders": []any{},
+				"allowedModels":    []any{},
+				"customPolicy": map[string]any{
+					"mixed": []any{"value", 42, true},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := issueTestContextToken(t, provider, nil, map[string]any{"tctx": tt.tctx})
+			ctxToken, err := validateContextToken(context.Background(), token, profile)
+			if err != nil {
+				t.Fatalf("validateContextToken returned error: %v", err)
+			}
+			if _, ok := tt.tctx["customPolicy"]; ok {
+				if _, ok := ctxToken.TransactionContext["customPolicy"]; !ok {
+					t.Fatal("validateContextToken dropped unknown transaction-context extension")
+				}
+			}
+		})
+	}
+}
+
+func TestValidateContextToken_TransactionRejectsMalformedAuthorizationClaims(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+	profile := testContextTokenConfig(t, provider, "").Profiles[0]
+
+	for _, claim := range []string{
+		"namespace", "taskType", "taskName", "task", "agent", "repo", "branch", "ref",
+		"configMap", "secret", "provider", "model",
+	} {
+		t.Run("wrong type "+claim, func(t *testing.T) {
+			token := issueTestContextToken(t, provider, nil, map[string]any{
+				"tctx": map[string]any{claim: 42},
+			})
+			_, err := validateContextToken(context.Background(), token, profile)
+			if err == nil || !strings.Contains(err.Error(), claim) {
+				t.Fatalf("validateContextToken error = %v, want invalid %s claim", err, claim)
+			}
+		})
+	}
+
+	for _, claim := range []string{"allowedAgents", "allowedTools", "allowedProviders", "allowedModels"} {
+		t.Run("mixed type "+claim, func(t *testing.T) {
+			token := issueTestContextToken(t, provider, nil, map[string]any{
+				"tctx": map[string]any{claim: []any{"allowed", 42}},
+			})
+			_, err := validateContextToken(context.Background(), token, profile)
+			if err == nil || !strings.Contains(err.Error(), claim) {
+				t.Fatalf("validateContextToken error = %v, want invalid %s claim", err, claim)
+			}
+		})
+	}
+
+	for _, tt := range []struct {
+		name  string
+		claim string
+		value any
+	}{
+		{name: "blank scalar", claim: "namespace", value: " "},
+		{name: "blank list string", claim: "allowedTools", value: " "},
+		{name: "invalid secret name", claim: "secret", value: "Invalid_Secret"},
+		{name: "fractional max depth", claim: "maxDepth", value: 1.5},
+		{name: "negative max depth", claim: "maxDepth", value: -1},
+		{name: "object transaction context", claim: "tctx", value: []any{"not-an-object"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			claims := map[string]any{"tctx": map[string]any{tt.claim: tt.value}}
+			if tt.claim == "tctx" {
+				claims["tctx"] = tt.value
+			}
+			token := issueTestContextToken(t, provider, nil, claims)
+			_, err := validateContextToken(context.Background(), token, profile)
+			if err == nil || !strings.Contains(err.Error(), tt.claim) {
+				t.Fatalf("validateContextToken error = %v, want invalid %s claim", err, tt.claim)
+			}
+		})
+	}
+}
+
 func TestValidateContextToken_TransactionTokenUsesDefaultJWKSURL(t *testing.T) {
 	provider := newTestOIDCProvider(t)
 	cfg, err := NewContextTokenConfig(ContextTokenProfileTransactionToken, provider.server.URL, provider.aud, "", "")

--- a/internal/api/jwt.go
+++ b/internal/api/jwt.go
@@ -8,18 +8,40 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"slices"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/lestrrat-go/jwx/v3/jwa"
 	"github.com/lestrrat-go/jwx/v3/jwk"
 	"github.com/lestrrat-go/jwx/v3/jws"
 	"github.com/lestrrat-go/jwx/v3/jwt"
+)
+
+const (
+	// A cached JWKS is used without I/O for five minutes. If refresh then fails,
+	// known keys may be used for one additional five-minute stale grace period;
+	// after that hard expiry, verification fails closed until refresh succeeds.
+	defaultJWKSFreshTTL              = 5 * time.Minute
+	defaultJWKSStaleTTL              = 5 * time.Minute
+	defaultJWKSRefreshRetryDelay     = 5 * time.Second
+	defaultJWKSForcedRefreshCooldown = 5 * time.Second
+	defaultMaxJWKSResponseBytes      = int64(1 << 20)
+	defaultMaxJWKSCacheEntries       = 64
+	defaultMaxJWKSNegativeKidCount   = 128
+)
+
+var (
+	errJWTKeyResolution      = errors.New("JWT key resolution failed")
+	errJWTSigningKeyNotFound = errors.New("JWT signing key not found")
 )
 
 type jwtVerificationConfig struct {
@@ -48,15 +70,156 @@ type verifiedJWT struct {
 	RawClaims json.RawMessage
 }
 
+type jwksCacheOptions struct {
+	client                *http.Client
+	now                   func() time.Time
+	requestTimeout        time.Duration
+	freshTTL              time.Duration
+	staleTTL              time.Duration
+	refreshRetryDelay     time.Duration
+	forcedRefreshCooldown time.Duration
+	maxResponseBytes      int64
+	maxEntries            int
+	maxNegativeKids       int
+}
+
+type jwksCache struct {
+	client                *http.Client
+	now                   func() time.Time
+	requestTimeout        time.Duration
+	freshTTL              time.Duration
+	staleTTL              time.Duration
+	refreshRetryDelay     time.Duration
+	forcedRefreshCooldown time.Duration
+	maxResponseBytes      int64
+	maxEntries            int
+	maxNegativeKids       int
+
+	mu             sync.Mutex
+	entries        map[string]*jwksCacheEntry
+	nextGeneration uint64
+}
+
+type jwksCacheEntry struct {
+	set                jwk.Set
+	freshUntil         time.Time
+	staleUntil         time.Time
+	retryAfter         time.Time
+	lastRefreshErr     error
+	generation         uint64
+	observedGeneration uint64
+	forcedRefreshAfter time.Time
+	negativeKids       map[[sha256.Size]byte]time.Time
+	lastUsed           time.Time
+	refresh            *jwksRefreshCall
+}
+
+type jwksRefreshCall struct {
+	done       chan struct{}
+	set        jwk.Set
+	generation uint64
+	err        error
+}
+
+type jwksLoadResult struct {
+	set        jwk.Set
+	generation uint64
+	refreshed  bool
+	refreshErr error
+}
+
+type jwtSigningKeySelection struct {
+	set              jwk.Set
+	generation       uint64
+	refreshAttempted bool
+}
+
+type jwtVerifier struct {
+	jwks      *jwksCache
+	discovery *oidcDiscoveryCache
+}
+
+var processJWTVerifier = newJWTVerifier()
+
+func newJWTVerifier() *jwtVerifier {
+	return newJWTVerifierWithCacheOptions(jwksCacheOptions{}, oidcDiscoveryCacheOptions{})
+}
+
+func newJWTVerifierWithOptions(opts jwksCacheOptions) *jwtVerifier {
+	return newJWTVerifierWithCacheOptions(opts, oidcDiscoveryCacheOptions{
+		client:         opts.client,
+		now:            opts.now,
+		requestTimeout: opts.requestTimeout,
+	})
+}
+
+func newJWTVerifierWithCacheOptions(jwksOpts jwksCacheOptions, discoveryOpts oidcDiscoveryCacheOptions) *jwtVerifier {
+	return &jwtVerifier{
+		jwks:      newJWKSCache(jwksOpts),
+		discovery: newOIDCDiscoveryCache(discoveryOpts),
+	}
+}
+
+func newJWKSCache(opts jwksCacheOptions) *jwksCache {
+	if opts.requestTimeout <= 0 {
+		opts.requestTimeout = authHTTPTimeout
+	}
+	if opts.client == nil {
+		opts.client = &http.Client{Timeout: opts.requestTimeout}
+	}
+	if opts.now == nil {
+		opts.now = time.Now
+	}
+	if opts.freshTTL <= 0 {
+		opts.freshTTL = defaultJWKSFreshTTL
+	}
+	if opts.staleTTL <= 0 {
+		opts.staleTTL = defaultJWKSStaleTTL
+	}
+	if opts.refreshRetryDelay <= 0 {
+		opts.refreshRetryDelay = defaultJWKSRefreshRetryDelay
+	}
+	if opts.forcedRefreshCooldown <= 0 {
+		opts.forcedRefreshCooldown = defaultJWKSForcedRefreshCooldown
+	}
+	if opts.maxResponseBytes <= 0 {
+		opts.maxResponseBytes = defaultMaxJWKSResponseBytes
+	}
+	if opts.maxEntries <= 0 {
+		opts.maxEntries = defaultMaxJWKSCacheEntries
+	}
+	if opts.maxNegativeKids <= 0 {
+		opts.maxNegativeKids = defaultMaxJWKSNegativeKidCount
+	}
+
+	return &jwksCache{
+		client:                opts.client,
+		now:                   opts.now,
+		requestTimeout:        opts.requestTimeout,
+		freshTTL:              opts.freshTTL,
+		staleTTL:              opts.staleTTL,
+		refreshRetryDelay:     opts.refreshRetryDelay,
+		forcedRefreshCooldown: opts.forcedRefreshCooldown,
+		maxResponseBytes:      opts.maxResponseBytes,
+		maxEntries:            opts.maxEntries,
+		maxNegativeKids:       opts.maxNegativeKids,
+		entries:               make(map[string]*jwksCacheEntry),
+	}
+}
+
 func verifyJWT(ctx context.Context, raw string, cfg jwtVerificationConfig) (*verifiedJWT, error) {
+	return processJWTVerifier.verifyJWT(ctx, raw, cfg)
+}
+
+func (v *jwtVerifier) verifyJWT(ctx context.Context, raw string, cfg jwtVerificationConfig) (*verifiedJWT, error) {
 	parsed, err := parseCompactJWT(raw)
 	if err != nil {
 		return nil, err
 	}
-	return verifyParsedJWT(ctx, parsed, cfg)
+	return v.verifyParsedJWT(ctx, parsed, cfg)
 }
 
-func verifyParsedJWT(ctx context.Context, parsed *parsedJWT, cfg jwtVerificationConfig) (*verifiedJWT, error) {
+func (v *jwtVerifier) verifyParsedJWT(ctx context.Context, parsed *parsedJWT, cfg jwtVerificationConfig) (*verifiedJWT, error) {
 	if !jwtSigningAlgorithmAllowed(parsed.Header.Algorithm, cfg.AllowedAlgorithms) {
 		return nil, fmt.Errorf("unsupported JWT signing algorithm %q", parsed.Header.Algorithm.String())
 	}
@@ -64,23 +227,12 @@ func verifyParsedJWT(ctx context.Context, parsed *parsedJWT, cfg jwtVerification
 		return nil, errors.New("missing JWKS URL")
 	}
 
-	fetchCtx, cancel := context.WithTimeout(ctx, authHTTPTimeout)
-	defer cancel()
-
-	keySet, err := jwk.Fetch(fetchCtx, cfg.JWKSURL, jwk.WithHTTPClient(&http.Client{Timeout: authHTTPTimeout}))
-	if err != nil {
-		return nil, fmt.Errorf("fetch JWKS: %w", err)
-	}
-
-	filteredSet, err := filterJWTSigningKeys(keySet, parsed.Header)
+	selection, err := v.jwks.signingKeys(ctx, cfg.JWKSURL, parsed.Header)
 	if err != nil {
 		return nil, err
 	}
 
-	tok, err := jwt.ParseString(parsed.Raw,
-		jwt.WithValidate(false),
-		jwt.WithKeySet(filteredSet, jws.WithUseDefault(true)),
-	)
+	tok, err := v.parseJWTWithRotationRetry(ctx, parsed, cfg.JWKSURL, selection)
 	if err != nil {
 		return nil, fmt.Errorf("verify JWT signature: %w", err)
 	}
@@ -111,6 +263,548 @@ func verifyParsedJWT(ctx context.Context, parsed *parsedJWT, cfg jwtVerification
 		Header:    parsed.Header,
 		RawClaims: parsed.RawClaims,
 	}, nil
+}
+
+func (v *jwtVerifier) parseJWTWithRotationRetry(ctx context.Context, parsed *parsedJWT, jwksURL string, selection jwtSigningKeySelection) (jwt.Token, error) {
+	tok, err := parseJWTWithKeySet(parsed.Raw, selection.set)
+	usedGeneration := selection.generation
+	if err != nil && errors.Is(err, jws.VerificationError()) && !selection.refreshAttempted {
+		currentSet, currentGeneration, _, refreshErr := v.jwks.refreshForRotation(ctx, jwksURL, selection.generation)
+		switch {
+		case refreshErr != nil:
+			err = fmt.Errorf("%w: %v; refresh JWKS after signature failure: %w", errJWTKeyResolution, err, refreshErr)
+		case currentSet != nil && currentGeneration != selection.generation:
+			usedGeneration = currentGeneration
+			filteredSet, filterErr := filterJWTSigningKeys(currentSet, parsed.Header)
+			if filterErr != nil {
+				if errors.Is(filterErr, errJWTSigningKeyNotFound) {
+					v.jwks.noteKeySelectionMiss(jwksURL, parsed.Header.KeyID, currentGeneration, true)
+				}
+				err = filterErr
+			} else {
+				tok, err = parseJWTWithKeySet(parsed.Raw, filteredSet)
+			}
+		}
+	}
+	if err == nil {
+		v.jwks.noteVerificationSuccess(jwksURL, usedGeneration)
+	} else if errors.Is(err, jws.VerificationError()) {
+		v.jwks.noteSignatureFailure(jwksURL, usedGeneration)
+	}
+	return tok, err
+}
+
+func parseJWTWithKeySet(raw string, keySet jwk.Set) (jwt.Token, error) {
+	return jwt.ParseString(raw,
+		jwt.WithValidate(false),
+		jwt.WithKeySet(keySet, jws.WithUseDefault(true)),
+	)
+}
+
+func (c *jwksCache) signingKeys(ctx context.Context, url string, header jwtHeader) (jwtSigningKeySelection, error) {
+	loaded, err := c.load(ctx, url)
+	if err != nil {
+		return jwtSigningKeySelection{}, fmt.Errorf("%w: fetch JWKS: %w", errJWTKeyResolution, err)
+	}
+
+	filtered, filterErr := filterJWTSigningKeys(loaded.set, header)
+	if filterErr == nil {
+		return jwtSigningKeySelection{
+			set:              filtered,
+			generation:       loaded.generation,
+			refreshAttempted: loaded.refreshed || loaded.refreshErr != nil,
+		}, nil
+	}
+	if !errors.Is(filterErr, errJWTSigningKeyNotFound) {
+		return jwtSigningKeySelection{}, filterErr
+	}
+
+	// A cache fill or TTL refresh already consulted the issuer for this request.
+	// Do not immediately fetch the same JWKS a second time for a key-set miss.
+	if loaded.refreshed {
+		c.noteKeySelectionMiss(url, header.KeyID, loaded.generation, true)
+		return jwtSigningKeySelection{}, filterErr
+	}
+	if loaded.refreshErr != nil {
+		c.noteKeySelectionMiss(url, header.KeyID, loaded.generation, true)
+		return jwtSigningKeySelection{}, fmt.Errorf("%w: %w; refresh JWKS: %v", errJWTKeyResolution, filterErr, loaded.refreshErr)
+	}
+
+	var currentSet jwk.Set
+	var currentGeneration uint64
+	if header.KeyID == "" {
+		currentSet, currentGeneration, _, err = c.refreshForRotation(ctx, url, loaded.generation)
+	} else {
+		currentSet, currentGeneration, _, err = c.refreshForUnknownKid(ctx, url, header.KeyID, loaded.generation)
+	}
+	if err != nil {
+		return jwtSigningKeySelection{}, fmt.Errorf("%w: %v; refresh JWKS: %w", errJWTKeyResolution, filterErr, err)
+	}
+	if currentSet == nil || currentGeneration == loaded.generation {
+		return jwtSigningKeySelection{}, filterErr
+	}
+
+	filtered, filterErr = filterJWTSigningKeys(currentSet, header)
+	if filterErr != nil {
+		if errors.Is(filterErr, errJWTSigningKeyNotFound) {
+			c.noteKeySelectionMiss(url, header.KeyID, currentGeneration, false)
+		}
+		return jwtSigningKeySelection{}, filterErr
+	}
+	return jwtSigningKeySelection{set: filtered, generation: currentGeneration, refreshAttempted: true}, nil
+}
+
+func (c *jwksCache) load(ctx context.Context, url string) (jwksLoadResult, error) {
+	now := c.now()
+	c.mu.Lock()
+	entry := c.entries[url]
+	if entry != nil {
+		entry.lastUsed = now
+		if entry.set != nil && now.Before(entry.freshUntil) {
+			set := entry.set
+			generation := entry.generation
+			refreshed := entry.observedGeneration != generation
+			c.mu.Unlock()
+			return jwksLoadResult{
+				set:        set,
+				generation: generation,
+				refreshed:  refreshed,
+			}, nil
+		}
+		if entry.refresh != nil {
+			call := entry.refresh
+			c.mu.Unlock()
+			set, generation, err := waitForJWKSRefresh(ctx, call)
+			if err == nil {
+				return jwksLoadResult{set: set, generation: generation, refreshed: true}, nil
+			}
+			if ctx.Err() != nil {
+				return jwksLoadResult{}, ctx.Err()
+			}
+			return c.loadStaleAfterRefreshError(url, err)
+		}
+		if now.Before(entry.retryAfter) {
+			if entry.set != nil && now.Before(entry.staleUntil) {
+				result := jwksLoadResult{set: entry.set, generation: entry.generation, refreshErr: entry.lastRefreshErr}
+				c.mu.Unlock()
+				return result, nil
+			}
+			err := entry.lastRefreshErr
+			c.mu.Unlock()
+			if err == nil {
+				err = errors.New("JWKS cache expired while refresh retry is deferred")
+			}
+			return jwksLoadResult{}, err
+		}
+	}
+	c.mu.Unlock()
+
+	set, generation, err := c.refresh(ctx, url)
+	if err == nil {
+		return jwksLoadResult{set: set, generation: generation, refreshed: true}, nil
+	}
+	if ctx.Err() != nil {
+		return jwksLoadResult{}, ctx.Err()
+	}
+	return c.loadStaleAfterRefreshError(url, err)
+}
+
+func (c *jwksCache) loadStaleAfterRefreshError(url string, refreshErr error) (jwksLoadResult, error) {
+	now := c.now()
+	c.mu.Lock()
+	entry := c.entries[url]
+	if entry != nil && entry.set != nil && now.Before(entry.staleUntil) {
+		result := jwksLoadResult{set: entry.set, generation: entry.generation, refreshErr: refreshErr}
+		c.mu.Unlock()
+		return result, nil
+	}
+	c.mu.Unlock()
+	return jwksLoadResult{}, refreshErr
+}
+
+func (c *jwksCache) refresh(ctx context.Context, url string) (jwk.Set, uint64, error) {
+	now := c.now()
+	c.mu.Lock()
+	entry, err := c.getOrCreateEntryLocked(url, now)
+	if err != nil {
+		c.mu.Unlock()
+		return nil, 0, err
+	}
+	entry.lastUsed = now
+	if entry.refresh != nil {
+		call := entry.refresh
+		c.mu.Unlock()
+		return waitForJWKSRefresh(ctx, call)
+	}
+	if entry.set != nil && now.Before(entry.freshUntil) {
+		set := entry.set
+		generation := entry.generation
+		c.mu.Unlock()
+		return set, generation, nil
+	}
+	if now.Before(entry.retryAfter) {
+		err := entry.lastRefreshErr
+		generation := entry.generation
+		c.mu.Unlock()
+		if err == nil {
+			err = errors.New("JWKS refresh retry is deferred")
+		}
+		return nil, generation, err
+	}
+
+	call := &jwksRefreshCall{done: make(chan struct{})}
+	entry.refresh = call
+	entry.retryAfter = now.Add(c.refreshRetryDelay)
+	c.mu.Unlock()
+
+	go c.completeRefresh(url, entry, call)
+	return waitForJWKSRefresh(ctx, call)
+}
+
+func (c *jwksCache) refreshForUnknownKid(ctx context.Context, url, kid string, expectedGeneration uint64) (jwk.Set, uint64, bool, error) {
+	now := c.now()
+	digest := sha256.Sum256([]byte(kid))
+	c.mu.Lock()
+	entry := c.entries[url]
+	if entry != nil && entry.refresh == nil && c.negativeKidActiveLocked(entry, digest, now) {
+		set := entry.set
+		generation := entry.generation
+		c.mu.Unlock()
+		return set, generation, false, nil
+	}
+	c.mu.Unlock()
+
+	set, generation, refreshed, err := c.refreshForRotation(ctx, url, expectedGeneration)
+	if err == nil && !refreshed {
+		c.noteUnknownKid(url, kid, generation, false)
+	}
+	return set, generation, refreshed, err
+}
+
+func (c *jwksCache) refreshForRotation(ctx context.Context, url string, expectedGeneration uint64) (jwk.Set, uint64, bool, error) {
+	now := c.now()
+	c.mu.Lock()
+	entry, err := c.getOrCreateEntryLocked(url, now)
+	if err != nil {
+		c.mu.Unlock()
+		return nil, 0, false, err
+	}
+	entry.lastUsed = now
+	if entry.refresh != nil {
+		call := entry.refresh
+		c.mu.Unlock()
+		set, generation, err := waitForJWKSRefresh(ctx, call)
+		return set, generation, true, err
+	}
+	if expectedGeneration != 0 && entry.set != nil && entry.generation != expectedGeneration && now.Before(entry.staleUntil) {
+		set := entry.set
+		generation := entry.generation
+		c.mu.Unlock()
+		return set, generation, true, nil
+	}
+	if now.Before(entry.forcedRefreshAfter) {
+		set := entry.set
+		generation := entry.generation
+		c.mu.Unlock()
+		return set, generation, false, nil
+	}
+	if now.Before(entry.retryAfter) {
+		set := entry.set
+		generation := entry.generation
+		err := entry.lastRefreshErr
+		c.mu.Unlock()
+		if err == nil {
+			return set, generation, false, nil
+		}
+		return set, generation, false, err
+	}
+
+	call := &jwksRefreshCall{done: make(chan struct{})}
+	entry.refresh = call
+	entry.forcedRefreshAfter = now.Add(c.forcedRefreshCooldown)
+	entry.retryAfter = now.Add(c.refreshRetryDelay)
+	c.mu.Unlock()
+
+	go c.completeRefresh(url, entry, call)
+	set, generation, err := waitForJWKSRefresh(ctx, call)
+	return set, generation, true, err
+}
+
+func (c *jwksCache) completeRefresh(url string, entry *jwksCacheEntry, call *jwksRefreshCall) {
+	set, err := c.fetch(url)
+	now := c.now()
+
+	c.mu.Lock()
+	if err == nil {
+		c.nextGeneration++
+		if c.nextGeneration == 0 {
+			c.nextGeneration++
+		}
+		entry.set = set
+		entry.generation = c.nextGeneration
+		entry.freshUntil = now.Add(c.freshTTL)
+		entry.staleUntil = entry.freshUntil.Add(c.staleTTL)
+		entry.retryAfter = time.Time{}
+		entry.lastRefreshErr = nil
+		entry.negativeKids = nil
+	} else {
+		entry.retryAfter = now.Add(c.refreshRetryDelay)
+		entry.lastRefreshErr = err
+	}
+	entry.lastUsed = now
+	if entry.refresh == call {
+		entry.refresh = nil
+	}
+	call.set = set
+	call.generation = entry.generation
+	call.err = err
+	close(call.done)
+	c.mu.Unlock()
+}
+
+func waitForJWKSRefresh(ctx context.Context, call *jwksRefreshCall) (jwk.Set, uint64, error) {
+	select {
+	case <-call.done:
+		return call.set, call.generation, call.err
+	case <-ctx.Done():
+		return nil, 0, ctx.Err()
+	}
+}
+
+func (c *jwksCache) fetch(url string) (jwk.Set, error) {
+	// The shared refresh must outlive any one request waiting on it, while this
+	// independent deadline still bounds the outbound operation.
+	ctx, cancel := context.WithTimeout(context.Background(), c.requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, c.maxResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > c.maxResponseBytes {
+		return nil, fmt.Errorf("JWKS response exceeds maximum size of %d bytes", c.maxResponseBytes)
+	}
+	set, err := jwk.Parse(body)
+	if err != nil {
+		return nil, fmt.Errorf("parse JWKS: %w", err)
+	}
+	publicSet, err := publicJWKSForCache(set)
+	if err != nil {
+		return nil, fmt.Errorf("sanitize JWKS public keys: %w", err)
+	}
+	return publicSet, nil
+}
+
+func publicJWKSForCache(set jwk.Set) (jwk.Set, error) {
+	publicSet := jwk.NewSet()
+	for i := 0; i < set.Len(); i++ {
+		key, ok := set.Key(i)
+		if !ok {
+			return nil, fmt.Errorf("JWK missing at index %d", i)
+		}
+		// Symmetric JWKs have no public form. Never retain their secret material,
+		// but do not reject unrelated asymmetric signing keys in a mixed set.
+		if key.KeyType() == jwa.OctetSeq() {
+			continue
+		}
+
+		rawPublicKey, err := jwk.PublicRawKeyOf(key)
+		if err != nil {
+			return nil, fmt.Errorf("export public JWK at index %d: %w", i, err)
+		}
+		cleanKey, err := jwk.Import(rawPublicKey)
+		if err != nil {
+			return nil, fmt.Errorf("import public JWK at index %d: %w", i, err)
+		}
+		if err := copyPublicJWKMetadata(key, cleanKey); err != nil {
+			return nil, fmt.Errorf("copy public JWK metadata at index %d: %w", i, err)
+		}
+		if err := publicSet.AddKey(cleanKey); err != nil {
+			return nil, fmt.Errorf("add public JWK: %w", err)
+		}
+	}
+	return publicSet, nil
+}
+
+func copyPublicJWKMetadata(source, destination jwk.Key) error {
+	if value, ok := source.KeyID(); ok {
+		if err := destination.Set(jwk.KeyIDKey, value); err != nil {
+			return fmt.Errorf("set kid: %w", err)
+		}
+	}
+	if value, ok := source.Algorithm(); ok {
+		if err := destination.Set(jwk.AlgorithmKey, value); err != nil {
+			return fmt.Errorf("set alg: %w", err)
+		}
+	}
+	if value, ok := source.KeyUsage(); ok {
+		if err := destination.Set(jwk.KeyUsageKey, value); err != nil {
+			return fmt.Errorf("set use: %w", err)
+		}
+	}
+	if value, ok := source.KeyOps(); ok {
+		if err := destination.Set(jwk.KeyOpsKey, value); err != nil {
+			return fmt.Errorf("set key_ops: %w", err)
+		}
+	}
+	if value, ok := source.X509URL(); ok {
+		if err := destination.Set(jwk.X509URLKey, value); err != nil {
+			return fmt.Errorf("set x5u: %w", err)
+		}
+	}
+	if value, ok := source.X509CertChain(); ok {
+		if err := destination.Set(jwk.X509CertChainKey, value); err != nil {
+			return fmt.Errorf("set x5c: %w", err)
+		}
+	}
+	if value, ok := source.X509CertThumbprint(); ok {
+		if err := destination.Set(jwk.X509CertThumbprintKey, value); err != nil {
+			return fmt.Errorf("set x5t: %w", err)
+		}
+	}
+	if value, ok := source.X509CertThumbprintS256(); ok {
+		if err := destination.Set(jwk.X509CertThumbprintS256Key, value); err != nil {
+			return fmt.Errorf("set x5t#S256: %w", err)
+		}
+	}
+	return nil
+}
+
+func (c *jwksCache) noteUnknownKid(url, kid string, generation uint64, setCooldown bool) {
+	now := c.now()
+	digest := sha256.Sum256([]byte(kid))
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry := c.entries[url]
+	if entry == nil || entry.generation != generation {
+		return
+	}
+	entry.observedGeneration = generation
+	if setCooldown {
+		c.startForcedRefreshCooldownLocked(entry, now)
+	}
+	c.addNegativeKidLocked(entry, digest, now)
+}
+
+func (c *jwksCache) noteKeySelectionMiss(url, kid string, generation uint64, setCooldown bool) {
+	if kid != "" {
+		c.noteUnknownKid(url, kid, generation, setCooldown)
+		return
+	}
+	c.noteKeylessFailure(url, generation, setCooldown)
+}
+
+func (c *jwksCache) noteKeylessFailure(url string, generation uint64, setCooldown bool) {
+	now := c.now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if entry := c.entries[url]; entry != nil && entry.generation == generation {
+		entry.observedGeneration = generation
+		if !setCooldown {
+			return
+		}
+		c.startForcedRefreshCooldownLocked(entry, now)
+	}
+}
+
+func (c *jwksCache) noteSignatureFailure(url string, generation uint64) {
+	c.noteKeylessFailure(url, generation, true)
+}
+
+func (c *jwksCache) noteVerificationSuccess(url string, generation uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if entry := c.entries[url]; entry != nil && entry.generation == generation {
+		entry.observedGeneration = generation
+	}
+}
+
+func (c *jwksCache) startForcedRefreshCooldownLocked(entry *jwksCacheEntry, now time.Time) {
+	if !now.Before(entry.forcedRefreshAfter) {
+		entry.forcedRefreshAfter = now.Add(c.forcedRefreshCooldown)
+	}
+}
+
+func (c *jwksCache) negativeKidActiveLocked(entry *jwksCacheEntry, digest [sha256.Size]byte, now time.Time) bool {
+	if entry.negativeKids == nil {
+		return false
+	}
+	expiresAt, ok := entry.negativeKids[digest]
+	if !ok {
+		return false
+	}
+	if now.Before(expiresAt) {
+		return true
+	}
+	delete(entry.negativeKids, digest)
+	return false
+}
+
+func (c *jwksCache) addNegativeKidLocked(entry *jwksCacheEntry, digest [sha256.Size]byte, now time.Time) {
+	if entry.negativeKids == nil {
+		entry.negativeKids = make(map[[sha256.Size]byte]time.Time)
+	}
+	if len(entry.negativeKids) >= c.maxNegativeKids {
+		var oldestDigest [sha256.Size]byte
+		var oldestExpiry time.Time
+		for candidate, expiresAt := range entry.negativeKids {
+			if !now.Before(expiresAt) {
+				delete(entry.negativeKids, candidate)
+				continue
+			}
+			if oldestExpiry.IsZero() || expiresAt.Before(oldestExpiry) {
+				oldestDigest = candidate
+				oldestExpiry = expiresAt
+			}
+		}
+		if len(entry.negativeKids) >= c.maxNegativeKids && !oldestExpiry.IsZero() {
+			delete(entry.negativeKids, oldestDigest)
+		}
+	}
+	entry.negativeKids[digest] = now.Add(c.forcedRefreshCooldown)
+}
+
+func (c *jwksCache) getOrCreateEntryLocked(url string, now time.Time) (*jwksCacheEntry, error) {
+	if entry := c.entries[url]; entry != nil {
+		return entry, nil
+	}
+
+	if len(c.entries) >= c.maxEntries {
+		var oldestURL string
+		var oldestUsed time.Time
+		for candidateURL, entry := range c.entries {
+			if entry.refresh != nil {
+				continue
+			}
+			if oldestURL == "" || entry.lastUsed.Before(oldestUsed) {
+				oldestURL = candidateURL
+				oldestUsed = entry.lastUsed
+			}
+		}
+		if oldestURL == "" {
+			return nil, errors.New("JWKS cache capacity is exhausted by active refreshes")
+		}
+		delete(c.entries, oldestURL)
+	}
+
+	entry := &jwksCacheEntry{lastUsed: now}
+	c.entries[url] = entry
+	return entry, nil
 }
 
 func parseCompactJWT(raw string) (*parsedJWT, error) {
@@ -227,9 +921,9 @@ func filterJWTSigningKeys(keySet jwk.Set, header jwtHeader) (jwk.Set, error) {
 
 	if filtered.Len() == 0 {
 		if header.KeyID != "" {
-			return nil, fmt.Errorf("no usable %s signing key found for kid %q", expectedKeyTypeName, header.KeyID)
+			return nil, fmt.Errorf("%w: no usable %s signing key found for kid %q", errJWTSigningKeyNotFound, expectedKeyTypeName, header.KeyID)
 		}
-		return nil, fmt.Errorf("no usable %s signing key found", expectedKeyTypeName)
+		return nil, fmt.Errorf("%w: no usable %s signing key found", errJWTSigningKeyNotFound, expectedKeyTypeName)
 	}
 	return filtered, nil
 }

--- a/internal/api/jwt_test.go
+++ b/internal/api/jwt_test.go
@@ -11,12 +11,318 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/lestrrat-go/jwx/v3/jwa"
 	"github.com/lestrrat-go/jwx/v3/jwk"
 )
+
+const (
+	testOIDCDiscoveryPath   = "/.well-known/openid-configuration"
+	testJWKSURIJSONKey      = "jwks_uri"
+	testJWKSKeysJSONKey     = "keys"
+	testJWTAlgorithmJSONKey = "alg"
+	testJWTTypeJSONKey      = "typ"
+	testJWTTypeValue        = "JWT"
+	testJWTIssuerJSONKey    = "iss"
+	testJWTSubjectJSONKey   = "sub"
+	testJWTAudienceJSONKey  = "aud"
+	testJWTExpiryJSONKey    = "exp"
+	testJWKSPathA           = "/jwks-a"
+	testJWKSPathB           = "/jwks-b"
+	testOIDCAudience        = "orka-api"
+)
+
+type cacheTestOIDCProvider struct {
+	server *httptest.Server
+	aud    string
+
+	mu               sync.RWMutex
+	key              *rsa.PrivateKey
+	kid              string
+	jwksStatus       int
+	jwksPadding      int
+	jwksEmpty        bool
+	jwksStarted      chan<- struct{}
+	jwksRelease      <-chan struct{}
+	discoveryStatus  int
+	discoveryPadding int
+	discoveryStarted chan<- struct{}
+	discoveryRelease <-chan struct{}
+
+	jwksHits      atomic.Int64
+	discoveryHits atomic.Int64
+}
+
+type cacheTestClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+type cacheTestBlockingClock struct {
+	now     time.Time
+	blockAt int64
+	calls   atomic.Int64
+	started chan<- struct{}
+	release <-chan struct{}
+}
+
+func (c *cacheTestClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *cacheTestClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	c.mu.Unlock()
+}
+
+func (c *cacheTestBlockingClock) Now() time.Time {
+	if c.calls.Add(1) == c.blockAt {
+		c.started <- struct{}{}
+		<-c.release
+	}
+	return c.now
+}
+
+func newCacheTestOIDCProvider(t *testing.T) *cacheTestOIDCProvider {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	provider := &cacheTestOIDCProvider{
+		aud: testOIDCAudience,
+		key: key,
+		kid: "cache-key-1",
+	}
+	provider.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, testOIDCDiscoveryPath) {
+			provider.discoveryHits.Add(1)
+			provider.mu.RLock()
+			status := provider.discoveryStatus
+			padding := provider.discoveryPadding
+			started := provider.discoveryStarted
+			release := provider.discoveryRelease
+			provider.mu.RUnlock()
+			if started != nil {
+				select {
+				case started <- struct{}{}:
+				default:
+				}
+			}
+			if release != nil {
+				<-release
+			}
+			if status != 0 {
+				http.Error(w, http.StatusText(status), status)
+				return
+			}
+			response := map[string]any{testJWKSURIJSONKey: provider.server.URL + "/jwks"}
+			if padding > 0 {
+				response["padding"] = strings.Repeat("x", padding)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(response)
+			return
+		}
+
+		provider.jwksHits.Add(1)
+
+		provider.mu.RLock()
+		key := &provider.key.PublicKey
+		kid := provider.kid
+		status := provider.jwksStatus
+		padding := provider.jwksPadding
+		empty := provider.jwksEmpty
+		started := provider.jwksStarted
+		release := provider.jwksRelease
+		provider.mu.RUnlock()
+
+		if started != nil {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+		}
+		if release != nil {
+			<-release
+		}
+		if status != 0 {
+			http.Error(w, http.StatusText(status), status)
+			return
+		}
+
+		keys := []testJWKKey{testJWKFromPublicKey(key, kid)}
+		if empty {
+			keys = []testJWKKey{}
+		}
+		response := map[string]any{testJWKSKeysJSONKey: keys}
+		if padding > 0 {
+			response["padding"] = strings.Repeat("x", padding)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	t.Cleanup(provider.server.Close)
+	return provider
+}
+
+func (p *cacheTestOIDCProvider) snapshot() *testOIDCProvider {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return &testOIDCProvider{
+		server: p.server,
+		key:    p.key,
+		kid:    p.kid,
+		aud:    p.aud,
+	}
+}
+
+func (p *cacheTestOIDCProvider) config() OIDCConfig {
+	return p.snapshot().config()
+}
+
+func (p *cacheTestOIDCProvider) configWithoutJWKSURL() OIDCConfig {
+	return p.snapshot().configWithoutJWKSURL()
+}
+
+func (p *cacheTestOIDCProvider) issueToken(t *testing.T, opts testOIDCTokenOptions) string {
+	t.Helper()
+	return p.snapshot().issueToken(t, opts)
+}
+
+func (p *cacheTestOIDCProvider) blockJWKS() (<-chan struct{}, func()) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	p.mu.Lock()
+	p.jwksStarted = started
+	p.jwksRelease = release
+	p.mu.Unlock()
+	return started, func() { releaseOnce.Do(func() { close(release) }) }
+}
+
+func (p *cacheTestOIDCProvider) blockDiscovery() (<-chan struct{}, func()) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	p.mu.Lock()
+	p.discoveryStarted = started
+	p.discoveryRelease = release
+	p.mu.Unlock()
+	return started, func() { releaseOnce.Do(func() { close(release) }) }
+}
+
+func (p *cacheTestOIDCProvider) rotate(t *testing.T) {
+	p.rotateWithKid(t, "cache-key-2")
+}
+
+func (p *cacheTestOIDCProvider) rotateWithKid(t *testing.T, kid string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate rotated RSA key: %v", err)
+	}
+	p.mu.Lock()
+	p.key = key
+	p.kid = kid
+	p.mu.Unlock()
+}
+
+func (p *cacheTestOIDCProvider) setJWKSStatus(status int) {
+	p.mu.Lock()
+	p.jwksStatus = status
+	p.mu.Unlock()
+}
+
+func (p *cacheTestOIDCProvider) setJWKSPadding(size int) {
+	p.mu.Lock()
+	p.jwksPadding = size
+	p.mu.Unlock()
+}
+
+func (p *cacheTestOIDCProvider) setJWKSEmpty(empty bool) {
+	p.mu.Lock()
+	p.jwksEmpty = empty
+	p.mu.Unlock()
+}
+
+func (p *cacheTestOIDCProvider) setDiscoveryStatus(status int) {
+	p.mu.Lock()
+	p.discoveryStatus = status
+	p.mu.Unlock()
+}
+
+func (p *cacheTestOIDCProvider) setDiscoveryPadding(size int) {
+	p.mu.Lock()
+	p.discoveryPadding = size
+	p.mu.Unlock()
+}
+
+func issueES256Token(t *testing.T, issuer, audience string, key *ecdsa.PrivateKey) string {
+	t.Helper()
+	headerPart := mustBase64JSON(t, map[string]any{
+		testJWTAlgorithmJSONKey: "ES256",
+		testJWTTypeJSONKey:      testJWTTypeValue,
+	})
+	claimsPart := mustBase64JSON(t, map[string]any{
+		testJWTIssuerJSONKey:   issuer,
+		testJWTSubjectJSONKey:  "user-123",
+		testJWTAudienceJSONKey: audience,
+		testJWTExpiryJSONKey:   time.Now().Add(time.Hour).Unix(),
+	})
+	signedContent := headerPart + "." + claimsPart
+	digest := sha256.Sum256([]byte(signedContent))
+	r, s, err := ecdsa.Sign(rand.Reader, key, digest[:])
+	if err != nil {
+		t.Fatalf("failed to sign ES256 JWT: %v", err)
+	}
+	const coordinateSize = 32
+	signature := make([]byte, 2*coordinateSize)
+	r.FillBytes(signature[:coordinateSize])
+	s.FillBytes(signature[coordinateSize:])
+	return signedContent + "." + base64.RawURLEncoding.EncodeToString(signature)
+}
+
+func marshalPublicJWKS(t *testing.T, rawKey any, alg jwa.SignatureAlgorithm) []byte {
+	t.Helper()
+	key, err := jwk.Import(rawKey)
+	if err != nil {
+		t.Fatalf("import JWK: %v", err)
+	}
+	if err := key.Set(jwk.AlgorithmKey, alg); err != nil {
+		t.Fatalf("set JWK algorithm: %v", err)
+	}
+	if err := key.Set(jwk.KeyUsageKey, string(jwk.ForSignature)); err != nil {
+		t.Fatalf("set JWK usage: %v", err)
+	}
+	set := jwk.NewSet()
+	if err := set.AddKey(key); err != nil {
+		t.Fatalf("add JWK: %v", err)
+	}
+	body, err := json.Marshal(set)
+	if err != nil {
+		t.Fatalf("marshal JWKS: %v", err)
+	}
+	return body
+}
 
 func TestVerifyJWT_MissingJWKSURL(t *testing.T) {
 	provider := newTestOIDCProvider(t)
@@ -31,13 +337,1280 @@ func TestVerifyJWT_MissingJWKSURL(t *testing.T) {
 	}
 }
 
+func TestValidateOIDCToken_RepeatedInvalidSignaturesReuseJWKS(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	token := tamperJWTSignature(t, provider.issueToken(t, testOIDCTokenOptions{}))
+
+	for i := range 8 {
+		_, err := validateOIDCToken(context.Background(), token, provider.config())
+		if err == nil || !strings.Contains(err.Error(), "signature") {
+			t.Fatalf("validateOIDCToken attempt %d error = %v, want signature error", i, err)
+		}
+	}
+
+	if got := provider.jwksHits.Load(); got != 1 {
+		t.Fatalf("JWKS fetches = %d, want 1 for repeated invalid signatures", got)
+	}
+}
+
+func TestValidateOIDCToken_DiscoveryCachedForRepeatedInvalidSignatures(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	token := tamperJWTSignature(t, provider.issueToken(t, testOIDCTokenOptions{}))
+
+	for i := range 8 {
+		_, err := validateOIDCToken(context.Background(), token, provider.configWithoutJWKSURL())
+		if err == nil || !strings.Contains(err.Error(), "signature") {
+			t.Fatalf("validateOIDCToken attempt %d error = %v, want signature error", i, err)
+		}
+	}
+
+	if got := provider.discoveryHits.Load(); got != 1 {
+		t.Fatalf("OIDC discovery fetches = %d, want 1", got)
+	}
+	if got := provider.jwksHits.Load(); got != 1 {
+		t.Fatalf("JWKS fetches = %d, want 1", got)
+	}
+}
+
+func TestValidateOIDCToken_ConcurrentInvalidSignaturesCoalesceDiscoveryFetch(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	started, release := provider.blockDiscovery()
+	defer release()
+	token := tamperJWTSignature(t, provider.issueToken(t, testOIDCTokenOptions{}))
+
+	const requests = 32
+	start := make(chan struct{})
+	errs := make(chan error, requests)
+	var wg sync.WaitGroup
+	for range requests {
+		wg.Go(func() {
+			<-start
+			_, err := validateOIDCToken(context.Background(), token, provider.configWithoutJWKSURL())
+			errs <- err
+		})
+	}
+	close(start)
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for OIDC discovery fetch")
+	}
+	release()
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err == nil || !strings.Contains(err.Error(), "signature") {
+			t.Fatalf("validateOIDCToken error = %v, want signature error", err)
+		}
+	}
+	if got := provider.discoveryHits.Load(); got != 1 {
+		t.Fatalf("OIDC discovery fetches = %d, want 1 for %d concurrent invalid signatures", got, requests)
+	}
+	if got := provider.jwksHits.Load(); got != 1 {
+		t.Fatalf("JWKS fetches = %d, want 1", got)
+	}
+}
+
+func TestValidateOIDCToken_DiscoveryOutageUsesFreshCache(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	token := provider.issueToken(t, testOIDCTokenOptions{})
+	cfg := provider.configWithoutJWKSURL()
+	if _, err := validateOIDCToken(context.Background(), token, cfg); err != nil {
+		t.Fatalf("warm discovery cache: %v", err)
+	}
+
+	provider.setDiscoveryStatus(http.StatusServiceUnavailable)
+	if _, err := validateOIDCToken(context.Background(), token, cfg); err != nil {
+		t.Fatalf("validate with fresh discovery cache during outage: %v", err)
+	}
+	if got := provider.discoveryHits.Load(); got != 1 {
+		t.Fatalf("OIDC discovery fetches = %d, want 1", got)
+	}
+}
+
+func TestJWTVerifier_DiscoveryOutageFailsClosedAfterExpiry(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	clock := &cacheTestClock{now: time.Date(2026, time.July, 10, 0, 0, 0, 0, time.UTC)}
+	const (
+		discoveryTTL = time.Minute
+		retryDelay   = 5 * time.Second
+	)
+	verifier := newJWTVerifierWithCacheOptions(
+		jwksCacheOptions{now: clock.Now},
+		oidcDiscoveryCacheOptions{
+			now:               clock.Now,
+			ttl:               discoveryTTL,
+			refreshRetryDelay: retryDelay,
+		},
+	)
+	token := provider.issueToken(t, testOIDCTokenOptions{})
+	cfg := provider.configWithoutJWKSURL()
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), token, cfg, verifier); err != nil {
+		t.Fatalf("warm discovery cache: %v", err)
+	}
+
+	provider.setDiscoveryStatus(http.StatusServiceUnavailable)
+	clock.Advance(discoveryTTL + time.Second)
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), token, cfg, verifier); err == nil {
+		t.Fatal("token unexpectedly validated after discovery cache expiry during outage")
+	}
+	if got := provider.discoveryHits.Load(); got != 2 {
+		t.Fatalf("OIDC discovery fetches after expiry = %d, want 2", got)
+	}
+
+	provider.setDiscoveryStatus(0)
+	clock.Advance(retryDelay + time.Second)
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), token, cfg, verifier); err != nil {
+		t.Fatalf("validate after discovery endpoint recovery: %v", err)
+	}
+	if got := provider.discoveryHits.Load(); got != 3 {
+		t.Fatalf("OIDC discovery fetches after recovery = %d, want 3", got)
+	}
+}
+
+func TestValidateOIDCToken_RejectsOversizedDiscoveryDocument(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	provider.setDiscoveryPadding((64 << 10) + 4096)
+
+	token := provider.issueToken(t, testOIDCTokenOptions{})
+	for i := range 8 {
+		_, err := validateOIDCToken(context.Background(), token, provider.configWithoutJWKSURL())
+		if err == nil || !strings.Contains(err.Error(), "OIDC discovery response exceeds maximum size") {
+			t.Fatalf("validateOIDCToken attempt %d error = %v, want oversized discovery error", i, err)
+		}
+	}
+	if got := provider.jwksHits.Load(); got != 0 {
+		t.Fatalf("JWKS fetches = %d, want 0", got)
+	}
+	if got := provider.discoveryHits.Load(); got != 1 {
+		t.Fatalf("OIDC discovery fetches = %d, want 1 during refresh backoff", got)
+	}
+}
+
+func TestValidateOIDCToken_ConcurrentInvalidSignaturesCoalesceJWKSFetch(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	if _, err := validateOIDCToken(context.Background(), provider.issueToken(t, testOIDCTokenOptions{}), provider.config()); err != nil {
+		t.Fatalf("warm JWKS cache: %v", err)
+	}
+	started, release := provider.blockJWKS()
+	defer release()
+	token := tamperJWTSignature(t, provider.issueToken(t, testOIDCTokenOptions{}))
+
+	const requests = 32
+	start := make(chan struct{})
+	errs := make(chan error, requests)
+	var wg sync.WaitGroup
+	for range requests {
+		wg.Go(func() {
+			<-start
+			_, err := validateOIDCToken(context.Background(), token, provider.config())
+			errs <- err
+		})
+	}
+	close(start)
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for JWKS fetch")
+	}
+	release()
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err == nil || !strings.Contains(err.Error(), "signature") {
+			t.Fatalf("validateOIDCToken error = %v, want signature error", err)
+		}
+	}
+	if got := provider.jwksHits.Load(); got != 2 {
+		t.Fatalf("JWKS fetches = %d, want 2 (initial load plus one refresh for %d concurrent invalid signatures)", got, requests)
+	}
+}
+
+func TestJWKSCache_LateOverlappingLoadSharesCompletedRefresh(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	fetchStarted, releaseFetch := provider.blockJWKS()
+	defer releaseFetch()
+	lateLoadStarted := make(chan struct{}, 1)
+	releaseLateLoad := make(chan struct{})
+	var releaseLateLoadOnce sync.Once
+	unblockLateLoad := func() { releaseLateLoadOnce.Do(func() { close(releaseLateLoad) }) }
+	defer unblockLateLoad()
+	clock := &cacheTestBlockingClock{
+		now:     time.Date(2026, time.July, 10, 0, 0, 0, 0, time.UTC),
+		blockAt: 3, // first load, refresh setup, then the overlapping load
+		started: lateLoadStarted,
+		release: releaseLateLoad,
+	}
+	cache := newJWKSCache(jwksCacheOptions{now: clock.Now})
+	url := provider.config().JWKSURL
+	type loadOutcome struct {
+		result jwksLoadResult
+		err    error
+	}
+	first := make(chan loadOutcome, 1)
+	late := make(chan loadOutcome, 1)
+	go func() {
+		result, err := cache.load(context.Background(), url)
+		first <- loadOutcome{result: result, err: err}
+	}()
+	select {
+	case <-fetchStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for initial JWKS fetch")
+	}
+	go func() {
+		result, err := cache.load(context.Background(), url)
+		late <- loadOutcome{result: result, err: err}
+	}()
+	select {
+	case <-lateLoadStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for overlapping JWKS load")
+	}
+
+	releaseFetch()
+	firstOutcome := <-first
+	if firstOutcome.err != nil || !firstOutcome.result.refreshed {
+		t.Fatalf("initial JWKS load: refreshed=%v err=%v, want successful refresh", firstOutcome.result.refreshed, firstOutcome.err)
+	}
+	unblockLateLoad()
+	lateOutcome := <-late
+	if lateOutcome.err != nil || !lateOutcome.result.refreshed {
+		t.Fatalf("overlapping JWKS load: refreshed=%v err=%v, want completed refresh attribution", lateOutcome.result.refreshed, lateOutcome.err)
+	}
+	if got := provider.jwksHits.Load(); got != 1 {
+		t.Fatalf("JWKS fetches = %d, want 1", got)
+	}
+}
+
+func TestOIDCDiscoveryCache_LateOverlappingLoadSharesCompletedRefresh(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	fetchStarted, releaseFetch := provider.blockDiscovery()
+	defer releaseFetch()
+	lateLoadStarted := make(chan struct{}, 1)
+	releaseLateLoad := make(chan struct{})
+	var releaseLateLoadOnce sync.Once
+	unblockLateLoad := func() { releaseLateLoadOnce.Do(func() { close(releaseLateLoad) }) }
+	defer unblockLateLoad()
+	clock := &cacheTestBlockingClock{
+		now:     time.Date(2026, time.July, 10, 0, 0, 0, 0, time.UTC),
+		blockAt: 3, // first load, refresh setup, then the overlapping load
+		started: lateLoadStarted,
+		release: releaseLateLoad,
+	}
+	cache := newOIDCDiscoveryCache(oidcDiscoveryCacheOptions{now: clock.Now})
+	issuer := provider.config().Issuer
+	type loadOutcome struct {
+		selection oidcDiscoverySelection
+		err       error
+	}
+	first := make(chan loadOutcome, 1)
+	late := make(chan loadOutcome, 1)
+	go func() {
+		selection, err := cache.load(context.Background(), issuer)
+		first <- loadOutcome{selection: selection, err: err}
+	}()
+	select {
+	case <-fetchStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for initial discovery fetch")
+	}
+	go func() {
+		selection, err := cache.load(context.Background(), issuer)
+		late <- loadOutcome{selection: selection, err: err}
+	}()
+	select {
+	case <-lateLoadStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for overlapping discovery load")
+	}
+
+	releaseFetch()
+	firstOutcome := <-first
+	if firstOutcome.err != nil || !firstOutcome.selection.refreshed {
+		t.Fatalf("initial discovery load: refreshed=%v err=%v, want successful refresh", firstOutcome.selection.refreshed, firstOutcome.err)
+	}
+	unblockLateLoad()
+	lateOutcome := <-late
+	if lateOutcome.err != nil || !lateOutcome.selection.refreshed {
+		t.Fatalf("overlapping discovery load: refreshed=%v err=%v, want completed refresh attribution", lateOutcome.selection.refreshed, lateOutcome.err)
+	}
+	if got := provider.discoveryHits.Load(); got != 1 {
+		t.Fatalf("OIDC discovery fetches = %d, want 1", got)
+	}
+}
+
+func TestValidateOIDCToken_UnknownKidFloodCoalescesRefresh(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	if _, err := validateOIDCToken(context.Background(), provider.issueToken(t, testOIDCTokenOptions{}), provider.config()); err != nil {
+		t.Fatalf("warm JWKS cache: %v", err)
+	}
+
+	const requests = 32
+	tokens := make([]string, requests)
+	for i := range tokens {
+		tokens[i] = provider.issueToken(t, testOIDCTokenOptions{Kid: fmt.Sprintf("unknown-%d", i)})
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, requests)
+	var wg sync.WaitGroup
+	for _, token := range tokens {
+		wg.Go(func() {
+			<-start
+			_, err := validateOIDCToken(context.Background(), token, provider.config())
+			errs <- err
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err == nil || !strings.Contains(err.Error(), "kid") {
+			t.Fatalf("validateOIDCToken error = %v, want unknown kid error", err)
+		}
+	}
+	for i := range 8 {
+		token := provider.issueToken(t, testOIDCTokenOptions{Kid: fmt.Sprintf("later-unknown-%d", i)})
+		if _, err := validateOIDCToken(context.Background(), token, provider.config()); err == nil || !strings.Contains(err.Error(), "kid") {
+			t.Fatalf("validateOIDCToken later unknown kid error = %v, want unknown kid error", err)
+		}
+	}
+
+	if got := provider.jwksHits.Load(); got != 2 {
+		t.Fatalf("JWKS fetches = %d, want 2 (initial load plus one coalesced unknown-kid refresh)", got)
+	}
+}
+
+func TestValidateOIDCToken_UnknownKidRefreshSupportsRotation(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	if _, err := validateOIDCToken(context.Background(), provider.issueToken(t, testOIDCTokenOptions{}), provider.config()); err != nil {
+		t.Fatalf("validate token before rotation: %v", err)
+	}
+
+	provider.rotate(t)
+	if _, err := validateOIDCToken(context.Background(), provider.issueToken(t, testOIDCTokenOptions{}), provider.config()); err != nil {
+		t.Fatalf("validate token after rotation: %v", err)
+	}
+
+	if got := provider.jwksHits.Load(); got != 2 {
+		t.Fatalf("JWKS fetches = %d, want 2 for initial load and rotation refresh", got)
+	}
+}
+
+func TestValidateOIDCToken_DiscoveryRefreshSupportsJWKSURLRotation(t *testing.T) {
+	keyA, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate first RSA key: %v", err)
+	}
+	keyB, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate second RSA key: %v", err)
+	}
+	bodyA, err := json.Marshal(map[string]any{testJWKSKeysJSONKey: []testJWKKey{testJWKFromPublicKey(&keyA.PublicKey, "key-a")}})
+	if err != nil {
+		t.Fatalf("marshal first JWKS: %v", err)
+	}
+	bodyB, err := json.Marshal(map[string]any{testJWKSKeysJSONKey: []testJWKKey{testJWKFromPublicKey(&keyB.PublicKey, "key-b")}})
+	if err != nil {
+		t.Fatalf("marshal second JWKS: %v", err)
+	}
+
+	var discoveryMu sync.RWMutex
+	var discoveryJWKSPath = testJWKSPathA
+	var discoveryHits atomic.Int64
+	var jwksAHits atomic.Int64
+	var jwksBHits atomic.Int64
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case testOIDCDiscoveryPath:
+			discoveryHits.Add(1)
+			discoveryMu.RLock()
+			path := discoveryJWKSPath
+			discoveryMu.RUnlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{testJWKSURIJSONKey: server.URL + path})
+		case testJWKSPathA:
+			jwksAHits.Add(1)
+			_, _ = w.Write(bodyA)
+		case testJWKSPathB:
+			jwksBHits.Add(1)
+			_, _ = w.Write(bodyB)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	const audience = testOIDCAudience
+	cfg := OIDCConfig{Issuer: server.URL, Audience: audience, AllowedSubjects: []string{"*"}}
+	providerA := &testOIDCProvider{server: server, key: keyA, kid: "key-a", aud: audience}
+	if _, err := validateOIDCToken(context.Background(), providerA.issueToken(t, testOIDCTokenOptions{}), cfg); err != nil {
+		t.Fatalf("validate token with initial discovered JWKS URL: %v", err)
+	}
+
+	discoveryMu.Lock()
+	discoveryJWKSPath = testJWKSPathB
+	discoveryMu.Unlock()
+	providerB := &testOIDCProvider{server: server, key: keyB, kid: "key-b", aud: audience}
+	if _, err := validateOIDCToken(context.Background(), providerB.issueToken(t, testOIDCTokenOptions{}), cfg); err != nil {
+		t.Fatalf("validate token after discovered JWKS URL rotation: %v", err)
+	}
+
+	if got := discoveryHits.Load(); got != 2 {
+		t.Fatalf("OIDC discovery fetches = %d, want 2", got)
+	}
+	if got := jwksAHits.Load(); got != 2 {
+		t.Fatalf("old JWKS URL fetches = %d, want 2 (initial load plus rotation probe)", got)
+	}
+	if got := jwksBHits.Load(); got != 1 {
+		t.Fatalf("new JWKS URL fetches = %d, want 1", got)
+	}
+}
+
+func TestValidateOIDCToken_DiscoveryRefreshSupportsJWKSURLRotationAfterStaleRefreshFailure(t *testing.T) {
+	keyA, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate first RSA key: %v", err)
+	}
+	keyB, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate second RSA key: %v", err)
+	}
+	bodyA, err := json.Marshal(map[string]any{testJWKSKeysJSONKey: []testJWKKey{testJWKFromPublicKey(&keyA.PublicKey, "key-a")}})
+	if err != nil {
+		t.Fatalf("marshal first JWKS: %v", err)
+	}
+	bodyB, err := json.Marshal(map[string]any{testJWKSKeysJSONKey: []testJWKKey{testJWKFromPublicKey(&keyB.PublicKey, "key-b")}})
+	if err != nil {
+		t.Fatalf("marshal second JWKS: %v", err)
+	}
+
+	var stateMu sync.RWMutex
+	discoveryJWKSPath := testJWKSPathA
+	jwksAUnavailable := false
+	var discoveryHits atomic.Int64
+	var jwksAHits atomic.Int64
+	var jwksBHits atomic.Int64
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case testOIDCDiscoveryPath:
+			discoveryHits.Add(1)
+			stateMu.RLock()
+			path := discoveryJWKSPath
+			stateMu.RUnlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{testJWKSURIJSONKey: server.URL + path})
+		case testJWKSPathA:
+			jwksAHits.Add(1)
+			stateMu.RLock()
+			unavailable := jwksAUnavailable
+			stateMu.RUnlock()
+			if unavailable {
+				http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
+				return
+			}
+			_, _ = w.Write(bodyA)
+		case testJWKSPathB:
+			jwksBHits.Add(1)
+			_, _ = w.Write(bodyB)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	clock := &cacheTestClock{now: time.Date(2026, time.July, 10, 0, 0, 0, 0, time.UTC)}
+	const jwksFreshTTL = time.Minute
+	verifier := newJWTVerifierWithCacheOptions(
+		jwksCacheOptions{now: clock.Now, freshTTL: jwksFreshTTL, staleTTL: 2 * time.Minute},
+		oidcDiscoveryCacheOptions{now: clock.Now, ttl: 5 * time.Minute},
+	)
+	const audience = testOIDCAudience
+	cfg := OIDCConfig{Issuer: server.URL, Audience: audience, AllowedSubjects: []string{"*"}}
+	providerA := &testOIDCProvider{server: server, key: keyA, kid: "key-a", aud: audience}
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), providerA.issueToken(t, testOIDCTokenOptions{}), cfg, verifier); err != nil {
+		t.Fatalf("validate token with initial discovered JWKS URL: %v", err)
+	}
+
+	stateMu.Lock()
+	discoveryJWKSPath = testJWKSPathB
+	jwksAUnavailable = true
+	stateMu.Unlock()
+	clock.Advance(jwksFreshTTL + time.Second)
+	providerB := &testOIDCProvider{server: server, key: keyB, kid: "key-b", aud: audience}
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), providerB.issueToken(t, testOIDCTokenOptions{}), cfg, verifier); err != nil {
+		t.Fatalf("validate rotated token after stale JWKS refresh failure: %v", err)
+	}
+
+	if got := discoveryHits.Load(); got != 2 {
+		t.Fatalf("OIDC discovery fetches = %d, want 2", got)
+	}
+	if got := jwksAHits.Load(); got != 2 {
+		t.Fatalf("old JWKS URL fetches = %d, want 2", got)
+	}
+	if got := jwksBHits.Load(); got != 1 {
+		t.Fatalf("new JWKS URL fetches = %d, want 1", got)
+	}
+}
+
+func TestValidateOIDCToken_SignatureFailureRefreshSupportsSameKidRotation(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	if _, err := validateOIDCToken(context.Background(), provider.issueToken(t, testOIDCTokenOptions{}), provider.config()); err != nil {
+		t.Fatalf("validate token before rotation: %v", err)
+	}
+
+	provider.rotateWithKid(t, "cache-key-1")
+	if _, err := validateOIDCToken(context.Background(), provider.issueToken(t, testOIDCTokenOptions{}), provider.config()); err != nil {
+		t.Fatalf("validate same-kid token after rotation: %v", err)
+	}
+
+	if got := provider.jwksHits.Load(); got != 2 {
+		t.Fatalf("JWKS fetches = %d, want 2 for initial load and same-kid rotation refresh", got)
+	}
+}
+
+func TestValidateOIDCToken_SignatureFailureRefreshSupportsKidlessRotation(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	if _, err := validateOIDCToken(context.Background(), provider.issueToken(t, testOIDCTokenOptions{OmitKid: true}), provider.config()); err != nil {
+		t.Fatalf("validate kid-less token before rotation: %v", err)
+	}
+
+	provider.rotate(t)
+	if _, err := validateOIDCToken(context.Background(), provider.issueToken(t, testOIDCTokenOptions{OmitKid: true}), provider.config()); err != nil {
+		t.Fatalf("validate kid-less token after rotation: %v", err)
+	}
+
+	if got := provider.jwksHits.Load(); got != 2 {
+		t.Fatalf("JWKS fetches = %d, want 2 for initial load and kid-less rotation refresh", got)
+	}
+}
+
+func TestJWTVerifier_InvalidSignaturesDoNotSlideRotationRefreshCooldown(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	clock := &cacheTestClock{now: time.Date(2026, time.July, 10, 0, 0, 0, 0, time.UTC)}
+	const forcedRefreshCooldown = 5 * time.Second
+	verifier := newJWTVerifierWithOptions(jwksCacheOptions{
+		now:                   clock.Now,
+		forcedRefreshCooldown: forcedRefreshCooldown,
+	})
+	validToken := provider.issueToken(t, testOIDCTokenOptions{})
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), validToken, provider.config(), verifier); err != nil {
+		t.Fatalf("warm JWKS cache: %v", err)
+	}
+	tamperedToken := tamperJWTSignature(t, validToken)
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), tamperedToken, provider.config(), verifier); err == nil {
+		t.Fatal("tampered token unexpectedly validated")
+	}
+	if got := provider.jwksHits.Load(); got != 2 {
+		t.Fatalf("JWKS fetches after first invalid signature = %d, want 2", got)
+	}
+
+	clock.Advance(4 * time.Second)
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), tamperedToken, provider.config(), verifier); err == nil {
+		t.Fatal("second tampered token unexpectedly validated")
+	}
+	if got := provider.jwksHits.Load(); got != 2 {
+		t.Fatalf("JWKS fetches inside forced-refresh cooldown = %d, want 2", got)
+	}
+
+	clock.Advance(2 * time.Second)
+	provider.rotateWithKid(t, "cache-key-1")
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), provider.issueToken(t, testOIDCTokenOptions{}), provider.config(), verifier); err != nil {
+		t.Fatalf("validate same-kid rotation after original cooldown: %v", err)
+	}
+	if got := provider.jwksHits.Load(); got != 3 {
+		t.Fatalf("JWKS fetches after rotation = %d, want 3", got)
+	}
+}
+
+func TestJWTVerifier_KidlessAlgorithmRotationRefreshesMissingCompatibleKey(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate EC key: %v", err)
+	}
+
+	var bodyMu sync.RWMutex
+	body := marshalPublicJWKS(t, &rsaKey.PublicKey, jwa.RS256())
+	var jwksHits atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		jwksHits.Add(1)
+		bodyMu.RLock()
+		defer bodyMu.RUnlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(server.Close)
+
+	const audience = testOIDCAudience
+	verifier := newJWTVerifier()
+	cfg := jwtVerificationConfig{
+		Issuer:            server.URL,
+		Audience:          audience,
+		JWKSURL:           server.URL,
+		AllowedAlgorithms: []jwa.SignatureAlgorithm{jwa.RS256(), jwa.ES256()},
+	}
+	rsaProvider := &testOIDCProvider{server: server, key: rsaKey, kid: "unused", aud: audience}
+	if _, err := verifier.verifyJWT(context.Background(), rsaProvider.issueToken(t, testOIDCTokenOptions{OmitKid: true}), cfg); err != nil {
+		t.Fatalf("validate kid-less RSA JWT: %v", err)
+	}
+
+	bodyMu.Lock()
+	body = marshalPublicJWKS(t, &ecKey.PublicKey, jwa.ES256())
+	bodyMu.Unlock()
+	if _, err := verifier.verifyJWT(context.Background(), issueES256Token(t, server.URL, audience, ecKey), cfg); err != nil {
+		t.Fatalf("validate kid-less ES256 token after algorithm rotation: %v", err)
+	}
+	if got := jwksHits.Load(); got != 2 {
+		t.Fatalf("JWKS fetches = %d, want 2 for initial load and kid-less algorithm rotation", got)
+	}
+}
+
+func TestJWTVerifier_RotationRetryUsesRefreshCompletedAfterSnapshot(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	verifier := newJWTVerifier()
+	cfg := jwtVerificationConfig{
+		Issuer:   provider.server.URL,
+		Audience: provider.aud,
+		JWKSURL:  provider.server.URL,
+	}
+	if _, err := verifier.verifyJWT(context.Background(), provider.issueToken(t, testOIDCTokenOptions{}), cfg); err != nil {
+		t.Fatalf("warm JWKS cache: %v", err)
+	}
+
+	provider.rotateWithKid(t, "cache-key-1")
+	parsed, err := parseCompactJWT(provider.issueToken(t, testOIDCTokenOptions{}))
+	if err != nil {
+		t.Fatalf("parse rotated JWT: %v", err)
+	}
+	staleSelection, err := verifier.jwks.signingKeys(context.Background(), cfg.JWKSURL, parsed.Header)
+	if err != nil {
+		t.Fatalf("select cached signing key: %v", err)
+	}
+	if _, _, refreshed, err := verifier.jwks.refreshForRotation(context.Background(), cfg.JWKSURL, 0); err != nil || !refreshed {
+		t.Fatalf("complete concurrent rotation refresh: refreshed=%v err=%v", refreshed, err)
+	}
+
+	if _, err := verifier.parseJWTWithRotationRetry(context.Background(), parsed, cfg.JWKSURL, staleSelection); err != nil {
+		t.Fatalf("retry rotated token after concurrent refresh: %v", err)
+	}
+	if got := provider.jwksHits.Load(); got != 2 {
+		t.Fatalf("JWKS fetches = %d, want 2", got)
+	}
+}
+
+func TestJWTVerifier_RotationRetryUsesTTLRefreshCompletedAfterSnapshot(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	clock := &cacheTestClock{now: time.Date(2026, time.July, 10, 0, 0, 0, 0, time.UTC)}
+	const freshTTL = time.Minute
+	verifier := newJWTVerifierWithOptions(jwksCacheOptions{now: clock.Now, freshTTL: freshTTL})
+	cfg := jwtVerificationConfig{
+		Issuer:   provider.server.URL,
+		Audience: provider.aud,
+		JWKSURL:  provider.config().JWKSURL,
+	}
+	if _, err := verifier.verifyJWT(context.Background(), provider.issueToken(t, testOIDCTokenOptions{}), cfg); err != nil {
+		t.Fatalf("warm JWKS cache: %v", err)
+	}
+
+	provider.rotateWithKid(t, "cache-key-1")
+	parsed, err := parseCompactJWT(provider.issueToken(t, testOIDCTokenOptions{}))
+	if err != nil {
+		t.Fatalf("parse rotated JWT: %v", err)
+	}
+	staleSelection, err := verifier.jwks.signingKeys(context.Background(), cfg.JWKSURL, parsed.Header)
+	if err != nil {
+		t.Fatalf("select cached signing key: %v", err)
+	}
+	clock.Advance(freshTTL + time.Second)
+	if _, _, err := verifier.jwks.refresh(context.Background(), cfg.JWKSURL); err != nil {
+		t.Fatalf("complete ordinary TTL refresh: %v", err)
+	}
+	provider.setJWKSStatus(http.StatusServiceUnavailable)
+
+	if _, err := verifier.parseJWTWithRotationRetry(context.Background(), parsed, cfg.JWKSURL, staleSelection); err != nil {
+		t.Fatalf("retry rotated token using completed TTL refresh: %v", err)
+	}
+	if got := provider.jwksHits.Load(); got != 2 {
+		t.Fatalf("JWKS fetches = %d, want 2 without a redundant post-snapshot fetch", got)
+	}
+}
+
+func TestOIDCDiscoveryCache_RotationUsesTTLRefreshCompletedAfterSnapshot(t *testing.T) {
+	var stateMu sync.RWMutex
+	discoveryPath := testJWKSPathA
+	discoveryStatus := 0
+	var discoveryHits atomic.Int64
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, testOIDCDiscoveryPath) {
+			http.NotFound(w, r)
+			return
+		}
+		discoveryHits.Add(1)
+		stateMu.RLock()
+		path := discoveryPath
+		status := discoveryStatus
+		stateMu.RUnlock()
+		if status != 0 {
+			http.Error(w, http.StatusText(status), status)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{testJWKSURIJSONKey: server.URL + path})
+	}))
+	t.Cleanup(server.Close)
+
+	clock := &cacheTestClock{now: time.Date(2026, time.July, 10, 0, 0, 0, 0, time.UTC)}
+	const discoveryTTL = time.Minute
+	cache := newOIDCDiscoveryCache(oidcDiscoveryCacheOptions{now: clock.Now, ttl: discoveryTTL})
+	selection, err := cache.load(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("load initial discovery document: %v", err)
+	}
+
+	stateMu.Lock()
+	discoveryPath = testJWKSPathB
+	stateMu.Unlock()
+	clock.Advance(discoveryTTL + time.Second)
+	currentURL, currentGeneration, err := cache.refresh(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("complete ordinary discovery TTL refresh: %v", err)
+	}
+	stateMu.Lock()
+	discoveryStatus = http.StatusServiceUnavailable
+	stateMu.Unlock()
+
+	reusedURL, reusedGeneration, refreshed, err := cache.refreshForRotation(context.Background(), server.URL, selection.generation)
+	if err != nil {
+		t.Fatalf("reuse completed discovery refresh: %v", err)
+	}
+	if !refreshed || reusedURL != currentURL || reusedGeneration != currentGeneration {
+		t.Fatalf("reused discovery = (%q, %d, refreshed=%v), want (%q, %d, true)", reusedURL, reusedGeneration, refreshed, currentURL, currentGeneration)
+	}
+	if got := discoveryHits.Load(); got != 2 {
+		t.Fatalf("OIDC discovery fetches = %d, want 2 without a redundant post-snapshot fetch", got)
+	}
+}
+
+func TestJWTVerifier_MixedJWKSUsesPublicKeysWithoutCachingSymmetricSecrets(t *testing.T) {
+	signingKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	const rsaKid = "mixed-rsa-key"
+	rsaJWK, err := jwk.Import(&signingKey.PublicKey)
+	if err != nil {
+		t.Fatalf("import RSA JWK: %v", err)
+	}
+	if err := rsaJWK.Set(jwk.KeyIDKey, rsaKid); err != nil {
+		t.Fatalf("set RSA JWK kid: %v", err)
+	}
+	if err := rsaJWK.Set(jwk.AlgorithmKey, jwa.RS256()); err != nil {
+		t.Fatalf("set RSA JWK algorithm: %v", err)
+	}
+	if err := rsaJWK.Set(jwk.KeyUsageKey, string(jwk.ForSignature)); err != nil {
+		t.Fatalf("set RSA JWK usage: %v", err)
+	}
+	symmetricJWK, err := jwk.Import([]byte("test-only-symmetric-material"))
+	if err != nil {
+		t.Fatalf("import symmetric JWK: %v", err)
+	}
+	if err := symmetricJWK.Set(jwk.KeyIDKey, "unrelated-symmetric-key"); err != nil {
+		t.Fatalf("set symmetric JWK kid: %v", err)
+	}
+	mixedSet := jwk.NewSet()
+	if err := mixedSet.AddKey(rsaJWK); err != nil {
+		t.Fatalf("add RSA JWK: %v", err)
+	}
+	if err := mixedSet.AddKey(symmetricJWK); err != nil {
+		t.Fatalf("add symmetric JWK: %v", err)
+	}
+	body, err := json.Marshal(mixedSet)
+	if err != nil {
+		t.Fatalf("marshal mixed JWKS: %v", err)
+	}
+
+	var jwksHits atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		jwksHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(server.Close)
+	const audience = testOIDCAudience
+	provider := &testOIDCProvider{server: server, key: signingKey, kid: rsaKid, aud: audience}
+	verifier := newJWTVerifier()
+	cfg := provider.config()
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), provider.issueToken(t, testOIDCTokenOptions{}), cfg, verifier); err != nil {
+		t.Fatalf("validate token from mixed JWKS: %v", err)
+	}
+
+	verifier.jwks.mu.Lock()
+	entry := verifier.jwks.entries[cfg.JWKSURL]
+	cachedKeyCount := 0
+	cachedKeyType := ""
+	if entry != nil && entry.set != nil {
+		cachedKeyCount = entry.set.Len()
+		if key, ok := entry.set.Key(0); ok {
+			cachedKeyType = key.KeyType().String()
+		}
+	}
+	verifier.jwks.mu.Unlock()
+	if cachedKeyCount != 1 || cachedKeyType != jwa.RSA().String() {
+		t.Fatalf("cached mixed JWKS has %d key(s) of type %s, want one RSA public key", cachedKeyCount, cachedKeyType)
+	}
+	if got := jwksHits.Load(); got != 1 {
+		t.Fatalf("JWKS fetches = %d, want 1", got)
+	}
+}
+
+func TestJWTVerifier_FullAsymmetricJWKDoesNotCacheSensitiveFields(t *testing.T) {
+	signingKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	const (
+		rsaKid                 = "full-rsa-key"
+		otherPrimesField       = "oth"
+		metadataExtensionField = "private_extension"
+		metadataExtensionValue = "test-only-private-metadata"
+	)
+	fullJWK, err := jwk.Import(signingKey)
+	if err != nil {
+		t.Fatalf("import full RSA JWK: %v", err)
+	}
+	if err := fullJWK.Set(jwk.KeyIDKey, rsaKid); err != nil {
+		t.Fatalf("set RSA JWK kid: %v", err)
+	}
+	if err := fullJWK.Set(jwk.AlgorithmKey, jwa.RS256()); err != nil {
+		t.Fatalf("set RSA JWK algorithm: %v", err)
+	}
+	if err := fullJWK.Set(jwk.KeyUsageKey, string(jwk.ForSignature)); err != nil {
+		t.Fatalf("set RSA JWK usage: %v", err)
+	}
+	if err := fullJWK.Set(otherPrimesField, []any{map[string]any{"r": "other-prime-value"}}); err != nil {
+		t.Fatalf("set RSA other-primes field: %v", err)
+	}
+	if err := fullJWK.Set(metadataExtensionField, metadataExtensionValue); err != nil {
+		t.Fatalf("set private JWK extension: %v", err)
+	}
+	set := jwk.NewSet()
+	if err := set.AddKey(fullJWK); err != nil {
+		t.Fatalf("add full RSA JWK: %v", err)
+	}
+	body, err := json.Marshal(set)
+	if err != nil {
+		t.Fatalf("marshal private JWKS: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(server.Close)
+	provider := &testOIDCProvider{server: server, key: signingKey, kid: rsaKid, aud: testOIDCAudience}
+	verifier := newJWTVerifier()
+	cfg := provider.config()
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), provider.issueToken(t, testOIDCTokenOptions{}), cfg, verifier); err != nil {
+		t.Fatalf("validate token from full-key JWKS: %v", err)
+	}
+
+	verifier.jwks.mu.Lock()
+	entry := verifier.jwks.entries[cfg.JWKSURL]
+	var cachedKey jwk.Key
+	if entry != nil && entry.set != nil {
+		cachedKey, _ = entry.set.Key(0)
+	}
+	verifier.jwks.mu.Unlock()
+	if cachedKey == nil {
+		t.Fatal("cached public JWK is missing")
+	}
+	sensitiveFields := []string{
+		jwk.RSADKey,
+		jwk.RSAPKey,
+		jwk.RSAQKey,
+		jwk.RSADPKey,
+		jwk.RSADQKey,
+		jwk.RSAQIKey,
+		otherPrimesField,
+		metadataExtensionField,
+	}
+	for _, field := range sensitiveFields {
+		if cachedKey.Has(field) {
+			t.Fatalf("cached public JWK retained sensitive field %q", field)
+		}
+	}
+	cachedJSON, err := json.Marshal(cachedKey)
+	if err != nil {
+		t.Fatalf("marshal cached public JWK: %v", err)
+	}
+	if strings.Contains(string(cachedJSON), metadataExtensionValue) || strings.Contains(string(cachedJSON), "other-prime-value") {
+		t.Fatalf("cached public JWK retained sensitive extension data: %s", cachedJSON)
+	}
+}
+
+func TestJWTVerifier_EmptyJWKSWithdrawsCachedKeys(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	clock := &cacheTestClock{now: time.Date(2026, time.July, 10, 0, 0, 0, 0, time.UTC)}
+	const freshTTL = time.Minute
+	verifier := newJWTVerifierWithOptions(jwksCacheOptions{
+		now:      clock.Now,
+		freshTTL: freshTTL,
+		staleTTL: 2 * time.Minute,
+	})
+	token := provider.issueToken(t, testOIDCTokenOptions{})
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), token, provider.config(), verifier); err != nil {
+		t.Fatalf("warm JWKS cache: %v", err)
+	}
+
+	provider.setJWKSEmpty(true)
+	clock.Advance(freshTTL + time.Second)
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), token, provider.config(), verifier); err == nil {
+		t.Fatal("token signed by withdrawn key unexpectedly validated")
+	}
+	if got := provider.jwksHits.Load(); got != 2 {
+		t.Fatalf("JWKS fetches = %d, want 2", got)
+	}
+}
+
+func TestValidateOIDCToken_RejectsOversizedJWKS(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	provider.setJWKSPadding((1 << 20) + 4096)
+
+	token := provider.issueToken(t, testOIDCTokenOptions{})
+	for i := range 8 {
+		_, err := validateOIDCToken(context.Background(), token, provider.config())
+		if err == nil || !strings.Contains(err.Error(), "JWKS response exceeds maximum size") {
+			t.Fatalf("validateOIDCToken attempt %d error = %v, want oversized JWKS error", i, err)
+		}
+	}
+	if got := provider.jwksHits.Load(); got != 1 {
+		t.Fatalf("JWKS fetches = %d, want 1 during refresh backoff", got)
+	}
+}
+
+func TestJWTVerifier_JWKSOutageUsesBoundedStaleCacheAndFailsClosedAfterExpiry(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	clock := &cacheTestClock{now: time.Date(2026, time.July, 10, 0, 0, 0, 0, time.UTC)}
+	const (
+		freshTTL   = time.Minute
+		staleTTL   = 2 * time.Minute
+		retryDelay = 5 * time.Second
+	)
+	verifier := newJWTVerifierWithOptions(jwksCacheOptions{
+		now:               clock.Now,
+		freshTTL:          freshTTL,
+		staleTTL:          staleTTL,
+		refreshRetryDelay: retryDelay,
+	})
+	token := provider.issueToken(t, testOIDCTokenOptions{})
+
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), token, provider.config(), verifier); err != nil {
+		t.Fatalf("warm JWKS cache: %v", err)
+	}
+	provider.setJWKSStatus(http.StatusServiceUnavailable)
+	clock.Advance(freshTTL + time.Second)
+
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), token, provider.config(), verifier); err != nil {
+		t.Fatalf("validate with stale JWKS during outage: %v", err)
+	}
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), token, provider.config(), verifier); err != nil {
+		t.Fatalf("validate with stale JWKS during refresh backoff: %v", err)
+	}
+	if got := provider.jwksHits.Load(); got != 2 {
+		t.Fatalf("JWKS fetches during stale outage = %d, want 2 (initial load plus one failed refresh)", got)
+	}
+
+	clock.Advance(staleTTL)
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), token, provider.config(), verifier); err == nil {
+		t.Fatal("validateOIDCTokenWithVerifier succeeded after the hard stale expiry during outage")
+	}
+	if got := provider.jwksHits.Load(); got != 3 {
+		t.Fatalf("JWKS fetches after hard expiry = %d, want 3", got)
+	}
+
+	provider.setJWKSStatus(0)
+	clock.Advance(retryDelay + time.Second)
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), token, provider.config(), verifier); err != nil {
+		t.Fatalf("validate after JWKS endpoint recovery: %v", err)
+	}
+	if got := provider.jwksHits.Load(); got != 4 {
+		t.Fatalf("JWKS fetches after recovery = %d, want 4", got)
+	}
+}
+
+func TestJWTVerifier_ConcurrentJWKSOutageCoalescesAndBacksOff(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	provider.setJWKSStatus(http.StatusServiceUnavailable)
+	verifier := newJWTVerifier()
+	token := provider.issueToken(t, testOIDCTokenOptions{})
+	cfg := provider.config()
+
+	const requests = 32
+	start := make(chan struct{})
+	errs := make(chan error, requests)
+	var wg sync.WaitGroup
+	for range requests {
+		wg.Go(func() {
+			<-start
+			_, err := validateOIDCTokenWithVerifier(context.Background(), token, cfg, verifier)
+			errs <- err
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err == nil || !strings.Contains(err.Error(), "fetch JWKS") {
+			t.Fatalf("validateOIDCTokenWithVerifier error = %v, want JWKS fetch error", err)
+		}
+	}
+	if got := provider.jwksHits.Load(); got != 1 {
+		t.Fatalf("JWKS fetches = %d, want 1 for %d concurrent failures", got, requests)
+	}
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), token, cfg, verifier); err == nil {
+		t.Fatal("token unexpectedly validated during JWKS refresh backoff")
+	}
+	if got := provider.jwksHits.Load(); got != 1 {
+		t.Fatalf("JWKS fetches during retry backoff = %d, want 1", got)
+	}
+}
+
+func TestJWTVerifier_ConcurrentDiscoveryOutageCoalescesAndBacksOff(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	provider.setDiscoveryStatus(http.StatusServiceUnavailable)
+	verifier := newJWTVerifier()
+	token := provider.issueToken(t, testOIDCTokenOptions{})
+	cfg := provider.configWithoutJWKSURL()
+
+	const requests = 32
+	start := make(chan struct{})
+	errs := make(chan error, requests)
+	var wg sync.WaitGroup
+	for range requests {
+		wg.Go(func() {
+			<-start
+			_, err := validateOIDCTokenWithVerifier(context.Background(), token, cfg, verifier)
+			errs <- err
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err == nil || !strings.Contains(err.Error(), "fetch OIDC discovery document") {
+			t.Fatalf("validateOIDCTokenWithVerifier error = %v, want discovery fetch error", err)
+		}
+	}
+	if got := provider.discoveryHits.Load(); got != 1 {
+		t.Fatalf("OIDC discovery fetches = %d, want 1 for %d concurrent failures", got, requests)
+	}
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), token, cfg, verifier); err == nil {
+		t.Fatal("token unexpectedly validated during discovery refresh backoff")
+	}
+	if got := provider.discoveryHits.Load(); got != 1 {
+		t.Fatalf("OIDC discovery fetches during retry backoff = %d, want 1", got)
+	}
+	if got := provider.jwksHits.Load(); got != 0 {
+		t.Fatalf("JWKS fetches = %d, want 0 while discovery is unavailable", got)
+	}
+}
+
+func TestJWKSCache_EvictsLeastRecentlyUsedEntryAtCapacity(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	clock := &cacheTestClock{now: time.Date(2026, time.July, 10, 0, 0, 0, 0, time.UTC)}
+	cache := newJWKSCache(jwksCacheOptions{now: clock.Now, maxEntries: 2})
+	urls := []string{
+		provider.server.URL + "/jwks?cache=0",
+		provider.server.URL + "/jwks?cache=1",
+		provider.server.URL + "/jwks?cache=2",
+	}
+
+	if _, err := cache.load(context.Background(), urls[0]); err != nil {
+		t.Fatalf("load first JWKS: %v", err)
+	}
+	clock.Advance(time.Second)
+	if _, err := cache.load(context.Background(), urls[1]); err != nil {
+		t.Fatalf("load second JWKS: %v", err)
+	}
+	clock.Advance(time.Second)
+	if _, err := cache.load(context.Background(), urls[0]); err != nil {
+		t.Fatalf("touch first JWKS: %v", err)
+	}
+	clock.Advance(time.Second)
+	if _, err := cache.load(context.Background(), urls[2]); err != nil {
+		t.Fatalf("load third JWKS: %v", err)
+	}
+
+	cache.mu.Lock()
+	entryCount := len(cache.entries)
+	_, keptFirst := cache.entries[urls[0]]
+	_, evictedSecond := cache.entries[urls[1]]
+	_, keptThird := cache.entries[urls[2]]
+	cache.mu.Unlock()
+	if entryCount != 2 || !keptFirst || evictedSecond || !keptThird {
+		t.Fatalf("JWKS cache entries = %d, first=%v second=%v third=%v; want bounded LRU contents", entryCount, keptFirst, evictedSecond, keptThird)
+	}
+
+	clock.Advance(time.Second)
+	if _, err := cache.load(context.Background(), urls[1]); err != nil {
+		t.Fatalf("reload evicted JWKS: %v", err)
+	}
+	if got := provider.jwksHits.Load(); got != 4 {
+		t.Fatalf("JWKS fetches = %d, want 4 including the evicted entry reload", got)
+	}
+}
+
+func TestOIDCDiscoveryCache_EvictsLeastRecentlyUsedEntryAtCapacity(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	clock := &cacheTestClock{now: time.Date(2026, time.July, 10, 0, 0, 0, 0, time.UTC)}
+	cache := newOIDCDiscoveryCache(oidcDiscoveryCacheOptions{now: clock.Now, maxEntries: 2})
+	issuers := []string{
+		provider.server.URL + "/issuer-0",
+		provider.server.URL + "/issuer-1",
+		provider.server.URL + "/issuer-2",
+	}
+
+	if _, err := cache.load(context.Background(), issuers[0]); err != nil {
+		t.Fatalf("load first discovery document: %v", err)
+	}
+	clock.Advance(time.Second)
+	if _, err := cache.load(context.Background(), issuers[1]); err != nil {
+		t.Fatalf("load second discovery document: %v", err)
+	}
+	clock.Advance(time.Second)
+	if _, err := cache.load(context.Background(), issuers[0]); err != nil {
+		t.Fatalf("touch first discovery document: %v", err)
+	}
+	clock.Advance(time.Second)
+	if _, err := cache.load(context.Background(), issuers[2]); err != nil {
+		t.Fatalf("load third discovery document: %v", err)
+	}
+
+	cache.mu.Lock()
+	entryCount := len(cache.entries)
+	_, keptFirst := cache.entries[issuers[0]]
+	_, evictedSecond := cache.entries[issuers[1]]
+	_, keptThird := cache.entries[issuers[2]]
+	cache.mu.Unlock()
+	if entryCount != 2 || !keptFirst || evictedSecond || !keptThird {
+		t.Fatalf("discovery cache entries = %d, first=%v second=%v third=%v; want bounded LRU contents", entryCount, keptFirst, evictedSecond, keptThird)
+	}
+
+	clock.Advance(time.Second)
+	if _, err := cache.load(context.Background(), issuers[1]); err != nil {
+		t.Fatalf("reload evicted discovery document: %v", err)
+	}
+	if got := provider.discoveryHits.Load(); got != 4 {
+		t.Fatalf("OIDC discovery fetches = %d, want 4 including the evicted entry reload", got)
+	}
+}
+
+func TestJWKSCache_NegativeKidEntriesAreBounded(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	const maxNegativeKids = 3
+	verifier := newJWTVerifierWithOptions(jwksCacheOptions{maxNegativeKids: maxNegativeKids})
+	cfg := provider.config()
+	if _, err := validateOIDCTokenWithVerifier(context.Background(), provider.issueToken(t, testOIDCTokenOptions{}), cfg, verifier); err != nil {
+		t.Fatalf("warm JWKS cache: %v", err)
+	}
+
+	for i := range 12 {
+		token := provider.issueToken(t, testOIDCTokenOptions{Kid: fmt.Sprintf("unknown-bounded-%d", i)})
+		if _, err := validateOIDCTokenWithVerifier(context.Background(), token, cfg, verifier); err == nil {
+			t.Fatalf("unknown kid %d unexpectedly validated", i)
+		}
+	}
+
+	verifier.jwks.mu.Lock()
+	entry := verifier.jwks.entries[cfg.JWKSURL]
+	negativeKidCount := 0
+	if entry != nil {
+		negativeKidCount = len(entry.negativeKids)
+	}
+	verifier.jwks.mu.Unlock()
+	if negativeKidCount != maxNegativeKids {
+		t.Fatalf("negative kid entries = %d, want bounded size %d", negativeKidCount, maxNegativeKids)
+	}
+	if got := provider.jwksHits.Load(); got != 2 {
+		t.Fatalf("JWKS fetches = %d, want initial load plus one bounded rotation refresh", got)
+	}
+}
+
+func TestAuthMetadataCaches_BoundOutboundRequestDuration(t *testing.T) {
+	const requestTimeout = 25 * time.Millisecond
+
+	tests := []struct {
+		name string
+		load func(context.Context, string) error
+		url  func(string) string
+	}{
+		{
+			name: "JWKS",
+			load: func(ctx context.Context, url string) error {
+				_, err := newJWKSCache(jwksCacheOptions{requestTimeout: requestTimeout}).load(ctx, url)
+				return err
+			},
+			url: func(serverURL string) string { return serverURL + "/jwks" },
+		},
+		{
+			name: "OIDC discovery",
+			load: func(ctx context.Context, issuer string) error {
+				_, err := newOIDCDiscoveryCache(oidcDiscoveryCacheOptions{requestTimeout: requestTimeout}).load(ctx, issuer)
+				return err
+			},
+			url: func(serverURL string) string { return serverURL },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var hits atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				hits.Add(1)
+				select {
+				case <-r.Context().Done():
+				case <-time.After(2 * time.Second):
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			started := time.Now()
+			err := tt.load(context.Background(), tt.url(server.URL))
+			elapsed := time.Since(started)
+			if err == nil {
+				t.Fatal("metadata request unexpectedly succeeded")
+			}
+			if elapsed > 500*time.Millisecond {
+				t.Fatalf("metadata request took %v, want a bounded timeout near %v", elapsed, requestTimeout)
+			}
+			if got := hits.Load(); got != 1 {
+				t.Fatalf("metadata fetches = %d, want 1", got)
+			}
+		})
+	}
+}
+
 func TestFilterJWTSigningKeys_AllowsECKeyForES256(t *testing.T) {
-	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	signingKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatalf("failed to generate EC key: %v", err)
 	}
 
-	key, err := jwk.Import(&privateKey.PublicKey)
+	key, err := jwk.Import(&signingKey.PublicKey)
 	if err != nil {
 		t.Fatalf("failed to import EC key: %v", err)
 	}

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"regexp"
 	"strings"
 )
@@ -55,34 +54,25 @@ type oidcRealmAccess struct {
 	Roles stringList `json:"roles,omitempty"`
 }
 
-type oidcDiscoveryDocument struct {
-	JWKSURI string `json:"jwks_uri"`
-}
-
 var errOIDCAuthorization = errors.New("OIDC authorization failed")
 
 func validateOIDCToken(ctx context.Context, token string, cfg OIDCConfig) (*UserInfo, error) {
+	return validateOIDCTokenWithVerifier(ctx, token, cfg, processJWTVerifier)
+}
+
+func validateOIDCTokenWithVerifier(ctx context.Context, token string, cfg OIDCConfig, verifier *jwtVerifier) (*UserInfo, error) {
 	parsed, err := parseOIDCTokenCandidate(token, cfg)
 	if err != nil {
 		return nil, err
 	}
-	return validateParsedOIDCToken(ctx, parsed, cfg)
+	return validateParsedOIDCTokenWithVerifier(ctx, parsed, cfg, verifier)
 }
 
-func validateParsedOIDCToken(ctx context.Context, parsed *parsedJWT, cfg OIDCConfig) (*UserInfo, error) {
-	jwksURL := cfg.JWKSURL
-	if jwksURL == "" {
-		discovered, err := discoverOIDCJWKSURL(ctx, cfg.Issuer)
-		if err != nil {
-			return nil, err
-		}
-		jwksURL = discovered
-	}
-
-	verified, err := verifyParsedJWT(ctx, parsed, jwtVerificationConfig{
+func validateParsedOIDCTokenWithVerifier(ctx context.Context, parsed *parsedJWT, cfg OIDCConfig, verifier *jwtVerifier) (*UserInfo, error) {
+	verified, err := verifier.verifyParsedJWTWithDiscovery(ctx, parsed, jwtVerificationConfig{
 		Issuer:   cfg.Issuer,
 		Audience: cfg.Audience,
-		JWKSURL:  jwksURL,
+		JWKSURL:  cfg.JWKSURL,
 	})
 	if err != nil {
 		return nil, err
@@ -180,38 +170,4 @@ func userInfoFromOIDCClaims(claims oidcClaims, cfg OIDCConfig) *UserInfo {
 		Issuer:    claims.Issuer,
 		Roles:     roles,
 	}
-}
-
-func discoverOIDCJWKSURL(ctx context.Context, issuer string) (string, error) {
-	discoveryURL := strings.TrimRight(issuer, "/") + "/.well-known/openid-configuration"
-
-	var discovery oidcDiscoveryDocument
-	if err := getJSON(ctx, discoveryURL, &discovery); err != nil {
-		return "", fmt.Errorf("fetch OIDC discovery document: %w", err)
-	}
-	if discovery.JWKSURI == "" {
-		return "", errors.New("OIDC discovery document missing jwks_uri")
-	}
-	return discovery.JWKSURI, nil
-}
-
-func getJSON(ctx context.Context, url string, out any) error {
-	ctx, cancel := context.WithTimeout(ctx, authHTTPTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return err
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return fmt.Errorf("unexpected status %d", resp.StatusCode)
-	}
-	return json.NewDecoder(resp.Body).Decode(out)
 }

--- a/internal/api/oidc_discovery.go
+++ b/internal/api/oidc_discovery.go
@@ -1,0 +1,423 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v3/jws"
+)
+
+const (
+	// Discovery metadata is reused for five minutes. Unlike signing keys, it has
+	// no stale grace: once expired, an unreachable issuer fails closed.
+	defaultOIDCDiscoveryTTL                   = 5 * time.Minute
+	defaultOIDCDiscoveryRefreshRetryDelay     = 5 * time.Second
+	defaultOIDCDiscoveryForcedRefreshCooldown = 5 * time.Second
+	defaultMaxOIDCDiscoveryResponseBytes      = int64(64 << 10)
+	defaultMaxOIDCDiscoveryCacheEntries       = 64
+)
+
+type oidcDiscoveryCacheOptions struct {
+	client                *http.Client
+	now                   func() time.Time
+	requestTimeout        time.Duration
+	ttl                   time.Duration
+	refreshRetryDelay     time.Duration
+	forcedRefreshCooldown time.Duration
+	maxResponseBytes      int64
+	maxEntries            int
+}
+
+type oidcDiscoveryCache struct {
+	client                *http.Client
+	now                   func() time.Time
+	requestTimeout        time.Duration
+	ttl                   time.Duration
+	refreshRetryDelay     time.Duration
+	forcedRefreshCooldown time.Duration
+	maxResponseBytes      int64
+	maxEntries            int
+
+	mu             sync.Mutex
+	entries        map[string]*oidcDiscoveryCacheEntry
+	nextGeneration uint64
+}
+
+type oidcDiscoveryCacheEntry struct {
+	jwksURL            string
+	expiresAt          time.Time
+	retryAfter         time.Time
+	lastRefreshErr     error
+	forcedRefreshAfter time.Time
+	generation         uint64
+	observedGeneration uint64
+	lastUsed           time.Time
+	refresh            *oidcDiscoveryRefreshCall
+}
+
+type oidcDiscoveryRefreshCall struct {
+	done       chan struct{}
+	jwksURL    string
+	generation uint64
+	err        error
+}
+
+type oidcDiscoverySelection struct {
+	jwksURL    string
+	generation uint64
+	refreshed  bool
+}
+
+type oidcDiscoveryDocument struct {
+	JWKSURI string `json:"jwks_uri"`
+}
+
+func newOIDCDiscoveryCache(opts oidcDiscoveryCacheOptions) *oidcDiscoveryCache {
+	if opts.requestTimeout <= 0 {
+		opts.requestTimeout = authHTTPTimeout
+	}
+	if opts.client == nil {
+		opts.client = &http.Client{Timeout: opts.requestTimeout}
+	}
+	if opts.now == nil {
+		opts.now = time.Now
+	}
+	if opts.ttl <= 0 {
+		opts.ttl = defaultOIDCDiscoveryTTL
+	}
+	if opts.refreshRetryDelay <= 0 {
+		opts.refreshRetryDelay = defaultOIDCDiscoveryRefreshRetryDelay
+	}
+	if opts.forcedRefreshCooldown <= 0 {
+		opts.forcedRefreshCooldown = defaultOIDCDiscoveryForcedRefreshCooldown
+	}
+	if opts.maxResponseBytes <= 0 {
+		opts.maxResponseBytes = defaultMaxOIDCDiscoveryResponseBytes
+	}
+	if opts.maxEntries <= 0 {
+		opts.maxEntries = defaultMaxOIDCDiscoveryCacheEntries
+	}
+	return &oidcDiscoveryCache{
+		client:                opts.client,
+		now:                   opts.now,
+		requestTimeout:        opts.requestTimeout,
+		ttl:                   opts.ttl,
+		refreshRetryDelay:     opts.refreshRetryDelay,
+		forcedRefreshCooldown: opts.forcedRefreshCooldown,
+		maxResponseBytes:      opts.maxResponseBytes,
+		maxEntries:            opts.maxEntries,
+		entries:               make(map[string]*oidcDiscoveryCacheEntry),
+	}
+}
+
+func (v *jwtVerifier) verifyParsedJWTWithDiscovery(ctx context.Context, parsed *parsedJWT, cfg jwtVerificationConfig) (*verifiedJWT, error) {
+	if jwksURL := strings.TrimSpace(cfg.JWKSURL); jwksURL != "" {
+		cfg.JWKSURL = jwksURL
+		return v.verifyParsedJWT(ctx, parsed, cfg)
+	}
+
+	selection, err := v.discovery.load(ctx, cfg.Issuer)
+	if err != nil {
+		return nil, fmt.Errorf("fetch OIDC discovery document: %w", err)
+	}
+	cfg.JWKSURL = selection.jwksURL
+	verified, verifyErr := v.verifyParsedJWT(ctx, parsed, cfg)
+	if verifyErr == nil {
+		v.discovery.noteVerificationSuccess(cfg.Issuer, selection.generation)
+		return verified, nil
+	}
+	if ctx.Err() != nil {
+		return verified, verifyErr
+	}
+	if !jwtVerificationMayNeedDiscoveryRefresh(verifyErr) {
+		v.discovery.noteVerificationSuccess(cfg.Issuer, selection.generation)
+		return verified, verifyErr
+	}
+	if selection.refreshed {
+		v.discovery.noteVerificationFailure(cfg.Issuer, selection.generation)
+		return nil, verifyErr
+	}
+
+	currentURL, currentGeneration, _, refreshErr := v.discovery.refreshForRotation(ctx, cfg.Issuer, selection.generation)
+	if refreshErr != nil {
+		return nil, fmt.Errorf("%v; refresh OIDC discovery: %w", verifyErr, refreshErr)
+	}
+	if currentURL == "" || currentURL == selection.jwksURL {
+		v.discovery.noteVerificationFailure(cfg.Issuer, currentGeneration)
+		return nil, verifyErr
+	}
+	cfg.JWKSURL = currentURL
+	verified, verifyErr = v.verifyParsedJWT(ctx, parsed, cfg)
+	if verifyErr == nil {
+		v.discovery.noteVerificationSuccess(cfg.Issuer, currentGeneration)
+		return verified, nil
+	}
+	if ctx.Err() == nil && !jwtVerificationMayNeedDiscoveryRefresh(verifyErr) {
+		v.discovery.noteVerificationSuccess(cfg.Issuer, currentGeneration)
+	} else if ctx.Err() == nil {
+		v.discovery.noteVerificationFailure(cfg.Issuer, currentGeneration)
+	}
+	return verified, verifyErr
+}
+
+func jwtVerificationMayNeedDiscoveryRefresh(err error) bool {
+	return errors.Is(err, errJWTKeyResolution) ||
+		errors.Is(err, errJWTSigningKeyNotFound) ||
+		errors.Is(err, jws.VerificationError())
+}
+
+func (c *oidcDiscoveryCache) load(ctx context.Context, issuer string) (oidcDiscoverySelection, error) {
+	now := c.now()
+	c.mu.Lock()
+	entry := c.entries[issuer]
+	if entry != nil {
+		entry.lastUsed = now
+		if entry.jwksURL != "" && now.Before(entry.expiresAt) {
+			selection := oidcDiscoverySelection{
+				jwksURL:    entry.jwksURL,
+				generation: entry.generation,
+				refreshed:  entry.observedGeneration != entry.generation,
+			}
+			c.mu.Unlock()
+			return selection, nil
+		}
+		if entry.refresh != nil {
+			call := entry.refresh
+			c.mu.Unlock()
+			jwksURL, generation, err := waitForOIDCDiscoveryRefresh(ctx, call)
+			return oidcDiscoverySelection{jwksURL: jwksURL, generation: generation, refreshed: err == nil}, err
+		}
+		if now.Before(entry.retryAfter) {
+			err := entry.lastRefreshErr
+			c.mu.Unlock()
+			if err == nil {
+				err = errors.New("OIDC discovery refresh retry is deferred")
+			}
+			return oidcDiscoverySelection{}, err
+		}
+	}
+	c.mu.Unlock()
+
+	jwksURL, generation, err := c.refresh(ctx, issuer)
+	return oidcDiscoverySelection{jwksURL: jwksURL, generation: generation, refreshed: err == nil}, err
+}
+
+func (c *oidcDiscoveryCache) refresh(ctx context.Context, issuer string) (string, uint64, error) {
+	now := c.now()
+	c.mu.Lock()
+	entry, err := c.getOrCreateEntryLocked(issuer, now)
+	if err != nil {
+		c.mu.Unlock()
+		return "", 0, err
+	}
+	entry.lastUsed = now
+	if entry.refresh != nil {
+		call := entry.refresh
+		c.mu.Unlock()
+		return waitForOIDCDiscoveryRefresh(ctx, call)
+	}
+	if entry.jwksURL != "" && now.Before(entry.expiresAt) {
+		jwksURL := entry.jwksURL
+		generation := entry.generation
+		c.mu.Unlock()
+		return jwksURL, generation, nil
+	}
+	if now.Before(entry.retryAfter) {
+		err := entry.lastRefreshErr
+		generation := entry.generation
+		c.mu.Unlock()
+		if err == nil {
+			err = errors.New("OIDC discovery refresh retry is deferred")
+		}
+		return "", generation, err
+	}
+
+	call := &oidcDiscoveryRefreshCall{done: make(chan struct{})}
+	entry.refresh = call
+	entry.retryAfter = now.Add(c.refreshRetryDelay)
+	c.mu.Unlock()
+	go c.completeRefresh(issuer, entry, call)
+	return waitForOIDCDiscoveryRefresh(ctx, call)
+}
+
+func (c *oidcDiscoveryCache) refreshForRotation(ctx context.Context, issuer string, expectedGeneration uint64) (string, uint64, bool, error) {
+	now := c.now()
+	c.mu.Lock()
+	entry, err := c.getOrCreateEntryLocked(issuer, now)
+	if err != nil {
+		c.mu.Unlock()
+		return "", 0, false, err
+	}
+	entry.lastUsed = now
+	if entry.refresh != nil {
+		call := entry.refresh
+		c.mu.Unlock()
+		jwksURL, generation, err := waitForOIDCDiscoveryRefresh(ctx, call)
+		return jwksURL, generation, true, err
+	}
+	if expectedGeneration != 0 && entry.jwksURL != "" && entry.generation != expectedGeneration && now.Before(entry.expiresAt) {
+		jwksURL := entry.jwksURL
+		generation := entry.generation
+		c.mu.Unlock()
+		return jwksURL, generation, true, nil
+	}
+	if now.Before(entry.forcedRefreshAfter) {
+		jwksURL := entry.jwksURL
+		generation := entry.generation
+		c.mu.Unlock()
+		return jwksURL, generation, false, nil
+	}
+	if now.Before(entry.retryAfter) {
+		jwksURL := entry.jwksURL
+		generation := entry.generation
+		err := entry.lastRefreshErr
+		c.mu.Unlock()
+		if err == nil {
+			return jwksURL, generation, false, nil
+		}
+		return jwksURL, generation, false, err
+	}
+
+	call := &oidcDiscoveryRefreshCall{done: make(chan struct{})}
+	entry.refresh = call
+	entry.forcedRefreshAfter = now.Add(c.forcedRefreshCooldown)
+	entry.retryAfter = now.Add(c.refreshRetryDelay)
+	c.mu.Unlock()
+	go c.completeRefresh(issuer, entry, call)
+	jwksURL, generation, err := waitForOIDCDiscoveryRefresh(ctx, call)
+	return jwksURL, generation, true, err
+}
+
+func (c *oidcDiscoveryCache) noteVerificationFailure(issuer string, generation uint64) {
+	now := c.now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if entry := c.entries[issuer]; entry != nil && entry.generation == generation {
+		entry.observedGeneration = generation
+		if !now.Before(entry.forcedRefreshAfter) {
+			entry.forcedRefreshAfter = now.Add(c.forcedRefreshCooldown)
+		}
+	}
+}
+
+func (c *oidcDiscoveryCache) noteVerificationSuccess(issuer string, generation uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if entry := c.entries[issuer]; entry != nil && entry.generation == generation {
+		entry.observedGeneration = generation
+	}
+}
+
+func (c *oidcDiscoveryCache) completeRefresh(issuer string, entry *oidcDiscoveryCacheEntry, call *oidcDiscoveryRefreshCall) {
+	jwksURL, err := c.fetch(issuer)
+	now := c.now()
+	c.mu.Lock()
+	if err == nil {
+		c.nextGeneration++
+		if c.nextGeneration == 0 {
+			c.nextGeneration++
+		}
+		entry.jwksURL = jwksURL
+		entry.generation = c.nextGeneration
+		entry.expiresAt = now.Add(c.ttl)
+		entry.retryAfter = time.Time{}
+		entry.lastRefreshErr = nil
+	} else {
+		entry.retryAfter = now.Add(c.refreshRetryDelay)
+		entry.lastRefreshErr = err
+	}
+	entry.lastUsed = now
+	if entry.refresh == call {
+		entry.refresh = nil
+	}
+	call.jwksURL = jwksURL
+	call.generation = entry.generation
+	call.err = err
+	close(call.done)
+	c.mu.Unlock()
+}
+
+func waitForOIDCDiscoveryRefresh(ctx context.Context, call *oidcDiscoveryRefreshCall) (string, uint64, error) {
+	select {
+	case <-call.done:
+		return call.jwksURL, call.generation, call.err
+	case <-ctx.Done():
+		return "", 0, ctx.Err()
+	}
+}
+
+func (c *oidcDiscoveryCache) fetch(issuer string) (string, error) {
+	// Discovery refreshes are shared across requests, so they use an independent
+	// bounded deadline instead of being canceled with the first waiter.
+	ctx, cancel := context.WithTimeout(context.Background(), c.requestTimeout)
+	defer cancel()
+	discoveryURL := strings.TrimRight(issuer, "/") + "/.well-known/openid-configuration"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, c.maxResponseBytes+1))
+	if err != nil {
+		return "", err
+	}
+	if int64(len(body)) > c.maxResponseBytes {
+		return "", fmt.Errorf("OIDC discovery response exceeds maximum size of %d bytes", c.maxResponseBytes)
+	}
+	var document oidcDiscoveryDocument
+	if err := json.Unmarshal(body, &document); err != nil {
+		return "", fmt.Errorf("parse OIDC discovery document: %w", err)
+	}
+	if strings.TrimSpace(document.JWKSURI) == "" {
+		return "", errors.New("OIDC discovery document missing jwks_uri")
+	}
+	return strings.TrimSpace(document.JWKSURI), nil
+}
+
+func (c *oidcDiscoveryCache) getOrCreateEntryLocked(issuer string, now time.Time) (*oidcDiscoveryCacheEntry, error) {
+	if entry := c.entries[issuer]; entry != nil {
+		return entry, nil
+	}
+	if len(c.entries) >= c.maxEntries {
+		var oldestIssuer string
+		var oldestUsed time.Time
+		for candidateIssuer, entry := range c.entries {
+			if entry.refresh != nil {
+				continue
+			}
+			if oldestIssuer == "" || entry.lastUsed.Before(oldestUsed) {
+				oldestIssuer = candidateIssuer
+				oldestUsed = entry.lastUsed
+			}
+		}
+		if oldestIssuer == "" {
+			return nil, errors.New("OIDC discovery cache capacity is exhausted by active refreshes")
+		}
+		delete(c.entries, oldestIssuer)
+	}
+	entry := &oidcDiscoveryCacheEntry{lastUsed: now}
+	c.entries[issuer] = entry
+	return entry, nil
+}

--- a/internal/api/oidc_test.go
+++ b/internal/api/oidc_test.go
@@ -43,6 +43,7 @@ type testOIDCTokenOptions struct {
 	ExpiresAt  time.Time
 	NotBefore  *time.Time
 	Kid        string
+	OmitKid    bool
 	Algorithm  string
 	Username   string
 	Email      string
@@ -140,7 +141,9 @@ func (p *testOIDCProvider) issueToken(t *testing.T, opts testOIDCTokenOptions) s
 	header := map[string]any{
 		"alg": algorithm,
 		"typ": "JWT",
-		"kid": kid,
+	}
+	if !opts.OmitKid {
+		header["kid"] = kid
 	}
 	claims := map[string]any{
 		"iss": issuer,
@@ -465,6 +468,50 @@ func TestNewAuthMiddleware_OIDC_ValidToken(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestNewAuthMiddleware_OIDC_CachesJWKSAndDiscoveryPerMiddleware(t *testing.T) {
+	provider := newCacheTestOIDCProvider(t)
+	token := tamperJWTSignature(t, provider.issueToken(t, testOIDCTokenOptions{}))
+
+	newApp := func() *fiber.App {
+		app := fiber.New()
+		app.Use(NewAuthMiddleware(nil, AuthConfig{OIDC: provider.configWithoutJWKSURL()}))
+		app.Get("/test", func(ctx fiber.Ctx) error {
+			return ctx.SendStatus(http.StatusOK)
+		})
+		return app
+	}
+	requestInvalidToken := func(t *testing.T, app *fiber.App) {
+		t.Helper()
+		for i := range 8 {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set(AuthHeader, BearerPrefix+token)
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("request %d failed: %v", i, err)
+			}
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("request %d status = %d, want %d", i, resp.StatusCode, http.StatusUnauthorized)
+			}
+		}
+	}
+
+	requestInvalidToken(t, newApp())
+	if got := provider.discoveryHits.Load(); got != 1 {
+		t.Fatalf("first middleware discovery fetches = %d, want 1", got)
+	}
+	if got := provider.jwksHits.Load(); got != 1 {
+		t.Fatalf("first middleware JWKS fetches = %d, want 1", got)
+	}
+
+	requestInvalidToken(t, newApp())
+	if got := provider.discoveryHits.Load(); got != 2 {
+		t.Fatalf("two middleware discovery fetches = %d, want 2 isolated cache fills", got)
+	}
+	if got := provider.jwksHits.Load(); got != 2 {
+		t.Fatalf("two middleware JWKS fetches = %d, want 2 isolated cache fills", got)
 	}
 }
 

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -1070,18 +1070,20 @@ func (b *JobBuilder) addAIEnvVars(ctx context.Context, //nolint:gocyclo
 	}.EnvVars()...)
 
 	cfg.tools = aitools.Resolve(task, agent)
-	isChildTask := labels.ParentTaskName(task.Labels, task.Annotations) != ""
+	coordinationConfigured := agent != nil && agent.Spec.Coordination != nil && agent.Spec.Coordination.Enabled
 
 	if len(cfg.tools) > 0 {
 		envVars = setControllerEnvValue(envVars, workerenv.AITools, strings.Join(cfg.tools, ","))
 	}
 
-	if agent != nil && agent.Spec.Coordination != nil && agent.Spec.Coordination.Enabled {
+	if coordinationConfigured {
 		envVars = b.addCoordinationEnvVars(envVars, task, agent)
 	}
 
-	// Enable coordination in worker for child tasks so messaging tools are registered
-	if isChildTask && (agent == nil || agent.Spec.Coordination == nil || !agent.Spec.Coordination.Enabled) {
+	// Child identity enables the coordination registry even when implicit tool
+	// injection is disabled, so explicitly selected coordination tools resolve to
+	// the platform implementations rather than Tool CRs.
+	if aitools.RegistersCoordinationTools(task, agent) && !coordinationConfigured {
 		envVars = append(envVars, corev1.EnvVar{Name: workerenv.CoordinationEnabled, Value: scheduledRunLabelValue})
 	}
 

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"path"
 	"reflect"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -30,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+	"github.com/orka-agents/orka/internal/aitools"
 	"github.com/orka-agents/orka/internal/contexttoken"
 	"github.com/orka-agents/orka/internal/labels"
 	"github.com/orka-agents/orka/internal/metrics"
@@ -1069,53 +1069,8 @@ func (b *JobBuilder) addAIEnvVars(ctx context.Context, //nolint:gocyclo
 		AzureAPIVersion: cfg.azureAPIVersion,
 	}.EnvVars()...)
 
-	disableCoordinationToolInjection := task.Annotations[labels.AnnotationDisableCoordinationToolInject] == scheduledRunLabelValue
-
-	// Auto-inject coordination tools when coordination is enabled, unless the
-	// task deliberately supplies a narrower explicit tool set.
-	if agent != nil && agent.Spec.Coordination != nil && agent.Spec.Coordination.Enabled && !disableCoordinationToolInjection {
-		for _, ct := range []string{
-			"delegate_task",
-			"wait_for_tasks",
-			"create_container_task",
-			"cancel_task",
-			"send_message",
-			"check_messages",
-			"recall_memory",
-			"remember",
-			"propose_memory",
-			"search_transcript",
-			"create_pull_request",
-			"list_pull_requests",
-			"check_pr_review_marker",
-			"check_pull_request_ci",
-			"merge_pull_request",
-			"auto_merge_pull_request",
-			"review_pull_request",
-			"post_review_comment",
-			"create_agent",
-			"delete_agent",
-			"update_plan",
-		} {
-			if !slices.Contains(cfg.tools, ct) {
-				cfg.tools = append(cfg.tools, ct)
-			}
-		}
-		if agent.Spec.Coordination.Autonomous && !slices.Contains(cfg.tools, "request_approval") {
-			cfg.tools = append(cfg.tools, "request_approval")
-		}
-	}
-
-	// Auto-inject messaging tools for child tasks (tasks delegated by a coordinator)
-	// so they can communicate with sibling tasks via send_message/check_messages
-	_, isChildTask := task.Labels[labels.LabelParentTask]
-	if isChildTask && !disableCoordinationToolInjection {
-		for _, ct := range []string{"send_message", "check_messages"} {
-			if !slices.Contains(cfg.tools, ct) {
-				cfg.tools = append(cfg.tools, ct)
-			}
-		}
-	}
+	cfg.tools = aitools.Resolve(task, agent)
+	isChildTask := labels.ParentTaskName(task.Labels, task.Annotations) != ""
 
 	if len(cfg.tools) > 0 {
 		envVars = setControllerEnvValue(envVars, workerenv.AITools, strings.Join(cfg.tools, ","))

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -2395,6 +2395,45 @@ func TestAddAIEnvVars_ChildTaskMessagingDisabled(t *testing.T) {
 	}
 }
 
+func TestAddAIEnvVars_ChildTaskExplicitCoordinationWithInjectionDisabled(t *testing.T) {
+	jb := setupJobBuilder()
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testTask,
+			Namespace:   defaultNS,
+			Labels:      map[string]string{labels.LabelParentTask: "parent"},
+			Annotations: map[string]string{labels.AnnotationDisableCoordinationToolInject: scheduledRunLabelValue},
+		},
+		Spec: corev1alpha1.TaskSpec{
+			Type: corev1alpha1.TaskTypeAI,
+			AI: &corev1alpha1.AISpec{
+				Prompt: "test",
+				Tools:  []string{"send_message", "list_pull_requests"},
+			},
+		},
+	}
+
+	envVars := jb.addAIEnvVars(context.Background(), nil, task, nil, nil)
+	envMap := make(map[string]string)
+	for _, envVar := range envVars {
+		envMap[envVar.Name] = envVar.Value
+	}
+	if enabled := envMap[workerenv.CoordinationEnabled]; enabled != scheduledRunLabelValue {
+		t.Fatalf("%s = %q, want %q", workerenv.CoordinationEnabled, enabled, scheduledRunLabelValue)
+	}
+	tools := workerenv.SplitCSV(envMap[workerenv.AITools])
+	for _, tool := range []string{"send_message", "list_pull_requests"} {
+		if !slices.Contains(tools, tool) {
+			t.Fatalf("%s = %#v, want explicitly selected coordination tool %q", workerenv.AITools, tools, tool)
+		}
+	}
+	for _, tool := range []string{"delegate_task", "check_messages", "merge_pull_request"} {
+		if slices.Contains(tools, tool) {
+			t.Fatalf("%s = %#v, want no implicitly injected coordination tool %q", workerenv.AITools, tools, tool)
+		}
+	}
+}
+
 func TestJobBuilderEffectiveAIToolsMatchAuthorizationResolver(t *testing.T) {
 	jb := setupJobBuilder()
 	tests := []struct {

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -8,6 +8,7 @@ package controller
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -23,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+	"github.com/orka-agents/orka/internal/aitools"
 	"github.com/orka-agents/orka/internal/contexttoken"
 	"github.com/orka-agents/orka/internal/labels"
 	"github.com/orka-agents/orka/internal/workerenv"
@@ -2374,14 +2376,67 @@ func TestAddAIEnvVars_ChildTaskMessagingDisabled(t *testing.T) {
 	for _, e := range envVars {
 		envMap[e.Name] = e.Value
 	}
-	if tools := envMap[workerenv.AITools]; tools != "" {
-		t.Fatalf("%s = %q, want no auto-injected child messaging tools", workerenv.AITools, tools)
+	tools := workerenv.SplitCSV(envMap[workerenv.AITools])
+	for _, tool := range []string{"recall_memory", "remember", "propose_memory", "search_transcript"} {
+		if !slices.Contains(tools, tool) {
+			t.Fatalf("%s = %#v, want memory tool %q", workerenv.AITools, tools, tool)
+		}
+	}
+	for _, tool := range []string{"send_message", "check_messages", "delegate_task", "request_approval"} {
+		if slices.Contains(tools, tool) {
+			t.Fatalf("%s = %#v, want no implicitly injected coordination tool %q", workerenv.AITools, tools, tool)
+		}
 	}
 	// Disabling coordination tool injection should not change the existing child-task
 	// coordination mode marker; it only prevents implicit messaging tools from being
 	// exposed to the LLM.
 	if enabled := envMap[workerenv.CoordinationEnabled]; enabled != scheduledRunLabelValue {
 		t.Fatalf("%s = %q, want %q", workerenv.CoordinationEnabled, enabled, scheduledRunLabelValue)
+	}
+}
+
+func TestJobBuilderEffectiveAIToolsMatchAuthorizationResolver(t *testing.T) {
+	jb := setupJobBuilder()
+	tests := []struct {
+		name         string
+		labels       map[string]string
+		annotations  map[string]string
+		tools        []string
+		coordination *corev1alpha1.CoordinationConfig
+	}{
+		{name: "memory only"},
+		{name: "autonomous coordinator", coordination: &corev1alpha1.CoordinationConfig{Enabled: true, Autonomous: true}},
+		{name: "child label", labels: map[string]string{labels.LabelParentTask: "parent-task"}},
+		{name: "child annotation", annotations: map[string]string{labels.AnnotationParentTaskName: "long-parent-task-name"}},
+		{
+			name:         "disabled implicit injection",
+			labels:       map[string]string{labels.LabelParentTask: "parent-task"},
+			annotations:  map[string]string{labels.AnnotationDisableCoordinationToolInject: scheduledRunLabelValue},
+			tools:        []string{"explicit_tool"},
+			coordination: &corev1alpha1.CoordinationConfig{Enabled: true, Autonomous: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &corev1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testTask, Namespace: defaultNS, Labels: tt.labels, Annotations: tt.annotations,
+				},
+				Spec: corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeAI, AI: &corev1alpha1.AISpec{Tools: tt.tools}},
+			}
+			agent := &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{Coordination: tt.coordination}}
+			envVars := jb.addAIEnvVars(context.Background(), nil, task, agent, nil)
+			env, found := findEnvVar(envVars, workerenv.AITools)
+			if !found {
+				t.Fatalf("missing %s", workerenv.AITools)
+			}
+			got := workerenv.SplitCSV(env.Value)
+			want := aitools.Resolve(task, agent)
+			if !slices.Equal(got, want) {
+				t.Fatalf("%s = %#v, authorization resolver = %#v", workerenv.AITools, got, want)
+			}
+		})
 	}
 }
 
@@ -2829,8 +2884,10 @@ func TestJobBuilder_buildEnvVars_TaskEnvCannotSpoofApprovalState(t *testing.T) {
 	if env, ok := findEnvVar(envVars, workerenv.AgentName); !ok || env.Value != "real-agent" {
 		t.Fatalf("%s = %#v, found=%t; want real-agent", workerenv.AgentName, env, ok)
 	}
+	if env, ok := findEnvVar(envVars, workerenv.AITools); !ok || !slices.Equal(workerenv.SplitCSV(env.Value), aitools.Resolve(task, agent)) {
+		t.Fatalf("%s = %#v, found=%t; want %#v", workerenv.AITools, env, ok, aitools.Resolve(task, agent))
+	}
 	for _, name := range []string{
-		workerenv.AITools,
 		workerenv.CoordinationEnabled,
 		workerenv.AutonomousMode,
 		workerenv.ResolvedApprovals,

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -2874,6 +2874,34 @@ func TestJobBuilder_buildEnvVars_KeepsEmptyResolvedApprovalsEnvOverride(t *testi
 	}
 }
 
+func TestJobBuilder_buildEnvVars_ChildAgentDoesNotEnableAIWorkerCoordination(t *testing.T) {
+	builder := setupJobBuilder()
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testTask,
+			Namespace: defaultNS,
+			Labels:    map[string]string{labels.LabelParentTask: "parent-task"},
+		},
+		Spec: corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeAgent, Prompt: "Do work"},
+	}
+	agent := &corev1alpha1.Agent{Spec: corev1alpha1.AgentSpec{
+		Runtime:      &corev1alpha1.AgentCLIRuntime{Type: corev1alpha1.AgentRuntimeCodex, DefaultAllowedTools: []string{"Read"}},
+		Coordination: &corev1alpha1.CoordinationConfig{Enabled: true, Autonomous: true},
+	}}
+
+	envVars := builder.buildEnvVars(context.Background(), task, agent, nil)
+	for _, name := range []string{workerenv.AITools, workerenv.CoordinationEnabled} {
+		env, found := findEnvVar(envVars, name)
+		if !found || env.Value != "" {
+			t.Fatalf("%s = %#v, found=%t; want explicit empty AI-worker value", name, env, found)
+		}
+	}
+	allowedTools, found := findEnvVar(envVars, workerenv.AllowedTools)
+	if !found || allowedTools.Value != "Read" {
+		t.Fatalf("%s = %#v, found=%t; want explicit runtime tools", workerenv.AllowedTools, allowedTools, found)
+	}
+}
+
 func TestJobBuilder_buildEnvVars_AutonomousCoordinationIncludesRequestApprovalTool(t *testing.T) {
 	builder := setupJobBuilder()
 	task := &corev1alpha1.Task{

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+	"github.com/orka-agents/orka/internal/aitools"
 	"github.com/orka-agents/orka/internal/approvals"
 	"github.com/orka-agents/orka/internal/llm"
 	"github.com/orka-agents/orka/internal/store"
@@ -676,32 +677,7 @@ func ChatToolNames() []string {
 // CoordinationToolNames returns the names of all coordination tools registered by
 // RegisterCoordinationTools in worker processes.
 func CoordinationToolNames() []string {
-	return []string{
-		delegateTaskToolName,
-		waitForTasksToolName,
-		createContainerTaskToolName,
-		cancelTaskToolName,
-		sendMessageToolName,
-		checkMessagesToolName,
-		createPullRequestToolName,
-		checkPullRequestCIToolName,
-		mergePullRequestToolName,
-		autoMergePullRequestToolName,
-		reviewPullRequestToolName,
-		postReviewCommentToolName,
-		checkPRReviewMarkerToolName,
-		listIssuesToolName,
-		listPullRequestsToolName,
-		getIssueToolName,
-		commentOnIssueToolName,
-		createAgentToolName,
-		deleteAgentToolName,
-		updatePlanToolName,
-		"recall_memory",
-		"remember",
-		"propose_memory",
-		"search_transcript",
-	}
+	return aitools.CoordinationToolNames()
 }
 
 func init() {

--- a/internal/tools/transaction_context_authorization.go
+++ b/internal/tools/transaction_context_authorization.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
-	"github.com/orka-agents/orka/internal/labels"
+	"github.com/orka-agents/orka/internal/aitools"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -321,48 +321,7 @@ func hasNonEmptyTransactionTools(tools []string) bool {
 }
 
 func childTransactionEffectiveAITools(child *corev1alpha1.Task, agent *corev1alpha1.Agent) []string {
-	tools := []string{}
-	if agent != nil {
-		for _, tool := range agent.Spec.Tools {
-			if tool.Enabled != nil && !*tool.Enabled {
-				continue
-			}
-			if strings.TrimSpace(tool.Name) != "" {
-				tools = append(tools, tool.Name)
-			}
-		}
-		if agent.Spec.Coordination != nil && agent.Spec.Coordination.Enabled && child.Annotations[labels.AnnotationDisableCoordinationToolInject] != "true" {
-			for _, tool := range transactionCoordinationToolNames() {
-				if !slices.Contains(tools, tool) {
-					tools = append(tools, tool)
-				}
-			}
-		}
-	}
-	if child.Spec.AI != nil {
-		for _, tool := range child.Spec.AI.Tools {
-			if strings.TrimSpace(tool) != "" {
-				tools = append(tools, tool)
-			}
-		}
-	}
-	if child.Spec.Type == corev1alpha1.TaskTypeAI {
-		for _, tool := range transactionMemoryToolNames() {
-			if !slices.Contains(tools, tool) {
-				tools = append(tools, tool)
-			}
-		}
-	}
-	return tools
-}
-
-func transactionMemoryToolNames() []string {
-	return []string{
-		"recall_memory",
-		"remember",
-		"propose_memory",
-		"search_transcript",
-	}
+	return aitools.Resolve(child, agent)
 }
 
 func childTransactionEffectiveRuntimeAllowedTools(child *corev1alpha1.Task, agent *corev1alpha1.Agent) []string {
@@ -384,32 +343,6 @@ func childTransactionEffectiveRuntimeAllowBash(child *corev1alpha1.Task, agent *
 		allowBash = *child.Spec.AgentRuntime.AllowBash
 	}
 	return allowBash
-}
-
-func transactionCoordinationToolNames() []string {
-	return []string{
-		"delegate_task",
-		"wait_for_tasks",
-		"create_container_task",
-		"cancel_task",
-		"send_message",
-		"check_messages",
-		"recall_memory",
-		"remember",
-		"propose_memory",
-		"search_transcript",
-		"create_pull_request",
-		"list_pull_requests",
-		"check_pr_review_marker",
-		"check_pull_request_ci",
-		"merge_pull_request",
-		"auto_merge_pull_request",
-		"review_pull_request",
-		"post_review_comment",
-		"create_agent",
-		"delete_agent",
-		"update_plan",
-	}
 }
 
 func transactionContextStringList(value string) ([]string, bool) {

--- a/internal/tools/transaction_context_authorization_test.go
+++ b/internal/tools/transaction_context_authorization_test.go
@@ -8,12 +8,14 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+	"github.com/orka-agents/orka/internal/aitools"
 	"github.com/orka-agents/orka/internal/labels"
 )
 
@@ -162,8 +164,9 @@ func TestValidateChildTaskAgainstParentTransactionRejectsEnabledBashOutsideAllow
 
 func TestChildTransactionEffectiveAIToolsSkipsDisabledCoordinationInjection(t *testing.T) {
 	agent := researcherAgent()
-	agent.Spec.Coordination = &corev1alpha1.CoordinationConfig{Enabled: true}
+	agent.Spec.Coordination = &corev1alpha1.CoordinationConfig{Enabled: true, Autonomous: true}
 	child := childTaskForResearcherAgent()
+	child.Labels = map[string]string{labels.LabelParentTask: "parent-task"}
 	child.Annotations = map[string]string{labels.AnnotationDisableCoordinationToolInject: "true"}
 	child.Spec.Type = corev1alpha1.TaskTypeAI
 	child.Spec.AI = &corev1alpha1.AISpec{
@@ -181,7 +184,7 @@ func TestChildTransactionEffectiveAIToolsSkipsDisabledCoordinationInjection(t *t
 			t.Fatalf("expected memory tool %q in %q", tool, got)
 		}
 	}
-	for _, tool := range []string{"delegate_task", "merge_pull_request", "auto_merge_pull_request"} {
+	for _, tool := range []string{"delegate_task", "send_message", "check_messages", "request_approval", "merge_pull_request", "auto_merge_pull_request"} {
 		if strings.Contains(got, tool) {
 			t.Fatalf("unexpected coordination tool %q in %q", tool, got)
 		}
@@ -200,6 +203,91 @@ func TestChildTransactionEffectiveAIToolsIncludesPRReviewCoordinationTools(t *te
 			t.Fatalf("expected PR review coordination tool %q in %q", tool, got)
 		}
 	}
+}
+
+func TestChildTransactionEffectiveAIToolsMatchesSharedResolver(t *testing.T) {
+	agent := researcherAgent()
+	agent.Spec.Coordination = &corev1alpha1.CoordinationConfig{Enabled: true, Autonomous: true}
+	child := childTaskForResearcherAgent()
+	child.Labels = map[string]string{labels.LabelParentTask: "parent-task"}
+	child.Spec.AI = &corev1alpha1.AISpec{Tools: []string{"task_tool"}}
+
+	want := aitools.Resolve(child, agent)
+	got := childTransactionEffectiveAITools(child, agent)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("child authorization tools = %#v, shared resolver = %#v", got, want)
+	}
+}
+
+func TestValidateChildTaskAgainstParentTransactionRejectsOmittedAutonomousApprovalTool(t *testing.T) {
+	agent := researcherAgent()
+	agent.Spec.Coordination = &corev1alpha1.CoordinationConfig{Enabled: true, Autonomous: true}
+	child := childTaskForResearcherAgent()
+	parent := parentTaskWithAllowedTools(t, childTransactionEffectiveAITools(child, agent), "request_approval")
+
+	err := validateChildTaskAgainstParentTransaction(context.Background(), newFakeClient(agent), parent, child, testResearcherAgentName)
+	if err == nil || !strings.Contains(err.Error(), `tool "request_approval"`) {
+		t.Fatalf("validateChildTaskAgainstParentTransaction() error = %v, want request_approval denial", err)
+	}
+}
+
+func TestValidateChildTaskAgainstParentTransactionAllowsAutonomousApprovalTool(t *testing.T) {
+	agent := researcherAgent()
+	agent.Spec.Coordination = &corev1alpha1.CoordinationConfig{Enabled: true, Autonomous: true}
+	child := childTaskForResearcherAgent()
+	parent := parentTaskWithAllowedTools(t, childTransactionEffectiveAITools(child, agent))
+
+	if err := validateChildTaskAgainstParentTransaction(context.Background(), newFakeClient(agent), parent, child, testResearcherAgentName); err != nil {
+		t.Fatalf("validateChildTaskAgainstParentTransaction() error = %v", err)
+	}
+}
+
+func TestValidateChildTaskAgainstParentTransactionRejectsOmittedChildMessagingTools(t *testing.T) {
+	agent := researcherAgent()
+	child := childTaskForResearcherAgent()
+	child.Labels = map[string]string{labels.LabelParentTask: "parent-task"}
+	parent := parentTaskWithAllowedTools(t, childTransactionEffectiveAITools(child, agent), "send_message", "check_messages")
+
+	err := validateChildTaskAgainstParentTransaction(context.Background(), newFakeClient(agent), parent, child, testResearcherAgentName)
+	if err == nil || (!strings.Contains(err.Error(), `tool "send_message"`) && !strings.Contains(err.Error(), `tool "check_messages"`)) {
+		t.Fatalf("validateChildTaskAgainstParentTransaction() error = %v, want child messaging denial", err)
+	}
+}
+
+func TestValidateChildTaskAgainstParentTransactionAllowsChildMessagingTools(t *testing.T) {
+	agent := researcherAgent()
+	child := childTaskForResearcherAgent()
+	child.Labels = map[string]string{labels.LabelParentTask: "parent-task"}
+	parent := parentTaskWithAllowedTools(t, childTransactionEffectiveAITools(child, agent))
+
+	if err := validateChildTaskAgainstParentTransaction(context.Background(), newFakeClient(agent), parent, child, testResearcherAgentName); err != nil {
+		t.Fatalf("validateChildTaskAgainstParentTransaction() error = %v", err)
+	}
+}
+
+func parentTaskWithAllowedTools(t *testing.T, tools []string, omitted ...string) *corev1alpha1.Task {
+	t.Helper()
+	omit := make(map[string]struct{}, len(omitted))
+	for _, tool := range omitted {
+		omit[tool] = struct{}{}
+	}
+	allowed := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		if _, found := omit[tool]; !found {
+			allowed = append(allowed, tool)
+		}
+	}
+	encoded, err := json.Marshal(allowed)
+	if err != nil {
+		t.Fatalf("marshal allowed tools: %v", err)
+	}
+	parent := parentTask()
+	parent.Spec.Transaction.Context = map[string]string{
+		"namespace":     defaultNamespace,
+		"allowedAgents": `["researcher"]`,
+		"allowedTools":  string(encoded),
+	}
+	return parent
 }
 
 func childTaskForResearcherAgent() *corev1alpha1.Task {

--- a/internal/tools/transaction_context_authorization_test.go
+++ b/internal/tools/transaction_context_authorization_test.go
@@ -162,6 +162,29 @@ func TestValidateChildTaskAgainstParentTransactionRejectsEnabledBashOutsideAllow
 	}
 }
 
+func TestValidateChildTaskAgainstParentTransactionDoesNotRequireImplicitAgentCoordination(t *testing.T) {
+	agent := researcherAgent()
+	agent.Spec.Coordination = &corev1alpha1.CoordinationConfig{Enabled: true, Autonomous: true}
+	agent.Spec.Runtime = &corev1alpha1.AgentCLIRuntime{
+		Type:                corev1alpha1.AgentRuntimeCodex,
+		DefaultAllowedTools: []string{"Read"},
+		DefaultAllowBash:    new(false),
+	}
+	child := childTaskForResearcherAgent()
+	child.Spec.Type = corev1alpha1.TaskTypeAgent
+	child.Labels = map[string]string{labels.LabelParentTask: "parent-task"}
+	parent := parentTask()
+	parent.Spec.Transaction.Context = map[string]string{
+		"namespace":     defaultNamespace,
+		"allowedAgents": `["researcher"]`,
+		"allowedTools":  `["Read"]`,
+	}
+
+	if err := validateChildTaskAgainstParentTransaction(context.Background(), newFakeClient(agent), parent, child, testResearcherAgentName); err != nil {
+		t.Fatalf("validateChildTaskAgainstParentTransaction() error = %v", err)
+	}
+}
+
 func TestChildTransactionEffectiveAIToolsSkipsDisabledCoordinationInjection(t *testing.T) {
 	agent := researcherAgent()
 	agent.Spec.Coordination = &corev1alpha1.CoordinationConfig{Enabled: true, Autonomous: true}


### PR DESCRIPTION
## Summary

Stacked salvage from #280. Base: #310 (`fix/transaction-constraint-authorization`).

- Cache OIDC discovery metadata and JWKS key sets with bounded entries, response sizes, timeouts, and coordinated refreshes.
- Refresh safely on key rotation or discovery changes while throttling repeated unknown-key and signature-failure refreshes.
- Permit a short stale-key grace only for known JWKS entries, while discovery expiry and hard key expiry continue to fail closed.

## Scope

This PR changes JWT/OIDC verification fetch and cache behavior only. It does not broaden accepted issuers, audiences, algorithms, transaction claims, or token transport.

## Verification

- `go test ./internal/api -run 'JWT|JWKS|OIDC|ContextToken' -count=1`
- `make lint-fix && make test`
- Full required CI

After #310 merges, this PR should be retargeted to `main`.