### PR TITLE
fix(ai): harden tool updates and context recovery

### DIFF
--- a/internal/llm/truncate.go
+++ b/internal/llm/truncate.go
@@ -18,6 +18,184 @@ func estimateTokens(text string) int {
 	return (len(text) + 3) / 4
 }
 
+// CompletionRequestSize describes the serialized size and approximate token
+// count of a complete provider request.
+type CompletionRequestSize struct {
+	SerializedBytes int
+	EstimatedTokens int
+}
+
+const currentUserTaskTruncationMarker = "\n\n[Current user task truncated for context recovery.]\n\n"
+
+// EstimateCompletionRequestSize estimates the complete serialized request,
+// including system prompts, tool schemas, messages, and tool-call arguments.
+func EstimateCompletionRequestSize(req *CompletionRequest) (CompletionRequestSize, error) {
+	serialized, err := json.Marshal(req)
+	if err != nil {
+		return CompletionRequestSize{}, fmt.Errorf("marshal completion request: %w", err)
+	}
+	return CompletionRequestSize{
+		SerializedBytes: len(serialized),
+		EstimatedTokens: (len(serialized) + 3) / 4,
+	}, nil
+}
+
+// TruncateCompletionRequest returns a copy of req reduced toward tokenBudget.
+// The newest user message is mandatory; if it alone is oversized, its middle
+// is replaced with an explicit recovery marker while preserving both ends.
+func TruncateCompletionRequest(req *CompletionRequest, tokenBudget int) (*CompletionRequest, error) {
+	if req == nil {
+		return nil, fmt.Errorf("completion request is nil")
+	}
+
+	size, err := EstimateCompletionRequestSize(req)
+	if err != nil {
+		return nil, err
+	}
+	truncated, err := cloneCompletionRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	if size.EstimatedTokens <= tokenBudget || len(truncated.Messages) == 0 {
+		return truncated, nil
+	}
+
+	currentUserIndex := newestUserMessageIndex(truncated.Messages)
+	if currentUserIndex < 0 {
+		return truncated, nil
+	}
+
+	blocks, mandatoryBlock := groupRecoveryMessageBlocks(truncated.Messages, currentUserIndex)
+	kept := make([]bool, len(blocks))
+	for i := range kept {
+		kept[i] = true
+	}
+	for size.EstimatedTokens > tokenBudget {
+		drop := -1
+		for i := range blocks {
+			if kept[i] && i != mandatoryBlock {
+				drop = i
+				break
+			}
+		}
+		if drop < 0 {
+			break
+		}
+		kept[drop] = false
+		truncated.Messages = messagesFromKeptBlocks(blocks, kept)
+		size, err = EstimateCompletionRequestSize(truncated)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if size.EstimatedTokens <= tokenBudget {
+		return truncated, nil
+	}
+
+	currentUserIndex = newestUserMessageIndex(truncated.Messages)
+	if _, err := truncateCurrentUserPrompt(truncated, currentUserIndex, tokenBudget); err != nil {
+		return nil, err
+	}
+	return truncated, nil
+}
+
+func messagesFromKeptBlocks(blocks []messageBlock, kept []bool) []Message {
+	messages := make([]Message, 0)
+	for i, block := range blocks {
+		if kept[i] {
+			messages = append(messages, block.messages...)
+		}
+	}
+	return messages
+}
+
+func groupRecoveryMessageBlocks(messages []Message, currentUserIndex int) ([]messageBlock, int) {
+	blocks := make([]messageBlock, 0)
+	for i := 0; i < currentUserIndex; {
+		start := i
+		i++
+		for i < currentUserIndex && messages[i].Role != "user" {
+			i++
+		}
+		blocks = append(blocks, messageBlock{messages: messages[start:i]})
+	}
+
+	mandatoryBlock := len(blocks)
+	blocks = append(blocks, messageBlock{messages: []Message{messages[currentUserIndex]}})
+	blocks = append(blocks, groupMessageBlocks(messages[currentUserIndex+1:])...)
+	return blocks, mandatoryBlock
+}
+
+func cloneCompletionRequest(req *CompletionRequest) (*CompletionRequest, error) {
+	serialized, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal completion request copy: %w", err)
+	}
+	var cloned CompletionRequest
+	if err := json.Unmarshal(serialized, &cloned); err != nil {
+		return nil, fmt.Errorf("unmarshal completion request copy: %w", err)
+	}
+	return &cloned, nil
+}
+
+func newestUserMessageIndex(messages []Message) int {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == "user" {
+			return i
+		}
+	}
+	return -1
+}
+
+func truncateCurrentUserPrompt(req *CompletionRequest, messageIndex, tokenBudget int) (bool, error) {
+	original := req.Messages[messageIndex].Content
+	originalRunes := []rune(original)
+	if len(originalRunes) < 3 {
+		return false, nil
+	}
+
+	setContent := func(content string) (CompletionRequestSize, error) {
+		req.Messages[messageIndex].Content = content
+		return EstimateCompletionRequestSize(req)
+	}
+
+	const minimumRetainedRunes = 2
+	bestContent := balancedTruncatedCurrentTask(originalRunes, minimumRetainedRunes)
+	bestSize, err := setContent(bestContent)
+	if err != nil {
+		return false, err
+	}
+	if bestSize.EstimatedTokens > tokenBudget {
+		req.Messages[messageIndex].Content = original
+		return false, nil
+	}
+
+	for low, high := minimumRetainedRunes, len(originalRunes)-1; low <= high; {
+		mid := low + (high-low)/2
+		content := balancedTruncatedCurrentTask(originalRunes, mid)
+		size, sizeErr := setContent(content)
+		if sizeErr != nil {
+			return false, sizeErr
+		}
+		if size.EstimatedTokens <= tokenBudget {
+			bestContent = content
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+
+	req.Messages[messageIndex].Content = bestContent
+	return true, nil
+}
+
+func balancedTruncatedCurrentTask(original []rune, retained int) string {
+	prefixRunes := (retained + 1) / 2
+	suffixRunes := retained / 2
+	return string(original[:prefixRunes]) + currentUserTaskTruncationMarker +
+		string(original[len(original)-suffixRunes:])
+}
+
 // estimateMessageTokens returns approximate tokens for a Message including tool call content.
 func estimateMessageTokens(m Message) int {
 	tokens := estimateTokens(m.Content)

--- a/internal/llm/truncate.go
+++ b/internal/llm/truncate.go
@@ -25,7 +25,10 @@ type CompletionRequestSize struct {
 	EstimatedTokens int
 }
 
-const currentUserTaskTruncationMarker = "\n\n[Current user task truncated for context recovery.]\n\n"
+const (
+	currentUserTaskTruncationMarker = "\n\n[Current user task truncated for context recovery.]\n\n"
+	minimalRecoveryTruncationNote   = "[Earlier messages truncated for context recovery.]"
+)
 
 // EstimateCompletionRequestSize estimates the complete serialized request,
 // including system prompts, tool schemas, messages, and tool-call arguments.
@@ -82,8 +85,7 @@ func TruncateCompletionRequest(req *CompletionRequest, tokenBudget int) (*Comple
 			break
 		}
 		kept[drop] = false
-		truncated.Messages = messagesFromKeptBlocks(blocks, kept)
-		size, err = EstimateCompletionRequestSize(truncated)
+		truncated.Messages, size, err = recoveryMessagesWithinBudget(truncated, blocks, kept, tokenBudget)
 		if err != nil {
 			return nil, err
 		}
@@ -97,6 +99,41 @@ func TruncateCompletionRequest(req *CompletionRequest, tokenBudget int) (*Comple
 		return nil, err
 	}
 	return truncated, nil
+}
+
+func recoveryMessagesWithinBudget(
+	req *CompletionRequest,
+	blocks []messageBlock,
+	kept []bool,
+	tokenBudget int,
+) ([]Message, CompletionRequestSize, error) {
+	keptMessages := messagesFromKeptBlocks(blocks, kept)
+	dropped := make([]messageBlock, 0)
+	for i, block := range blocks {
+		if !kept[i] {
+			dropped = append(dropped, block)
+		}
+	}
+	if len(dropped) == 0 {
+		req.Messages = keptMessages
+		size, err := EstimateCompletionRequestSize(req)
+		return keptMessages, size, err
+	}
+
+	withNote := func(content string) ([]Message, CompletionRequestSize, error) {
+		messages := make([]Message, 0, len(keptMessages)+1)
+		messages = append(messages, Message{Role: "system", Content: content})
+		messages = append(messages, keptMessages...)
+		req.Messages = messages
+		size, err := EstimateCompletionRequestSize(req)
+		return messages, size, err
+	}
+
+	messages, size, err := withNote(extractDroppedSummary(dropped))
+	if err != nil || size.EstimatedTokens <= tokenBudget {
+		return messages, size, err
+	}
+	return withNote(minimalRecoveryTruncationNote)
 }
 
 func messagesFromKeptBlocks(blocks []messageBlock, kept []bool) []Message {

--- a/internal/llm/truncate.go
+++ b/internal/llm/truncate.go
@@ -28,6 +28,8 @@ type CompletionRequestSize struct {
 const (
 	currentUserTaskTruncationMarker = "\n\n[Current user task truncated for context recovery.]\n\n"
 	minimalRecoveryTruncationNote   = "[Earlier messages truncated for context recovery.]"
+	recoveryRoleAssistant           = "assistant"
+	recoveryRoleTool                = "tool"
 )
 
 // EstimateCompletionRequestSize estimates the complete serialized request,
@@ -44,8 +46,9 @@ func EstimateCompletionRequestSize(req *CompletionRequest) (CompletionRequestSiz
 }
 
 // TruncateCompletionRequest returns a copy of req reduced toward tokenBudget.
-// The newest user message is mandatory; if it alone is oversized, its middle
-// is replaced with an explicit recovery marker while preserving both ends.
+// The newest user message and newest complete post-task tool exchange are
+// recovery anchors. If fixed request overhead makes the target impossible, the
+// user task is still reduced with an explicit marker while preserving both ends.
 func TruncateCompletionRequest(req *CompletionRequest, tokenBudget int) (*CompletionRequest, error) {
 	if req == nil {
 		return nil, fmt.Errorf("completion request is nil")
@@ -68,7 +71,9 @@ func TruncateCompletionRequest(req *CompletionRequest, tokenBudget int) (*Comple
 		return truncated, nil
 	}
 
-	blocks, mandatoryBlock := groupRecoveryMessageBlocks(truncated.Messages, currentUserIndex)
+	blocks, mandatoryBlock, newestEvidenceBlock := groupRecoveryMessageBlocks(
+		truncated.Messages, currentUserIndex,
+	)
 	kept := make([]bool, len(blocks))
 	for i := range kept {
 		kept[i] = true
@@ -76,7 +81,7 @@ func TruncateCompletionRequest(req *CompletionRequest, tokenBudget int) (*Comple
 	for size.EstimatedTokens > tokenBudget {
 		drop := -1
 		for i := range blocks {
-			if kept[i] && i != mandatoryBlock {
+			if kept[i] && i != mandatoryBlock && i != newestEvidenceBlock {
 				drop = i
 				break
 			}
@@ -95,8 +100,45 @@ func TruncateCompletionRequest(req *CompletionRequest, tokenBudget int) (*Comple
 	}
 
 	currentUserIndex = newestUserMessageIndex(truncated.Messages)
-	if _, err := truncateCurrentUserPrompt(truncated, currentUserIndex, tokenBudget); err != nil {
+	if err := truncateCurrentUserPrompt(
+		truncated, currentUserIndex, tokenBudget, newestEvidenceBlock >= 0,
+	); err != nil {
 		return nil, err
+	}
+	if newestEvidenceBlock < 0 {
+		return truncated, nil
+	}
+
+	anchoredSize, err := EstimateCompletionRequestSize(truncated)
+	if err != nil || anchoredSize.EstimatedTokens <= tokenBudget {
+		return truncated, err
+	}
+	anchoredMessages := append([]Message(nil), truncated.Messages...)
+
+	// The newest evidence block is protected through task truncation. Drop it only
+	// when doing so makes the requested budget attainable; if fixed overhead still
+	// prevents fitting, restore the evidence and return the smaller best-effort request.
+	kept[newestEvidenceBlock] = false
+	truncated.Messages, size, err = recoveryMessagesWithinBudget(
+		truncated, blocks, kept, tokenBudget,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if size.EstimatedTokens > tokenBudget {
+		currentUserIndex = newestUserMessageIndex(truncated.Messages)
+		if err := truncateCurrentUserPrompt(
+			truncated, currentUserIndex, tokenBudget, false,
+		); err != nil {
+			return nil, err
+		}
+		size, err = EstimateCompletionRequestSize(truncated)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if size.EstimatedTokens > tokenBudget {
+		truncated.Messages = anchoredMessages
 	}
 	return truncated, nil
 }
@@ -146,7 +188,10 @@ func messagesFromKeptBlocks(blocks []messageBlock, kept []bool) []Message {
 	return messages
 }
 
-func groupRecoveryMessageBlocks(messages []Message, currentUserIndex int) ([]messageBlock, int) {
+// groupRecoveryMessageBlocks keeps the current user task and the newest complete
+// post-task tool exchange as recovery anchors. Older and incomplete blocks remain
+// eligible for atomic removal.
+func groupRecoveryMessageBlocks(messages []Message, currentUserIndex int) ([]messageBlock, int, int) {
 	blocks := make([]messageBlock, 0)
 	for i := 0; i < currentUserIndex; {
 		start := i
@@ -159,8 +204,46 @@ func groupRecoveryMessageBlocks(messages []Message, currentUserIndex int) ([]mes
 
 	mandatoryBlock := len(blocks)
 	blocks = append(blocks, messageBlock{messages: []Message{messages[currentUserIndex]}})
-	blocks = append(blocks, groupMessageBlocks(messages[currentUserIndex+1:])...)
-	return blocks, mandatoryBlock
+	postTaskBlocks := groupMessageBlocks(messages[currentUserIndex+1:])
+	newestEvidenceBlock := -1
+	for i := len(postTaskBlocks) - 1; i >= 0; i-- {
+		if completeAssistantToolBlock(postTaskBlocks[i]) {
+			newestEvidenceBlock = len(blocks) + i
+			break
+		}
+	}
+	blocks = append(blocks, postTaskBlocks...)
+	return blocks, mandatoryBlock, newestEvidenceBlock
+}
+
+func completeAssistantToolBlock(block messageBlock) bool {
+	if len(block.messages) < 2 {
+		return false
+	}
+	assistant := block.messages[0]
+	if assistant.Role != recoveryRoleAssistant || len(assistant.ToolCalls) == 0 {
+		return false
+	}
+
+	pending := make(map[string]int, len(assistant.ToolCalls))
+	for _, call := range assistant.ToolCalls {
+		if call.ID == "" {
+			return false
+		}
+		pending[call.ID]++
+	}
+	for _, result := range block.messages[1:] {
+		if result.Role != recoveryRoleTool || pending[result.ToolCallID] == 0 {
+			return false
+		}
+		pending[result.ToolCallID]--
+	}
+	for _, remaining := range pending {
+		if remaining != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func cloneCompletionRequest(req *CompletionRequest) (*CompletionRequest, error) {
@@ -184,11 +267,20 @@ func newestUserMessageIndex(messages []Message) int {
 	return -1
 }
 
-func truncateCurrentUserPrompt(req *CompletionRequest, messageIndex, tokenBudget int) (bool, error) {
+func truncateCurrentUserPrompt(
+	req *CompletionRequest,
+	messageIndex int,
+	tokenBudget int,
+	bestEffort bool,
+) error {
 	original := req.Messages[messageIndex].Content
 	originalRunes := []rune(original)
 	if len(originalRunes) < 3 {
-		return false, nil
+		return nil
+	}
+	originalSize, err := EstimateCompletionRequestSize(req)
+	if err != nil {
+		return err
 	}
 
 	setContent := func(content string) (CompletionRequestSize, error) {
@@ -200,11 +292,17 @@ func truncateCurrentUserPrompt(req *CompletionRequest, messageIndex, tokenBudget
 	bestContent := balancedTruncatedCurrentTask(originalRunes, minimumRetainedRunes)
 	bestSize, err := setContent(bestContent)
 	if err != nil {
-		return false, err
+		return err
 	}
 	if bestSize.EstimatedTokens > tokenBudget {
+		// Fixed request overhead can make the target impossible. When recent
+		// evidence is anchored, keep the smallest bounded task if it still shrinks
+		// the request rather than discarding that evidence.
+		if bestEffort && bestSize.SerializedBytes < originalSize.SerializedBytes {
+			return nil
+		}
 		req.Messages[messageIndex].Content = original
-		return false, nil
+		return nil
 	}
 
 	for low, high := minimumRetainedRunes, len(originalRunes)-1; low <= high; {
@@ -212,7 +310,7 @@ func truncateCurrentUserPrompt(req *CompletionRequest, messageIndex, tokenBudget
 		content := balancedTruncatedCurrentTask(originalRunes, mid)
 		size, sizeErr := setContent(content)
 		if sizeErr != nil {
-			return false, sizeErr
+			return sizeErr
 		}
 		if size.EstimatedTokens <= tokenBudget {
 			bestContent = content
@@ -223,7 +321,7 @@ func truncateCurrentUserPrompt(req *CompletionRequest, messageIndex, tokenBudget
 	}
 
 	req.Messages[messageIndex].Content = bestContent
-	return true, nil
+	return nil
 }
 
 func balancedTruncatedCurrentTask(original []rune, retained int) string {

--- a/internal/llm/truncate_test.go
+++ b/internal/llm/truncate_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 )
 
+const testRoleUser = "user"
+
 func Test_estimateTokens(t *testing.T) {
 	tests := []struct {
 		name string
@@ -76,6 +78,274 @@ func Test_estimateMessageTokens(t *testing.T) {
 	}
 }
 
+func TestEstimateCompletionRequestSizeIncludesCompleteSerializedRequest(t *testing.T) {
+	req := &CompletionRequest{
+		Model:        "test-model",
+		SystemPrompt: strings.Repeat("system ", 80),
+		Messages: []Message{
+			{
+				Role: "assistant",
+				ToolCalls: []ToolCall{{
+					ID:        "call-1",
+					Name:      "lookup",
+					Arguments: json.RawMessage(fmt.Sprintf(`{"query":%q}`, strings.Repeat("argument ", 80))),
+				}},
+			},
+			{Role: "tool", ToolCallID: "call-1", Content: "tool result"},
+			{Role: testRoleUser, Content: "current task"},
+		},
+		Tools: []Tool{{
+			Name:        "lookup",
+			Description: strings.Repeat("description ", 80),
+			Parameters:  json.RawMessage(fmt.Sprintf(`{"type":"object","description":%q}`, strings.Repeat("schema ", 80))),
+		}},
+	}
+
+	got, err := EstimateCompletionRequestSize(req)
+	if err != nil {
+		t.Fatalf("EstimateCompletionRequestSize() error = %v", err)
+	}
+	serialized, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if got.SerializedBytes != len(serialized) {
+		t.Fatalf("SerializedBytes = %d, want %d", got.SerializedBytes, len(serialized))
+	}
+	if got.EstimatedTokens != estimateTokens(string(serialized)) {
+		t.Fatalf("EstimatedTokens = %d, want %d", got.EstimatedTokens, estimateTokens(string(serialized)))
+	}
+
+	messagesOnly, err := EstimateCompletionRequestSize(&CompletionRequest{Messages: req.Messages})
+	if err != nil {
+		t.Fatalf("messages-only EstimateCompletionRequestSize() error = %v", err)
+	}
+	if got.SerializedBytes <= messagesOnly.SerializedBytes {
+		t.Fatalf("complete request size = %d, messages-only size = %d; system prompt/tools were ignored",
+			got.SerializedBytes, messagesOnly.SerializedBytes)
+	}
+}
+
+func TestTruncateCompletionRequestDeepCopiesNestedToolData(t *testing.T) {
+	req := &CompletionRequest{
+		Messages: []Message{
+			{
+				Role: "assistant",
+				ToolCalls: []ToolCall{{
+					ID:        "call-1",
+					Name:      "lookup",
+					Arguments: json.RawMessage(`{"query":"original"}`),
+				}},
+			},
+			{Role: "tool", ToolCallID: "call-1", Content: "result"},
+			{Role: testRoleUser, Content: "current task"},
+		},
+		Tools: []Tool{{
+			Name:       "lookup",
+			Parameters: json.RawMessage(`{"type":"object"}`),
+		}},
+	}
+
+	cloned, err := TruncateCompletionRequest(req, 10000)
+	if err != nil {
+		t.Fatalf("TruncateCompletionRequest() error = %v", err)
+	}
+	cloned.Messages[0].ToolCalls[0].Name = "mutated"
+	cloned.Messages[0].ToolCalls[0].Arguments[0] = '['
+	cloned.Tools[0].Parameters[0] = '['
+
+	if got := req.Messages[0].ToolCalls[0].Name; got != "lookup" {
+		t.Fatalf("original tool call name = %q, want lookup", got)
+	}
+	if got := string(req.Messages[0].ToolCalls[0].Arguments); got != `{"query":"original"}` {
+		t.Fatalf("original tool arguments mutated: %q", got)
+	}
+	if got := string(req.Tools[0].Parameters); got != `{"type":"object"}` {
+		t.Fatalf("original tool schema mutated: %q", got)
+	}
+}
+
+func TestTruncateCompletionRequestTruncatesSingleOversizedCurrentPrompt(t *testing.T) {
+	originalPrompt := "BEGIN-CURRENT-TASK\n" + strings.Repeat("details ", 2000) + "\nEND-CURRENT-TASK"
+	req := &CompletionRequest{
+		Model:        "test-model",
+		SystemPrompt: "system",
+		Messages:     []Message{{Role: testRoleUser, Content: originalPrompt}},
+		MaxTokens:    4096,
+	}
+	before, err := EstimateCompletionRequestSize(req)
+	if err != nil {
+		t.Fatalf("EstimateCompletionRequestSize() error = %v", err)
+	}
+
+	truncated, err := TruncateCompletionRequest(req, before.EstimatedTokens/2)
+	if err != nil {
+		t.Fatalf("TruncateCompletionRequest() error = %v", err)
+	}
+	if req.Messages[0].Content != originalPrompt {
+		t.Fatal("TruncateCompletionRequest() mutated the original request")
+	}
+	if len(truncated.Messages) != 1 || truncated.Messages[0].Role != testRoleUser {
+		t.Fatalf("messages = %#v, want the current user task", truncated.Messages)
+	}
+	gotPrompt := truncated.Messages[0].Content
+	if !strings.Contains(gotPrompt, "[Current user task truncated for context recovery.]") {
+		t.Fatalf("truncated prompt lacks explicit marker: %q", gotPrompt)
+	}
+	if !strings.Contains(gotPrompt, "BEGIN-CURRENT-TASK") || !strings.Contains(gotPrompt, "END-CURRENT-TASK") {
+		t.Fatalf("truncated prompt did not preserve task boundaries: %q", gotPrompt)
+	}
+	after, err := EstimateCompletionRequestSize(truncated)
+	if err != nil {
+		t.Fatalf("truncated EstimateCompletionRequestSize() error = %v", err)
+	}
+	if after.EstimatedTokens > before.EstimatedTokens/2 {
+		t.Fatalf("truncated request estimate = %d, budget = %d", after.EstimatedTokens, before.EstimatedTokens/2)
+	}
+	if after.SerializedBytes >= before.SerializedBytes {
+		t.Fatalf("truncated bytes = %d, original bytes = %d", after.SerializedBytes, before.SerializedBytes)
+	}
+}
+
+func TestTruncateCompletionRequestBalancesTightCurrentTaskBoundaries(t *testing.T) {
+	const (
+		beginSentinel = "BEGIN-SENTINEL--"
+		endSentinel   = "--END-SENTINEL"
+	)
+	originalPrompt := beginSentinel + strings.Repeat("middle ", 500) + endSentinel
+	req := &CompletionRequest{
+		Model:        "test-model",
+		SystemPrompt: strings.Repeat("fixed system ", 200),
+		Messages:     []Message{{Role: testRoleUser, Content: originalPrompt}},
+	}
+	budgetReq, err := cloneCompletionRequest(req)
+	if err != nil {
+		t.Fatalf("cloneCompletionRequest() error = %v", err)
+	}
+	originalRunes := []rune(originalPrompt)
+	budgetReq.Messages[0].Content = string(originalRunes[:16]) + currentUserTaskTruncationMarker +
+		string(originalRunes[len(originalRunes)-16:])
+	budget, err := EstimateCompletionRequestSize(budgetReq)
+	if err != nil {
+		t.Fatalf("EstimateCompletionRequestSize() error = %v", err)
+	}
+
+	truncated, err := TruncateCompletionRequest(req, budget.EstimatedTokens)
+	if err != nil {
+		t.Fatalf("TruncateCompletionRequest() error = %v", err)
+	}
+	gotPrompt := truncated.Messages[0].Content
+	if !strings.Contains(gotPrompt, beginSentinel) || !strings.Contains(gotPrompt, endSentinel) {
+		t.Fatalf("tight truncation did not preserve both task boundaries: %q", gotPrompt)
+	}
+	if !strings.Contains(gotPrompt, "[Current user task truncated for context recovery.]") {
+		t.Fatalf("tight truncation lacks marker: %q", gotPrompt)
+	}
+}
+
+func TestTruncateCompletionRequestDropsOversizedOldHistoryBeforeCurrentTask(t *testing.T) {
+	const currentTask = "CURRENT-TASK-SENTINEL: answer this request"
+	req := &CompletionRequest{
+		Model: "test-model",
+		Messages: []Message{
+			{Role: testRoleUser, Content: "OLD-FIRST-HISTORY:" + strings.Repeat("old ", 3000)},
+			{Role: "assistant", Content: "old answer"},
+			{Role: testRoleUser, Content: currentTask},
+		},
+	}
+	currentOnly := &CompletionRequest{
+		Model:    req.Model,
+		Messages: []Message{{Role: testRoleUser, Content: currentTask}},
+	}
+	budget, err := EstimateCompletionRequestSize(currentOnly)
+	if err != nil {
+		t.Fatalf("EstimateCompletionRequestSize() error = %v", err)
+	}
+
+	truncated, err := TruncateCompletionRequest(req, budget.EstimatedTokens+20)
+	if err != nil {
+		t.Fatalf("TruncateCompletionRequest() error = %v", err)
+	}
+	if len(truncated.Messages) == 0 {
+		t.Fatal("TruncateCompletionRequest() dropped every message")
+	}
+	if truncated.Messages[0].Role != testRoleUser {
+		t.Fatalf("first retained message = %#v, want a user turn", truncated.Messages[0])
+	}
+	if got := truncated.Messages[len(truncated.Messages)-1]; got.Role != testRoleUser || got.Content != currentTask {
+		t.Fatalf("newest message = %#v, want preserved current task", got)
+	}
+	for _, message := range truncated.Messages {
+		if strings.Contains(message.Content, "OLD-FIRST-HISTORY") || message.Content == "old answer" {
+			t.Fatalf("oversized old history was retained: %#v", truncated.Messages)
+		}
+	}
+}
+
+func TestTruncateCompletionRequestKeepsAssistantToolResultBlocksAtomic(t *testing.T) {
+	const currentTask = "CURRENT-TASK-SENTINEL"
+	newestBlock := []Message{
+		{
+			Role: "assistant",
+			ToolCalls: []ToolCall{{
+				ID:        "new-call",
+				Name:      "lookup",
+				Arguments: json.RawMessage(`{"query":"new"}`),
+			}},
+		},
+		{Role: "tool", ToolCallID: "new-call", Content: "new result"},
+	}
+	req := &CompletionRequest{
+		Model: "test-model",
+		Messages: []Message{
+			{Role: testRoleUser, Content: strings.Repeat("old history ", 1000)},
+			{Role: testRoleUser, Content: currentTask},
+			{
+				Role: "assistant",
+				ToolCalls: []ToolCall{{
+					ID:        "old-call",
+					Name:      "lookup",
+					Arguments: json.RawMessage(fmt.Sprintf(`{"query":%q}`, strings.Repeat("old argument ", 1000))),
+				}},
+			},
+			{Role: "tool", ToolCallID: "old-call", Content: "old result"},
+		},
+	}
+	req.Messages = append(req.Messages, newestBlock...)
+	wantMessages := append([]Message{{Role: testRoleUser, Content: currentTask}}, newestBlock...)
+	wantSize, err := EstimateCompletionRequestSize(&CompletionRequest{Model: req.Model, Messages: wantMessages})
+	if err != nil {
+		t.Fatalf("EstimateCompletionRequestSize() error = %v", err)
+	}
+
+	truncated, err := TruncateCompletionRequest(req, wantSize.EstimatedTokens)
+	if err != nil {
+		t.Fatalf("TruncateCompletionRequest() error = %v", err)
+	}
+	if len(truncated.Messages) != len(wantMessages) {
+		t.Fatalf("messages = %#v, want current task plus newest complete tool block", truncated.Messages)
+	}
+	if truncated.Messages[0].Content != currentTask {
+		t.Fatalf("current task = %q, want %q", truncated.Messages[0].Content, currentTask)
+	}
+	if got := truncated.Messages[1].ToolCalls; len(got) != 1 || got[0].ID != "new-call" {
+		t.Fatalf("assistant tool calls = %#v, want new-call", got)
+	}
+	if got := truncated.Messages[2]; got.Role != "tool" || got.ToolCallID != "new-call" {
+		t.Fatalf("tool result = %#v, want matching new-call result", got)
+	}
+	for _, message := range truncated.Messages {
+		if message.ToolCallID == "old-call" {
+			t.Fatalf("orphaned old tool result retained: %#v", truncated.Messages)
+		}
+		for _, call := range message.ToolCalls {
+			if call.ID == "old-call" {
+				t.Fatalf("partial old assistant/tool block retained: %#v", truncated.Messages)
+			}
+		}
+	}
+}
+
 func TestGroupMessageBlocks(t *testing.T) {
 	t.Run("no messages", func(t *testing.T) {
 		blocks := groupMessageBlocks(nil)
@@ -86,9 +356,9 @@ func TestGroupMessageBlocks(t *testing.T) {
 
 	t.Run("simple messages no tool calls", func(t *testing.T) {
 		msgs := []Message{
-			{Role: "user", Content: "hi"},
+			{Role: testRoleUser, Content: "hi"},
 			{Role: "assistant", Content: "hello"},
-			{Role: "user", Content: "bye"},
+			{Role: testRoleUser, Content: "bye"},
 		}
 		blocks := groupMessageBlocks(msgs)
 		if len(blocks) != 3 {
@@ -106,7 +376,7 @@ func TestGroupMessageBlocks(t *testing.T) {
 			{Role: "assistant", Content: "", ToolCalls: []ToolCall{{ID: "1", Name: "search", Arguments: json.RawMessage(`{}`)}}},
 			{Role: "tool", Content: "result1", ToolCallID: "1"},
 			{Role: "tool", Content: "result2", ToolCallID: "2"},
-			{Role: "user", Content: "next"},
+			{Role: testRoleUser, Content: "next"},
 		}
 		blocks := groupMessageBlocks(msgs)
 		if len(blocks) != 2 {
@@ -144,7 +414,7 @@ func TestTruncateMessages(t *testing.T) {
 
 	t.Run("within budget returns all", func(t *testing.T) {
 		msgs := []Message{
-			{Role: "user", Content: "hi"},
+			{Role: testRoleUser, Content: "hi"},
 			{Role: "assistant", Content: "hello"},
 		}
 		result := TruncateMessages(msgs, 10000)
@@ -155,7 +425,7 @@ func TestTruncateMessages(t *testing.T) {
 
 	t.Run("budget too small keeps only first", func(t *testing.T) {
 		msgs := []Message{
-			{Role: "user", Content: "hi"},
+			{Role: testRoleUser, Content: "hi"},
 			{Role: "assistant", Content: "hello there how are you doing today"},
 		}
 		// First message "hi" ≈ 1 token. Set budget to 1.
@@ -171,11 +441,11 @@ func TestTruncateMessages(t *testing.T) {
 	t.Run("truncation adds system note", func(t *testing.T) {
 		// Create messages where total exceeds budget
 		msgs := []Message{
-			{Role: "user", Content: "system prompt"},
-			{Role: "assistant", Content: strings.Repeat("a", 100)}, // ~25 tokens
-			{Role: "user", Content: strings.Repeat("b", 100)},      // ~25 tokens
-			{Role: "assistant", Content: strings.Repeat("c", 100)}, // ~25 tokens
-			{Role: "user", Content: "last"},                        // ~1 token
+			{Role: testRoleUser, Content: "system prompt"},
+			{Role: "assistant", Content: strings.Repeat("a", 100)},  // ~25 tokens
+			{Role: testRoleUser, Content: strings.Repeat("b", 100)}, // ~25 tokens
+			{Role: "assistant", Content: strings.Repeat("c", 100)},  // ~25 tokens
+			{Role: testRoleUser, Content: "last"},                   // ~1 token
 		}
 		// Budget large enough for first + enriched note + last message, but not all
 		result := TruncateMessages(msgs, 40)
@@ -196,10 +466,10 @@ func TestTruncateMessages(t *testing.T) {
 
 	t.Run("tool call groups kept atomically", func(t *testing.T) {
 		msgs := []Message{
-			{Role: "user", Content: "go"},
+			{Role: testRoleUser, Content: "go"},
 			{Role: "assistant", ToolCalls: []ToolCall{{ID: "1", Name: "fn", Arguments: json.RawMessage(`{}`)}}},
 			{Role: "tool", Content: "result", ToolCallID: "1"},
-			{Role: "user", Content: "ok"},
+			{Role: testRoleUser, Content: "ok"},
 		}
 		// Budget large enough for everything
 		result := TruncateMessages(msgs, 10000)
@@ -210,11 +480,11 @@ func TestTruncateMessages(t *testing.T) {
 
 	t.Run("truncation with tool calls produces enriched note", func(t *testing.T) {
 		msgs := []Message{
-			{Role: "user", Content: "system prompt"},
+			{Role: testRoleUser, Content: "system prompt"},
 			{Role: "assistant", ToolCalls: []ToolCall{{ID: "1", Name: "file_read", Arguments: json.RawMessage(`{"path":"main.go"}`)}}},
 			{Role: "tool", Content: "package main", ToolCallID: "1"},
-			{Role: "user", Content: strings.Repeat("x", 400)}, // ~100 tokens
-			{Role: "user", Content: "last"},
+			{Role: testRoleUser, Content: strings.Repeat("x", 400)}, // ~100 tokens
+			{Role: testRoleUser, Content: "last"},
 		}
 		// Budget large enough for first + enriched note + last, but not the big middle block
 		result := TruncateMessages(msgs, 60)
@@ -237,7 +507,7 @@ func TestTruncateMessages(t *testing.T) {
 
 	t.Run("single message within budget", func(t *testing.T) {
 		msgs := []Message{
-			{Role: "user", Content: "hello"},
+			{Role: testRoleUser, Content: "hello"},
 		}
 		result := TruncateMessages(msgs, 10000)
 		if len(result) != 1 {
@@ -256,7 +526,7 @@ func TestExtractDroppedSummary(t *testing.T) {
 
 	t.Run("user messages only no tool calls", func(t *testing.T) {
 		blocks := []messageBlock{
-			{messages: []Message{{Role: "user", Content: "hello"}}, tokens: 2},
+			{messages: []Message{{Role: testRoleUser, Content: "hello"}}, tokens: 2},
 			{messages: []Message{{Role: "assistant", Content: "hi there"}}, tokens: 3},
 		}
 		result := extractDroppedSummary(blocks)

--- a/internal/llm/truncate_test.go
+++ b/internal/llm/truncate_test.go
@@ -7,7 +7,10 @@ import (
 	"testing"
 )
 
-const testRoleUser = "user"
+const (
+	testRoleUser   = "user"
+	testRoleSystem = "system"
+)
 
 func Test_estimateTokens(t *testing.T) {
 	tests := []struct {
@@ -269,8 +272,8 @@ func TestTruncateCompletionRequestDropsOversizedOldHistoryBeforeCurrentTask(t *t
 	if len(truncated.Messages) == 0 {
 		t.Fatal("TruncateCompletionRequest() dropped every message")
 	}
-	if truncated.Messages[0].Role != testRoleUser {
-		t.Fatalf("first retained message = %#v, want a user turn", truncated.Messages[0])
+	if truncated.Messages[0].Role != testRoleSystem || !strings.Contains(truncated.Messages[0].Content, "truncated") {
+		t.Fatalf("first retained message = %#v, want a truncation note", truncated.Messages[0])
 	}
 	if got := truncated.Messages[len(truncated.Messages)-1]; got.Role != testRoleUser || got.Content != currentTask {
 		t.Fatalf("newest message = %#v, want preserved current task", got)
@@ -318,20 +321,23 @@ func TestTruncateCompletionRequestKeepsAssistantToolResultBlocksAtomic(t *testin
 		t.Fatalf("EstimateCompletionRequestSize() error = %v", err)
 	}
 
-	truncated, err := TruncateCompletionRequest(req, wantSize.EstimatedTokens)
+	truncated, err := TruncateCompletionRequest(req, wantSize.EstimatedTokens+100)
 	if err != nil {
 		t.Fatalf("TruncateCompletionRequest() error = %v", err)
 	}
-	if len(truncated.Messages) != len(wantMessages) {
-		t.Fatalf("messages = %#v, want current task plus newest complete tool block", truncated.Messages)
+	if len(truncated.Messages) != len(wantMessages)+1 {
+		t.Fatalf("messages = %#v, want truncation note plus current task and newest complete tool block", truncated.Messages)
 	}
-	if truncated.Messages[0].Content != currentTask {
-		t.Fatalf("current task = %q, want %q", truncated.Messages[0].Content, currentTask)
+	if truncated.Messages[0].Role != testRoleSystem || !strings.Contains(truncated.Messages[0].Content, "truncated") {
+		t.Fatalf("truncation note = %#v", truncated.Messages[0])
 	}
-	if got := truncated.Messages[1].ToolCalls; len(got) != 1 || got[0].ID != "new-call" {
+	if truncated.Messages[1].Content != currentTask {
+		t.Fatalf("current task = %q, want %q", truncated.Messages[1].Content, currentTask)
+	}
+	if got := truncated.Messages[2].ToolCalls; len(got) != 1 || got[0].ID != "new-call" {
 		t.Fatalf("assistant tool calls = %#v, want new-call", got)
 	}
-	if got := truncated.Messages[2]; got.Role != "tool" || got.ToolCallID != "new-call" {
+	if got := truncated.Messages[3]; got.Role != "tool" || got.ToolCallID != "new-call" {
 		t.Fatalf("tool result = %#v, want matching new-call result", got)
 	}
 	for _, message := range truncated.Messages {
@@ -456,7 +462,7 @@ func TestTruncateMessages(t *testing.T) {
 			t.Error("first message should be preserved")
 		}
 		// Should have a truncation note
-		if result[1].Role != "system" {
+		if result[1].Role != testRoleSystem {
 			t.Error("expected truncation note to have system role")
 		}
 		if !strings.Contains(result[1].Content, "truncated") {
@@ -491,7 +497,7 @@ func TestTruncateMessages(t *testing.T) {
 		if len(result) < 2 {
 			t.Fatalf("expected at least 2 messages, got %d", len(result))
 		}
-		if result[1].Role != "system" {
+		if result[1].Role != testRoleSystem {
 			t.Error("expected system role for truncation note")
 		}
 		if !strings.Contains(result[1].Content, "truncated") {

--- a/internal/llm/truncate_test.go
+++ b/internal/llm/truncate_test.go
@@ -8,8 +8,10 @@ import (
 )
 
 const (
-	testRoleUser   = "user"
-	testRoleSystem = "system"
+	testRoleAssistant = "assistant"
+	testRoleSystem    = "system"
+	testRoleTool      = "tool"
+	testRoleUser      = "user"
 )
 
 func Test_estimateTokens(t *testing.T) {
@@ -87,14 +89,14 @@ func TestEstimateCompletionRequestSizeIncludesCompleteSerializedRequest(t *testi
 		SystemPrompt: strings.Repeat("system ", 80),
 		Messages: []Message{
 			{
-				Role: "assistant",
+				Role: testRoleAssistant,
 				ToolCalls: []ToolCall{{
 					ID:        "call-1",
 					Name:      "lookup",
 					Arguments: json.RawMessage(fmt.Sprintf(`{"query":%q}`, strings.Repeat("argument ", 80))),
 				}},
 			},
-			{Role: "tool", ToolCallID: "call-1", Content: "tool result"},
+			{Role: testRoleTool, ToolCallID: "call-1", Content: "tool result"},
 			{Role: testRoleUser, Content: "current task"},
 		},
 		Tools: []Tool{{
@@ -133,14 +135,14 @@ func TestTruncateCompletionRequestDeepCopiesNestedToolData(t *testing.T) {
 	req := &CompletionRequest{
 		Messages: []Message{
 			{
-				Role: "assistant",
+				Role: testRoleAssistant,
 				ToolCalls: []ToolCall{{
 					ID:        "call-1",
 					Name:      "lookup",
 					Arguments: json.RawMessage(`{"query":"original"}`),
 				}},
 			},
-			{Role: "tool", ToolCallID: "call-1", Content: "result"},
+			{Role: testRoleTool, ToolCallID: "call-1", Content: "result"},
 			{Role: testRoleUser, Content: "current task"},
 		},
 		Tools: []Tool{{
@@ -252,7 +254,7 @@ func TestTruncateCompletionRequestDropsOversizedOldHistoryBeforeCurrentTask(t *t
 		Model: "test-model",
 		Messages: []Message{
 			{Role: testRoleUser, Content: "OLD-FIRST-HISTORY:" + strings.Repeat("old ", 3000)},
-			{Role: "assistant", Content: "old answer"},
+			{Role: testRoleAssistant, Content: "old answer"},
 			{Role: testRoleUser, Content: currentTask},
 		},
 	}
@@ -289,14 +291,14 @@ func TestTruncateCompletionRequestKeepsAssistantToolResultBlocksAtomic(t *testin
 	const currentTask = "CURRENT-TASK-SENTINEL"
 	newestBlock := []Message{
 		{
-			Role: "assistant",
+			Role: testRoleAssistant,
 			ToolCalls: []ToolCall{{
 				ID:        "new-call",
 				Name:      "lookup",
 				Arguments: json.RawMessage(`{"query":"new"}`),
 			}},
 		},
-		{Role: "tool", ToolCallID: "new-call", Content: "new result"},
+		{Role: testRoleTool, ToolCallID: "new-call", Content: "new result"},
 	}
 	req := &CompletionRequest{
 		Model: "test-model",
@@ -304,14 +306,14 @@ func TestTruncateCompletionRequestKeepsAssistantToolResultBlocksAtomic(t *testin
 			{Role: testRoleUser, Content: strings.Repeat("old history ", 1000)},
 			{Role: testRoleUser, Content: currentTask},
 			{
-				Role: "assistant",
+				Role: testRoleAssistant,
 				ToolCalls: []ToolCall{{
 					ID:        "old-call",
 					Name:      "lookup",
 					Arguments: json.RawMessage(fmt.Sprintf(`{"query":%q}`, strings.Repeat("old argument ", 1000))),
 				}},
 			},
-			{Role: "tool", ToolCallID: "old-call", Content: "old result"},
+			{Role: testRoleTool, ToolCallID: "old-call", Content: "old result"},
 		},
 	}
 	req.Messages = append(req.Messages, newestBlock...)
@@ -337,7 +339,7 @@ func TestTruncateCompletionRequestKeepsAssistantToolResultBlocksAtomic(t *testin
 	if got := truncated.Messages[2].ToolCalls; len(got) != 1 || got[0].ID != "new-call" {
 		t.Fatalf("assistant tool calls = %#v, want new-call", got)
 	}
-	if got := truncated.Messages[3]; got.Role != "tool" || got.ToolCallID != "new-call" {
+	if got := truncated.Messages[3]; got.Role != testRoleTool || got.ToolCallID != "new-call" {
 		t.Fatalf("tool result = %#v, want matching new-call result", got)
 	}
 	for _, message := range truncated.Messages {
@@ -352,6 +354,189 @@ func TestTruncateCompletionRequestKeepsAssistantToolResultBlocksAtomic(t *testin
 	}
 }
 
+func TestTruncateCompletionRequestPreservesNewestCompletePostTaskEvidenceBeforePromptTruncation(t *testing.T) {
+	const (
+		currentTaskStart = "CURRENT-TASK-BEGIN"
+		currentTaskEnd   = "CURRENT-TASK-END"
+		newestResult     = "NEWEST-COMPLETE-EVIDENCE"
+	)
+	currentTask := currentTaskStart + strings.Repeat(" important task detail", 600) + currentTaskEnd
+	req := &CompletionRequest{
+		Model:        "test-model",
+		SystemPrompt: strings.Repeat("fixed system overhead ", 2000),
+		Tools: []Tool{{
+			Name:        "lookup",
+			Description: strings.Repeat("fixed tool description ", 1200),
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"query":{"type":"string"}}}`),
+		}},
+		Messages: []Message{
+			{Role: testRoleUser, Content: currentTask},
+			{
+				Role: testRoleAssistant,
+				ToolCalls: []ToolCall{{
+					ID:        "older-call",
+					Name:      "lookup",
+					Arguments: json.RawMessage(fmt.Sprintf(`{"query":%q}`, strings.Repeat("older evidence ", 400))),
+				}},
+			},
+			{Role: testRoleTool, ToolCallID: "older-call", Content: strings.Repeat("older result ", 400)},
+			{
+				Role: testRoleAssistant,
+				ToolCalls: []ToolCall{{
+					ID:        "newest-call",
+					Name:      "lookup",
+					Arguments: json.RawMessage(`{"query":"newest"}`),
+				}},
+			},
+			{Role: testRoleTool, ToolCallID: "newest-call", Content: newestResult},
+			{
+				Role: testRoleAssistant,
+				ToolCalls: []ToolCall{{
+					ID:        "incomplete-call",
+					Name:      "lookup",
+					Arguments: json.RawMessage(fmt.Sprintf(`{"query":%q}`, strings.Repeat("incomplete ", 400))),
+				}},
+			},
+		},
+	}
+
+	before, err := EstimateCompletionRequestSize(req)
+	if err != nil {
+		t.Fatalf("EstimateCompletionRequestSize() error = %v", err)
+	}
+	budget := before.EstimatedTokens / 2
+	fixedRequest := *req
+	fixedRequest.Messages = nil
+	fixedSize, err := EstimateCompletionRequestSize(&fixedRequest)
+	if err != nil {
+		t.Fatalf("fixed EstimateCompletionRequestSize() error = %v", err)
+	}
+	if fixedSize.EstimatedTokens <= budget {
+		t.Fatalf("test fixture fixed tokens = %d, want greater than budget %d", fixedSize.EstimatedTokens, budget)
+	}
+
+	truncated, err := TruncateCompletionRequest(req, budget)
+	if err != nil {
+		t.Fatalf("TruncateCompletionRequest() error = %v", err)
+	}
+	after, err := EstimateCompletionRequestSize(truncated)
+	if err != nil {
+		t.Fatalf("truncated EstimateCompletionRequestSize() error = %v", err)
+	}
+	if after.SerializedBytes >= before.SerializedBytes {
+		t.Fatalf("truncated bytes = %d, original bytes = %d; request did not shrink", after.SerializedBytes, before.SerializedBytes)
+	}
+	if after.EstimatedTokens <= budget {
+		t.Fatalf("truncated tokens = %d, want fixture to remain above impossible budget %d", after.EstimatedTokens, budget)
+	}
+
+	var (
+		truncatedCurrentTask bool
+		keptNewestCall       bool
+		keptNewestResult     bool
+	)
+	for _, message := range truncated.Messages {
+		if message.Role == testRoleUser {
+			truncatedCurrentTask = strings.Contains(message.Content, currentUserTaskTruncationMarker) &&
+				strings.HasPrefix(message.Content, currentTask[:1]) &&
+				strings.HasSuffix(message.Content, currentTask[len(currentTask)-1:])
+		}
+		for _, call := range message.ToolCalls {
+			switch call.ID {
+			case "newest-call":
+				keptNewestCall = true
+			case "older-call", "incomplete-call":
+				t.Fatalf("dropped post-task tool block retained: %#v", truncated.Messages)
+			}
+		}
+		if message.ToolCallID == "newest-call" && message.Content == newestResult {
+			keptNewestResult = true
+		}
+		if message.ToolCallID == "older-call" || message.ToolCallID == "incomplete-call" {
+			t.Fatalf("dropped post-task tool result retained: %#v", truncated.Messages)
+		}
+	}
+	if !truncatedCurrentTask {
+		t.Fatalf("current task was not best-effort truncated with both boundaries: %#v", truncated.Messages)
+	}
+	if !keptNewestCall || !keptNewestResult {
+		t.Fatalf("newest complete post-task tool block was not retained atomically: %#v", truncated.Messages)
+	}
+}
+
+func TestTruncateCompletionRequestDropsNewestEvidenceOnlyWhenNeededToReachBudget(t *testing.T) {
+	const currentTask = "CURRENT-TASK-SENTINEL: preserve this request"
+	req := &CompletionRequest{
+		Model:        "test-model",
+		SystemPrompt: "small fixed system prompt",
+		Tools: []Tool{{
+			Name:        "lookup",
+			Description: "small fixed tool",
+			Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),
+		}},
+		Messages: []Message{
+			{Role: testRoleUser, Content: currentTask},
+			{
+				Role: testRoleAssistant,
+				ToolCalls: []ToolCall{{
+					ID:        "oversized-call",
+					Name:      "lookup",
+					Arguments: json.RawMessage(`{"query":"large"}`),
+				}},
+			},
+			{Role: testRoleTool, ToolCallID: "oversized-call", Content: strings.Repeat("large evidence ", 2000)},
+		},
+	}
+
+	before, err := EstimateCompletionRequestSize(req)
+	if err != nil {
+		t.Fatalf("EstimateCompletionRequestSize() error = %v", err)
+	}
+	budget := before.EstimatedTokens / 2
+	withoutEvidence := *req
+	withoutEvidence.Messages = []Message{{Role: testRoleUser, Content: currentTask}}
+	withoutEvidenceSize, err := EstimateCompletionRequestSize(&withoutEvidence)
+	if err != nil {
+		t.Fatalf("without-evidence EstimateCompletionRequestSize() error = %v", err)
+	}
+	if withoutEvidenceSize.EstimatedTokens > budget {
+		t.Fatalf(
+			"test fixture without-evidence tokens = %d, want no more than budget %d",
+			withoutEvidenceSize.EstimatedTokens, budget,
+		)
+	}
+
+	truncated, err := TruncateCompletionRequest(req, budget)
+	if err != nil {
+		t.Fatalf("TruncateCompletionRequest() error = %v", err)
+	}
+	after, err := EstimateCompletionRequestSize(truncated)
+	if err != nil {
+		t.Fatalf("truncated EstimateCompletionRequestSize() error = %v", err)
+	}
+	if after.EstimatedTokens > budget {
+		t.Fatalf("truncated tokens = %d, want no more than budget %d", after.EstimatedTokens, budget)
+	}
+
+	var keptCurrentTask bool
+	for _, message := range truncated.Messages {
+		if message.Role == testRoleUser && message.Content == currentTask {
+			keptCurrentTask = true
+		}
+		for _, call := range message.ToolCalls {
+			if call.ID == "oversized-call" {
+				t.Fatalf("oversized evidence call retained: %#v", truncated.Messages)
+			}
+		}
+		if message.ToolCallID == "oversized-call" {
+			t.Fatalf("oversized evidence result retained: %#v", truncated.Messages)
+		}
+	}
+	if !keptCurrentTask {
+		t.Fatalf("current task was not restored after dropping oversized evidence: %#v", truncated.Messages)
+	}
+}
+
 func TestGroupMessageBlocks(t *testing.T) {
 	t.Run("no messages", func(t *testing.T) {
 		blocks := groupMessageBlocks(nil)
@@ -363,7 +548,7 @@ func TestGroupMessageBlocks(t *testing.T) {
 	t.Run("simple messages no tool calls", func(t *testing.T) {
 		msgs := []Message{
 			{Role: testRoleUser, Content: "hi"},
-			{Role: "assistant", Content: "hello"},
+			{Role: testRoleAssistant, Content: "hello"},
 			{Role: testRoleUser, Content: "bye"},
 		}
 		blocks := groupMessageBlocks(msgs)
@@ -379,9 +564,9 @@ func TestGroupMessageBlocks(t *testing.T) {
 
 	t.Run("assistant with tool calls groups with tool results", func(t *testing.T) {
 		msgs := []Message{
-			{Role: "assistant", Content: "", ToolCalls: []ToolCall{{ID: "1", Name: "search", Arguments: json.RawMessage(`{}`)}}},
-			{Role: "tool", Content: "result1", ToolCallID: "1"},
-			{Role: "tool", Content: "result2", ToolCallID: "2"},
+			{Role: testRoleAssistant, Content: "", ToolCalls: []ToolCall{{ID: "1", Name: "search", Arguments: json.RawMessage(`{}`)}}},
+			{Role: testRoleTool, Content: "result1", ToolCallID: "1"},
+			{Role: testRoleTool, Content: "result2", ToolCallID: "2"},
 			{Role: testRoleUser, Content: "next"},
 		}
 		blocks := groupMessageBlocks(msgs)
@@ -400,8 +585,8 @@ func TestGroupMessageBlocks(t *testing.T) {
 
 	t.Run("assistant without tool calls not grouped", func(t *testing.T) {
 		msgs := []Message{
-			{Role: "assistant", Content: "no tools"},
-			{Role: "tool", Content: "orphan", ToolCallID: "x"},
+			{Role: testRoleAssistant, Content: "no tools"},
+			{Role: testRoleTool, Content: "orphan", ToolCallID: "x"},
 		}
 		blocks := groupMessageBlocks(msgs)
 		if len(blocks) != 2 {
@@ -421,7 +606,7 @@ func TestTruncateMessages(t *testing.T) {
 	t.Run("within budget returns all", func(t *testing.T) {
 		msgs := []Message{
 			{Role: testRoleUser, Content: "hi"},
-			{Role: "assistant", Content: "hello"},
+			{Role: testRoleAssistant, Content: "hello"},
 		}
 		result := TruncateMessages(msgs, 10000)
 		if len(result) != 2 {
@@ -432,7 +617,7 @@ func TestTruncateMessages(t *testing.T) {
 	t.Run("budget too small keeps only first", func(t *testing.T) {
 		msgs := []Message{
 			{Role: testRoleUser, Content: "hi"},
-			{Role: "assistant", Content: "hello there how are you doing today"},
+			{Role: testRoleAssistant, Content: "hello there how are you doing today"},
 		}
 		// First message "hi" ≈ 1 token. Set budget to 1.
 		result := TruncateMessages(msgs, 1)
@@ -448,10 +633,10 @@ func TestTruncateMessages(t *testing.T) {
 		// Create messages where total exceeds budget
 		msgs := []Message{
 			{Role: testRoleUser, Content: "system prompt"},
-			{Role: "assistant", Content: strings.Repeat("a", 100)},  // ~25 tokens
-			{Role: testRoleUser, Content: strings.Repeat("b", 100)}, // ~25 tokens
-			{Role: "assistant", Content: strings.Repeat("c", 100)},  // ~25 tokens
-			{Role: testRoleUser, Content: "last"},                   // ~1 token
+			{Role: testRoleAssistant, Content: strings.Repeat("a", 100)}, // ~25 tokens
+			{Role: testRoleUser, Content: strings.Repeat("b", 100)},      // ~25 tokens
+			{Role: testRoleAssistant, Content: strings.Repeat("c", 100)}, // ~25 tokens
+			{Role: testRoleUser, Content: "last"},                        // ~1 token
 		}
 		// Budget large enough for first + enriched note + last message, but not all
 		result := TruncateMessages(msgs, 40)
@@ -473,8 +658,8 @@ func TestTruncateMessages(t *testing.T) {
 	t.Run("tool call groups kept atomically", func(t *testing.T) {
 		msgs := []Message{
 			{Role: testRoleUser, Content: "go"},
-			{Role: "assistant", ToolCalls: []ToolCall{{ID: "1", Name: "fn", Arguments: json.RawMessage(`{}`)}}},
-			{Role: "tool", Content: "result", ToolCallID: "1"},
+			{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "1", Name: "fn", Arguments: json.RawMessage(`{}`)}}},
+			{Role: testRoleTool, Content: "result", ToolCallID: "1"},
 			{Role: testRoleUser, Content: "ok"},
 		}
 		// Budget large enough for everything
@@ -487,8 +672,8 @@ func TestTruncateMessages(t *testing.T) {
 	t.Run("truncation with tool calls produces enriched note", func(t *testing.T) {
 		msgs := []Message{
 			{Role: testRoleUser, Content: "system prompt"},
-			{Role: "assistant", ToolCalls: []ToolCall{{ID: "1", Name: "file_read", Arguments: json.RawMessage(`{"path":"main.go"}`)}}},
-			{Role: "tool", Content: "package main", ToolCallID: "1"},
+			{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "1", Name: "file_read", Arguments: json.RawMessage(`{"path":"main.go"}`)}}},
+			{Role: testRoleTool, Content: "package main", ToolCallID: "1"},
 			{Role: testRoleUser, Content: strings.Repeat("x", 400)}, // ~100 tokens
 			{Role: testRoleUser, Content: "last"},
 		}
@@ -533,7 +718,7 @@ func TestExtractDroppedSummary(t *testing.T) {
 	t.Run("user messages only no tool calls", func(t *testing.T) {
 		blocks := []messageBlock{
 			{messages: []Message{{Role: testRoleUser, Content: "hello"}}, tokens: 2},
-			{messages: []Message{{Role: "assistant", Content: "hi there"}}, tokens: 3},
+			{messages: []Message{{Role: testRoleAssistant, Content: "hi there"}}, tokens: 3},
 		}
 		result := extractDroppedSummary(blocks)
 		if !strings.Contains(result, "messages dropped") {
@@ -548,8 +733,8 @@ func TestExtractDroppedSummary(t *testing.T) {
 		blocks := []messageBlock{
 			{
 				messages: []Message{
-					{Role: "assistant", ToolCalls: []ToolCall{{ID: "1", Name: "file_read", Arguments: json.RawMessage(`{"path":"main.go"}`)}}},
-					{Role: "tool", Content: "package main", ToolCallID: "1"},
+					{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "1", Name: "file_read", Arguments: json.RawMessage(`{"path":"main.go"}`)}}},
+					{Role: testRoleTool, Content: "package main", ToolCallID: "1"},
 				},
 				tokens: 10,
 			},
@@ -567,15 +752,15 @@ func TestExtractDroppedSummary(t *testing.T) {
 		blocks := []messageBlock{
 			{
 				messages: []Message{
-					{Role: "assistant", ToolCalls: []ToolCall{{ID: "1", Name: "file_read", Arguments: json.RawMessage(`{"path":"main.go"}`)}}},
-					{Role: "tool", Content: "content1", ToolCallID: "1"},
+					{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "1", Name: "file_read", Arguments: json.RawMessage(`{"path":"main.go"}`)}}},
+					{Role: testRoleTool, Content: "content1", ToolCallID: "1"},
 				},
 				tokens: 10,
 			},
 			{
 				messages: []Message{
-					{Role: "assistant", ToolCalls: []ToolCall{{ID: "2", Name: "file_read", Arguments: json.RawMessage(`{"path":"utils.go"}`)}}},
-					{Role: "tool", Content: "content2", ToolCallID: "2"},
+					{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "2", Name: "file_read", Arguments: json.RawMessage(`{"path":"utils.go"}`)}}},
+					{Role: testRoleTool, Content: "content2", ToolCallID: "2"},
 				},
 				tokens: 10,
 			},
@@ -596,8 +781,8 @@ func TestExtractDroppedSummary(t *testing.T) {
 		blocks := []messageBlock{
 			{
 				messages: []Message{
-					{Role: "assistant", ToolCalls: []ToolCall{{ID: "1", Name: "code_exec", Arguments: json.RawMessage(`{"language":"bash","code":"echo hi"}`)}}},
-					{Role: "tool", Content: "hi", ToolCallID: "1"},
+					{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "1", Name: "code_exec", Arguments: json.RawMessage(`{"language":"bash","code":"echo hi"}`)}}},
+					{Role: testRoleTool, Content: "hi", ToolCallID: "1"},
 				},
 				tokens: 10,
 			},
@@ -612,29 +797,29 @@ func TestExtractDroppedSummary(t *testing.T) {
 		blocks := []messageBlock{
 			{
 				messages: []Message{
-					{Role: "assistant", ToolCalls: []ToolCall{{ID: "1", Name: "file_read", Arguments: json.RawMessage(`{"path":"main.go"}`)}}},
-					{Role: "tool", Content: "pkg", ToolCallID: "1"},
+					{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "1", Name: "file_read", Arguments: json.RawMessage(`{"path":"main.go"}`)}}},
+					{Role: testRoleTool, Content: "pkg", ToolCallID: "1"},
 				},
 				tokens: 10,
 			},
 			{
 				messages: []Message{
-					{Role: "assistant", ToolCalls: []ToolCall{{ID: "2", Name: "web_search", Arguments: json.RawMessage(`{"query":"kubernetes pods"}`)}}},
-					{Role: "tool", Content: "results", ToolCallID: "2"},
+					{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "2", Name: "web_search", Arguments: json.RawMessage(`{"query":"kubernetes pods"}`)}}},
+					{Role: testRoleTool, Content: "results", ToolCallID: "2"},
 				},
 				tokens: 10,
 			},
 			{
 				messages: []Message{
-					{Role: "assistant", ToolCalls: []ToolCall{{ID: "3", Name: "web_fetch", Arguments: json.RawMessage(`{"url":"https://example.com"}`)}}},
-					{Role: "tool", Content: "page", ToolCallID: "3"},
+					{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "3", Name: "web_fetch", Arguments: json.RawMessage(`{"url":"https://example.com"}`)}}},
+					{Role: testRoleTool, Content: "page", ToolCallID: "3"},
 				},
 				tokens: 10,
 			},
 			{
 				messages: []Message{
-					{Role: "assistant", ToolCalls: []ToolCall{{ID: "4", Name: "code_exec", Arguments: json.RawMessage(`{"language":"python","code":"print(1)"}`)}}},
-					{Role: "tool", Content: "1", ToolCallID: "4"},
+					{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "4", Name: "code_exec", Arguments: json.RawMessage(`{"language":"python","code":"print(1)"}`)}}},
+					{Role: testRoleTool, Content: "1", ToolCallID: "4"},
 				},
 				tokens: 10,
 			},
@@ -661,8 +846,8 @@ func TestExtractDroppedSummary(t *testing.T) {
 		blocks := []messageBlock{
 			{
 				messages: []Message{
-					{Role: "assistant", ToolCalls: []ToolCall{{ID: "1", Name: "broken_tool", Arguments: json.RawMessage(`{invalid json`)}}},
-					{Role: "tool", Content: "error", ToolCallID: "1"},
+					{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "1", Name: "broken_tool", Arguments: json.RawMessage(`{invalid json`)}}},
+					{Role: testRoleTool, Content: "error", ToolCallID: "1"},
 				},
 				tokens: 10,
 			},
@@ -681,8 +866,8 @@ func TestExtractDroppedSummary(t *testing.T) {
 		blocks := []messageBlock{
 			{
 				messages: []Message{
-					{Role: "assistant", ToolCalls: []ToolCall{{ID: "1", Name: "web_fetch", Arguments: json.RawMessage(`{"url":"https://example.com"}`)}}},
-					{Role: "tool", Content: "page content", ToolCallID: "1"},
+					{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "1", Name: "web_fetch", Arguments: json.RawMessage(`{"url":"https://example.com"}`)}}},
+					{Role: testRoleTool, Content: "page content", ToolCallID: "1"},
 				},
 				tokens: 10,
 			},
@@ -697,8 +882,8 @@ func TestExtractDroppedSummary(t *testing.T) {
 		blocks := []messageBlock{
 			{
 				messages: []Message{
-					{Role: "assistant", ToolCalls: []ToolCall{{ID: "1", Name: "web_search", Arguments: json.RawMessage(`{"query":"kubernetes pods"}`)}}},
-					{Role: "tool", Content: "search results", ToolCallID: "1"},
+					{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "1", Name: "web_search", Arguments: json.RawMessage(`{"query":"kubernetes pods"}`)}}},
+					{Role: testRoleTool, Content: "search results", ToolCallID: "1"},
 				},
 				tokens: 10,
 			},
@@ -713,22 +898,22 @@ func TestExtractDroppedSummary(t *testing.T) {
 		blocks := []messageBlock{
 			{
 				messages: []Message{
-					{Role: "assistant", ToolCalls: []ToolCall{{ID: "1", Name: "sometool", Arguments: json.RawMessage(`{"x":1}`)}}},
-					{Role: "tool", Content: "r1", ToolCallID: "1"},
+					{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "1", Name: "sometool", Arguments: json.RawMessage(`{"x":1}`)}}},
+					{Role: testRoleTool, Content: "r1", ToolCallID: "1"},
 				},
 				tokens: 5,
 			},
 			{
 				messages: []Message{
-					{Role: "assistant", ToolCalls: []ToolCall{{ID: "2", Name: "sometool", Arguments: json.RawMessage(`{"x":2}`)}}},
-					{Role: "tool", Content: "r2", ToolCallID: "2"},
+					{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "2", Name: "sometool", Arguments: json.RawMessage(`{"x":2}`)}}},
+					{Role: testRoleTool, Content: "r2", ToolCallID: "2"},
 				},
 				tokens: 5,
 			},
 			{
 				messages: []Message{
-					{Role: "assistant", ToolCalls: []ToolCall{{ID: "3", Name: "sometool", Arguments: json.RawMessage(`{"x":3}`)}}},
-					{Role: "tool", Content: "r3", ToolCallID: "3"},
+					{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "3", Name: "sometool", Arguments: json.RawMessage(`{"x":3}`)}}},
+					{Role: testRoleTool, Content: "r3", ToolCallID: "3"},
 				},
 				tokens: 5,
 			},
@@ -750,8 +935,8 @@ func TestExtractDroppedSummary(t *testing.T) {
 				Arguments: json.RawMessage(fmt.Sprintf(`{"path":"file%d.go"}`, i)),
 			}
 			blockMsgs = append(blockMsgs,
-				Message{Role: "assistant", ToolCalls: []ToolCall{args[i]}},
-				Message{Role: "tool", Content: "ok", ToolCallID: args[i].ID},
+				Message{Role: testRoleAssistant, ToolCalls: []ToolCall{args[i]}},
+				Message{Role: testRoleTool, Content: "ok", ToolCallID: args[i].ID},
 			)
 		}
 		blocks := []messageBlock{{messages: blockMsgs, tokens: 50}}
@@ -769,8 +954,8 @@ func TestExtractDroppedSummary(t *testing.T) {
 		blocks := []messageBlock{
 			{
 				messages: []Message{
-					{Role: "assistant", ToolCalls: []ToolCall{{ID: "1", Name: "file_read", Arguments: json.RawMessage(fmt.Sprintf(`{"path":%q}`, longPath))}}},
-					{Role: "tool", Content: "ok", ToolCallID: "1"},
+					{Role: testRoleAssistant, ToolCalls: []ToolCall{{ID: "1", Name: "file_read", Arguments: json.RawMessage(fmt.Sprintf(`{"path":%q}`, longPath))}}},
+					{Role: testRoleTool, Content: "ok", ToolCallID: "1"},
 				},
 				tokens: 10,
 			},

--- a/internal/tools/common_constants.go
+++ b/internal/tools/common_constants.go
@@ -152,6 +152,7 @@ const (
 	falseStr               = "false"
 	mergeMethodMerge       = "merge"
 	mergeMethodRebase      = "rebase"
+	providerAnthropic      = "anthropic"
 	providerOpenAI         = "openai"
 	errTypeNotFound        = "not_found"
 	internalErrorType      = "internal_error"

--- a/internal/tools/update_agent.go
+++ b/internal/tools/update_agent.go
@@ -29,7 +29,18 @@ func (t *UpdateAgentTool) Description() string {
 
 func (t *UpdateAgentTool) Parameters() json.RawMessage {
 	return mustMarshalSchema(map[string]any{jsonSchemaTypeField: jsonSchemaTypeObject, jsonSchemaPropertiesField: map[string]any{nameField: map[string]any{jsonSchemaTypeField: jsonSchemaTypeString, jsonSchemaDescriptionField: agentNameDescription}, namespaceField: map[string]any{jsonSchemaTypeField: jsonSchemaTypeString, jsonSchemaDescriptionField: namespaceDescription}, systemPromptField: map[string]any{jsonSchemaTypeField: jsonSchemaTypeString, jsonSchemaDescriptionField: "System prompt for the agent"}, toolsField: map[string]any{jsonSchemaTypeField: jsonSchemaTypeArray, itemsField: map[string]any{jsonSchemaTypeField: jsonSchemaTypeString}, jsonSchemaDescriptionField: "Tool names to attach"}, modelField: map[string]any{jsonSchemaTypeField: jsonSchemaTypeObject, jsonSchemaPropertiesField: map[string]any{
-		"provider": map[string]any{jsonSchemaTypeField: jsonSchemaTypeString, jsonSchemaDescriptionField: "Model provider (e.g. anthropic, openai)"}, nameField: map[string]any{jsonSchemaTypeField: jsonSchemaTypeString, jsonSchemaDescriptionField: "Model name"}, "temperature": map[string]any{jsonSchemaTypeField: "number", jsonSchemaDescriptionField: "Sampling temperature", jsonSchemaMinimumField: 0, jsonSchemaMaximumField: 2},
+		"provider": map[string]any{
+			jsonSchemaTypeField:        jsonSchemaTypeString,
+			jsonSchemaEnumField:        []string{providerAnthropic, providerOpenAI},
+			jsonSchemaDescriptionField: "Model provider (anthropic or openai)",
+		},
+		nameField: map[string]any{jsonSchemaTypeField: jsonSchemaTypeString, jsonSchemaDescriptionField: "Model name"},
+		"temperature": map[string]any{
+			jsonSchemaTypeField:        "number",
+			jsonSchemaDescriptionField: "Sampling temperature",
+			jsonSchemaMinimumField:     0,
+			jsonSchemaMaximumField:     2,
+		},
 	},
 	},
 	}, jsonSchemaRequiredField: []string{nameField},
@@ -109,6 +120,9 @@ func applyAgentModelUpdate(agent *corev1alpha1.Agent, value any) error {
 			if !ok {
 				return fmt.Errorf("model.provider must be a string")
 			}
+			if err := validateAgentModelProvider(providerValue); err != nil {
+				return err
+			}
 			provider = &providerValue
 		}
 
@@ -155,6 +169,11 @@ func applyAgentModelUpdate(agent *corev1alpha1.Agent, value any) error {
 			return nil
 		}
 		provider, name := splitModelString(model)
+		if provider != "" {
+			if err := validateAgentModelProvider(provider); err != nil {
+				return err
+			}
+		}
 		if agent.Spec.Model == nil {
 			agent.Spec.Model = &corev1alpha1.ModelConfig{}
 		}
@@ -166,5 +185,17 @@ func applyAgentModelUpdate(agent *corev1alpha1.Agent, value any) error {
 
 	default:
 		return fmt.Errorf("model must be an object or legacy provider/name string")
+	}
+}
+
+func validateAgentModelProvider(provider string) error {
+	switch provider {
+	case providerAnthropic, providerOpenAI:
+		return nil
+	default:
+		return fmt.Errorf(
+			"model.provider must be one of %q or %q",
+			providerAnthropic, providerOpenAI,
+		)
 	}
 }

--- a/internal/tools/update_agent.go
+++ b/internal/tools/update_agent.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -19,6 +18,8 @@ import (
 
 // UpdateAgentTool updates an existing Agent CRD.
 type UpdateAgentTool struct{}
+
+const updateAgentInvalidArgumentsErrorType = "invalid_arguments"
 
 func (t *UpdateAgentTool) Name() string { return updateAgentToolName }
 
@@ -43,12 +44,12 @@ func (t *UpdateAgentTool) Execute(ctx context.Context, args json.RawMessage) (st
 
 	var a map[string]any
 	if err := json.Unmarshal(args, &a); err != nil {
-		return ChatToolErrorResult("invalid_arguments", fmt.Sprintf("failed to parse arguments: %v", err), "Ensure arguments are valid JSON")
+		return ChatToolErrorResult(updateAgentInvalidArgumentsErrorType, fmt.Sprintf("failed to parse arguments: %v", err), "Ensure arguments are valid JSON")
 	}
 
 	name := chatGetStringArg(a, nameField)
 	if name == "" {
-		return ChatToolErrorResult("invalid_arguments", "name is required", "Provide the agent name")
+		return ChatToolErrorResult(updateAgentInvalidArgumentsErrorType, "name is required", "Provide the agent name")
 	}
 
 	namespace := chatGetStringArgDefault(a, namespaceField, tc.Namespace)
@@ -59,16 +60,13 @@ func (t *UpdateAgentTool) Execute(ctx context.Context, args json.RawMessage) (st
 	}
 
 	// Update specified fields
-	if modelProvider := chatGetStringArg(a, modelField); modelProvider != "" {
-		parts := strings.SplitN(modelProvider, "/", 2)
-		if agent.Spec.Model == nil {
-			agent.Spec.Model = &corev1alpha1.ModelConfig{}
-		}
-		if len(parts) == 2 {
-			agent.Spec.Model.Provider = parts[0]
-			agent.Spec.Model.Name = parts[1]
-		} else {
-			agent.Spec.Model.Name = modelProvider
+	if modelValue, ok := a[modelField]; ok {
+		if err := applyAgentModelUpdate(agent, modelValue); err != nil {
+			return ChatToolErrorResult(
+				updateAgentInvalidArgumentsErrorType,
+				err.Error(),
+				"Provide model as an object with string provider/name fields and a numeric temperature",
+			)
 		}
 	}
 
@@ -100,4 +98,70 @@ func (t *UpdateAgentTool) Execute(ctx context.Context, args json.RawMessage) (st
 	}
 
 	return ChatToolSuccess(map[string]any{nameField: agent.Name, messageField: "Agent updated"})
+}
+
+func applyAgentModelUpdate(agent *corev1alpha1.Agent, value any) error {
+	switch model := value.(type) {
+	case map[string]any:
+		var provider *string
+		if value, ok := model["provider"]; ok {
+			providerValue, ok := value.(string)
+			if !ok {
+				return fmt.Errorf("model.provider must be a string")
+			}
+			provider = &providerValue
+		}
+
+		var name *string
+		if value, ok := model[nameField]; ok {
+			nameValue, ok := value.(string)
+			if !ok {
+				return fmt.Errorf("model.name must be a string")
+			}
+			name = &nameValue
+		}
+
+		var temperature *float64
+		if value, ok := model["temperature"]; ok {
+			temperatureValue, ok := value.(float64)
+			if !ok {
+				return fmt.Errorf("model.temperature must be a number")
+			}
+			temperature = &temperatureValue
+		}
+
+		if provider == nil && name == nil && temperature == nil {
+			return nil
+		}
+		if agent.Spec.Model == nil {
+			agent.Spec.Model = &corev1alpha1.ModelConfig{}
+		}
+		if provider != nil {
+			agent.Spec.Model.Provider = *provider
+		}
+		if name != nil {
+			agent.Spec.Model.Name = *name
+		}
+		if temperature != nil {
+			agent.Spec.Model.Temperature = temperature
+		}
+		return nil
+
+	case string:
+		if model == "" {
+			return nil
+		}
+		provider, name := splitModelString(model)
+		if agent.Spec.Model == nil {
+			agent.Spec.Model = &corev1alpha1.ModelConfig{}
+		}
+		if provider != "" {
+			agent.Spec.Model.Provider = provider
+		}
+		agent.Spec.Model.Name = name
+		return nil
+
+	default:
+		return fmt.Errorf("model must be an object or legacy provider/name string")
+	}
 }

--- a/internal/tools/update_agent.go
+++ b/internal/tools/update_agent.go
@@ -29,7 +29,7 @@ func (t *UpdateAgentTool) Description() string {
 
 func (t *UpdateAgentTool) Parameters() json.RawMessage {
 	return mustMarshalSchema(map[string]any{jsonSchemaTypeField: jsonSchemaTypeObject, jsonSchemaPropertiesField: map[string]any{nameField: map[string]any{jsonSchemaTypeField: jsonSchemaTypeString, jsonSchemaDescriptionField: agentNameDescription}, namespaceField: map[string]any{jsonSchemaTypeField: jsonSchemaTypeString, jsonSchemaDescriptionField: namespaceDescription}, systemPromptField: map[string]any{jsonSchemaTypeField: jsonSchemaTypeString, jsonSchemaDescriptionField: "System prompt for the agent"}, toolsField: map[string]any{jsonSchemaTypeField: jsonSchemaTypeArray, itemsField: map[string]any{jsonSchemaTypeField: jsonSchemaTypeString}, jsonSchemaDescriptionField: "Tool names to attach"}, modelField: map[string]any{jsonSchemaTypeField: jsonSchemaTypeObject, jsonSchemaPropertiesField: map[string]any{
-		"provider": map[string]any{jsonSchemaTypeField: jsonSchemaTypeString, jsonSchemaDescriptionField: "Model provider (e.g. anthropic, openai)"}, nameField: map[string]any{jsonSchemaTypeField: jsonSchemaTypeString, jsonSchemaDescriptionField: "Model name"}, "temperature": map[string]any{jsonSchemaTypeField: "number", jsonSchemaDescriptionField: "Sampling temperature"},
+		"provider": map[string]any{jsonSchemaTypeField: jsonSchemaTypeString, jsonSchemaDescriptionField: "Model provider (e.g. anthropic, openai)"}, nameField: map[string]any{jsonSchemaTypeField: jsonSchemaTypeString, jsonSchemaDescriptionField: "Model name"}, "temperature": map[string]any{jsonSchemaTypeField: "number", jsonSchemaDescriptionField: "Sampling temperature", jsonSchemaMinimumField: 0, jsonSchemaMaximumField: 2},
 	},
 	},
 	}, jsonSchemaRequiredField: []string{nameField},
@@ -126,6 +126,9 @@ func applyAgentModelUpdate(agent *corev1alpha1.Agent, value any) error {
 			temperatureValue, ok := value.(float64)
 			if !ok {
 				return fmt.Errorf("model.temperature must be a number")
+			}
+			if temperatureValue < 0 || temperatureValue > 2 {
+				return fmt.Errorf("model.temperature must be between 0 and 2")
 			}
 			temperature = &temperatureValue
 		}

--- a/internal/tools/update_agent_test.go
+++ b/internal/tools/update_agent_test.go
@@ -61,6 +61,15 @@ func TestUpdateAgentTool_Parameters(t *testing.T) {
 	if !ok {
 		t.Fatal("model schema properties are missing")
 	}
+	provider, ok := modelProps["provider"].(map[string]any)
+	if !ok {
+		t.Fatal("provider schema is missing")
+	}
+	providerEnum, ok := provider[jsonSchemaEnumField].([]any)
+	if !ok || len(providerEnum) != 2 ||
+		providerEnum[0] != providerAnthropic || providerEnum[1] != providerOpenAI {
+		t.Fatalf("provider enum = %#v, want [anthropic openai]", provider[jsonSchemaEnumField])
+	}
 	temperature, ok := modelProps["temperature"].(map[string]any)
 	if !ok {
 		t.Fatal("temperature schema is missing")
@@ -320,6 +329,9 @@ func TestUpdateAgentTool_Execute_RejectsUnsupportedModelTypes(t *testing.T) {
 	}{
 		{name: "model must be object or legacy string", model: []any{"openai", testGPT4OModel}},
 		{name: "provider must be string", model: map[string]any{"provider": true}},
+		{name: "object provider must not be empty", model: map[string]any{"provider": ""}},
+		{name: "object provider must be supported", model: map[string]any{"provider": "anthorpic"}},
+		{name: "legacy provider must be supported", model: "anthorpic/claude-sonnet"},
 		{name: "name must be string", model: map[string]any{nameField: 42}},
 		{name: "temperature must be number", model: map[string]any{"temperature": "warm"}},
 		{name: "temperature below minimum", model: map[string]any{"temperature": -0.1}},

--- a/internal/tools/update_agent_test.go
+++ b/internal/tools/update_agent_test.go
@@ -199,6 +199,158 @@ func TestUpdateAgentTool_Execute_VerifyUpdatedFields(t *testing.T) {
 	}
 }
 
+func TestUpdateAgentTool_Execute_ModelObjectUpdatesAndPreservesUnspecifiedFields(t *testing.T) {
+	originalTemperature := 0.2
+	originalMaxTokens := int32(4096)
+	agent := &corev1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testMyAgentName,
+			Namespace: defaultNamespace,
+		},
+		Spec: corev1alpha1.AgentSpec{
+			Model: &corev1alpha1.ModelConfig{
+				Provider:    providerOpenAI,
+				Name:        testGPT4OModel,
+				Temperature: &originalTemperature,
+				MaxTokens:   &originalMaxTokens,
+			},
+		},
+	}
+
+	fc := newFakeClient(agent)
+	ctx := WithToolContext(context.Background(), &ToolContext{Client: fc, Namespace: defaultNamespace})
+	result, err := (&UpdateAgentTool{}).Execute(ctx, json.RawMessage(`{
+		"name":"my-agent",
+		"model":{"provider":"anthropic","name":"claude-sonnet-4-20250514","temperature":0.4}
+	}`))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	var res ChatToolResult
+	if err := json.Unmarshal([]byte(result), &res); err != nil {
+		t.Fatalf("failed to parse result: %v", err)
+	}
+	if !res.Success {
+		t.Fatalf("Execute() result = %#v, want success", res)
+	}
+
+	updated := &corev1alpha1.Agent{}
+	if err := fc.Get(context.Background(), apitypes.NamespacedName{Name: testMyAgentName, Namespace: defaultNamespace}, updated); err != nil {
+		t.Fatalf("failed to get updated agent: %v", err)
+	}
+	if updated.Spec.Model == nil {
+		t.Fatal("model is nil")
+	}
+	if updated.Spec.Model.Provider != "anthropic" {
+		t.Errorf("model.provider = %q, want anthropic", updated.Spec.Model.Provider)
+	}
+	if updated.Spec.Model.Name != "claude-sonnet-4-20250514" {
+		t.Errorf("model.name = %q, want claude-sonnet-4-20250514", updated.Spec.Model.Name)
+	}
+	if updated.Spec.Model.Temperature == nil || *updated.Spec.Model.Temperature != 0.4 {
+		t.Errorf("model.temperature = %v, want 0.4", updated.Spec.Model.Temperature)
+	}
+	if updated.Spec.Model.MaxTokens == nil || *updated.Spec.Model.MaxTokens != originalMaxTokens {
+		t.Errorf("model.maxTokens = %v, want preserved value %d", updated.Spec.Model.MaxTokens, originalMaxTokens)
+	}
+}
+
+func TestUpdateAgentTool_Execute_ModelObjectPreservesOmittedModelFields(t *testing.T) {
+	originalTemperature := 0.2
+	agent := &corev1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: testMyAgentName, Namespace: defaultNamespace},
+		Spec: corev1alpha1.AgentSpec{Model: &corev1alpha1.ModelConfig{
+			Provider:    providerOpenAI,
+			Name:        testGPT4OModel,
+			Temperature: &originalTemperature,
+		}},
+	}
+
+	fc := newFakeClient(agent)
+	ctx := WithToolContext(context.Background(), &ToolContext{Client: fc, Namespace: defaultNamespace})
+	result, err := (&UpdateAgentTool{}).Execute(ctx, json.RawMessage(`{"name":"my-agent","model":{"temperature":0}}`))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	var res ChatToolResult
+	if err := json.Unmarshal([]byte(result), &res); err != nil {
+		t.Fatalf("failed to parse result: %v", err)
+	}
+	if !res.Success {
+		t.Fatalf("Execute() result = %#v, want success", res)
+	}
+
+	updated := &corev1alpha1.Agent{}
+	if err := fc.Get(context.Background(), apitypes.NamespacedName{Name: testMyAgentName, Namespace: defaultNamespace}, updated); err != nil {
+		t.Fatalf("failed to get updated agent: %v", err)
+	}
+	if updated.Spec.Model == nil {
+		t.Fatal("model is nil")
+	}
+	if updated.Spec.Model.Provider != providerOpenAI {
+		t.Errorf("model.provider = %q, want preserved value %q", updated.Spec.Model.Provider, providerOpenAI)
+	}
+	if updated.Spec.Model.Name != testGPT4OModel {
+		t.Errorf("model.name = %q, want preserved value %q", updated.Spec.Model.Name, testGPT4OModel)
+	}
+	if updated.Spec.Model.Temperature == nil || *updated.Spec.Model.Temperature != 0 {
+		t.Errorf("model.temperature = %v, want 0", updated.Spec.Model.Temperature)
+	}
+}
+
+func TestUpdateAgentTool_Execute_RejectsUnsupportedModelTypes(t *testing.T) {
+	tests := []struct {
+		name  string
+		model any
+	}{
+		{name: "model must be object or legacy string", model: []any{"openai", testGPT4OModel}},
+		{name: "provider must be string", model: map[string]any{"provider": true}},
+		{name: "name must be string", model: map[string]any{nameField: 42}},
+		{name: "temperature must be number", model: map[string]any{"temperature": "warm"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agent := &corev1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{Name: testMyAgentName, Namespace: defaultNamespace},
+				Spec: corev1alpha1.AgentSpec{Model: &corev1alpha1.ModelConfig{
+					Provider: providerOpenAI,
+					Name:     testGPT4OModel,
+				}},
+			}
+			fc := newFakeClient(agent)
+			ctx := WithToolContext(context.Background(), &ToolContext{Client: fc, Namespace: defaultNamespace})
+			args, err := json.Marshal(map[string]any{nameField: testMyAgentName, modelField: tt.model})
+			if err != nil {
+				t.Fatalf("failed to marshal args: %v", err)
+			}
+
+			result, err := (&UpdateAgentTool{}).Execute(ctx, args)
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			var res ChatToolResult
+			if err := json.Unmarshal([]byte(result), &res); err != nil {
+				t.Fatalf("failed to parse result: %v", err)
+			}
+			if res.Success {
+				t.Fatalf("Execute() result = %#v, want invalid_arguments", res)
+			}
+			if res.ErrorType != errTypeInvalidArgs {
+				t.Fatalf("errorType = %q, want invalid_arguments", res.ErrorType)
+			}
+
+			unchanged := &corev1alpha1.Agent{}
+			if err := fc.Get(context.Background(), apitypes.NamespacedName{Name: testMyAgentName, Namespace: defaultNamespace}, unchanged); err != nil {
+				t.Fatalf("failed to get agent: %v", err)
+			}
+			if unchanged.Spec.Model == nil || unchanged.Spec.Model.Provider != providerOpenAI || unchanged.Spec.Model.Name != testGPT4OModel {
+				t.Fatalf("model changed after rejected input: %#v", unchanged.Spec.Model)
+			}
+		})
+	}
+}
+
 func TestUpdateAgentTool_Execute_MissingToolContext(t *testing.T) {
 	tool := &UpdateAgentTool{}
 	result, err := tool.Execute(context.Background(), json.RawMessage(`{"name":"x"}`))
@@ -231,7 +383,7 @@ func TestUpdateAgentTool_Execute_InvalidJSON(t *testing.T) {
 	if res.Success {
 		t.Error("expected failure for invalid JSON")
 	}
-	if res.ErrorType != "invalid_arguments" {
+	if res.ErrorType != errTypeInvalidArgs {
 		t.Errorf("expected errorType 'invalid_arguments', got %q", res.ErrorType)
 	}
 }

--- a/internal/tools/update_agent_test.go
+++ b/internal/tools/update_agent_test.go
@@ -53,6 +53,21 @@ func TestUpdateAgentTool_Parameters(t *testing.T) {
 			t.Errorf("missing %s property", key)
 		}
 	}
+	modelSchema, ok := props[modelField].(map[string]any)
+	if !ok {
+		t.Fatal("model schema is not an object")
+	}
+	modelProps, ok := modelSchema[jsonSchemaPropertiesField].(map[string]any)
+	if !ok {
+		t.Fatal("model schema properties are missing")
+	}
+	temperature, ok := modelProps["temperature"].(map[string]any)
+	if !ok {
+		t.Fatal("temperature schema is missing")
+	}
+	if temperature[jsonSchemaMinimumField] != float64(0) || temperature[jsonSchemaMaximumField] != float64(2) {
+		t.Fatalf("temperature bounds = %#v, want [0,2]", temperature)
+	}
 }
 
 func TestUpdateAgentTool_Execute(t *testing.T) {
@@ -307,6 +322,8 @@ func TestUpdateAgentTool_Execute_RejectsUnsupportedModelTypes(t *testing.T) {
 		{name: "provider must be string", model: map[string]any{"provider": true}},
 		{name: "name must be string", model: map[string]any{nameField: 42}},
 		{name: "temperature must be number", model: map[string]any{"temperature": "warm"}},
+		{name: "temperature below minimum", model: map[string]any{"temperature": -0.1}},
+		{name: "temperature above maximum", model: map[string]any{"temperature": 2.1}},
 	}
 
 	for _, tt := range tests {

--- a/internal/tools/update_plan.go
+++ b/internal/tools/update_plan.go
@@ -12,18 +12,63 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/orka-agents/orka/internal/workerenv"
 )
 
+const (
+	updatePlanRequestTimeout         = 10 * time.Second
+	updatePlanResponseHeaderTimeout  = 10 * time.Second
+	updatePlanResponseBodyTimeout    = 100 * time.Millisecond
+	updatePlanErrorBodyLimit         = 4 << 10
+	updatePlanResponseBodyDrainLimit = 64 << 10
+)
+
 // UpdatePlanTool allows the LLM to update the autonomous plan state.
-type UpdatePlanTool struct{}
+type UpdatePlanTool struct {
+	client              *http.Client
+	requestTimeout      time.Duration
+	responseBodyTimeout time.Duration
+}
 
 // NewUpdatePlanTool creates a new UpdatePlanTool.
 func NewUpdatePlanTool() *UpdatePlanTool {
-	return &UpdatePlanTool{}
+	return &UpdatePlanTool{
+		client:              newUpdatePlanHTTPClient(updatePlanResponseHeaderTimeout),
+		requestTimeout:      updatePlanRequestTimeout,
+		responseBodyTimeout: updatePlanResponseBodyTimeout,
+	}
+}
+
+// newUpdatePlanHTTPClient preserves the standard dial, TLS, and idle-connection
+// safeguards while adding a bounded wait for controller response headers.
+func newUpdatePlanHTTPClient(responseHeaderTimeout time.Duration) *http.Client {
+	transport := cloneDefaultUpdatePlanTransport()
+	transport.ResponseHeaderTimeout = responseHeaderTimeout
+	return &http.Client{Transport: transport}
+}
+
+func cloneDefaultUpdatePlanTransport() *http.Transport {
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		return transport.Clone()
+	}
+
+	const defaultDialTimeout = 30 * time.Second
+	return &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           (&net.Dialer{Timeout: defaultDialTimeout, KeepAlive: defaultDialTimeout}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: time.Second,
+	}
 }
 
 // Name returns the tool name.
@@ -107,8 +152,15 @@ func (t *UpdatePlanTool) Execute(ctx context.Context, args json.RawMessage) (str
 		return "", fmt.Errorf("failed to marshal plan: %w", err)
 	}
 
+	requestTimeout := t.requestTimeout
+	if requestTimeout <= 0 {
+		requestTimeout = updatePlanRequestTimeout
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
 	url := fmt.Sprintf("%s/internal/v1/plans/%s/%s", controllerURL, taskNamespace, taskName)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
@@ -117,15 +169,41 @@ func (t *UpdatePlanTool) Execute(ctx context.Context, args json.RawMessage) (str
 		req.Header.Set("Authorization", "Bearer "+saToken)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	client := t.client
+	if client == nil {
+		client = newUpdatePlanHTTPClient(updatePlanResponseHeaderTimeout)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to save plan: %w", err)
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	if resp.Body == nil {
+		return "", fmt.Errorf("failed to save plan: controller returned an empty response body handle")
+	}
+
+	responseBodyTimeout := t.responseBodyTimeout
+	if responseBodyTimeout <= 0 {
+		responseBodyTimeout = updatePlanResponseBodyTimeout
+	}
+	bodyTimer := time.AfterFunc(responseBodyTimeout, cancel)
+	defer func() {
+		bodyTimer.Stop()
+		cancel()
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		preview, consumed, readErr := readUpdatePlanErrorBody(resp.Body)
+		drainUpdatePlanResponseBody(resp.Body, updatePlanResponseBodyDrainLimit-consumed)
+		if preview != "" {
+			return "", fmt.Errorf("failed to save plan: HTTP %d: %s", resp.StatusCode, preview)
+		}
+		if readErr != nil {
+			return "", fmt.Errorf("failed to save plan: HTTP %d: read error response: %w", resp.StatusCode, readErr)
+		}
 		return "", fmt.Errorf("failed to save plan: HTTP %d", resp.StatusCode)
 	}
+	drainUpdatePlanResponseBody(resp.Body, updatePlanResponseBodyDrainLimit)
 
 	result := fmt.Sprintf("Plan updated: %s (progress: %d%%", a.Summary, a.ProgressPct)
 	if a.GoalComplete {
@@ -134,4 +212,26 @@ func (t *UpdatePlanTool) Execute(ctx context.Context, args json.RawMessage) (str
 	result += ")"
 
 	return result, nil
+}
+
+func readUpdatePlanErrorBody(body io.Reader) (string, int64, error) {
+	limited := &io.LimitedReader{R: body, N: updatePlanErrorBodyLimit + 1}
+	data, err := io.ReadAll(limited)
+	consumed := int64(len(data))
+	truncated := len(data) > updatePlanErrorBodyLimit
+	if truncated {
+		data = data[:updatePlanErrorBodyLimit]
+	}
+	preview := strings.TrimSpace(string(data))
+	if truncated {
+		preview += " [truncated]"
+	}
+	return preview, consumed, err
+}
+
+func drainUpdatePlanResponseBody(body io.Reader, limit int64) {
+	if limit <= 0 {
+		return
+	}
+	_, _ = io.CopyN(io.Discard, body, limit)
 }

--- a/internal/tools/update_plan_test.go
+++ b/internal/tools/update_plan_test.go
@@ -7,18 +7,69 @@ MIT License - see LICENSE file for details.
 package tools
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestUpdatePlanTool_Name(t *testing.T) {
 	tool := NewUpdatePlanTool()
 	if got := tool.Name(); got != updatePlanToolName {
 		t.Errorf("Name() = %q, want %q", got, updatePlanToolName)
+	}
+}
+
+func TestNewUpdatePlanTool_DoesNotAssumeDefaultTransportType(t *testing.T) {
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = updatePlanRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("unused")
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	tool := NewUpdatePlanTool()
+	if tool.client == nil || tool.client.Transport == nil {
+		t.Fatal("NewUpdatePlanTool() did not configure an HTTP transport")
+	}
+}
+
+func TestNewUpdatePlanTool_ConfiguresBoundedClientAndContext(t *testing.T) {
+	tool := NewUpdatePlanTool()
+	if tool.requestTimeout != updatePlanRequestTimeout {
+		t.Fatalf("requestTimeout = %s, want %s", tool.requestTimeout, updatePlanRequestTimeout)
+	}
+	if tool.responseBodyTimeout != updatePlanResponseBodyTimeout {
+		t.Fatalf("responseBodyTimeout = %s, want %s", tool.responseBodyTimeout, updatePlanResponseBodyTimeout)
+	}
+	if tool.client == nil {
+		t.Fatal("HTTP client is nil")
+	}
+	if tool.client.Timeout != 0 {
+		t.Fatalf("HTTP client timeout = %s, want request context to own overall timeout", tool.client.Timeout)
+	}
+
+	transport, ok := tool.client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("HTTP client transport = %T, want *http.Transport", tool.client.Transport)
+	}
+	if transport.DialContext == nil {
+		t.Fatal("transport DialContext is nil")
+	}
+	if transport.TLSHandshakeTimeout <= 0 {
+		t.Fatalf("TLSHandshakeTimeout = %s, want positive timeout", transport.TLSHandshakeTimeout)
+	}
+	if transport.ResponseHeaderTimeout != updatePlanResponseHeaderTimeout {
+		t.Fatalf("ResponseHeaderTimeout = %s, want %s", transport.ResponseHeaderTimeout, updatePlanResponseHeaderTimeout)
+	}
+	if transport.IdleConnTimeout <= 0 {
+		t.Fatalf("IdleConnTimeout = %s, want positive timeout", transport.IdleConnTimeout)
 	}
 }
 
@@ -314,4 +365,203 @@ func TestUpdatePlanTool_Execute_RequestBodyValid(t *testing.T) {
 	if received.PlanDocument != "# My Plan" {
 		t.Errorf("body plan_document = %q, want %q", received.PlanDocument, "# My Plan")
 	}
+}
+
+func TestUpdatePlanTool_Execute_ResponseHeaderStallIsBounded(t *testing.T) {
+	const requestTimeout = 25 * time.Millisecond
+
+	requestStarted := make(chan struct{})
+	tool := &UpdatePlanTool{
+		client: &http.Client{Transport: updatePlanRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			close(requestStarted)
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		})},
+		requestTimeout:      requestTimeout,
+		responseBodyTimeout: time.Second,
+	}
+	t.Setenv(envOrkaControllerURL, localhostURL)
+	t.Setenv(envOrkaTaskName, "task")
+	t.Setenv(envOrkaTaskNamespace, "ns")
+	t.Setenv("ORKA_SA_TOKEN", "")
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := tool.Execute(context.Background(), json.RawMessage(testPlanJSON))
+		done <- err
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("update_plan request did not start")
+	}
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+			t.Fatalf("Execute() error = %v, want context deadline exceeded", err)
+		}
+	case <-time.After(10 * requestTimeout):
+		t.Fatalf("Execute() did not return within bounded request timeout %s", requestTimeout)
+	}
+}
+
+func TestUpdatePlanTool_Execute_BoundsErrorBodyReadAndDrain(t *testing.T) {
+	body := &updatePlanTrackingReadCloser{reader: strings.NewReader(strings.Repeat("x", 1<<20))}
+	tool := &UpdatePlanTool{
+		client: &http.Client{Transport: updatePlanRoundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Header:     make(http.Header),
+				Body:       body,
+			}, nil
+		})},
+		requestTimeout:      time.Second,
+		responseBodyTimeout: time.Second,
+	}
+	setUpdatePlanTestEnv(t)
+
+	_, err := tool.Execute(t.Context(), json.RawMessage(testPlanJSON))
+	if err == nil {
+		t.Fatal("Execute() error = nil, want HTTP error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 500") || !strings.Contains(err.Error(), "[truncated]") {
+		t.Fatalf("Execute() error = %q, want bounded truncated preview", err)
+	}
+	if !body.closed {
+		t.Fatal("response body was not closed")
+	}
+	if body.bytesRead != updatePlanResponseBodyDrainLimit {
+		t.Fatalf("response body bytes read = %d, want bounded total %d", body.bytesRead, updatePlanResponseBodyDrainLimit)
+	}
+}
+
+func TestUpdatePlanTool_Execute_ErrorBodyStallIsBounded(t *testing.T) {
+	const bodyTimeout = 25 * time.Millisecond
+	body := newUpdatePlanBlockingReadCloser()
+	tool := &UpdatePlanTool{
+		client: &http.Client{Transport: updatePlanRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			go func() {
+				<-req.Context().Done()
+				_ = body.Close()
+			}()
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Header:     make(http.Header),
+				Body:       body,
+			}, nil
+		})},
+		requestTimeout:      time.Second,
+		responseBodyTimeout: bodyTimeout,
+	}
+	setUpdatePlanTestEnv(t)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := tool.Execute(context.Background(), json.RawMessage(testPlanJSON))
+		done <- err
+	}()
+
+	select {
+	case <-body.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("error response read did not start")
+	}
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "HTTP 500") {
+			t.Fatalf("Execute() error = %v, want HTTP status error", err)
+		}
+	case <-time.After(10 * bodyTimeout):
+		_ = body.Close()
+		t.Fatal("error response read did not return within its body timeout")
+	}
+}
+
+func TestUpdatePlanTool_Execute_BoundsSuccessResponseDrain(t *testing.T) {
+	body := &updatePlanTrackingReadCloser{reader: strings.NewReader(strings.Repeat("x", 1<<20))}
+	tool := &UpdatePlanTool{
+		client: &http.Client{Transport: updatePlanRoundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       body,
+			}, nil
+		})},
+		requestTimeout:      time.Second,
+		responseBodyTimeout: time.Second,
+	}
+	setUpdatePlanTestEnv(t)
+
+	result, err := tool.Execute(t.Context(), json.RawMessage(testPlanJSON))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result == "" {
+		t.Fatal("Execute() result is empty")
+	}
+	if !body.closed {
+		t.Fatal("response body was not closed")
+	}
+	if body.bytesRead != updatePlanResponseBodyDrainLimit {
+		t.Fatalf("response body bytes read = %d, want bounded drain %d", body.bytesRead, updatePlanResponseBodyDrainLimit)
+	}
+}
+
+func setUpdatePlanTestEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(envOrkaControllerURL, localhostURL)
+	t.Setenv(envOrkaTaskName, "task")
+	t.Setenv(envOrkaTaskNamespace, "ns")
+	t.Setenv("ORKA_SA_TOKEN", "")
+}
+
+type updatePlanRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f updatePlanRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type updatePlanTrackingReadCloser struct {
+	reader    io.Reader
+	bytesRead int64
+	closed    bool
+}
+
+func (r *updatePlanTrackingReadCloser) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.bytesRead += int64(n)
+	return n, err
+}
+
+func (r *updatePlanTrackingReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+type updatePlanBlockingReadCloser struct {
+	readStarted chan struct{}
+	closed      chan struct{}
+	readOnce    sync.Once
+	closeOnce   sync.Once
+}
+
+func newUpdatePlanBlockingReadCloser() *updatePlanBlockingReadCloser {
+	return &updatePlanBlockingReadCloser{
+		readStarted: make(chan struct{}),
+		closed:      make(chan struct{}),
+	}
+}
+
+func (r *updatePlanBlockingReadCloser) Read([]byte) (int, error) {
+	r.readOnce.Do(func() { close(r.readStarted) })
+	<-r.closed
+	return 0, io.ErrClosedPipe
+}
+
+func (r *updatePlanBlockingReadCloser) Close() error {
+	r.closeOnce.Do(func() { close(r.closed) })
+	return nil
 }

--- a/internal/tools/wait_for_tasks.go
+++ b/internal/tools/wait_for_tasks.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -178,6 +179,7 @@ func (t *WaitForTasksTool) Execute(ctx context.Context, args json.RawMessage) (s
 			if err != nil {
 				results[taskName].Phase = taskPhaseErrorString
 				results[taskName].Result = fmt.Sprintf("error: %v", err)
+				allTerminal = allTerminal && isPermanentWaitForTasksGetError(err)
 				continue
 			}
 
@@ -287,6 +289,15 @@ func (t *WaitForTasksTool) Execute(ctx context.Context, args json.RawMessage) (s
 	}
 
 	return string(data), nil
+}
+
+func isPermanentWaitForTasksGetError(err error) bool {
+	// NotFound remains retryable because cache-backed controller-runtime clients
+	// can briefly miss a Task that was just created through the same client.
+	return apierrors.IsForbidden(err) ||
+		apierrors.IsUnauthorized(err) ||
+		apierrors.IsBadRequest(err) ||
+		apierrors.IsInvalid(err)
 }
 
 func fetchTaskResultForNamespace(ctx context.Context, namespace, taskName string) (string, error) {

--- a/internal/tools/wait_for_tasks.go
+++ b/internal/tools/wait_for_tasks.go
@@ -28,7 +28,9 @@ import (
 
 // WaitForTasksTool implements waiting for child tasks to complete
 type WaitForTasksTool struct {
-	k8sClient client.Client
+	k8sClient     client.Client
+	pollInterval  time.Duration
+	notFoundGrace time.Duration
 }
 
 // WaitForTasksArgs are the arguments for the wait_for_tasks tool
@@ -85,14 +87,18 @@ type FailureDetails struct {
 }
 
 const (
-	maxWaitTaskSummaryChars = 4096
-	maxWaitTaskDataBytes    = 32 * 1024
+	maxWaitTaskSummaryChars      = 4096
+	maxWaitTaskDataBytes         = 32 * 1024
+	defaultWaitTaskPollInterval  = 5 * time.Second
+	defaultWaitTaskNotFoundGrace = 15 * time.Second
 )
 
 // NewWaitForTasksTool creates a new wait_for_tasks tool
 func NewWaitForTasksTool(k8sClient client.Client) *WaitForTasksTool {
 	return &WaitForTasksTool{
-		k8sClient: k8sClient,
+		k8sClient:     k8sClient,
+		pollInterval:  defaultWaitTaskPollInterval,
+		notFoundGrace: defaultWaitTaskNotFoundGrace,
 	}
 }
 
@@ -158,9 +164,7 @@ func (t *WaitForTasksTool) Execute(ctx context.Context, args json.RawMessage) (s
 	}
 
 	deadline := time.Now().Add(timeout)
-	pollInterval := 5 * time.Second
-	ticker := time.NewTicker(pollInterval)
-	defer ticker.Stop()
+	pollInterval, notFoundGrace := t.waitDurations()
 
 	results := make(map[string]*TaskResultInfo)
 	for _, taskName := range waitArgs.Tasks {
@@ -170,6 +174,7 @@ func (t *WaitForTasksTool) Execute(ctx context.Context, args json.RawMessage) (s
 		}
 	}
 
+	notFoundSince := make(map[string]time.Time)
 	allTerminal := false
 	for {
 		allTerminal = true
@@ -177,11 +182,11 @@ func (t *WaitForTasksTool) Execute(ctx context.Context, args json.RawMessage) (s
 			var task corev1alpha1.Task
 			err := t.k8sClient.Get(ctx, types.NamespacedName{Name: taskName, Namespace: ns}, &task)
 			if err != nil {
-				results[taskName].Phase = taskPhaseErrorString
-				results[taskName].Result = fmt.Sprintf("error: %v", err)
-				allTerminal = allTerminal && isPermanentWaitForTasksGetError(err)
+				permanent := recordWaitTaskGetError(results[taskName], taskName, err, notFoundSince, notFoundGrace)
+				allTerminal = allTerminal && permanent
 				continue
 			}
+			clearRecoveredWaitTaskGetError(results[taskName], taskName, notFoundSince)
 
 			phase := task.Status.Phase
 
@@ -289,6 +294,50 @@ func (t *WaitForTasksTool) Execute(ctx context.Context, args json.RawMessage) (s
 	}
 
 	return string(data), nil
+}
+
+func (t *WaitForTasksTool) waitDurations() (time.Duration, time.Duration) {
+	pollInterval := t.pollInterval
+	if pollInterval <= 0 {
+		pollInterval = defaultWaitTaskPollInterval
+	}
+	notFoundGrace := t.notFoundGrace
+	if notFoundGrace <= 0 {
+		notFoundGrace = defaultWaitTaskNotFoundGrace
+	}
+	return pollInterval, notFoundGrace
+}
+
+func recordWaitTaskGetError(
+	result *TaskResultInfo,
+	taskName string,
+	err error,
+	notFoundSince map[string]time.Time,
+	notFoundGrace time.Duration,
+) bool {
+	result.Phase = taskPhaseErrorString
+	result.Result = fmt.Sprintf("error: %v", err)
+	if !apierrors.IsNotFound(err) {
+		delete(notFoundSince, taskName)
+		return isPermanentWaitForTasksGetError(err)
+	}
+	firstMiss, seen := notFoundSince[taskName]
+	if !seen {
+		firstMiss = time.Now()
+		notFoundSince[taskName] = firstMiss
+	}
+	return time.Since(firstMiss) >= notFoundGrace
+}
+
+func clearRecoveredWaitTaskGetError(
+	result *TaskResultInfo,
+	taskName string,
+	notFoundSince map[string]time.Time,
+) {
+	delete(notFoundSince, taskName)
+	if result.Phase == taskPhaseErrorString {
+		result.Result = ""
+	}
 }
 
 func isPermanentWaitForTasksGetError(err error) bool {

--- a/internal/tools/wait_for_tasks_test.go
+++ b/internal/tools/wait_for_tasks_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -415,6 +416,78 @@ func TestWaitForTasksTool_Execute_RetriesNotFoundCacheMissUntilRecovery(t *testi
 	}
 	if len(got.Results) != 1 || got.Results[0].Phase != taskPhaseSucceededString {
 		t.Fatalf("Results = %#v, want eventually visible task to succeed", got.Results)
+	}
+	if got.Results[0].Result != "" {
+		t.Fatalf("Result = %q, want stale NotFound error cleared after recovery", got.Results[0].Result)
+	}
+}
+
+func TestWaitForTasksTool_Execute_PersistentNotFoundStopsAfterGrace(t *testing.T) {
+	t.Setenv(envOrkaTaskNamespace, testNamespace)
+	getCalls := 0
+	fakeClient := newFakeClientWithInterceptorFuncs(interceptor.Funcs{
+		Get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			getCalls++
+			return apierrors.NewNotFound(
+				apischema.GroupResource{Group: corev1alpha1.GroupVersion.Group, Resource: "tasks"}, key.Name,
+			)
+		},
+	})
+	tool := NewWaitForTasksTool(fakeClient)
+	tool.pollInterval = time.Millisecond
+	tool.notFoundGrace = 3 * time.Millisecond
+
+	result, err := tool.Execute(context.Background(), json.RawMessage(`{"tasks":["missing-task"],"timeout":"1m"}`))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	var got WaitForTasksResult
+	if err := json.Unmarshal([]byte(result), &got); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if !got.Completed {
+		t.Fatalf("Completed = false after NotFound grace, result = %#v", got)
+	}
+	if getCalls < 2 || getCalls > 20 {
+		t.Fatalf("Get calls = %d, want bounded NotFound retries", getCalls)
+	}
+	if len(got.Results) != 1 || got.Results[0].Phase != taskPhaseErrorString {
+		t.Fatalf("Results = %#v, want terminal Error result", got.Results)
+	}
+}
+
+func TestWaitForTasksTool_Execute_TransientErrorClearsAfterRecovery(t *testing.T) {
+	t.Setenv(envOrkaTaskNamespace, testNamespace)
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "recovered-task", Namespace: testNamespace},
+		Status:     corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseSucceeded},
+	}
+	getCalls := 0
+	fakeClient := newFakeClientWithInterceptorFuncs(interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			getCalls++
+			if getCalls == 1 {
+				return errors.New("temporary read failure")
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	}, task)
+	tool := NewWaitForTasksTool(fakeClient)
+	tool.pollInterval = time.Millisecond
+
+	result, err := tool.Execute(context.Background(), json.RawMessage(`{"tasks":["recovered-task"],"timeout":"100ms"}`))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	var got WaitForTasksResult
+	if err := json.Unmarshal([]byte(result), &got); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if !got.Completed || len(got.Results) != 1 || got.Results[0].Phase != taskPhaseSucceededString {
+		t.Fatalf("result = %#v, want recovered success", got)
+	}
+	if got.Results[0].Result != "" {
+		t.Fatalf("Result = %q, want transient read error cleared", got.Results[0].Result)
 	}
 }
 

--- a/internal/tools/wait_for_tasks_test.go
+++ b/internal/tools/wait_for_tasks_test.go
@@ -9,15 +9,19 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apischema "k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
 	"github.com/orka-agents/orka/internal/labels"
@@ -160,10 +164,43 @@ func TestWaitForTasksTool_Execute(t *testing.T) {
 			},
 		},
 		{
+			name: "finalizing remains nonterminal",
+			tasks: []corev1alpha1.Task{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "finalizing-task", Namespace: testNamespace},
+					Status: corev1alpha1.TaskStatus{
+						Phase: corev1alpha1.TaskPhaseFinalizing,
+					},
+				},
+			},
+			args:          WaitForTasksArgs{Tasks: []string{"finalizing-task"}, Timeout: shortPollIntervalString},
+			wantCompleted: false,
+			wantResults: []TaskResultInfo{
+				{Task: "finalizing-task", Phase: string(corev1alpha1.TaskPhaseFinalizing)},
+			},
+		},
+		{
+			name: "cancelled is terminal",
+			tasks: []corev1alpha1.Task{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "cancelled-task", Namespace: testNamespace},
+					Status: corev1alpha1.TaskStatus{
+						Phase:   corev1alpha1.TaskPhaseCancelled,
+						Message: "cancelled by user",
+					},
+				},
+			},
+			args:          WaitForTasksArgs{Tasks: []string{"cancelled-task"}, Timeout: "1s"},
+			wantCompleted: true,
+			wantResults: []TaskResultInfo{
+				{Task: "cancelled-task", Phase: string(corev1alpha1.TaskPhaseCancelled), Result: "cancelled by user"},
+			},
+		},
+		{
 			name:          "missing task",
 			tasks:         []corev1alpha1.Task{},
 			args:          WaitForTasksArgs{Tasks: []string{testNonexistentName}, Timeout: shortPollIntervalString},
-			wantCompleted: true,
+			wantCompleted: false,
 			wantResults: []TaskResultInfo{
 				{Task: testNonexistentName, Phase: taskPhaseErrorString},
 			},
@@ -257,6 +294,188 @@ func TestWaitForTasksTool_Execute(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestWaitForTasksTool_Execute_PreservesFinalizingOutcomeAndWorkspaceStatus(t *testing.T) {
+	t.Setenv(envOrkaTaskNamespace, testNamespace)
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "finalizing-with-status", Namespace: testNamespace},
+		Status: corev1alpha1.TaskStatus{
+			Phase: corev1alpha1.TaskPhaseFinalizing,
+			ExecutionOutcome: &corev1alpha1.TaskExecutionOutcome{
+				Phase:   corev1alpha1.TaskPhaseSucceeded,
+				Attempt: 2,
+				Message: "workload completed",
+			},
+			ExecutionWorkspace: &corev1alpha1.ExecutionWorkspaceStatus{
+				State:         "Attached",
+				AttachedEpoch: 7,
+			},
+		},
+	}
+	tool := NewWaitForTasksTool(newFakeClient(task))
+
+	result, err := tool.Execute(t.Context(), json.RawMessage(`{"tasks":["finalizing-with-status"],"timeout":"20ms"}`))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	var got WaitForTasksResult
+	if err := json.Unmarshal([]byte(result), &got); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if got.Completed {
+		t.Fatal("Completed = true for Finalizing task")
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("Results = %#v, want one result", got.Results)
+	}
+	info := got.Results[0]
+	if info.ExecutionOutcome == nil || info.ExecutionOutcome.Phase != corev1alpha1.TaskPhaseSucceeded || info.ExecutionOutcome.Attempt != 2 {
+		t.Fatalf("ExecutionOutcome = %#v, want preserved successful attempt", info.ExecutionOutcome)
+	}
+	if info.WorkspaceStatus == nil || info.WorkspaceStatus.State != "Attached" || info.WorkspaceStatus.AttachedEpoch != 7 {
+		t.Fatalf("WorkspaceStatus = %#v, want preserved status", info.WorkspaceStatus)
+	}
+}
+
+func TestWaitForTasksTool_Execute_TransientGetErrorTimesOutIncomplete(t *testing.T) {
+	t.Setenv(envOrkaTaskNamespace, testNamespace)
+
+	transientErr := errors.New("temporary Kubernetes read failure")
+	getCalls := 0
+	fakeClient := newFakeClientWithInterceptorFuncs(interceptor.Funcs{
+		Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			getCalls++
+			return transientErr
+		},
+	})
+
+	result, err := NewWaitForTasksTool(fakeClient).Execute(
+		context.Background(),
+		json.RawMessage(`{"tasks":["temporarily-unreadable"],"timeout":"20ms"}`),
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got WaitForTasksResult
+	if err := json.Unmarshal([]byte(result), &got); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if got.Completed {
+		t.Fatal("Completed = true after transient Get errors, want false")
+	}
+	if getCalls < 2 {
+		t.Fatalf("Get calls = %d, want at least 2 attempts before timeout", getCalls)
+	}
+	if len(got.Results) != 1 || got.Results[0].Phase != taskPhaseErrorString {
+		t.Fatalf("Results = %#v, want one Error result", got.Results)
+	}
+	if !strings.Contains(got.Results[0].Result, transientErr.Error()) {
+		t.Fatalf("Result = %q, want transient error details", got.Results[0].Result)
+	}
+}
+
+func TestWaitForTasksTool_Execute_RetriesNotFoundCacheMissUntilRecovery(t *testing.T) {
+	t.Setenv(envOrkaTaskNamespace, testNamespace)
+
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "eventually-visible", Namespace: testNamespace},
+		Status:     corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseSucceeded},
+	}
+	getCalls := 0
+	fakeClient := newFakeClientWithInterceptorFuncs(interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			getCalls++
+			if getCalls == 1 {
+				return apierrors.NewNotFound(apischema.GroupResource{Group: corev1alpha1.GroupVersion.Group, Resource: "tasks"}, key.Name)
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	}, task)
+
+	result, err := NewWaitForTasksTool(fakeClient).Execute(
+		context.Background(),
+		json.RawMessage(`{"tasks":["eventually-visible"],"timeout":"20ms"}`),
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got WaitForTasksResult
+	if err := json.Unmarshal([]byte(result), &got); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if !got.Completed {
+		t.Fatalf("Completed = false after NotFound cache miss recovered, result = %#v", got)
+	}
+	if getCalls < 2 {
+		t.Fatalf("Get calls = %d, want a retry after NotFound", getCalls)
+	}
+	if len(got.Results) != 1 || got.Results[0].Phase != taskPhaseSucceededString {
+		t.Fatalf("Results = %#v, want eventually visible task to succeed", got.Results)
+	}
+}
+
+func TestWaitForTasksTool_Execute_PermanentGetErrorCompletesWithError(t *testing.T) {
+	t.Setenv(envOrkaTaskNamespace, testNamespace)
+
+	getCalls := 0
+	fakeClient := newFakeClientWithInterceptorFuncs(interceptor.Funcs{
+		Get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			getCalls++
+			return apierrors.NewForbidden(
+				apischema.GroupResource{Group: corev1alpha1.GroupVersion.Group, Resource: "tasks"},
+				key.Name,
+				errors.New("access denied"),
+			)
+		},
+	})
+
+	result, err := NewWaitForTasksTool(fakeClient).Execute(
+		context.Background(),
+		json.RawMessage(`{"tasks":["forbidden-task"],"timeout":"1m"}`),
+	)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got WaitForTasksResult
+	if err := json.Unmarshal([]byte(result), &got); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if !got.Completed {
+		t.Fatalf("Completed = false for permanent Get error, result = %#v", got)
+	}
+	if getCalls != 1 {
+		t.Fatalf("Get calls = %d, want no retries for permanent error", getCalls)
+	}
+	if len(got.Results) != 1 || got.Results[0].Phase != taskPhaseErrorString {
+		t.Fatalf("Results = %#v, want one Error result", got.Results)
+	}
+}
+
+func TestWaitForTasksTool_Execute_HonorsCanceledContextDuringGetErrors(t *testing.T) {
+	t.Setenv(envOrkaTaskNamespace, testNamespace)
+
+	fakeClient := newFakeClientWithInterceptorFuncs(interceptor.Funcs{
+		Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			return errors.New("temporary Kubernetes read failure")
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := NewWaitForTasksTool(fakeClient).Execute(
+		ctx,
+		json.RawMessage(`{"tasks":["temporarily-unreadable"],"timeout":"1m"}`),
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Execute() error = %v, want context.Canceled", err)
+	}
+	if result != "" {
+		t.Fatalf("Execute() result = %q, want empty result on cancellation", result)
 	}
 }
 

--- a/workers/ai/context_overflow_test.go
+++ b/workers/ai/context_overflow_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/orka-agents/orka/internal/llm"
+)
+
+type contextOverflowCaptureProvider struct {
+	requests       []*llm.CompletionRequest
+	captureErr     error
+	alwaysOverflow bool
+	validateRetry  func(*llm.CompletionRequest) error
+}
+
+func (p *contextOverflowCaptureProvider) Complete(
+	_ context.Context,
+	req *llm.CompletionRequest,
+) (*llm.CompletionResponse, error) {
+	serialized, err := json.Marshal(req)
+	if err != nil {
+		p.captureErr = err
+		return nil, err
+	}
+	var captured llm.CompletionRequest
+	if err := json.Unmarshal(serialized, &captured); err != nil {
+		p.captureErr = err
+		return nil, err
+	}
+	p.requests = append(p.requests, &captured)
+	if len(p.requests) == 1 || p.alwaysOverflow {
+		return nil, &llm.ProviderError{StatusCode: 400, Message: "context length exceeded"}
+	}
+	if p.validateRetry != nil {
+		if err := p.validateRetry(&captured); err != nil {
+			return nil, err
+		}
+	}
+	return &llm.CompletionResponse{Content: "recovered", StopReason: "end_turn"}, nil
+}
+
+func (p *contextOverflowCaptureProvider) Stream(
+	context.Context,
+	*llm.CompletionRequest,
+) (<-chan llm.StreamChunk, error) {
+	return nil, fmt.Errorf("stream not implemented")
+}
+
+func (p *contextOverflowCaptureProvider) Name() string { return "context-overflow-capture" }
+
+func TestExecuteAgentLoopContextOverflowShrinksSingleCurrentPrompt(t *testing.T) {
+	provider := &contextOverflowCaptureProvider{}
+	prompt := "BEGIN-CURRENT-TASK\n" + strings.Repeat("details ", 2000) + "\nEND-CURRENT-TASK"
+
+	result, err := executeAgentLoop(
+		context.Background(), provider,
+		[]llm.Message{{Role: roleUser, Content: prompt}},
+		"system", "model", nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("executeAgentLoop() error = %v", err)
+	}
+	if result != "recovered" {
+		t.Fatalf("result = %q, want recovered", result)
+	}
+	if provider.captureErr != nil {
+		t.Fatalf("capture request: %v", provider.captureErr)
+	}
+	if len(provider.requests) != 2 {
+		t.Fatalf("provider calls = %d, want 2", len(provider.requests))
+	}
+
+	before, err := llm.EstimateCompletionRequestSize(provider.requests[0])
+	if err != nil {
+		t.Fatalf("estimate first request: %v", err)
+	}
+	after, err := llm.EstimateCompletionRequestSize(provider.requests[1])
+	if err != nil {
+		t.Fatalf("estimate retry request: %v", err)
+	}
+	if after.SerializedBytes >= before.SerializedBytes {
+		t.Fatalf("retry bytes = %d, first bytes = %d; retry did not shrink", after.SerializedBytes, before.SerializedBytes)
+	}
+	gotPrompt := provider.requests[1].Messages[0].Content
+	if !strings.Contains(gotPrompt, "[Current user task truncated for context recovery.]") {
+		t.Fatalf("retry prompt lacks truncation marker: %q", gotPrompt)
+	}
+	if !strings.Contains(gotPrompt, "BEGIN-CURRENT-TASK") || !strings.Contains(gotPrompt, "END-CURRENT-TASK") {
+		t.Fatalf("retry prompt lost current task boundaries: %q", gotPrompt)
+	}
+}
+
+func TestExecuteAgentLoopContextOverflowRefusesNonShrinkingRetry(t *testing.T) {
+	provider := &contextOverflowCaptureProvider{alwaysOverflow: true}
+	prompt := "BEGIN-CURRENT-TASK\n" + strings.Repeat("important details ", 100) + "\nEND-CURRENT-TASK"
+
+	_, err := executeAgentLoop(
+		context.Background(), provider,
+		[]llm.Message{{Role: roleUser, Content: prompt}},
+		strings.Repeat("fixed-system ", 2000), "model",
+		[]llm.Tool{{
+			Name:        "fixed_tool",
+			Description: strings.Repeat("fixed-description ", 1000),
+			Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),
+		}},
+		nil, nil,
+	)
+	if err == nil {
+		t.Fatal("executeAgentLoop() error = nil, want context overflow failure")
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("provider calls = %d, want 1 when retry request cannot shrink", len(provider.requests))
+	}
+}
+
+func TestExecuteAgentLoopContextOverflowAccountsForToolSchemasAndArguments(t *testing.T) {
+	const currentTask = "CURRENT-TASK-SENTINEL: keep this request"
+	provider := &contextOverflowCaptureProvider{
+		validateRetry: func(req *llm.CompletionRequest) error {
+			for _, message := range req.Messages {
+				if message.Role == roleUser && message.Content == currentTask {
+					return nil
+				}
+			}
+			return fmt.Errorf("retry dropped the current user task")
+		},
+	}
+	largeArguments := json.RawMessage(fmt.Sprintf(`{"payload":%q}`, strings.Repeat("argument ", 2000)))
+	messages := []llm.Message{
+		{Role: roleUser, Content: "old history"},
+		{
+			Role: "assistant",
+			ToolCalls: []llm.ToolCall{{
+				ID:        "old-call",
+				Name:      "large_tool",
+				Arguments: largeArguments,
+			}},
+		},
+		{Role: "tool", ToolCallID: "old-call", Content: "old result"},
+		{Role: roleUser, Content: currentTask},
+	}
+	tools := []llm.Tool{{
+		Name:        "large_tool",
+		Description: strings.Repeat("description ", 1000),
+		Parameters: json.RawMessage(fmt.Sprintf(
+			`{"type":"object","description":%q,"properties":{}}`, strings.Repeat("schema ", 1200),
+		)),
+	}}
+
+	result, err := executeAgentLoop(
+		context.Background(), provider, messages,
+		strings.Repeat("system ", 1000), "model", tools, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("executeAgentLoop() error = %v", err)
+	}
+	if result != "recovered" {
+		t.Fatalf("result = %q, want recovered", result)
+	}
+	if len(provider.requests) != 2 {
+		t.Fatalf("provider calls = %d, want 2", len(provider.requests))
+	}
+	before, err := llm.EstimateCompletionRequestSize(provider.requests[0])
+	if err != nil {
+		t.Fatalf("estimate first request: %v", err)
+	}
+	after, err := llm.EstimateCompletionRequestSize(provider.requests[1])
+	if err != nil {
+		t.Fatalf("estimate retry request: %v", err)
+	}
+	if after.SerializedBytes >= before.SerializedBytes {
+		t.Fatalf("retry bytes = %d, first bytes = %d", after.SerializedBytes, before.SerializedBytes)
+	}
+	if len(provider.requests[1].Tools) != 1 || provider.requests[1].SystemPrompt == "" {
+		t.Fatal("retry unexpectedly removed fixed system prompt or tool schemas")
+	}
+}

--- a/workers/ai/context_overflow_test.go
+++ b/workers/ai/context_overflow_test.go
@@ -185,3 +185,109 @@ func TestExecuteAgentLoopContextOverflowAccountsForToolSchemasAndArguments(t *te
 		t.Fatal("retry unexpectedly removed fixed system prompt or tool schemas")
 	}
 }
+
+func TestExecuteAgentLoopFinalAnswerContextRecoveryPreservesRealTaskAndEvidence(t *testing.T) {
+	const (
+		realTask       = "CURRENT-REAL-TASK-SENTINEL: explain the gathered evidence"
+		recentEvidence = "RECENT-EVIDENCE-SENTINEL: the deployment is healthy"
+		baseSystem     = "BASE-SYSTEM-SENTINEL"
+	)
+	provider := &mockProvider{
+		responses: []*llm.CompletionResponse{
+			{Content: " \n", StopReason: "end_turn"},
+			{Content: "recovered final answer", StopReason: "end_turn"},
+		},
+		errs: []error{
+			nil,
+			&llm.ProviderError{StatusCode: 400, Message: "context length exceeded"},
+			nil,
+		},
+	}
+	messages := []llm.Message{
+		{Role: roleUser, Content: "OLD-HISTORY-SENTINEL:" + strings.Repeat(" old history", 1200)},
+		{Role: "assistant", Content: "old answer"},
+		{Role: roleUser, Content: realTask},
+		{
+			Role: "assistant",
+			ToolCalls: []llm.ToolCall{{
+				ID:        "evidence-call",
+				Name:      "inspect",
+				Arguments: json.RawMessage(`{"target":"deployment"}`),
+			}},
+		},
+		{Role: "tool", ToolCallID: "evidence-call", Name: "inspect", Content: recentEvidence},
+	}
+
+	result, err := executeAgentLoop(
+		context.Background(), provider, messages,
+		baseSystem, "model", []llm.Tool{{Name: "inspect"}}, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("executeAgentLoop() error = %v", err)
+	}
+	if result != "recovered final answer" {
+		t.Fatalf("result = %q, want recovered final answer", result)
+	}
+	if len(provider.requests) != 3 {
+		t.Fatalf(
+			"provider calls = %d, want blank response, overflowing final retry, and recovered retry",
+			len(provider.requests),
+		)
+	}
+
+	finalRetry := provider.requests[1]
+	recoveredRetry := provider.requests[2]
+	wantSystemPrompt := appendSystemInstruction(baseSystem, finalAnswerRetryPrompt)
+	if finalRetry.SystemPrompt != wantSystemPrompt || recoveredRetry.SystemPrompt != wantSystemPrompt {
+		t.Fatalf(
+			"final retry system prompts = %q and %q, want %q",
+			finalRetry.SystemPrompt, recoveredRetry.SystemPrompt, wantSystemPrompt,
+		)
+	}
+	if len(finalRetry.Tools) != 0 || len(recoveredRetry.Tools) != 0 {
+		t.Fatalf(
+			"final answer retries unexpectedly advertised tools: before=%#v after=%#v",
+			finalRetry.Tools, recoveredRetry.Tools,
+		)
+	}
+
+	before, err := llm.EstimateCompletionRequestSize(finalRetry)
+	if err != nil {
+		t.Fatalf("estimate overflowing final retry: %v", err)
+	}
+	after, err := llm.EstimateCompletionRequestSize(recoveredRetry)
+	if err != nil {
+		t.Fatalf("estimate recovered final retry: %v", err)
+	}
+	if after.SerializedBytes >= before.SerializedBytes {
+		t.Fatalf(
+			"recovered retry bytes = %d, overflowing retry bytes = %d; retry did not shrink",
+			after.SerializedBytes, before.SerializedBytes,
+		)
+	}
+
+	var (
+		keptRealTask       bool
+		keptRecentEvidence bool
+		keptOldHistory     bool
+		syntheticUser      bool
+	)
+	for _, message := range recoveredRetry.Messages {
+		keptRealTask = keptRealTask || message.Role == roleUser && message.Content == realTask
+		keptRecentEvidence = keptRecentEvidence || strings.Contains(message.Content, recentEvidence)
+		keptOldHistory = keptOldHistory || strings.Contains(message.Content, "OLD-HISTORY-SENTINEL")
+		syntheticUser = syntheticUser || message.Role == roleUser && message.Content == finalAnswerRetryPrompt
+	}
+	if !keptRealTask {
+		t.Fatalf("context recovery dropped the real user task: %#v", recoveredRetry.Messages)
+	}
+	if !keptRecentEvidence {
+		t.Fatalf("context recovery dropped recent task evidence: %#v", recoveredRetry.Messages)
+	}
+	if keptOldHistory {
+		t.Fatalf("context recovery retained oversized old history: %#v", recoveredRetry.Messages)
+	}
+	if syntheticUser {
+		t.Fatalf("synthetic final-answer instruction was serialized as a user task: %#v", recoveredRetry.Messages)
+	}
+}

--- a/workers/ai/coverage_test.go
+++ b/workers/ai/coverage_test.go
@@ -805,17 +805,17 @@ func TestLoadPlanContext_RequestPathFormat(t *testing.T) {
 
 // --- writeResult tests ---
 
-func TestWriteResult_ServerError(t *testing.T) {
+func TestWriteResult_PermanentHTTPError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer server.Close()
 
 	t.Setenv("ORKA_RESULT_ENDPOINT", server.URL)
 
-	err := writeResult("test result")
-	if err == nil {
-		t.Fatal("expected error for server error response")
+	err := writeResult(context.Background(), "test result")
+	if err == nil || !strings.Contains(err.Error(), "HTTP 401") {
+		t.Fatalf("writeResult() error = %v, want HTTP 401", err)
 	}
 }
 

--- a/workers/ai/main.go
+++ b/workers/ai/main.go
@@ -105,18 +105,7 @@ func run() (err error) {
 	taskNamespace := workerEnv.TaskNamespace
 	eventRecorder := common.NewHTTPEventRecorderFromEnv()
 	defer func() {
-		if err != nil {
-			common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeWorkerFailed, 0,
-				common.WithEventSeverity(events.ExecutionEventSeverityError),
-				common.WithEventTaskName(taskName),
-				common.WithEventSummary(err.Error()),
-			)
-			return
-		}
-		common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeWorkerCompleted, 0,
-			common.WithEventTaskName(taskName),
-			common.WithEventSummary("AI worker completed"),
-		)
+		err = finishAIWorkerRun(ctx, eventRecorder, taskName, err)
 	}()
 	if err := workerEnv.ValidateRequired(); err != nil {
 		return err
@@ -341,8 +330,8 @@ func run() (err error) {
 		return fmt.Errorf("agent execution failed: %w", err)
 	}
 
-	// Write result to controller via HTTP
-	if err := writeResult(result); err != nil {
+	// Write result to controller via HTTP.
+	if err := writeResult(ctx, result); err != nil {
 		return fmt.Errorf("failed to write result: %w", err)
 	}
 	common.RecordEvent(ctx, eventRecorder, events.ExecutionEventTypeResultSubmitted,
@@ -351,22 +340,9 @@ func run() (err error) {
 		common.WithEventContent(eventContent(map[string]any{"resultLength": len(result)})),
 	)
 
-	// Upload any artifacts the agent wrote
-	if err := common.UploadArtifacts(); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: artifact upload failed: %v\n", err)
-		common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeArtifactUploadFailed, 0,
-			common.WithEventSeverity(events.ExecutionEventSeverityWarning),
-			common.WithEventTaskName(taskName),
-			common.WithEventSummary("AI worker artifact upload failed"),
-			common.WithEventContent(eventContent(map[string]any{"artifact": "all", "error": err.Error()})),
-		)
-		// Don't fail the task if artifact upload fails
-	} else {
-		common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeArtifactUploadCompleted, 0,
-			common.WithEventTaskName(taskName),
-			common.WithEventSummary("AI worker artifact upload completed"),
-			common.WithEventContent(eventContent(map[string]any{"artifact": "all"})),
-		)
+	// Upload any artifacts the agent wrote.
+	if err := uploadAIArtifacts(ctx, eventRecorder, taskName); err != nil {
+		return err
 	}
 
 	fmt.Printf("Task %s/%s completed successfully%s\n", taskNamespace, taskName, transactionLogFields)
@@ -1541,6 +1517,50 @@ func advertisedToolNames(llmTools []llm.Tool) map[string]struct{} {
 	return names
 }
 
+func finishAIWorkerRun(
+	ctx context.Context, eventRecorder common.EventRecorder, taskName string, runErr error,
+) error {
+	if runErr == nil {
+		runErr = ctx.Err()
+	}
+	if runErr != nil {
+		common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeWorkerFailed, 0,
+			common.WithEventSeverity(events.ExecutionEventSeverityError),
+			common.WithEventTaskName(taskName),
+			common.WithEventSummary(runErr.Error()),
+		)
+		return runErr
+	}
+	common.RecordEvent(ctx, eventRecorder, events.ExecutionEventTypeWorkerCompleted,
+		common.WithEventTaskName(taskName),
+		common.WithEventSummary("AI worker completed"),
+	)
+	return ctx.Err()
+}
+
+func uploadAIArtifacts(ctx context.Context, eventRecorder common.EventRecorder, taskName string) error {
+	err := common.UploadArtifactsContext(ctx)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("artifact upload canceled: %w", ctxErr)
+		}
+		fmt.Fprintf(os.Stderr, "warning: artifact upload failed: %v\n", err)
+		common.RecordEvent(ctx, eventRecorder, events.ExecutionEventTypeArtifactUploadFailed,
+			common.WithEventSeverity(events.ExecutionEventSeverityWarning),
+			common.WithEventTaskName(taskName),
+			common.WithEventSummary("AI worker artifact upload failed"),
+			common.WithEventContent(eventContent(map[string]any{"artifact": "all", "error": err.Error()})),
+		)
+		return ctx.Err()
+	}
+	common.RecordEvent(ctx, eventRecorder, events.ExecutionEventTypeArtifactUploadCompleted,
+		common.WithEventTaskName(taskName),
+		common.WithEventSummary("AI worker artifact upload completed"),
+		common.WithEventContent(eventContent(map[string]any{"artifact": "all"})),
+	)
+	return ctx.Err()
+}
+
 func eventContent(values map[string]any) json.RawMessage {
 	data, err := json.Marshal(values)
 	if err != nil {
@@ -1612,8 +1632,8 @@ func completionOutcomeError(outcome llm.CompletionOutcome, stopReason string) er
 }
 
 // writeResult submits the result to the controller via HTTP POST.
-func writeResult(result string) error {
-	return common.SubmitResult([]byte(result))
+func writeResult(ctx context.Context, result string) error {
+	return common.SubmitResultContext(ctx, []byte(result))
 }
 
 func workerSecretReadAuthorizer(

--- a/workers/ai/main.go
+++ b/workers/ai/main.go
@@ -1201,10 +1201,14 @@ func executeAgentLoopWithEvents(
 			requestTools = nil
 		}
 		stepCtx, stepSpan := startAgentStepSpan(ctx, iteration, provider, model, requestTools, baseToolCtx)
+		requestSystemPrompt := systemPrompt
+		if finalAnswerRetry {
+			requestSystemPrompt = appendSystemInstruction(requestSystemPrompt, finalAnswerRetryPrompt)
+		}
 		req := &llm.CompletionRequest{
 			Model:        model,
 			Messages:     messages,
-			SystemPrompt: systemPrompt,
+			SystemPrompt: requestSystemPrompt,
 			MaxTokens:    4096,
 			Tools:        requestTools,
 		}
@@ -1283,7 +1287,6 @@ func executeAgentLoopWithEvents(
 			blankFinalRetried = true
 			finalAnswerRetry = true
 			iterationLimit++
-			messages = append(messages, llm.Message{Role: "user", Content: finalAnswerRetryPrompt})
 			stepSpan.End()
 			continue
 		case completionDecisionToolCalls:
@@ -1427,6 +1430,13 @@ func executeAgentLoopWithEvents(
 	}
 
 	return "", fmt.Errorf("max iterations reached without completion")
+}
+
+func appendSystemInstruction(systemPrompt, instruction string) string {
+	if systemPrompt == "" {
+		return instruction
+	}
+	return systemPrompt + "\n\n" + instruction
 }
 
 func retryCompletionAfterContextOverflow(

--- a/workers/ai/main.go
+++ b/workers/ai/main.go
@@ -1221,23 +1221,9 @@ func executeAgentLoopWithEvents(
 
 		resp, err := provider.Complete(stepCtx, req)
 		if err != nil && llm.IsContextTooLongErr(err) {
-			tokenEstimate := 0
-			for _, m := range messages {
-				tokenEstimate += len(m.Content) / 4
-			}
-			beforeCount := len(messages)
-			messages = llm.TruncateMessages(messages, tokenEstimate/2)
-			req.Messages = messages
-			common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeContextTruncated, modelLoopEventTimeout,
-				common.WithEventSeverity(events.ExecutionEventSeverityWarning),
-				common.WithEventSummary("model context truncated after provider context limit error"),
-				common.WithEventContent(eventContent(map[string]any{
-					"iteration":          iteration + 1,
-					"messageCountBefore": beforeCount,
-					"messageCountAfter":  len(messages),
-				})),
+			resp, messages, err = retryCompletionAfterContextOverflow(
+				stepCtx, provider, req, err, eventRecorder, iteration,
 			)
-			resp, err = provider.Complete(stepCtx, req)
 		}
 		err = completionCallError(resp, err)
 		if err != nil {
@@ -1441,6 +1427,44 @@ func executeAgentLoopWithEvents(
 	}
 
 	return "", fmt.Errorf("max iterations reached without completion")
+}
+
+func retryCompletionAfterContextOverflow(
+	ctx context.Context,
+	provider llm.Provider,
+	req *llm.CompletionRequest,
+	overflowErr error,
+	eventRecorder common.EventRecorder,
+	iteration int,
+) (*llm.CompletionResponse, []llm.Message, error) {
+	beforeSize, err := llm.EstimateCompletionRequestSize(req)
+	if err != nil {
+		return nil, req.Messages, overflowErr
+	}
+	retryReq, err := llm.TruncateCompletionRequest(req, beforeSize.EstimatedTokens/2)
+	if err != nil {
+		return nil, req.Messages, overflowErr
+	}
+	afterSize, err := llm.EstimateCompletionRequestSize(retryReq)
+	if err != nil || afterSize.SerializedBytes >= beforeSize.SerializedBytes {
+		return nil, req.Messages, overflowErr
+	}
+
+	common.RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeContextTruncated, modelLoopEventTimeout,
+		common.WithEventSeverity(events.ExecutionEventSeverityWarning),
+		common.WithEventSummary("model context truncated after provider context limit error"),
+		common.WithEventContent(eventContent(map[string]any{
+			"iteration":             iteration + 1,
+			"messageCountBefore":    len(req.Messages),
+			"messageCountAfter":     len(retryReq.Messages),
+			"requestBytesBefore":    beforeSize.SerializedBytes,
+			"requestBytesAfter":     afterSize.SerializedBytes,
+			"estimatedTokensBefore": beforeSize.EstimatedTokens,
+			"estimatedTokensAfter":  afterSize.EstimatedTokens,
+		})),
+	)
+	resp, retryErr := provider.Complete(ctx, retryReq)
+	return resp, retryReq.Messages, retryErr
 }
 
 func optionalToolContext(contexts []*tools.ToolContext) *tools.ToolContext {

--- a/workers/ai/main_test.go
+++ b/workers/ai/main_test.go
@@ -9,6 +9,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -968,11 +969,109 @@ func TestExecuteAgentLoop_CompletionError(t *testing.T) {
 	}
 }
 
+func TestFinishAIWorkerRun_CancelsBlockedCompletionEvent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- finishAIWorkerRun(ctx, blockingAIEventRecorder{started: started}, "task", nil)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for completion event")
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("finishAIWorkerRun() error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("finishAIWorkerRun() did not stop after cancellation")
+	}
+}
+
+type blockingAIEventRecorder struct {
+	started chan struct{}
+}
+
+func (r blockingAIEventRecorder) Record(ctx context.Context, _ string, _ ...common.EventOption) {
+	close(r.started)
+	<-ctx.Done()
+}
+
+func TestUploadAIArtifacts_ReturnsCancellationDuringFailureEvent(t *testing.T) {
+	artifactDir := filepath.Join(t.TempDir(), "artifacts")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatalf("create artifacts dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(artifactDir, "evidence.txt"), []byte("evidence"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+	t.Setenv("ORKA_ARTIFACTS_DIR", artifactDir)
+	t.Setenv(workerenv.ControllerURL, server.URL)
+	t.Setenv(workerenv.TaskNamespace, "default")
+	t.Setenv(workerenv.TaskName, "artifact-failure-task")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err := uploadAIArtifacts(ctx, cancelAIEventRecorder{cancel: cancel}, "artifact-failure-task")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("uploadAIArtifacts() error = %v, want context canceled", err)
+	}
+}
+
+type cancelAIEventRecorder struct {
+	cancel context.CancelFunc
+}
+
+func (r cancelAIEventRecorder) Record(context.Context, string, ...common.EventOption) {
+	r.cancel()
+}
+
+func TestWriteResult_CancelsInFlightRequest(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	defer close(releaseRequest)
+
+	t.Setenv(workerenv.ResultEndpoint, server.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- writeResult(ctx, "test result") }()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for result request")
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("writeResult() error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("writeResult() did not stop after cancellation")
+	}
+}
+
 func TestWriteResult_NoEndpoint(t *testing.T) {
 	t.Setenv("ORKA_RESULT_ENDPOINT", "")
 	t.Setenv("ORKA_CONTROLLER_URL", "")
 
-	err := writeResult("test result")
+	err := writeResult(context.Background(), "test result")
 	if err == nil {
 		t.Fatal("expected error without result endpoint")
 	}
@@ -986,7 +1085,7 @@ func TestWriteResult_Success(t *testing.T) {
 
 	t.Setenv("ORKA_RESULT_ENDPOINT", server.URL)
 
-	err := writeResult("test result")
+	err := writeResult(context.Background(), "test result")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/workers/ai/main_test.go
+++ b/workers/ai/main_test.go
@@ -637,8 +637,11 @@ func TestExecuteAgentLoop_RetriesBlankFinalResponseOnceWithoutTools(t *testing.T
 		t.Fatalf("retry request tools = %d, want 0", len(provider.requests[1].Tools))
 	}
 	retryMessages := provider.requests[1].Messages
-	if len(retryMessages) != 2 || retryMessages[1].Role != roleUser || retryMessages[1].Content != finalAnswerRetryPrompt {
-		t.Fatalf("retry messages = %#v", retryMessages)
+	if len(retryMessages) != 1 || retryMessages[0].Role != roleUser || retryMessages[0].Content != "investigate" {
+		t.Fatalf("retry messages = %#v, want only the original user task", retryMessages)
+	}
+	if provider.requests[1].SystemPrompt != finalAnswerRetryPrompt {
+		t.Fatalf("retry system prompt = %q, want %q", provider.requests[1].SystemPrompt, finalAnswerRetryPrompt)
 	}
 }
 

--- a/workers/common/agent_runtime.go
+++ b/workers/common/agent_runtime.go
@@ -668,15 +668,7 @@ func RunAgent(name, workspaceDir string, defaultMaxTurns int, executor AgentExec
 		// RunAgent has a named error return. Go assigns every return expression
 		// to err before deferred functions run, including returns from shadowed
 		// inner err variables, so this observes the final worker outcome.
-		if err != nil {
-			recordAgentWorkerFailedEvent(eventRecorder, name, taskName, err)
-			return
-		}
-		RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeWorkerCompleted, 0,
-			WithEventTaskName(taskName),
-			WithEventAgentName(name),
-			WithEventSummary("agent worker completed"),
-		)
+		err = finishAgentWorkerRun(ctx, eventRecorder, name, taskName, err)
 	}()
 
 	cfg, err := LoadConfig(defaultMaxTurns)
@@ -813,24 +805,24 @@ func RunAgent(name, workspaceDir string, defaultMaxTurns int, executor AgentExec
 			fmt.Fprintf(os.Stderr, "failed to finalize error result: %v\n", finalizeErr)
 			resultBytes = []byte(errorOutput)
 		}
-		if submitErr := SubmitResult(resultBytes); submitErr != nil {
+		if submitErr := SubmitResultContext(ctx, resultBytes); submitErr != nil {
 			fmt.Fprintf(os.Stderr, "failed to submit error result: %v\n", submitErr)
 		} else {
-			RecordEventWithTimeout(eventRecorder, events.ExecutionEventTypeResultSubmitted, 0,
+			RecordEvent(ctx, eventRecorder, events.ExecutionEventTypeResultSubmitted,
 				WithEventTaskName(cfg.TaskName),
 				WithEventAgentName(name),
 				WithEventSummary("agent worker submitted partial result"),
 				WithEventContent(agentRuntimeEventContent(map[string]any{"resultBytes": len(resultBytes)})),
 			)
 		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("%s execution canceled: %w", name, ctxErr)
+		}
 		if restoreErr := RestoreSecurityReviewContextArtifact(cfg); restoreErr != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to restore security review context artifact: %v\n", restoreErr)
 		}
-		if artifactErr := UploadArtifacts(); artifactErr != nil {
-			fmt.Fprintf(os.Stderr, "warning: artifact upload failed: %v\n", artifactErr)
-			recordAgentArtifactUploadEvent(eventRecorder, name, cfg.TaskName, false, artifactErr)
-		} else {
-			recordAgentArtifactUploadEvent(eventRecorder, name, cfg.TaskName, true, nil)
+		if artifactErr := uploadAgentArtifacts(ctx, eventRecorder, name, cfg.TaskName); artifactErr != nil {
+			return fmt.Errorf("%s execution canceled: %w", name, artifactErr)
 		}
 		return fmt.Errorf("%s execution failed: %w", name, err)
 	}
@@ -840,11 +832,28 @@ func RunAgent(name, workspaceDir string, defaultMaxTurns int, executor AgentExec
 		WithEventSummary("agent runtime completed"),
 		WithEventContent(agentRuntimeEventContent(map[string]any{"resultChars": len([]rune(result))})),
 	)
+	if err := deliverAgentResult(ctx, eventRecorder, name, cfg, workspaceDir, result); err != nil {
+		return err
+	}
 
-	// Build structured result with diff if workspace has changes
+	fmt.Printf("Task %s/%s completed successfully%s\n",
+		cfg.TaskNamespace, cfg.TaskName, workerenv.TransactionLogFields(cfg.TransactionID, cfg.TransactionProfile))
+	return nil
+}
+
+func deliverAgentResult(
+	ctx context.Context,
+	recorder EventRecorder,
+	agentName string,
+	cfg *AgentConfig,
+	workspaceDir, result string,
+) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return fmt.Errorf("%s execution canceled: %w", agentName, ctxErr)
+	}
 	if result == "" {
-		fmt.Fprintf(os.Stderr, "warning: %s executor returned empty result\n", name)
-		result = fmt.Sprintf("%s completed without a final message", name)
+		fmt.Fprintf(os.Stderr, "warning: %s executor returned empty result\n", agentName)
+		result = fmt.Sprintf("%s completed without a final message", agentName)
 	}
 	resultDir := ""
 	if cfg.GitRepo != "" {
@@ -854,27 +863,24 @@ func RunAgent(name, workspaceDir string, defaultMaxTurns int, executor AgentExec
 	if err != nil {
 		return fmt.Errorf("failed to finalize result: %w", err)
 	}
-	if err := SubmitResult(resultBytes); err != nil {
+	if err := SubmitResultContext(ctx, resultBytes); err != nil {
 		return fmt.Errorf("failed to submit result: %w", err)
 	}
-	RecordEvent(ctx, eventRecorder, events.ExecutionEventTypeResultSubmitted,
+	RecordEvent(ctx, recorder, events.ExecutionEventTypeResultSubmitted,
 		WithEventTaskName(cfg.TaskName),
-		WithEventAgentName(name),
+		WithEventAgentName(agentName),
 		WithEventSummary("agent worker submitted result"),
 		WithEventContent(agentRuntimeEventContent(map[string]any{"resultBytes": len(resultBytes)})),
 	)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return fmt.Errorf("%s execution canceled: %w", agentName, ctxErr)
+	}
 	if err := RestoreSecurityReviewContextArtifact(cfg); err != nil {
 		return fmt.Errorf("failed to restore security review context artifact: %w", err)
 	}
-	if err := UploadArtifacts(); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: artifact upload failed: %v\n", err)
-		recordAgentArtifactUploadEvent(eventRecorder, name, cfg.TaskName, false, err)
-	} else {
-		recordAgentArtifactUploadEvent(eventRecorder, name, cfg.TaskName, true, nil)
+	if err := uploadAgentArtifacts(ctx, recorder, agentName, cfg.TaskName); err != nil {
+		return fmt.Errorf("artifact upload canceled: %w", err)
 	}
-
-	fmt.Printf("Task %s/%s completed successfully%s\n",
-		cfg.TaskNamespace, cfg.TaskName, workerenv.TransactionLogFields(cfg.TransactionID, cfg.TransactionProfile))
 	return nil
 }
 
@@ -886,7 +892,25 @@ func agentRuntimeEventContent(values map[string]any) json.RawMessage {
 	return json.RawMessage(data)
 }
 
-func recordAgentArtifactUploadEvent(recorder EventRecorder, agentName, taskName string, success bool, err error) {
+func uploadAgentArtifacts(
+	ctx context.Context, recorder EventRecorder, agentName, taskName string,
+) error {
+	err := UploadArtifactsContext(ctx)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		fmt.Fprintf(os.Stderr, "warning: artifact upload failed: %v\n", err)
+		recordAgentArtifactUploadEvent(ctx, recorder, agentName, taskName, false, err)
+		return ctx.Err()
+	}
+	recordAgentArtifactUploadEvent(ctx, recorder, agentName, taskName, true, nil)
+	return ctx.Err()
+}
+
+func recordAgentArtifactUploadEvent(
+	ctx context.Context, recorder EventRecorder, agentName, taskName string, success bool, err error,
+) {
 	eventType := events.ExecutionEventTypeArtifactUploadCompleted
 	severity := events.ExecutionEventSeverityInfo
 	summary := "agent worker artifact upload completed"
@@ -899,13 +923,31 @@ func recordAgentArtifactUploadEvent(recorder EventRecorder, agentName, taskName 
 			content["error"] = err.Error()
 		}
 	}
-	RecordEventWithTimeout(recorder, eventType, 0,
+	RecordEvent(ctx, recorder, eventType,
 		WithEventSeverity(severity),
 		WithEventTaskName(taskName),
 		WithEventAgentName(agentName),
 		WithEventSummary(summary),
 		WithEventContent(agentRuntimeEventContent(content)),
 	)
+}
+
+func finishAgentWorkerRun(
+	ctx context.Context, recorder EventRecorder, agentName, taskName string, runErr error,
+) error {
+	if runErr == nil {
+		runErr = ctx.Err()
+	}
+	if runErr != nil {
+		recordAgentWorkerFailedEvent(recorder, agentName, taskName, runErr)
+		return runErr
+	}
+	RecordEvent(ctx, recorder, events.ExecutionEventTypeWorkerCompleted,
+		WithEventTaskName(taskName),
+		WithEventAgentName(agentName),
+		WithEventSummary("agent worker completed"),
+	)
+	return ctx.Err()
 }
 
 func recordAgentWorkerFailedEvent(recorder EventRecorder, agentName, taskName string, err error) {

--- a/workers/common/agent_runtime_test.go
+++ b/workers/common/agent_runtime_test.go
@@ -7,9 +7,11 @@ MIT License - see LICENSE file for details.
 package common
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -19,9 +21,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1319,6 +1324,189 @@ func TestRunAgent_ManagedExecutionWorkspaceReusesExistingGitCheckout(t *testing.
 		t.Fatal("config.worktree remained after managed refresh")
 	} else if !os.IsNotExist(err) {
 		t.Fatalf("stat config.worktree: %v", err)
+	}
+}
+
+func TestFinishAgentWorkerRun_CancelsBlockedCompletionEvent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- finishAgentWorkerRun(
+			ctx, blockingAgentCompletionRecorder{started: started}, "agent", "task", nil,
+		)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for completion event")
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("finishAgentWorkerRun() error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("finishAgentWorkerRun() did not stop after cancellation")
+	}
+}
+
+type blockingAgentCompletionRecorder struct {
+	started chan struct{}
+}
+
+func (r blockingAgentCompletionRecorder) Record(ctx context.Context, _ string, _ ...EventOption) {
+	close(r.started)
+	<-ctx.Done()
+}
+
+func TestUploadAgentArtifacts_ReturnsCancellationDuringFailureEvent(t *testing.T) {
+	prepareArtifactsDir(t)
+	writeArtifactFile(t, "evidence.txt", []byte("evidence"))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+	t.Setenv(workerenv.ControllerURL, server.URL)
+	t.Setenv(workerenv.TaskNamespace, "default")
+	t.Setenv(workerenv.TaskName, "artifact-failure-task")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err := uploadAgentArtifacts(ctx, cancelOnRecordEventRecorder{cancel: cancel}, "agent", "artifact-failure-task")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("uploadAgentArtifacts() error = %v, want context canceled", err)
+	}
+}
+
+type cancelOnRecordEventRecorder struct {
+	cancel context.CancelFunc
+}
+
+func (r cancelOnRecordEventRecorder) Record(context.Context, string, ...EventOption) {
+	r.cancel()
+}
+
+func TestRunAgent_SIGTERMStopsArtifactDeliveryWithoutLateEvents(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SIGTERM subprocess behavior is Unix-specific")
+	}
+	var mu sync.Mutex
+	var eventTypes []string
+	artifactStarted := make(chan struct{})
+	releaseArtifact := make(chan struct{})
+	var startedOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/result":
+			w.WriteHeader(http.StatusNoContent)
+		case strings.HasPrefix(r.URL.Path, "/internal/v1/artifacts/default/sigterm-agent-task/"):
+			startedOnce.Do(func() { close(artifactStarted) })
+			<-releaseArtifact
+			w.WriteHeader(http.StatusCreated)
+		case strings.HasPrefix(r.URL.Path, "/internal/v1/events/default/task/sigterm-agent-task"):
+			defer r.Body.Close() //nolint:errcheck
+			var body struct {
+				Type string `json:"type"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			eventTypes = append(eventTypes, body.Type)
+			mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	defer close(releaseArtifact)
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunAgentSIGTERMHelper$", "-test.v")
+	cmd.Env = append(os.Environ(),
+		"ORKA_TEST_RUN_AGENT_SIGTERM_HELPER=1",
+		"ORKA_TEST_RUN_AGENT_WORKSPACE="+t.TempDir(),
+		workerenv.ControllerURL+"="+server.URL,
+		workerenv.ResultEndpoint+"="+server.URL+"/result",
+		workerenv.TaskNamespace+"=default",
+		workerenv.TaskName+"=sigterm-agent-task",
+		workerenv.Prompt+"=test prompt",
+		workerenv.GitRepo+"=",
+		workerenv.PriorTask+"=",
+		workerenv.ExecutionWorkspaceEnabled+"=",
+		workerenv.AgentSandboxEnabled+"=",
+		workerenv.ResultStdout+"=",
+		workerenv.EnableTelemetry+"=",
+		artifactsDirEnv+"="+filepath.Join(t.TempDir(), "artifacts"),
+	)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper agent: %v", err)
+	}
+
+	select {
+	case <-artifactStarted:
+	case <-time.After(10 * time.Second):
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("timed out waiting for artifact upload; helper output:\n%s", output.String())
+	}
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("signal helper agent: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("helper agent exited with %v; output:\n%s", err, output.String())
+		}
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		<-done
+		t.Fatalf("helper agent did not exit promptly after SIGTERM; output:\n%s", output.String())
+	}
+
+	mu.Lock()
+	gotEvents := append([]string(nil), eventTypes...)
+	mu.Unlock()
+	if !slices.Contains(gotEvents, events.ExecutionEventTypeResultSubmitted) {
+		t.Fatalf("events before SIGTERM = %#v, want ResultSubmitted before artifact upload", gotEvents)
+	}
+	lateEvents := map[string]bool{
+		events.ExecutionEventTypeArtifactUploadCompleted: true,
+		events.ExecutionEventTypeArtifactUploadFailed:    true,
+		events.ExecutionEventTypeWorkerCompleted:         true,
+	}
+	for _, eventType := range gotEvents {
+		if lateEvents[eventType] {
+			t.Fatalf("events after SIGTERM = %#v, must not contain %s", gotEvents, eventType)
+		}
+	}
+}
+
+func TestRunAgentSIGTERMHelper(t *testing.T) {
+	if os.Getenv("ORKA_TEST_RUN_AGENT_SIGTERM_HELPER") != "1" {
+		return
+	}
+	workspaceDir := os.Getenv("ORKA_TEST_RUN_AGENT_WORKSPACE")
+	err := RunAgent("test-agent", workspaceDir, 50, func(_ context.Context, _ *AgentConfig) (string, error) {
+		if err := WriteArtifactFile("evidence.txt", []byte("evidence")); err != nil {
+			return "", err
+		}
+		return "result ready", nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("RunAgent() error = %v, want context canceled", err)
 	}
 }
 

--- a/workers/common/artifacts.go
+++ b/workers/common/artifacts.go
@@ -7,7 +7,7 @@ MIT License - see LICENSE file for details.
 package common
 
 import (
-	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -29,6 +29,12 @@ const (
 	maxFileSize               = 10 << 20 // 10 MB
 	artifactPath              = "internal/v1/artifacts"
 )
+
+type pendingArtifact struct {
+	filename    string
+	data        []byte
+	contentType string
+}
 
 func artifactsDir() string {
 	if dir := strings.TrimSpace(os.Getenv(artifactsDirEnv)); dir != "" {
@@ -153,9 +159,20 @@ func artifactFilename(filename string) (string, error) {
 }
 
 // UploadArtifacts scans /tmp/artifacts and uploads each file to the controller.
-// It is called after SubmitResult to persist any files the agent wrote.
-// Returns nil if the artifacts directory does not exist or is empty.
+// It preserves the legacy background-context behavior for callers without a
+// worker lifecycle context.
 func UploadArtifacts() error {
+	return UploadArtifactsContext(context.Background())
+}
+
+// UploadArtifactsContext scans the artifacts directory and uploads each file
+// using the worker lifecycle context. It returns nil when the directory does
+// not exist or is empty.
+func UploadArtifactsContext(ctx context.Context) error {
+	ctx = contextOrBackground(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	artifactRoot := artifactsDir()
 	info, err := os.Lstat(artifactRoot)
 	if os.IsNotExist(err) {
@@ -199,15 +216,12 @@ func UploadArtifacts() error {
 
 	saToken := workerServiceAccountToken()
 
-	type pendingArtifact struct {
-		filename    string
-		data        []byte
-		contentType string
-	}
-
 	pending := make([]pendingArtifact, 0, len(entries))
 	var uploadErrors []string
 	for _, e := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if e.IsDir() {
 			continue
 		}
@@ -283,20 +297,39 @@ func UploadArtifacts() error {
 		})
 	}
 
+	return uploadPendingArtifacts(ctx, baseEndpoint, saToken, pending, uploadErrors)
+}
+
+func uploadPendingArtifacts(
+	ctx context.Context,
+	baseEndpoint, saToken string,
+	pending []pendingArtifact,
+	uploadErrors []string,
+) error {
 	for _, artifact := range pending {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		endpoint := fmt.Sprintf("%s/%s", baseEndpoint, url.PathEscape(artifact.filename))
-		if err := doPostWithContentType(endpoint, artifact.data, saToken, artifact.contentType); err != nil {
+		if err := doPostWithRetryContext(
+			ctx, "artifact upload", endpoint, artifact.data, saToken, artifact.contentType, 30*time.Second,
+		); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return fmt.Errorf("artifact upload canceled: %w", ctxErr)
+			}
 			fmt.Fprintf(os.Stderr, "artifact: failed to upload %s: %v\n", artifact.filename, err)
 			uploadErrors = append(uploadErrors, fmt.Sprintf("%s: %v", artifact.filename, err))
-		} else {
-			fmt.Printf("artifact: uploaded %s (%d bytes, %s)\n", artifact.filename, len(artifact.data), artifact.contentType)
+			continue
 		}
+		fmt.Printf(
+			"artifact: uploaded %s (%d bytes, %s)\n",
+			artifact.filename, len(artifact.data), artifact.contentType,
+		)
 	}
-
 	if len(uploadErrors) > 0 {
 		return fmt.Errorf("some artifacts failed to upload: %s", strings.Join(uploadErrors, "; "))
 	}
-	return nil
+	return ctx.Err()
 }
 
 func artifactEndpointBase() (string, error) {
@@ -358,42 +391,4 @@ func detectContentType(filename string, data []byte) string {
 	}
 
 	return http.DetectContentType(data)
-}
-
-func doPostWithContentType(endpoint string, data []byte, saToken, contentType string) error {
-	var lastErr error
-	for attempt := range maxRetries {
-		if attempt > 0 {
-			backoff := time.Duration(1<<uint(attempt)) * time.Second
-			time.Sleep(backoff)
-		}
-
-		req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(data))
-		if err != nil {
-			return fmt.Errorf("failed to create request: %w", err)
-		}
-		req.Header.Set("Content-Type", contentType)
-		if saToken != "" {
-			req.Header.Set("Authorization", "Bearer "+saToken)
-		}
-
-		client := &http.Client{Timeout: 30 * time.Second}
-		resp, err := client.Do(req)
-		if err != nil {
-			lastErr = fmt.Errorf("HTTP request failed: %w", err)
-			fmt.Fprintf(os.Stderr, "artifact upload attempt %d/%d failed: %v\n", attempt+1, maxRetries, lastErr)
-			continue
-		}
-
-		_, _ = io.Copy(io.Discard, resp.Body)
-		resp.Body.Close() //nolint:errcheck
-		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-			return nil
-		}
-
-		lastErr = fmt.Errorf("HTTP %d", resp.StatusCode)
-		fmt.Fprintf(os.Stderr, "artifact upload attempt %d/%d failed: %v\n", attempt+1, maxRetries, lastErr)
-	}
-
-	return fmt.Errorf("all %d artifact upload attempts failed: %w", maxRetries, lastErr)
 }

--- a/workers/common/artifacts_test.go
+++ b/workers/common/artifacts_test.go
@@ -7,6 +7,8 @@ MIT License - see LICENSE file for details.
 package common
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,7 +17,11 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/orka-agents/orka/internal/workerenv"
 )
 
 func cleanupArtifactsDir(t *testing.T) {
@@ -121,6 +127,96 @@ func TestEnsureWorkspaceArtifactsLink_CreatesRepoLocalSymlink(t *testing.T) {
 	}
 	if filepath.Clean(target) != filepath.Clean(artifactsDir()) {
 		t.Fatalf("symlink target = %q, want %q", target, artifactsDir())
+	}
+}
+
+func TestUploadArtifactsContext_CanceledBeforeDelivery(t *testing.T) {
+	prepareArtifactsDir(t)
+	writeArtifactFile(t, "evidence.txt", []byte("evidence"))
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+	t.Setenv(workerenv.ControllerURL, srv.URL)
+	t.Setenv(workerenv.TaskNamespace, "test-ns")
+	t.Setenv(workerenv.TaskName, "test-task")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := UploadArtifactsContext(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("UploadArtifactsContext() error = %v, want context canceled", err)
+	}
+	if got := attempts.Load(); got != 0 {
+		t.Fatalf("artifact requests = %d, want 0", got)
+	}
+}
+
+func TestUploadArtifactsContext_CancelsBlockedTransport(t *testing.T) {
+	prepareArtifactsDir(t)
+	writeArtifactFile(t, "evidence.txt", []byte("evidence"))
+
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+	defer close(releaseRequest)
+	t.Setenv(workerenv.ControllerURL, srv.URL)
+	t.Setenv(workerenv.TaskNamespace, "test-ns")
+	t.Setenv(workerenv.TaskName, "test-task")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- UploadArtifactsContext(ctx)
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for artifact request")
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("UploadArtifactsContext() error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("UploadArtifactsContext() did not stop after cancellation")
+	}
+}
+
+func TestUploadArtifactsContext_DoesNotRetryPermanentClientErrors(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusRequestEntityTooLarge} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			prepareArtifactsDir(t)
+			writeArtifactFile(t, "evidence.txt", []byte("evidence"))
+
+			var attempts atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				attempts.Add(1)
+				w.WriteHeader(status)
+			}))
+			defer srv.Close()
+			t.Setenv(workerenv.ControllerURL, srv.URL)
+			t.Setenv(workerenv.TaskNamespace, "test-ns")
+			t.Setenv(workerenv.TaskName, "test-task")
+
+			err := UploadArtifactsContext(context.Background())
+			if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("HTTP %d", status)) {
+				t.Fatalf("UploadArtifactsContext() error = %v, want HTTP %d", err, status)
+			}
+			if got := attempts.Load(); got != 1 {
+				t.Fatalf("attempts = %d, want 1 for HTTP %d", got, status)
+			}
+		})
 	}
 }
 

--- a/workers/common/result.go
+++ b/workers/common/result.go
@@ -8,8 +8,10 @@ package common
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,9 +23,11 @@ import (
 )
 
 const (
-	maxRetries      = 5
-	saTokenPath     = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-	saNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	maxRetries                 = 5
+	deliveryErrorBodyLimit     = 4 << 10
+	deliveryResponseDrainLimit = 64 << 10
+	saTokenPath                = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	saNamespacePath            = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
 	// MaxStructuredSummaryChars bounds agent-written summaries stored in structured
 	// results. Diffs remain intact for workspace handoff, but oversized summaries
@@ -34,11 +38,22 @@ const (
 var resultStdoutMarkerPath = agentSandboxResultMarkerExecPath
 
 // SubmitResult sends the task result to the controller via HTTP POST.
-// It reads ORKA_RESULT_ENDPOINT or constructs the URL from ORKA_CONTROLLER_URL.
-// Retries up to 5 times with exponential backoff (2s, 4s, 8s, 16s) on failure.
+// It preserves the legacy background-context behavior for callers without a
+// worker lifecycle context.
 func SubmitResult(result []byte) error {
+	return SubmitResultContext(context.Background(), result)
+}
+
+// SubmitResultContext sends the task result to the controller via HTTP POST.
+// It reads ORKA_RESULT_ENDPOINT or constructs the URL from ORKA_CONTROLLER_URL.
+// Retryable failures use bounded exponential backoff and stop when ctx is canceled.
+func SubmitResultContext(ctx context.Context, result []byte) error {
 	if len(bytes.TrimSpace(result)) == 0 {
 		return fmt.Errorf("result must not be blank")
+	}
+	ctx = contextOrBackground(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	if workerenv.IsTrue(os.Getenv(workerenv.ResultStdout)) {
@@ -51,7 +66,7 @@ func SubmitResult(result []byte) error {
 			fmt.Fprintf(os.Stderr, "warning: failed to write stdout result marker file: %v\n", err)
 		}
 		fmt.Println(marker)
-		return nil
+		return ctx.Err()
 	}
 
 	endpoint, err := resultEndpoint()
@@ -59,23 +74,81 @@ func SubmitResult(result []byte) error {
 		return err
 	}
 
-	saToken := workerServiceAccountToken()
+	return doPostWithRetryContext(
+		ctx,
+		"result submission",
+		endpoint,
+		result,
+		workerServiceAccountToken(),
+		"application/octet-stream",
+		30*time.Second,
+	)
+}
+
+type retryWaitFunc func(context.Context, time.Duration) error
+
+func doPostWithRetryContext(
+	ctx context.Context,
+	operation string,
+	endpoint string,
+	data []byte,
+	saToken, contentType string,
+	timeout time.Duration,
+) error {
+	return doPostWithRetry(ctx, operation, endpoint, data, saToken, contentType, timeout, waitForRetry)
+}
+
+func doPostWithRetry(
+	ctx context.Context,
+	operation string,
+	endpoint string,
+	data []byte,
+	saToken, contentType string,
+	timeout time.Duration,
+	wait retryWaitFunc,
+) error {
+	ctx = contextOrBackground(ctx)
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("%s canceled: %w", operation, err)
+	}
+	if wait == nil {
+		wait = waitForRetry
+	}
 
 	var lastErr error
 	for attempt := range maxRetries {
 		if attempt > 0 {
 			backoff := time.Duration(1<<uint(attempt)) * time.Second
-			time.Sleep(backoff)
+			if err := wait(ctx, backoff); err != nil {
+				return fmt.Errorf("%s canceled: %w", operation, err)
+			}
 		}
 
-		lastErr = doPost(endpoint, result, saToken)
+		lastErr = doPostOnceWithContentTypeContext(ctx, endpoint, data, saToken, contentType, timeout)
 		if lastErr == nil {
 			return nil
 		}
-		fmt.Fprintf(os.Stderr, "result submission attempt %d/%d failed: %v\n", attempt+1, maxRetries, lastErr)
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("%s canceled: %w", operation, err)
+		}
+		if !isRetryableDeliveryError(lastErr) {
+			return fmt.Errorf("%s failed: %w", operation, lastErr)
+		}
+		fmt.Fprintf(os.Stderr, "%s attempt %d/%d failed: %v\n", operation, attempt+1, maxRetries, lastErr)
 	}
 
-	return fmt.Errorf("all %d result submission attempts failed: %w", maxRetries, lastErr)
+	return fmt.Errorf("all %d %s attempts failed: %w", maxRetries, operation, lastErr)
+}
+
+func waitForRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func resultEndpoint() (string, error) {
@@ -123,33 +196,124 @@ func workerServiceAccountToken() string {
 	return strings.TrimSpace(os.Getenv(workerenv.ServiceAccountToken))
 }
 
-func doPost(endpoint string, data []byte, saToken string) error {
-	return doPostOnceWithContentType(endpoint, data, saToken, "application/octet-stream", 30*time.Second)
+func doPostOnceWithContentType(endpoint string, data []byte, saToken, contentType string, timeout time.Duration) error {
+	return doPostOnceWithContentTypeContext(
+		context.Background(), endpoint, data, saToken, contentType, timeout,
+	)
 }
 
-func doPostOnceWithContentType(endpoint string, data []byte, saToken, contentType string, timeout time.Duration) error {
-	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(data))
+func doPostOnceWithContentTypeContext(
+	ctx context.Context,
+	endpoint string,
+	data []byte,
+	saToken, contentType string,
+	timeout time.Duration,
+) error {
+	client := &http.Client{Timeout: timeout}
+	return doPostOnceWithClient(ctx, client, endpoint, data, saToken, contentType)
+}
+
+func doPostOnceWithClient(
+	ctx context.Context,
+	client *http.Client,
+	endpoint string,
+	data []byte,
+	saToken, contentType string,
+) error {
+	ctx = contextOrBackground(ctx)
+	if client == nil {
+		client = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(data))
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+		return permanentDeliveryError(fmt.Errorf("failed to create request: %w", err))
 	}
 	req.Header.Set("Content-Type", contentType)
 	if saToken != "" {
 		req.Header.Set("Authorization", "Bearer "+saToken)
 	}
 
-	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("HTTP request failed: %w", err)
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return retryableDeliveryError(fmt.Errorf("HTTP request failed: %w", err))
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+	bodyPreview := readAndDrainDeliveryResponse(resp.Body)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
 		return nil
 	}
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-	return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	statusErr := fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(bodyPreview)))
+	if isRetryableHTTPStatus(resp.StatusCode) {
+		return retryableDeliveryError(statusErr)
+	}
+	return permanentDeliveryError(statusErr)
+}
+
+func readAndDrainDeliveryResponse(body io.Reader) []byte {
+	if body == nil {
+		return nil
+	}
+	preview, _ := io.ReadAll(io.LimitReader(body, deliveryErrorBodyLimit))
+	remaining := int64(deliveryResponseDrainLimit - len(preview))
+	if remaining > 0 {
+		_, _ = io.CopyN(io.Discard, body, remaining)
+	}
+	return preview
+}
+
+func contextOrBackground(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
+}
+
+type deliveryError struct {
+	err       error
+	retryable bool
+}
+
+func (e *deliveryError) Error() string {
+	return e.err.Error()
+}
+
+func (e *deliveryError) Unwrap() error {
+	return e.err
+}
+
+func retryableDeliveryError(err error) error {
+	return &deliveryError{err: err, retryable: true}
+}
+
+func permanentDeliveryError(err error) error {
+	return &deliveryError{err: err}
+}
+
+func isRetryableDeliveryError(err error) bool {
+	var deliveryErr *deliveryError
+	return errors.As(err, &deliveryErr) && deliveryErr.retryable
+}
+
+func isRetryableHTTPStatus(statusCode int) bool {
+	switch statusCode {
+	case http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
 }
 
 // StructuredResult is an optional structured envelope for task results.

--- a/workers/common/result_test.go
+++ b/workers/common/result_test.go
@@ -7,8 +7,12 @@ MIT License - see LICENSE file for details.
 package common
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,9 +20,231 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/orka-agents/orka/internal/workerenv"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type trackingResponseBody struct {
+	reader io.Reader
+	read   int
+	closed bool
+}
+
+func (b *trackingResponseBody) Read(p []byte) (int, error) {
+	n, err := b.reader.Read(p)
+	b.read += n
+	return n, err
+}
+
+func (b *trackingResponseBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+type infiniteTrackingResponseBody struct {
+	read   int
+	closed bool
+}
+
+func (b *infiniteTrackingResponseBody) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'x'
+	}
+	b.read += len(p)
+	return len(p), nil
+}
+
+func (b *infiniteTrackingResponseBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func TestSubmitResultContext_CanceledBeforeDelivery(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	t.Setenv(workerenv.ResultEndpoint, srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := SubmitResultContext(ctx, []byte("late result")); !errors.Is(err, context.Canceled) {
+		t.Fatalf("SubmitResultContext() error = %v, want context canceled", err)
+	}
+	if got := attempts.Load(); got != 0 {
+		t.Fatalf("result requests = %d, want 0", got)
+	}
+}
+
+func TestSubmitResultContext_CancelsBlockedTransport(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	defer close(releaseRequest)
+	t.Setenv(workerenv.ResultEndpoint, srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- SubmitResultContext(ctx, []byte("late result"))
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for result request")
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("SubmitResultContext() error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SubmitResultContext() did not stop after cancellation")
+	}
+}
+
+func TestDoPostWithRetry_CancelsDuringBackoff(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	backoffStarted := make(chan struct{})
+	wait := func(ctx context.Context, _ time.Duration) error {
+		close(backoffStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- doPostWithRetry(
+			ctx, "result submission", srv.URL, []byte("cancel backoff"), "",
+			"application/octet-stream", time.Second, wait,
+		)
+	}()
+
+	select {
+	case <-backoffStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for retry backoff")
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("doPostWithRetry() error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("doPostWithRetry() did not interrupt retry backoff")
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("attempts = %d, want 1 before cancellation", got)
+	}
+}
+
+func TestDoPostOnceWithClient_DrainsAndClosesSuccessBody(t *testing.T) {
+	payload := strings.Repeat("ok", 1024)
+	body := &trackingResponseBody{reader: strings.NewReader(payload)}
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusNoContent, Body: body, Header: make(http.Header)}, nil
+	})}
+
+	if err := doPostOnceWithClient(
+		context.Background(), client, "http://controller.invalid/result", []byte("result"), "", "application/octet-stream",
+	); err != nil {
+		t.Fatalf("doPostOnceWithClient() error = %v", err)
+	}
+	if body.read != len(payload) {
+		t.Fatalf("response body bytes read = %d, want %d", body.read, len(payload))
+	}
+	if !body.closed {
+		t.Fatal("response body was not closed")
+	}
+}
+
+func TestDoPostOnceWithClient_BoundsErrorBodyDrainAndCloses(t *testing.T) {
+	body := &infiniteTrackingResponseBody{}
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusServiceUnavailable, Body: body, Header: make(http.Header)}, nil
+	})}
+
+	err := doPostOnceWithClient(
+		context.Background(), client, "http://controller.invalid/result", []byte("result"), "", "application/octet-stream",
+	)
+	if err == nil || !strings.Contains(err.Error(), "HTTP 503") {
+		t.Fatalf("doPostOnceWithClient() error = %v, want HTTP 503", err)
+	}
+	if body.read != deliveryResponseDrainLimit {
+		t.Fatalf("response body bytes read = %d, want bounded drain %d", body.read, deliveryResponseDrainLimit)
+	}
+	if !body.closed {
+		t.Fatal("response body was not closed")
+	}
+}
+
+func TestSubmitResultContext_DoesNotRetryPermanentClientErrors(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusRequestEntityTooLarge} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var attempts atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				attempts.Add(1)
+				w.WriteHeader(status)
+			}))
+			defer srv.Close()
+			t.Setenv(workerenv.ResultEndpoint, srv.URL)
+
+			err := SubmitResultContext(context.Background(), []byte("permanent failure"))
+			if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("HTTP %d", status)) {
+				t.Fatalf("SubmitResultContext() error = %v, want HTTP %d", err, status)
+			}
+			if got := attempts.Load(); got != 1 {
+				t.Fatalf("attempts = %d, want 1 for HTTP %d", got, status)
+			}
+		})
+	}
+}
+
+func TestRetryableHTTPStatusPolicy(t *testing.T) {
+	tests := []struct {
+		status    int
+		retryable bool
+	}{
+		{status: http.StatusRequestTimeout, retryable: true},
+		{status: http.StatusTooManyRequests, retryable: true},
+		{status: http.StatusInternalServerError, retryable: true},
+		{status: http.StatusBadGateway, retryable: true},
+		{status: http.StatusServiceUnavailable, retryable: true},
+		{status: http.StatusGatewayTimeout, retryable: true},
+		{status: http.StatusBadRequest, retryable: false},
+		{status: http.StatusUnauthorized, retryable: false},
+		{status: http.StatusRequestEntityTooLarge, retryable: false},
+		{status: http.StatusNotImplemented, retryable: false},
+	}
+	for _, tt := range tests {
+		if got := isRetryableHTTPStatus(tt.status); got != tt.retryable {
+			t.Errorf("isRetryableHTTPStatus(%d) = %v, want %v", tt.status, got, tt.retryable)
+		}
+	}
+}
 
 func TestSubmitResult_Success(t *testing.T) {
 	var received []byte
@@ -97,42 +323,44 @@ func TestSubmitResult_ResultStdoutWritesMarkerFile(t *testing.T) {
 	}
 }
 
-func TestSubmitResult_RetryOnFailure(t *testing.T) {
+func TestDoPostWithRetry_Retries500ThenSucceeds(t *testing.T) {
 	var attempts atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		n := attempts.Add(1)
-		if n < 3 {
+		if attempts.Add(1) < 3 {
 			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("temporary error")) //nolint:errcheck
+			_, _ = w.Write([]byte("temporary error"))
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
 
-	t.Setenv("ORKA_RESULT_ENDPOINT", srv.URL)
-
-	err := SubmitResult([]byte("retry result"))
+	wait := func(context.Context, time.Duration) error { return nil }
+	err := doPostWithRetry(
+		context.Background(), "result submission", srv.URL, []byte("retry result"), "",
+		"application/octet-stream", time.Second, wait,
+	)
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("doPostWithRetry() error = %v", err)
 	}
 	if got := attempts.Load(); got != 3 {
-		t.Errorf("attempts = %d, want 3", got)
+		t.Fatalf("attempts = %d, want 3", got)
 	}
 }
 
-func TestSubmitResult_AllRetriesFail(t *testing.T) {
+func TestSubmitResultContext_RetryableFailureStopsAtContextDeadline(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("always fails")) //nolint:errcheck
+		_, _ = w.Write([]byte("always fails"))
 	}))
 	defer srv.Close()
+	t.Setenv(workerenv.ResultEndpoint, srv.URL)
 
-	t.Setenv("ORKA_RESULT_ENDPOINT", srv.URL)
-
-	err := SubmitResult([]byte("failing result"))
-	if err == nil {
-		t.Fatal("expected error after all retries exhausted")
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	err := SubmitResultContext(ctx, []byte("failing result"))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("SubmitResultContext() error = %v, want context deadline exceeded", err)
 	}
 }
 

--- a/workers/general/main.go
+++ b/workers/general/main.go
@@ -58,14 +58,7 @@ func run() (err error) {
 	taskNamespace := baseEnv.TaskNamespace
 	eventRecorder := common.NewHTTPEventRecorderFromEnv()
 	defer func() {
-		if err != nil {
-			recordGeneralWorkerFailed(eventRecorder, taskName, err)
-			return
-		}
-		common.RecordEventWithTimeout(eventRecorder, "WorkerCompleted", 0,
-			common.WithEventTaskName(taskName),
-			common.WithEventSummary("General worker completed"),
-		)
+		err = finishGeneralWorkerRun(ctx, eventRecorder, taskName, err)
 	}()
 
 	transactionLogFields := workerenv.TransactionLogFields(
@@ -123,8 +116,11 @@ func run() (err error) {
 	output := stdout.String() + stderr.String()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			if submitErr := submitResult(workDir, output); submitErr == nil {
-				recordGeneralResultSubmitted(eventRecorder, taskName, len(output))
+			if submitErr := submitResult(ctx, workDir, output); submitErr == nil {
+				recordGeneralResultSubmitted(ctx, eventRecorder, taskName, len(output))
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
 			}
 			recordGeneralWorkerFailed(
 				eventRecorder,
@@ -136,18 +132,40 @@ func run() (err error) {
 		return err
 	}
 
-	if err := submitResult(workDir, output); err != nil {
+	if err := submitResult(ctx, workDir, output); err != nil {
 		return err
 	}
-	recordGeneralResultSubmitted(eventRecorder, taskName, len(output))
+	recordGeneralResultSubmitted(ctx, eventRecorder, taskName, len(output))
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	fmt.Printf("Task %s/%s completed successfully%s\n",
 		taskNamespace, taskName, transactionLogFields)
 	return nil
 }
 
-func recordGeneralResultSubmitted(recorder common.EventRecorder, taskName string, resultLength int) {
-	common.RecordEventWithTimeout(recorder, "ResultSubmitted", 0,
+func finishGeneralWorkerRun(
+	ctx context.Context, recorder common.EventRecorder, taskName string, runErr error,
+) error {
+	if runErr == nil {
+		runErr = ctx.Err()
+	}
+	if runErr != nil {
+		recordGeneralWorkerFailed(recorder, taskName, runErr)
+		return runErr
+	}
+	common.RecordEvent(ctx, recorder, "WorkerCompleted",
+		common.WithEventTaskName(taskName),
+		common.WithEventSummary("General worker completed"),
+	)
+	return ctx.Err()
+}
+
+func recordGeneralResultSubmitted(
+	ctx context.Context, recorder common.EventRecorder, taskName string, resultLength int,
+) {
+	common.RecordEvent(ctx, recorder, "ResultSubmitted",
 		common.WithEventTaskName(taskName),
 		common.WithEventSummary("General worker submitted result"),
 		common.WithEventContent(generalEventContent(map[string]any{"resultLength": resultLength})),
@@ -231,7 +249,7 @@ func workspaceRoot() string {
 	return workspaceDir
 }
 
-func submitResult(workDir, output string) error {
+func submitResult(ctx context.Context, workDir, output string) error {
 	if os.Getenv(workerenv.ResultEndpoint) == "" && os.Getenv(workerenv.ControllerURL) == "" {
 		return nil
 	}
@@ -243,10 +261,10 @@ func submitResult(workDir, output string) error {
 	if err != nil {
 		return err
 	}
-	if err := common.SubmitResult(resultBytes); err != nil {
+	if err := common.SubmitResultContext(ctx, resultBytes); err != nil {
 		return err
 	}
-	return common.UploadArtifacts()
+	return common.UploadArtifactsContext(ctx)
 }
 
 func runSecurityMapper(ctx context.Context) error {
@@ -292,7 +310,7 @@ func runSecurityMapper(ctx context.Context) error {
 	}
 	output := fmt.Sprintf("security mapper wrote %d review slices\n", len(slices))
 	fmt.Print(output)
-	return submitResult(workDir, output)
+	return submitResult(ctx, workDir, output)
 }
 
 func changedFilesForSecurityScan(

--- a/workers/general/main_test.go
+++ b/workers/general/main_test.go
@@ -7,6 +7,7 @@ MIT License - see LICENSE file for details.
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -17,13 +18,173 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
+	"slices"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/orka-agents/orka/internal/security"
 	"github.com/orka-agents/orka/internal/workerenv"
+	"github.com/orka-agents/orka/workers/common"
 )
+
+func TestFinishGeneralWorkerRun_CancelsBlockedCompletionEvent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- finishGeneralWorkerRun(ctx, blockingGeneralEventRecorder{started: started}, "task", nil)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for completion event")
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("finishGeneralWorkerRun() error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("finishGeneralWorkerRun() did not stop after cancellation")
+	}
+}
+
+type blockingGeneralEventRecorder struct {
+	started chan struct{}
+}
+
+func (r blockingGeneralEventRecorder) Record(ctx context.Context, _ string, _ ...common.EventOption) {
+	close(r.started)
+	<-ctx.Done()
+}
+
+func TestRun_SIGTERMStopsResultDeliveryWithoutLateEvents(t *testing.T) {
+	testGeneralWorkerSIGTERM(t, "success")
+}
+
+func TestRun_SIGTERMStopsFailedCommandResultDeliveryWithoutLateEvents(t *testing.T) {
+	testGeneralWorkerSIGTERM(t, "failure")
+}
+
+func testGeneralWorkerSIGTERM(t *testing.T, commandMode string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("SIGTERM subprocess behavior is Unix-specific")
+	}
+	var mu sync.Mutex
+	var eventTypes []string
+	resultStarted := make(chan struct{})
+	releaseResult := make(chan struct{})
+	var startedOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/internal/v1/results/default/sigterm-task"):
+			startedOnce.Do(func() { close(resultStarted) })
+			<-releaseResult
+			w.WriteHeader(http.StatusNoContent)
+		case strings.HasPrefix(r.URL.Path, "/internal/v1/events/default/task/sigterm-task"):
+			defer r.Body.Close() //nolint:errcheck
+			var body struct {
+				Type string `json:"type"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			eventTypes = append(eventTypes, body.Type)
+			mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	defer close(releaseResult)
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestGeneralWorkerSIGTERMHelper$", "-test.v")
+	cmd.Env = append(os.Environ(),
+		"ORKA_TEST_GENERAL_SIGTERM_HELPER=1",
+		"ORKA_TEST_GENERAL_SIGTERM_COMMAND="+commandMode,
+		workerenv.ControllerURL+"="+server.URL,
+		workerenv.ResultEndpoint+"=",
+		workerenv.TaskNamespace+"=default",
+		workerenv.TaskName+"=sigterm-task",
+		workerenv.GitRepo+"=",
+		workerenv.PriorTask+"=",
+		workerenv.ResultStdout+"=",
+		"ORKA_ARTIFACTS_DIR="+filepath.Join(t.TempDir(), "artifacts"),
+	)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper worker: %v", err)
+	}
+
+	select {
+	case <-resultStarted:
+	case <-time.After(10 * time.Second):
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("timed out waiting for result submission; helper output:\n%s", output.String())
+	}
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("signal helper worker: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("helper worker exited with %v; output:\n%s", err, output.String())
+		}
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		<-done
+		t.Fatalf("helper worker did not exit promptly after SIGTERM; output:\n%s", output.String())
+	}
+
+	mu.Lock()
+	gotEvents := append([]string(nil), eventTypes...)
+	mu.Unlock()
+	lateEventTypes := []string{
+		"ResultSubmitted", "ArtifactUploadCompleted", "ArtifactUploadFailed", "WorkerCompleted",
+	}
+	for _, lateType := range lateEventTypes {
+		if slices.Contains(gotEvents, lateType) {
+			t.Fatalf("events after SIGTERM = %#v, must not contain %s", gotEvents, lateType)
+		}
+	}
+}
+
+func TestGeneralWorkerSIGTERMHelper(t *testing.T) {
+	if os.Getenv("ORKA_TEST_GENERAL_SIGTERM_HELPER") != "1" {
+		return
+	}
+	originalArgs := os.Args
+	switch os.Getenv("ORKA_TEST_GENERAL_SIGTERM_COMMAND") {
+	case "failure":
+		os.Args = []string{"worker", "sh", "-c", "printf failed-result; exit 7"}
+	default:
+		os.Args = []string{"worker", "printf", "result ready"}
+	}
+	defer func() { os.Args = originalArgs }()
+
+	err := run()
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("run() error = %v, want context canceled", err)
+	}
+}
 
 func TestRun_Success(t *testing.T) {
 	os.Args = []string{"worker", "echo", "hello"}

--- a/workers/harness/cliwrapper/result.go
+++ b/workers/harness/cliwrapper/result.go
@@ -44,8 +44,7 @@ func FinalizeTurnResult(workDir, output string) ([]byte, error) {
 	return common.FinalizeResult(workDir, output)
 }
 
-// UploadTurnArtifacts reuses the existing worker artifact uploader. It is a
-// no-op when the selected turn artifact directory is absent.
+// ClearTurnArtifacts removes artifacts left by a completed turn.
 func ClearTurnArtifacts(artifactDirs ...string) {
 	artifactDir := firstNonEmpty(artifactDirs...)
 	if artifactDir == "" {
@@ -62,7 +61,10 @@ func wrapperArtifactsDir() string {
 	return "/tmp/artifacts"
 }
 
-func UploadTurnArtifacts(turn TurnContext, artifactDir string) error {
+// UploadTurnArtifacts reuses the existing worker artifact uploader. It is a
+// no-op when the selected turn artifact directory is absent and stops promptly
+// when the turn context is canceled.
+func UploadTurnArtifacts(ctx context.Context, turn TurnContext, artifactDir string) error {
 	resolvedArtifactDir := firstNonEmpty(artifactDir, wrapperArtifactsDir())
 	if err := prepareArtifactsForWrapper(resolvedArtifactDir); err != nil {
 		return fmt.Errorf("prepare artifacts for wrapper upload: %w", err)
@@ -75,7 +77,7 @@ func UploadTurnArtifacts(turn TurnContext, artifactDir string) error {
 	defer restoreTaskName()
 	restoreTaskNamespace := setTemporaryEnv(workerenv.TaskNamespace, turn.Namespace)
 	defer restoreTaskNamespace()
-	err := common.UploadArtifacts()
+	err := common.UploadArtifactsContext(ctx)
 	return err
 }
 

--- a/workers/harness/cliwrapper/result_test.go
+++ b/workers/harness/cliwrapper/result_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package cliwrapper
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/orka-agents/orka/internal/workerenv"
+)
+
+func TestUploadTurnArtifactsCancelsRetryBackoff(t *testing.T) {
+	artifactDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(artifactDir, "evidence.txt"), []byte("evidence"), 0o600); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+
+	firstAttempt := make(chan struct{})
+	var attempts atomic.Int32
+	controller := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) == 1 {
+			close(firstAttempt)
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer controller.Close()
+	t.Setenv(workerenv.ControllerURL, controller.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- UploadTurnArtifacts(ctx, TurnContext{
+			Namespace: "test-ns",
+			TaskName:  "test-task",
+		}, artifactDir)
+	}()
+
+	select {
+	case <-firstAttempt:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first artifact upload attempt")
+	}
+	// The first retry delay is two seconds. Give the response time to reach the
+	// uploader, then verify cancellation interrupts the delay rather than waiting
+	// for another attempt.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("UploadTurnArtifacts() error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("UploadTurnArtifacts() did not stop after cancellation")
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("artifact upload attempts = %d, want 1 before cancellation", got)
+	}
+}

--- a/workers/harness/cliwrapper/server.go
+++ b/workers/harness/cliwrapper/server.go
@@ -310,7 +310,7 @@ func (s *Server) handleCancel(w http.ResponseWriter, r *http.Request, turn *turn
 		writeSafeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	turn.cancel()
+	turn.requestCancel()
 	harness.WriteJSON(w, http.StatusAccepted, harness.CancelTurnResponse{
 		Version:          harness.ProtocolVersion,
 		Accepted:         true,
@@ -558,7 +558,11 @@ func (s *Server) runTurn(turn *turnState) { //nolint:gocyclo
 			}
 			restoreTurnEnv()
 		}
-		if artifactErr := UploadTurnArtifacts(turnCtx, turnArtifactsDir); artifactErr != nil {
+		artifactErr := UploadTurnArtifacts(ctx, turnCtx, turnArtifactsDir)
+		if s.appendTurnContextTerminalIfDone(ctx, turn) {
+			return
+		}
+		if artifactErr != nil {
 			turn.appendFrame(s.runtimeLogTextFrame(
 				turn,
 				"artifact-upload",
@@ -622,7 +626,11 @@ func (s *Server) runTurn(turn *turnState) { //nolint:gocyclo
 			))
 			return
 		}
-		if artifactErr := UploadTurnArtifacts(turnCtx, turnArtifactsDir); artifactErr != nil {
+		artifactErr := UploadTurnArtifacts(ctx, turnCtx, turnArtifactsDir)
+		if s.appendTurnContextTerminalIfDone(ctx, turn) {
+			return
+		}
+		if artifactErr != nil {
 			turn.appendFrame(s.runtimeLogTextFrame(
 				turn,
 				"artifact-upload",
@@ -638,8 +646,17 @@ func (s *Server) runTurn(turn *turnState) { //nolint:gocyclo
 				))
 			}
 		}
-		if frameErr := s.appendCompletedFrame(turn, parsed); frameErr != nil {
-			turn.appendFrame(s.failedFrame(turn, "result_store_failed", frameErr.Error(), false))
+		if frameErr := s.appendCompletedFrame(ctx, turn, parsed); frameErr != nil {
+			if errors.Is(frameErr, errTurnCanceledBeforeCompletion) ||
+				errors.Is(frameErr, context.Canceled) ||
+				errors.Is(frameErr, context.DeadlineExceeded) {
+				s.appendTurnContextTerminalFrame(turn, frameErr)
+				return
+			}
+			storeFailed := s.failedFrame(turn, "result_store_failed", frameErr.Error(), false)
+			if terminalErr := turn.tryAppendTerminalFrame(ctx, storeFailed); terminalErr != nil {
+				s.appendTurnContextTerminalFrame(turn, terminalErr)
+			}
 			return
 		}
 	}
@@ -878,13 +895,38 @@ func (s *Server) outputFrame(turn *turnState, stream, text string) harness.Harne
 	return frame
 }
 
-func (s *Server) appendCompletedFrame(turn *turnState, result TurnResult) error {
+var errTurnCanceledBeforeCompletion = errors.New("turn canceled before completion")
+
+func (s *Server) appendCompletedFrame(ctx context.Context, turn *turnState, result TurnResult) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	completed, err := s.completedFrame(turn, result)
 	if err != nil {
 		return err
 	}
-	turn.appendFrame(completed)
+	if err := turn.tryAppendTerminalFrame(ctx, completed); err != nil {
+		turn.cleanupOutput()
+		return err
+	}
 	return nil
+}
+
+func (s *Server) appendTurnContextTerminalIfDone(ctx context.Context, turn *turnState) bool {
+	err := ctx.Err()
+	if err == nil {
+		return false
+	}
+	s.appendTurnContextTerminalFrame(turn, err)
+	return true
+}
+
+func (s *Server) appendTurnContextTerminalFrame(turn *turnState, err error) {
+	if errors.Is(err, context.DeadlineExceeded) {
+		turn.appendFrame(s.failedFrame(turn, "timeout", "turn deadline exceeded", true))
+		return
+	}
+	turn.appendFrame(s.frame(turn, harness.FrameTurnCancelled, "turn cancelled", nil))
 }
 
 func (s *Server) completedFrame(turn *turnState, result TurnResult) (harness.HarnessEventFrame, error) {
@@ -1051,6 +1093,7 @@ type turnState struct {
 	mu              sync.Mutex
 	frames          []harness.HarnessEventFrame
 	terminal        bool
+	cancelRequested bool
 	closed          bool
 	resultPath      string
 	resultRead      bool
@@ -1184,6 +1227,39 @@ func (t *turnState) cleanupOutput() {
 func (t *turnState) appendFrame(frame harness.HarnessEventFrame) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.appendFrameLocked(frame)
+}
+
+func (t *turnState) tryAppendTerminalFrame(
+	ctx context.Context,
+	frame harness.HarnessEventFrame,
+) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.cancelRequested {
+		return errTurnCanceledBeforeCompletion
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	t.appendFrameLocked(frame)
+	return nil
+}
+
+func (t *turnState) appendFrameLocked(frame harness.HarnessEventFrame) {
+	if t.cancelRequested && frame.Type != harness.FrameTurnCancelled && isTerminalFrameType(frame.Type) {
+		frame.Type = harness.FrameTurnCancelled
+		frame.Severity = events.ExecutionEventSeverityInfo
+		frame.Summary = "turn cancelled"
+		frame.Content = nil
+		frame.ContentText = ""
+		frame.ToolName = ""
+		frame.ToolCallID = ""
+		frame.ApprovalID = ""
+		frame.Completed = nil
+		frame.Failed = nil
+		frame.Error = nil
+	}
 	if frame.Seq <= 0 {
 		frame.Seq = int64(len(t.frames) + 1)
 	}
@@ -1195,6 +1271,25 @@ func (t *turnState) appendFrame(frame harness.HarnessEventFrame) {
 	case harness.FrameTurnCompleted, harness.FrameTurnFailed, harness.FrameTurnCancelled:
 		t.terminal = true
 	}
+}
+
+func isTerminalFrameType(frameType harness.FrameType) bool {
+	switch frameType {
+	case harness.FrameTurnCompleted, harness.FrameTurnFailed, harness.FrameTurnCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func (t *turnState) requestCancel() {
+	t.mu.Lock()
+	if !t.terminal {
+		t.cancelRequested = true
+	}
+	cancel := t.cancel
+	t.mu.Unlock()
+	cancel()
 }
 
 func (t *turnState) framesFrom(seq int64) ([]harness.HarnessEventFrame, bool) {

--- a/workers/harness/cliwrapper/server_test.go
+++ b/workers/harness/cliwrapper/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -195,6 +196,163 @@ func TestServerCancelEmitsCancellation(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for cancel frame")
+	}
+}
+
+func TestServerCancelDuringArtifactUploadDoesNotAppendCompletion(t *testing.T) {
+	uploadStarted := make(chan struct{}, 1)
+	releaseUpload := make(chan struct{})
+	controller := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case uploadStarted <- struct{}{}:
+		default:
+		}
+		<-releaseUpload
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer func() {
+		close(releaseUpload)
+		controller.Close()
+	}()
+	t.Setenv(workerenv.ControllerURL, controller.URL)
+
+	cfg := DefaultConfig()
+	cfg.AllowUnauthenticated = true
+	cfg.Generic.Command = wrapperTestShellPath
+	cfg.Generic.Args = []string{
+		"-c",
+		`printf 'artifact' > "$ORKA_ARTIFACTS_DIR/evidence.txt"; printf 'done'`,
+	}
+	baseURL, cleanup := startWrapperServerWithConfig(t, cfg, NewGenericAdapter(cfg.Generic))
+	defer cleanup()
+	client, err := harness.NewClient(baseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := validWrapperStartTurnRequest()
+	if _, err := client.StartTurn(context.Background(), request); err != nil {
+		t.Fatalf("StartTurn: %v", err)
+	}
+
+	select {
+	case <-uploadStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for artifact upload")
+	}
+	if _, err := client.CancelTurn(context.Background(), harness.CancelTurnRequest{
+		Version:          harness.ProtocolVersion,
+		Namespace:        request.Namespace,
+		TaskName:         request.TaskName,
+		SessionName:      request.SessionName,
+		RuntimeSessionID: request.RuntimeSessionID,
+		TurnID:           request.TurnID,
+		CorrelationID:    request.CorrelationID,
+		Reason:           "test artifact cancellation",
+	}); err != nil {
+		t.Fatalf("CancelTurn: %v", err)
+	}
+	streamCtx, cancelStream := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelStream()
+	frames := []harness.HarnessEventFrame{}
+	if err := client.StreamFrames(streamCtx, request.TurnID, 0, func(frame harness.HarnessEventFrame) error {
+		frames = append(frames, frame)
+		return nil
+	}); err != nil {
+		t.Fatalf("StreamFrames after cancellation: %v", err)
+	}
+	if len(frames) == 0 {
+		t.Fatal("no frames after cancellation")
+	}
+	last := frames[len(frames)-1]
+	if last.Type != harness.FrameTurnCancelled {
+		t.Fatalf("last frame = %#v, want cancelled", last)
+	}
+	for _, frame := range frames {
+		if frame.Type == harness.FrameTurnCompleted {
+			t.Fatalf("frames contain late completion after cancellation: %#v", frames)
+		}
+	}
+}
+
+func TestTryAppendTerminalFrameRejectsContextDoneWhileWaitingForTurnLock(t *testing.T) {
+	turn := newTurnState(validWrapperStartTurnRequest(), time.Now)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	turn.mu.Lock()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- turn.tryAppendTerminalFrame(ctx, harness.HarnessEventFrame{
+			Type: harness.FrameTurnCompleted,
+			Completed: &harness.TurnCompleted{
+				Result: "late result",
+			},
+		})
+	}()
+	<-ctx.Done()
+	turn.mu.Unlock()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("tryAppendTerminalFrame() error = %v, want deadline exceeded", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("tryAppendTerminalFrame() did not return after deadline")
+	}
+	turn.mu.Lock()
+	defer turn.mu.Unlock()
+	if len(turn.frames) != 0 || turn.terminal {
+		t.Fatalf("turn state after expired completion = frames %#v, terminal %v", turn.frames, turn.terminal)
+	}
+}
+
+func TestTryAppendTerminalFrameRejectsAcceptedCancelBeforeFailure(t *testing.T) {
+	turn := newTurnState(validWrapperStartTurnRequest(), time.Now)
+	turn.requestCancel()
+
+	err := turn.tryAppendTerminalFrame(context.Background(), harness.HarnessEventFrame{
+		Type: harness.FrameTurnFailed,
+		Failed: &harness.TurnFailed{
+			Reason:  "result_store_failed",
+			Message: "store failed",
+		},
+	})
+	if !errors.Is(err, errTurnCanceledBeforeCompletion) {
+		t.Fatalf("tryAppendTerminalFrame() error = %v, want canceled-before-completion", err)
+	}
+	turn.mu.Lock()
+	defer turn.mu.Unlock()
+	if len(turn.frames) != 0 || turn.terminal {
+		t.Fatalf("turn state after rejected failure = frames %#v, terminal %v", turn.frames, turn.terminal)
+	}
+}
+
+func TestAppendFramePublishesCancellationAfterAcceptedCancel(t *testing.T) {
+	turn := newTurnState(validWrapperStartTurnRequest(), time.Now)
+	turn.requestCancel()
+	turn.appendFrame(harness.HarnessEventFrame{
+		Type:        harness.FrameTurnFailed,
+		Severity:    "error",
+		Summary:     "result store failed",
+		ContentText: "late failure detail",
+		Failed: &harness.TurnFailed{
+			Reason:  "result_store_failed",
+			Message: "store failed",
+		},
+	})
+
+	turn.mu.Lock()
+	defer turn.mu.Unlock()
+	if len(turn.frames) != 1 {
+		t.Fatalf("frames = %#v, want one cancellation", turn.frames)
+	}
+	frame := turn.frames[0]
+	if frame.Type != harness.FrameTurnCancelled || !turn.terminal {
+		t.Fatalf("frame after accepted cancel = %#v, terminal %v", frame, turn.terminal)
+	}
+	if frame.Failed != nil || frame.Completed != nil || frame.ContentText != "" {
+		t.Fatalf("cancellation retained late terminal payload: %#v", frame)
 	}
 }
 


### PR DESCRIPTION
## Summary

Stacked salvage from #280. Base: #311 (`fix/worker-delivery-cancellation`).

- Recover from provider context-limit errors using the complete serialized request size, dropping historical message/tool-result blocks atomically and only truncating the current task when required.
- Correct nested model updates while preserving omitted fields and legacy model-string compatibility.
- Bound `update_plan` network stalls and make `wait_for_tasks` tolerate transient reads without retrying authorization or validation failures.

## Scope

This PR is limited to AI context recovery and built-in tool reliability. It does not change worker result/artifact delivery, API schemas, or Task finalization semantics.

## Verification

- `go test ./internal/llm ./internal/tools ./workers/ai -count=1`
- `make lint-fix && make test`
- Full required CI

After #311 merges, this PR should be retargeted to `main`.