### PR TITLE
fix(logs): harden task streaming and SSE handling

### DIFF
--- a/cmd/cli/task_test.go
+++ b/cmd/cli/task_test.go
@@ -18,6 +18,8 @@ import (
 	"time"
 )
 
+const testTaskLogsPath = "/api/v1/tasks/my-task/logs"
+
 func TestFormatAge(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -204,7 +206,7 @@ func taskAPIServer() *httptest.Server {
 				},
 				"status": map[string]any{"phase": "Succeeded"},
 			})
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/tasks/my-task/logs":
+		case r.Method == http.MethodGet && r.URL.Path == testTaskLogsPath:
 			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
 				"logs": "line1\nline2\n",
 			})
@@ -561,7 +563,7 @@ func TestNewTaskLogsCmd_Follow(t *testing.T) {
 	t.Setenv("HOME", tmp)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/tasks/my-task/logs" && r.URL.Query().Get("follow") == "true" {
+		if r.URL.Path == testTaskLogsPath && r.URL.Query().Get("follow") == "true" {
 			w.Header().Set("Content-Type", "text/event-stream")
 			flusher, ok := w.(http.Flusher)
 			fmt.Fprint(w, "event: log\ndata: {\"line\":\"log line 1\"}\n\n") //nolint:errcheck
@@ -580,6 +582,29 @@ func TestNewTaskLogsCmd_Follow(t *testing.T) {
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
+func TestNewTaskLogsCmd_FollowReturnsStreamError(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != testTaskLogsPath || r.URL.Query().Get("follow") != "true" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "event: error\ndata: {\"error\":\"failed to read task logs: unexpected EOF\"}\n\n") //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	root := newRootCmd()
+	root.SetArgs([]string{"task", "logs", "--server", srv.URL, "--follow", "my-task"})
+
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "failed to read task logs: unexpected EOF") {
+		t.Fatalf("Execute() error = %v, want streamed task-log error", err)
 	}
 }
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -13,7 +13,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
@@ -24,6 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
 	gatewayruntime "github.com/orka-agents/orka/internal/gateway"
@@ -848,13 +851,18 @@ func (h *Handlers) GetTaskLogs(c fiber.Ctx) error {
 
 		streamNamespace := strings.Clone(namespace)
 		streamPodName := strings.Clone(podName)
+		streamLog := logf.FromContext(streamCtx)
 		streamErr := c.SendStreamWriter(func(w *bufio.Writer) {
 			defer func() {
 				streamCancel()
 				_ = stream.Close()
 			}()
 			if err := streamTaskLogsSSE(streamCtx, w, stream, heartbeatEvery); err != nil {
-				log.Error(err, "failed to relay task log stream", "namespace", streamNamespace, "pod", streamPodName)
+				if taskLogClientDisconnected(err) {
+					streamLog.V(1).Info("task log client disconnected", "namespace", streamNamespace, "pod", streamPodName)
+				} else {
+					streamLog.Error(err, "failed to relay task log stream", "namespace", streamNamespace, "pod", streamPodName)
+				}
 			}
 		})
 		if streamErr != nil {
@@ -892,6 +900,25 @@ type taskLogScanResult struct {
 	err  error
 }
 
+type taskLogDownstreamError struct{ err error }
+
+func (e taskLogDownstreamError) Error() string { return e.err.Error() }
+func (e taskLogDownstreamError) Unwrap() error { return e.err }
+
+func taskLogClientDisconnected(err error) bool {
+	var downstream taskLogDownstreamError
+	if !errors.As(err, &downstream) {
+		return false
+	}
+	err = downstream.err
+	if errors.Is(err, net.ErrClosed) || errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "broken pipe") || strings.Contains(message, "connection reset") ||
+		strings.Contains(message, "closed connection") || strings.Contains(message, "connection closed")
+}
+
 func streamTaskLogsSSE(
 	ctx context.Context,
 	w *bufio.Writer,
@@ -918,14 +945,14 @@ func streamTaskLogsSSE(
 				return result.err
 			}
 			if err := writeTaskLogLineSSE(w, result.line); err != nil {
-				return err
+				return taskLogDownstreamError{err: err}
 			}
 		case <-heartbeat.C:
 			if _, err := fmt.Fprint(w, ": heartbeat\n\n"); err != nil {
-				return fmt.Errorf("write task log heartbeat: %w", err)
+				return taskLogDownstreamError{err: fmt.Errorf("write task log heartbeat: %w", err)}
 			}
 			if err := w.Flush(); err != nil {
-				return fmt.Errorf("flush task log heartbeat: %w", err)
+				return taskLogDownstreamError{err: fmt.Errorf("flush task log heartbeat: %w", err)}
 			}
 		}
 	}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -33,7 +33,14 @@ import (
 	"github.com/orka-agents/orka/internal/tracing"
 )
 
-const queryTrue = "true"
+const (
+	queryTrue = "true"
+
+	defaultTaskLogStreamHeartbeatEvery = 15 * time.Second
+	taskLogStreamInitialBufferBytes    = 64 * 1024
+	taskLogStreamMaxLineBytes          = 1024 * 1024
+	taskLogStreamScannerBufferBytes    = taskLogStreamMaxLineBytes + 2
+)
 
 // Handlers contains all API handlers
 //
@@ -751,28 +758,70 @@ func (h *Handlers) GetTaskLogs(c fiber.Ctx) error {
 	follow := c.Query("follow") == queryTrue
 
 	if follow {
-		streamCtx, streamCancel := context.WithCancel(context.Background())
+		// SendStreamWriter outlives the Fiber handler, so the Kubernetes stream
+		// must not permanently inherit Fiber's recyclable request context. Mirror
+		// request cancellation only while the upstream stream is being established,
+		// then hand ownership to explicit deadlines plus heartbeat/write failure
+		// detection below. A bare post-handoff cancellation cannot be retained:
+		// Fiber uses that same signal when it recycles the handler context.
+		streamBaseCtx := context.WithoutCancel(ctx)
+		var streamCtx context.Context
+		var streamCancel context.CancelFunc
+		if deadline, ok := ctx.Deadline(); ok {
+			streamCtx, streamCancel = context.WithDeadline(streamBaseCtx, deadline)
+		} else {
+			streamCtx, streamCancel = context.WithCancel(streamBaseCtx)
+		}
+		stopSetupCancellation := context.AfterFunc(ctx, streamCancel)
 		stream, err := StreamPodLogs(streamCtx, h.clientset, namespace, podName, "worker")
 		if err != nil {
+			_ = stopSetupCancellation()
 			streamCancel()
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) ||
+				errors.Is(streamCtx.Err(), context.DeadlineExceeded) ||
+				errors.Is(err, context.DeadlineExceeded) {
+				return fiber.NewError(fiber.StatusGatewayTimeout, "task log stream setup timed out")
+			}
+			if ctx.Err() != nil {
+				return nil
+			}
 			return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to stream logs: %v", err))
+		}
+		if !stopSetupCancellation() || ctx.Err() != nil || streamCtx.Err() != nil {
+			streamCancel()
+			_ = stream.Close()
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(streamCtx.Err(), context.DeadlineExceeded) {
+				return fiber.NewError(fiber.StatusGatewayTimeout, "task log stream setup timed out")
+			}
+			return nil
 		}
 
 		c.Set("Content-Type", "text/event-stream")
 		c.Set("Cache-Control", "no-cache")
 		c.Set("Connection", "keep-alive")
+		c.Set("X-Accel-Buffering", "no")
 
-		return c.SendStreamWriter(func(w *bufio.Writer) {
-			defer streamCancel()
-			defer func() { _ = stream.Close() }()
-			scanner := bufio.NewScanner(stream)
-			for scanner.Scan() {
-				_, _ = fmt.Fprintf(w, "data: %s\n\n", scanner.Text())
-				if err := w.Flush(); err != nil {
-					return
-				}
+		heartbeatEvery := h.eventStreamHeartbeatEvery
+		if heartbeatEvery <= 0 {
+			heartbeatEvery = defaultTaskLogStreamHeartbeatEvery
+		}
+
+		streamNamespace := strings.Clone(namespace)
+		streamPodName := strings.Clone(podName)
+		streamErr := c.SendStreamWriter(func(w *bufio.Writer) {
+			defer func() {
+				streamCancel()
+				_ = stream.Close()
+			}()
+			if err := streamTaskLogsSSE(streamCtx, w, stream, heartbeatEvery); err != nil {
+				log.Error(err, "failed to relay task log stream", "namespace", streamNamespace, "pod", streamPodName)
 			}
 		})
+		if streamErr != nil {
+			streamCancel()
+			_ = stream.Close()
+		}
+		return streamErr
 	}
 
 	// Non-follow mode: return the last N lines
@@ -796,6 +845,123 @@ func (h *Handlers) GetTaskLogs(c fiber.Ctx) error {
 	return c.JSON(fiber.Map{
 		"logs": string(logBytes),
 	})
+}
+
+type taskLogScanResult struct {
+	line string
+	err  error
+}
+
+func streamTaskLogsSSE(
+	ctx context.Context,
+	w *bufio.Writer,
+	stream io.Reader,
+	heartbeatEvery time.Duration,
+) error {
+	results := make(chan taskLogScanResult)
+	go scanTaskLogLines(ctx, stream, results)
+
+	heartbeat := time.NewTicker(heartbeatEvery)
+	defer heartbeat.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case result, ok := <-results:
+			if !ok {
+				return nil
+			}
+			if result.err != nil {
+				if err := writeTaskLogStreamErrorSSE(w, result.err); err != nil {
+					return errors.Join(result.err, fmt.Errorf("report task log stream error: %w", err))
+				}
+				return result.err
+			}
+			if err := writeTaskLogLineSSE(w, result.line); err != nil {
+				return err
+			}
+		case <-heartbeat.C:
+			if _, err := fmt.Fprint(w, ": heartbeat\n\n"); err != nil {
+				return fmt.Errorf("write task log heartbeat: %w", err)
+			}
+			if err := w.Flush(); err != nil {
+				return fmt.Errorf("flush task log heartbeat: %w", err)
+			}
+		}
+	}
+}
+
+func scanTaskLogLines(ctx context.Context, stream io.Reader, results chan<- taskLogScanResult) {
+	defer close(results)
+	scanner := bufio.NewScanner(stream)
+	scanner.Buffer(make([]byte, taskLogStreamInitialBufferBytes), taskLogStreamScannerBufferBytes)
+	for scanner.Scan() {
+		if len(scanner.Bytes()) > taskLogStreamMaxLineBytes {
+			sendTaskLogScanResult(ctx, results, taskLogScanResult{err: taskLogLineTooLongError()})
+			return
+		}
+		if !sendTaskLogScanResult(ctx, results, taskLogScanResult{line: scanner.Text()}) {
+			return
+		}
+	}
+	if err := scanner.Err(); err != nil && ctx.Err() == nil {
+		if errors.Is(err, bufio.ErrTooLong) {
+			err = taskLogLineTooLongError()
+		}
+		sendTaskLogScanResult(ctx, results, taskLogScanResult{err: err})
+	}
+}
+
+func sendTaskLogScanResult(ctx context.Context, results chan<- taskLogScanResult, result taskLogScanResult) bool {
+	select {
+	case results <- result:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func writeTaskLogLineSSE(w *bufio.Writer, line string) error {
+	// SSE treats a bare carriage return as a field delimiter. Frame every
+	// carriage-return-delimited progress segment as data so task output cannot
+	// inject event fields; clients reconstruct the segments with newlines.
+	remaining := line
+	for {
+		segment, rest, found := strings.Cut(remaining, "\r")
+		if _, err := fmt.Fprintf(w, "data: %s\n", segment); err != nil {
+			return fmt.Errorf("write task log event: %w", err)
+		}
+		if !found {
+			break
+		}
+		remaining = rest
+	}
+	if _, err := fmt.Fprint(w, "\n"); err != nil {
+		return fmt.Errorf("write task log event: %w", err)
+	}
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("flush task log event: %w", err)
+	}
+	return nil
+}
+
+func taskLogLineTooLongError() error {
+	return fmt.Errorf("task log line exceeds %d bytes", taskLogStreamMaxLineBytes)
+}
+
+func writeTaskLogStreamErrorSSE(w *bufio.Writer, streamErr error) error {
+	data, err := json.Marshal(struct {
+		Error string `json:"error"`
+	}{
+		Error: fmt.Sprintf("failed to read task logs: %v", streamErr),
+	})
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "event: error\ndata: %s\n\n", data); err != nil {
+		return err
+	}
+	return w.Flush()
 }
 
 // GetTaskResult gets the result of a task

--- a/internal/api/task_logs_test.go
+++ b/internal/api/task_logs_test.go
@@ -1,0 +1,546 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package api
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+)
+
+func TestHandlers_GetTaskLogsFollowTreatsFinalizingAsLive(t *testing.T) {
+	h, app, _ := newTaskLogStreamTestAppWithPhase(
+		t,
+		corev1alpha1.TaskPhaseFinalizing,
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = io.WriteString(w, "finalizing-log\n")
+		},
+	)
+	app.Get("/tasks/:id/logs", h.GetTaskLogs)
+
+	resp, err := app.Test(
+		httptest.NewRequest(http.MethodGet, "/tasks/log-task/logs?follow="+queryTrue, nil),
+		fiber.TestConfig{Timeout: 2 * time.Second},
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "data: finalizing-log\n\n", string(body))
+}
+
+func TestStreamTaskLogsSSEPropagatesWriterErrors(t *testing.T) {
+	w := bufio.NewWriterSize(taskLogFailWriter{}, 1)
+	err := streamTaskLogsSSE(t.Context(), w, strings.NewReader("line\n"), time.Hour)
+	require.ErrorContains(t, err, "write task log event")
+	require.ErrorIs(t, err, io.ErrClosedPipe)
+}
+
+type taskLogFailWriter struct{}
+
+func (taskLogFailWriter) Write([]byte) (int, error) {
+	return 0, io.ErrClosedPipe
+}
+
+func TestHandlers_GetTaskLogsFollowFramesEmbeddedCarriageReturns(t *testing.T) {
+	line := "10%\r20%\revent: error\rdata: forged"
+	h, app, _ := newTaskLogStreamTestApp(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = io.WriteString(w, line+"\n")
+	})
+	app.Get("/tasks/:id/logs", h.GetTaskLogs)
+
+	resp, err := app.Test(
+		httptest.NewRequest(http.MethodGet, "/tasks/log-task/logs?follow="+queryTrue, nil),
+		fiber.TestConfig{Timeout: 2 * time.Second},
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "data: 10%\ndata: 20%\ndata: event: error\ndata: data: forged\n\n", string(body))
+	require.NotContains(t, string(body), "\nevent: error\n")
+}
+
+func TestHandlers_GetTaskLogsFollowStreamsLargeLines(t *testing.T) {
+	line := strings.Repeat("x", 128*1024)
+	h, app, _ := newTaskLogStreamTestApp(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = io.WriteString(w, line+"\n")
+	})
+	app.Get("/tasks/:id/logs", h.GetTaskLogs)
+
+	resp, err := app.Test(
+		httptest.NewRequest(http.MethodGet, "/tasks/log-task/logs?follow="+queryTrue, nil),
+		fiber.TestConfig{Timeout: 2 * time.Second},
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "no", resp.Header.Get("X-Accel-Buffering"))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "data: "+line+"\n\n", string(body))
+}
+
+func TestHandlers_GetTaskLogsFollowAcceptsExactMaximumLine(t *testing.T) {
+	line := strings.Repeat("x", taskLogStreamMaxLineBytes)
+	h, app, _ := newTaskLogStreamTestApp(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = io.WriteString(w, line+"\n")
+	})
+	app.Get("/tasks/:id/logs", h.GetTaskLogs)
+
+	resp, err := app.Test(
+		httptest.NewRequest(http.MethodGet, "/tasks/log-task/logs?follow="+queryTrue, nil),
+		fiber.TestConfig{Timeout: 2 * time.Second},
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "data: "+line+"\n\n", string(body))
+}
+
+func TestHandlers_GetTaskLogsFollowBoundsOversizeLines(t *testing.T) {
+	tests := []struct {
+		name      string
+		lineBytes int
+	}{
+		{name: "one byte over", lineBytes: taskLogStreamMaxLineBytes + 1},
+		{name: "well over", lineBytes: taskLogStreamMaxLineBytes + 128*1024},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			line := strings.Repeat("x", tt.lineBytes)
+			h, app, _ := newTaskLogStreamTestApp(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				_, _ = io.WriteString(w, line+"\n")
+			})
+			app.Get("/tasks/:id/logs", h.GetTaskLogs)
+
+			resp, err := app.Test(
+				httptest.NewRequest(http.MethodGet, "/tasks/log-task/logs?follow="+queryTrue, nil),
+				fiber.TestConfig{Timeout: 2 * time.Second},
+			)
+			require.NoError(t, err)
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.NotContains(t, string(body), "data: "+strings.Repeat("x", 64))
+			require.Contains(t, string(body), "event: error\n")
+			require.Contains(t, string(body), "task log line exceeds 1048576 bytes")
+		})
+	}
+}
+
+func TestHandlers_GetTaskLogsNonFollowRemainsJSON(t *testing.T) {
+	h, app, _ := newTaskLogStreamTestApp(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("tailLines"); got != "100" {
+			t.Errorf("tailLines = %q, want 100", got)
+		}
+		if got := r.URL.Query().Get("follow"); got != "" {
+			t.Errorf("follow = %q, want empty", got)
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = io.WriteString(w, "tail-one\ntail-two\n")
+	})
+	app.Get("/tasks/:id/logs", h.GetTaskLogs)
+
+	resp, err := app.Test(
+		httptest.NewRequest(http.MethodGet, "/tasks/log-task/logs", nil),
+		fiber.TestConfig{Timeout: 2 * time.Second},
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	var payload struct {
+		Logs string `json:"logs"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	require.Equal(t, "tail-one\ntail-two\n", payload.Logs)
+}
+
+func TestHandlers_GetTaskLogsFollowSurfacesScannerErrors(t *testing.T) {
+	const partial = "before-error\n"
+	h, app, _ := newTaskLogStreamTestApp(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Length", strconv.Itoa(len(partial)+32))
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, partial)
+	})
+	app.Get("/tasks/:id/logs", h.GetTaskLogs)
+
+	resp, err := app.Test(
+		httptest.NewRequest(http.MethodGet, "/tasks/log-task/logs?follow="+queryTrue, nil),
+		fiber.TestConfig{Timeout: 2 * time.Second},
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(body), "data: before-error\n\n")
+	require.Contains(t, string(body), "event: error\n")
+	require.Contains(t, string(body), "unexpected EOF")
+}
+
+func TestHandlers_GetTaskLogsFollowHeartbeatsWhileUpstreamIsQuiet(t *testing.T) {
+	releaseUpstream := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(releaseUpstream)
+		}
+	}()
+	h, app, _ := newTaskLogStreamTestApp(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-releaseUpstream
+	})
+	h.eventStreamHeartbeatEvery = 10 * time.Millisecond
+	app.Get("/tasks/:id/logs", h.GetTaskLogs)
+
+	client := newTaskLogHTTPClient()
+	resp, err := client.Get(startTaskLogFiberServer(t, app) + "/tasks/log-task/logs?follow=" + queryTrue)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	heartbeat := make([]byte, len(": heartbeat\n\n"))
+	_, err = io.ReadFull(resp.Body, heartbeat)
+	require.NoError(t, err)
+	require.Equal(t, ": heartbeat\n\n", string(heartbeat))
+
+	close(releaseUpstream)
+	released = true
+	_, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+}
+
+func TestHandlers_GetTaskLogsFollowDisconnectCancelsQuietUpstream(t *testing.T) {
+	upstreamCanceled := make(chan struct{})
+	h, app, kubeServer := newTaskLogStreamTestApp(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+		close(upstreamCanceled)
+	})
+	h.eventStreamHeartbeatEvery = 10 * time.Millisecond
+	app.Get("/tasks/:id/logs", h.GetTaskLogs)
+
+	client := newTaskLogHTTPClient()
+	resp, err := client.Get(startTaskLogFiberServer(t, app) + "/tasks/log-task/logs?follow=" + queryTrue)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	heartbeat := make([]byte, len(": heartbeat\n\n"))
+	_, err = io.ReadFull(resp.Body, heartbeat)
+	require.NoError(t, err)
+	require.Equal(t, ": heartbeat\n\n", string(heartbeat))
+	require.NoError(t, resp.Body.Close())
+
+	select {
+	case <-upstreamCanceled:
+	case <-time.After(2 * time.Second):
+		kubeServer.CloseClientConnections()
+		t.Fatal("client disconnect did not cancel the quiet Kubernetes log stream")
+	}
+}
+
+func TestHandlers_GetTaskLogsFollowCancelsUpstreamDuringSetup(t *testing.T) {
+	logStarted := make(chan struct{})
+	upstreamCanceled := make(chan struct{})
+	h, app, kubeServer := newTaskLogStreamTestApp(t, func(_ http.ResponseWriter, r *http.Request) {
+		close(logStarted)
+		<-r.Context().Done()
+		close(upstreamCanceled)
+	})
+
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	defer cancelRequest()
+	app.Use(func(c fiber.Ctx) error {
+		c.SetContext(requestCtx)
+		return c.Next()
+	})
+	app.Get("/tasks/:id/logs", h.GetTaskLogs)
+
+	result := make(chan error, 1)
+	go func() {
+		resp, err := app.Test(
+			httptest.NewRequest(http.MethodGet, "/tasks/log-task/logs?follow="+queryTrue, nil),
+			fiber.TestConfig{Timeout: 2 * time.Second},
+		)
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		result <- err
+	}()
+
+	select {
+	case <-logStarted:
+	case <-time.After(2 * time.Second):
+		kubeServer.CloseClientConnections()
+		t.Fatal("Kubernetes log stream setup did not start")
+	}
+	cancelRequest()
+
+	select {
+	case <-upstreamCanceled:
+	case <-time.After(2 * time.Second):
+		kubeServer.CloseClientConnections()
+		t.Fatal("request cancellation did not stop Kubernetes log stream setup")
+	}
+	select {
+	case err := <-result:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		kubeServer.CloseClientConnections()
+		t.Fatal("log request did not finish after setup cancellation")
+	}
+}
+
+func TestHandlers_GetTaskLogsFollowReturnsTimeoutWhenSetupDeadlineExpires(t *testing.T) {
+	upstreamCanceled := make(chan struct{})
+	h, app, kubeServer := newTaskLogStreamTestApp(t, func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+		close(upstreamCanceled)
+	})
+
+	requestCtx, cancelRequest := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancelRequest()
+	app.Use(func(c fiber.Ctx) error {
+		c.SetContext(requestCtx)
+		return c.Next()
+	})
+	app.Get("/tasks/:id/logs", h.GetTaskLogs)
+
+	resp, err := app.Test(
+		httptest.NewRequest(http.MethodGet, "/tasks/log-task/logs?follow="+queryTrue, nil),
+		fiber.TestConfig{Timeout: 2 * time.Second},
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusGatewayTimeout, resp.StatusCode)
+
+	select {
+	case <-upstreamCanceled:
+	case <-time.After(2 * time.Second):
+		kubeServer.CloseClientConnections()
+		t.Fatal("request deadline did not cancel Kubernetes log stream setup")
+	}
+}
+
+func TestHandlers_GetTaskLogsFollowOutlivesFiberRequestContext(t *testing.T) {
+	releaseUpstream := make(chan struct{})
+	upstreamCanceled := make(chan struct{})
+	h, app, kubeServer := newTaskLogStreamTestApp(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "before-request-context-cancel\n")
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		select {
+		case <-releaseUpstream:
+			_, _ = io.WriteString(w, "after-request-context-cancel\n")
+		case <-r.Context().Done():
+			close(upstreamCanceled)
+		}
+	})
+
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	defer cancelRequest()
+	app.Use(func(c fiber.Ctx) error {
+		c.SetContext(requestCtx)
+		return c.Next()
+	})
+	app.Get("/tasks/:id/logs", h.GetTaskLogs)
+
+	client := newTaskLogHTTPClient()
+	resp, err := client.Get(startTaskLogFiberServer(t, app) + "/tasks/log-task/logs?follow=" + queryTrue)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	firstFrame := make([]byte, len("data: before-request-context-cancel\n\n"))
+	_, err = io.ReadFull(resp.Body, firstFrame)
+	require.NoError(t, err)
+	require.Equal(t, "data: before-request-context-cancel\n\n", string(firstFrame))
+
+	cancelRequest()
+	select {
+	case <-upstreamCanceled:
+		kubeServer.CloseClientConnections()
+		t.Fatal("Fiber request context cancellation stopped the handed-off Kubernetes log stream")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseUpstream)
+
+	remainingBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(remainingBody), "data: after-request-context-cancel\n\n")
+}
+
+func TestHandlers_GetTaskLogsFollowHonorsDeadlineAfterHandoff(t *testing.T) {
+	upstreamCanceled := make(chan struct{})
+	h, app, kubeServer := newTaskLogStreamTestApp(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "before-request-deadline\n")
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+		close(upstreamCanceled)
+	})
+
+	requestCtx, cancelRequest := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancelRequest()
+	app.Use(func(c fiber.Ctx) error {
+		c.SetContext(requestCtx)
+		return c.Next()
+	})
+	app.Get("/tasks/:id/logs", h.GetTaskLogs)
+
+	client := newTaskLogHTTPClient()
+	resp, err := client.Get(startTaskLogFiberServer(t, app) + "/tasks/log-task/logs?follow=" + queryTrue)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	firstFrame := make([]byte, len("data: before-request-deadline\n\n"))
+	_, err = io.ReadFull(resp.Body, firstFrame)
+	require.NoError(t, err)
+	require.Equal(t, "data: before-request-deadline\n\n", string(firstFrame))
+
+	select {
+	case <-upstreamCanceled:
+	case <-time.After(2 * time.Second):
+		kubeServer.CloseClientConnections()
+		t.Fatal("request deadline did not cancel the handed-off Kubernetes log stream")
+	}
+}
+
+func startTaskLogFiberServer(t *testing.T, app *fiber.App) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- app.Listener(listener, fiber.ListenConfig{DisableStartupMessage: true})
+	}()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = app.ShutdownWithContext(shutdownCtx)
+		select {
+		case <-serveErr:
+		case <-time.After(time.Second):
+		}
+	})
+	return "http://" + listener.Addr().String()
+}
+
+func newTaskLogHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+		},
+	}
+}
+
+func newTaskLogStreamTestApp(
+	t *testing.T,
+	logHandler http.HandlerFunc,
+) (*Handlers, *fiber.App, *httptest.Server) {
+	t.Helper()
+	return newTaskLogStreamTestAppWithPhase(t, corev1alpha1.TaskPhaseRunning, logHandler)
+}
+
+func newTaskLogStreamTestAppWithPhase(
+	t *testing.T,
+	phase corev1alpha1.TaskPhase,
+	logHandler http.HandlerFunc,
+) (*Handlers, *fiber.App, *httptest.Server) {
+	t.Helper()
+
+	kubeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/namespaces/default/pods":
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(corev1.PodList{
+				TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "PodList"},
+				Items: []corev1.Pod{{
+					ObjectMeta: metav1.ObjectMeta{Name: "log-pod", Namespace: "default"},
+				}},
+			}); err != nil {
+				t.Errorf("encode pod list: %v", err)
+			}
+		case "/api/v1/namespaces/default/pods/log-pod/log":
+			logHandler(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(kubeServer.Close)
+
+	clientset, err := kubernetes.NewForConfig(&rest.Config{Host: kubeServer.URL})
+	require.NoError(t, err)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "log-task", Namespace: "default"},
+		Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeContainer},
+		Status:     corev1alpha1.TaskStatus{Phase: phase, JobName: "log-job"},
+	}
+	controllerClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(task).Build()
+	h := NewHandlers(HandlersConfig{Client: controllerClient, KubeClient: clientset})
+
+	return h, fiber.New(), kubeServer
+}

--- a/internal/cli/client/client.go
+++ b/internal/cli/client/client.go
@@ -7,18 +7,27 @@ MIT License - see LICENSE file for details.
 package client
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/orka-agents/orka/internal/labels"
+)
+
+const (
+	defaultResponseHeaderTimeout = 30 * time.Second
+	maxErrorResponseBodyBytes    = 64 << 10
+	maxResponseBodyDrainBytes    = 64 << 10
+	responseBodyDrainTimeout     = 100 * time.Millisecond
 )
 
 // Client is an HTTP client for the Orka API.
@@ -32,20 +41,45 @@ type Client struct {
 
 // New creates a new Orka API client.
 func New(baseURL, token string) *Client {
-	return &Client{
-		BaseURL:    baseURL,
-		Token:      token,
-		HTTPClient: http.DefaultClient,
-	}
+	return newClient(baseURL, token, "", defaultResponseHeaderTimeout)
 }
 
 // NewWithNamespace creates a new Orka API client with a default namespace.
 func NewWithNamespace(baseURL, token, namespace string) *Client {
+	return newClient(baseURL, token, namespace, defaultResponseHeaderTimeout)
+}
+
+func newClient(baseURL, token, namespace string, responseHeaderTimeout time.Duration) *Client {
 	return &Client{
 		BaseURL:    baseURL,
 		Token:      token,
 		Namespace:  namespace,
-		HTTPClient: http.DefaultClient,
+		HTTPClient: newHTTPClient(responseHeaderTimeout),
+	}
+}
+
+// newHTTPClient bounds connection setup and response headers without an overall
+// client timeout, so SSE and log bodies can remain open for their full lifetime.
+func newHTTPClient(responseHeaderTimeout time.Duration) *http.Client {
+	transport := cloneDefaultHTTPTransport()
+	transport.ResponseHeaderTimeout = responseHeaderTimeout
+	return &http.Client{Transport: transport}
+}
+
+func cloneDefaultHTTPTransport() *http.Transport {
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		return transport.Clone()
+	}
+
+	const defaultDialTimeout = 30 * time.Second
+	return &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           (&net.Dialer{Timeout: defaultDialTimeout, KeepAlive: defaultDialTimeout}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: time.Second,
 	}
 }
 
@@ -835,7 +869,10 @@ func (c *Client) StreamTaskLogs(ctx context.Context, name string, opts StreamLog
 	}
 	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(streamCtx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
@@ -851,27 +888,65 @@ func (c *Client) StreamTaskLogs(ctx context.Context, name string, opts StreamLog
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body := readTaskLogErrorResponse(resp.Body, cancel)
 		return fmt.Errorf("API error (HTTP %d): %s", resp.StatusCode, string(body))
 	}
+	defer resp.Body.Close() //nolint:errcheck
 
 	w := opts.Writer
 	if w == nil {
 		w = io.Discard
 	}
 
-	scanner := bufio.NewScanner(resp.Body)
-	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if after, ok := strings.CutPrefix(line, "data: "); ok {
-			fmt.Fprintln(w, after) //nolint:errcheck
+	reader := NewSSEReader(resp.Body)
+	for {
+		event, ok := reader.Next()
+		if !ok {
+			break
+		}
+		if event.Event == "error" {
+			return taskLogStreamError(event.Data)
+		}
+		if _, err := fmt.Fprintln(w, event.Data); err != nil {
+			return fmt.Errorf("failed to write task logs: %w", err)
 		}
 	}
-	return scanner.Err()
+	if err := reader.Err(); err != nil {
+		return fmt.Errorf("failed to read task logs: %w", err)
+	}
+	return nil
+}
+
+func readTaskLogErrorResponse(body io.ReadCloser, cancel context.CancelFunc) []byte {
+	if body == nil {
+		cancel()
+		return nil
+	}
+
+	timer := time.AfterFunc(responseBodyDrainTimeout, cancel)
+	data, _ := io.ReadAll(io.LimitReader(body, maxErrorResponseBodyBytes))
+	_, _ = io.CopyN(io.Discard, body, maxResponseBodyDrainBytes)
+	_ = timer.Stop()
+	cancel()
+	_ = body.Close()
+	return data
+}
+
+func taskLogStreamError(data string) error {
+	var payload struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(data), &payload); err == nil {
+		if message := strings.TrimSpace(payload.Error); message != "" {
+			return fmt.Errorf("task log stream error: %s", message)
+		}
+	}
+	if message := strings.TrimSpace(data); message != "" {
+		return fmt.Errorf("task log stream error: %s", message)
+	}
+	return errors.New("task log stream error")
 }
 
 // GetTaskResult gets the result of a task.

--- a/internal/cli/client/client.go
+++ b/internal/cli/client/client.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -61,26 +60,77 @@ func newClient(baseURL, token, namespace string, responseHeaderTimeout time.Dura
 // newHTTPClient bounds connection setup and response headers without an overall
 // client timeout, so SSE and log bodies can remain open for their full lifetime.
 func newHTTPClient(responseHeaderTimeout time.Duration) *http.Client {
-	transport := cloneDefaultHTTPTransport()
-	transport.ResponseHeaderTimeout = responseHeaderTimeout
-	return &http.Client{Transport: transport}
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		clone := transport.Clone()
+		clone.ResponseHeaderTimeout = responseHeaderTimeout
+		return &http.Client{Transport: clone}
+	}
+	// Preserve arbitrary auth, mTLS, tracing, and proxy wrappers while bounding
+	// the wait for response headers. The derived request context remains alive
+	// until the response body closes so long-lived streams are unaffected.
+	return &http.Client{Transport: headerTimeoutRoundTripper{
+		base: http.DefaultTransport, timeout: responseHeaderTimeout,
+	}}
 }
 
-func cloneDefaultHTTPTransport() *http.Transport {
-	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
-		return transport.Clone()
-	}
+type headerTimeoutRoundTripper struct {
+	base    http.RoundTripper
+	timeout time.Duration
+}
 
-	const defaultDialTimeout = 30 * time.Second
-	return &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           (&net.Dialer{Timeout: defaultDialTimeout, KeepAlive: defaultDialTimeout}).DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: time.Second,
+type roundTripResult struct {
+	response *http.Response
+	err      error
+}
+
+func (t headerTimeoutRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.timeout <= 0 {
+		return t.base.RoundTrip(req)
 	}
+	ctx, cancel := context.WithCancel(req.Context())
+	result := make(chan roundTripResult, 1)
+	go func() {
+		response, err := t.base.RoundTrip(req.Clone(ctx))
+		result <- roundTripResult{response: response, err: err}
+	}()
+	closeAbandonedResponse := func() {
+		go func() {
+			completed := <-result
+			if completed.response != nil && completed.response.Body != nil {
+				_ = completed.response.Body.Close()
+			}
+		}()
+	}
+	timer := time.NewTimer(t.timeout)
+	defer timer.Stop()
+	select {
+	case completed := <-result:
+		if completed.err != nil || completed.response == nil || completed.response.Body == nil {
+			cancel()
+			return completed.response, completed.err
+		}
+		completed.response.Body = cancelOnCloseBody{ReadCloser: completed.response.Body, cancel: cancel}
+		return completed.response, nil
+	case <-timer.C:
+		cancel()
+		closeAbandonedResponse()
+		return nil, context.DeadlineExceeded
+	case <-req.Context().Done():
+		cancel()
+		closeAbandonedResponse()
+		return nil, req.Context().Err()
+	}
+}
+
+type cancelOnCloseBody struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (b cancelOnCloseBody) Close() error {
+	err := b.ReadCloser.Close()
+	b.cancel()
+	return err
 }
 
 // ListOptions contains options for list operations.

--- a/internal/cli/client/client_test.go
+++ b/internal/cli/client/client_test.go
@@ -10,11 +10,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 const (
@@ -34,6 +38,108 @@ func TestNew(t *testing.T) {
 	}
 	if c.HTTPClient == nil {
 		t.Error("HTTPClient should not be nil")
+	}
+}
+
+func TestNew_DoesNotAssumeDefaultTransportType(t *testing.T) {
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = taskLogRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("unused")
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	c := New("http://localhost:8080", "")
+	if c.HTTPClient == nil || c.HTTPClient.Transport == nil {
+		t.Fatal("New() did not configure an HTTP transport")
+	}
+}
+
+func TestNew_ConfiguresTransportSafetyWithoutOverallTimeout(t *testing.T) {
+	c := New("http://localhost:8080", "")
+	if c.HTTPClient.Timeout != 0 {
+		t.Fatalf("HTTPClient.Timeout = %s, want no overall timeout", c.HTTPClient.Timeout)
+	}
+
+	transport, ok := c.HTTPClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("HTTPClient.Transport = %T, want *http.Transport", c.HTTPClient.Transport)
+	}
+	if transport.DialContext == nil {
+		t.Fatal("transport DialContext is nil")
+	}
+	if transport.TLSHandshakeTimeout <= 0 {
+		t.Fatalf("TLSHandshakeTimeout = %s, want positive timeout", transport.TLSHandshakeTimeout)
+	}
+	if transport.ResponseHeaderTimeout != defaultResponseHeaderTimeout {
+		t.Fatalf(
+			"ResponseHeaderTimeout = %s, want %s",
+			transport.ResponseHeaderTimeout,
+			defaultResponseHeaderTimeout,
+		)
+	}
+	if transport.IdleConnTimeout <= 0 {
+		t.Fatalf("IdleConnTimeout = %s, want positive timeout", transport.IdleConnTimeout)
+	}
+}
+
+func TestStreamTaskLogs_ResponseHeaderStallIsBounded(t *testing.T) {
+	const responseHeaderTimeout = 25 * time.Millisecond
+
+	requestStarted := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "", "", responseHeaderTimeout)
+	done := make(chan error, 1)
+	go func() {
+		done <- c.StreamTaskLogs(t.Context(), "task", StreamLogsOptions{})
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("task log request did not start")
+	}
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("StreamTaskLogs() error = nil, want response-header timeout")
+		}
+		var timeoutErr interface{ Timeout() bool }
+		if !errors.As(err, &timeoutErr) || !timeoutErr.Timeout() {
+			t.Fatalf("StreamTaskLogs() error = %v, want timeout error", err)
+		}
+	case <-time.After(10 * responseHeaderTimeout):
+		t.Fatalf("StreamTaskLogs() did not return within response-header timeout %s", responseHeaderTimeout)
+	}
+}
+
+func TestStreamTaskLogs_LongBodyRemainsUsablePastResponseHeaderTimeout(t *testing.T) {
+	const (
+		responseHeaderTimeout = 25 * time.Millisecond
+		bodyDelay             = 75 * time.Millisecond
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		time.Sleep(bodyDelay)
+		fmt.Fprint(w, "data: delayed log\n\n") //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	var output bytes.Buffer
+	c := newClient(srv.URL, "", "", responseHeaderTimeout)
+	if err := c.StreamTaskLogs(t.Context(), "task", StreamLogsOptions{Writer: &output}); err != nil {
+		t.Fatalf("StreamTaskLogs() error = %v", err)
+	}
+	if got, want := output.String(), "delayed log\n"; got != want {
+		t.Fatalf("stream output = %q, want %q", got, want)
 	}
 }
 
@@ -851,23 +957,42 @@ func TestGetChatConfig(t *testing.T) {
 
 func TestStreamTaskLogs(t *testing.T) {
 	tests := []struct {
-		name    string
-		status  int
-		body    string
-		wantOut string
-		wantErr bool
+		name            string
+		status          int
+		body            string
+		wantOut         string
+		wantErrContains string
 	}{
 		{
 			name:    "success",
 			status:  http.StatusOK,
-			body:    "data: line1\ndata: line2\n",
+			body:    "event: log\ndata: line1\n\nevent: log\ndata: line2\n\n",
 			wantOut: "line1\nline2\n",
 		},
 		{
-			name:    "server error",
-			status:  http.StatusInternalServerError,
-			body:    "error",
-			wantErr: true,
+			name:    "multiline data",
+			status:  http.StatusOK,
+			body:    "event: log\ndata: line1\ndata: line2\n\n",
+			wantOut: "line1\nline2\n",
+		},
+		{
+			name:            "stream error event",
+			status:          http.StatusOK,
+			body:            "event: log\ndata: before-error\n\nevent: error\ndata: {\"error\":\"failed to read task logs: unexpected EOF\"}\n\n",
+			wantOut:         "before-error\n",
+			wantErrContains: "failed to read task logs: unexpected EOF",
+		},
+		{
+			name:            "plain stream error event",
+			status:          http.StatusOK,
+			body:            "event: error\ndata: upstream failed\n\n",
+			wantErrContains: "upstream failed",
+		},
+		{
+			name:            "server error",
+			status:          http.StatusInternalServerError,
+			body:            "error",
+			wantErrContains: "API error (HTTP 500)",
 		},
 	}
 	for _, tt := range tests {
@@ -884,20 +1009,176 @@ func TestStreamTaskLogs(t *testing.T) {
 				Namespace: "ns1",
 				Writer:    &buf,
 			})
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			if tt.wantErrContains == "" {
+				if err != nil {
+					t.Fatalf("StreamTaskLogs() error = %v", err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), tt.wantErrContains) {
+				t.Fatalf("StreamTaskLogs() error = %v, want containing %q", err, tt.wantErrContains)
 			}
-			if !tt.wantErr && buf.String() != tt.wantOut {
+			if buf.String() != tt.wantOut {
 				t.Errorf("output = %q, want %q", buf.String(), tt.wantOut)
 			}
 		})
 	}
 }
 
+func TestStreamTaskLogs_SSELimits(t *testing.T) {
+	tests := []struct {
+		name            string
+		body            func() string
+		wantOutputBytes int
+		wantErrContains string
+	}{
+		{
+			name:            "accepts server maximum log line",
+			body:            func() string { return "data: " + strings.Repeat("x", sseMaxDataBytes) + "\n\n" },
+			wantOutputBytes: sseMaxDataBytes + 1,
+		},
+		{
+			name:            "rejects oversized SSE line",
+			body:            func() string { return "data: " + strings.Repeat("x", sseMaxDataBytes+1) + "\n\n" },
+			wantErrContains: "SSE line exceeds",
+		},
+		{
+			name: "rejects oversized aggregate event",
+			body: func() string {
+				return "data: " + strings.Repeat("a", sseMaxDataBytes/2+1) +
+					"\ndata: " + strings.Repeat("b", sseMaxDataBytes/2+1) + "\n\n"
+			},
+			wantErrContains: "SSE event data exceeds",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				fmt.Fprint(w, tt.body()) //nolint:errcheck
+			}))
+			defer srv.Close()
+
+			var output bytes.Buffer
+			c := New(srv.URL, "")
+			err := c.StreamTaskLogs(t.Context(), "t1", StreamLogsOptions{Writer: &output})
+			if tt.wantErrContains == "" {
+				if err != nil {
+					t.Fatalf("StreamTaskLogs() error = %v", err)
+				}
+				if got := output.Len(); got != tt.wantOutputBytes {
+					t.Fatalf("output length = %d, want %d", got, tt.wantOutputBytes)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErrContains) {
+				t.Fatalf("StreamTaskLogs() error = %v, want containing %q", err, tt.wantErrContains)
+			}
+			if output.Len() != 0 {
+				t.Fatalf("output length = %d, want 0", output.Len())
+			}
+		})
+	}
+}
+
+func TestStreamTaskLogs_PropagatesScannerError(t *testing.T) {
+	const event = "data: before-error\n\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Content-Length", fmt.Sprint(len(event)+32))
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, event) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	var output bytes.Buffer
+	c := New(srv.URL, "")
+	err := c.StreamTaskLogs(t.Context(), "t1", StreamLogsOptions{Writer: &output})
+	if err == nil || !strings.Contains(err.Error(), "unexpected EOF") {
+		t.Fatalf("StreamTaskLogs() error = %v, want scanner error", err)
+	}
+	if got, want := output.String(), "before-error\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestStreamTaskLogs_PropagatesWriterError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: line\n\n") //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	wantErr := errors.New("writer failed")
+	c := New(srv.URL, "")
+	err := c.StreamTaskLogs(t.Context(), "t1", StreamLogsOptions{Writer: taskLogErrorWriter{err: wantErr}})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("StreamTaskLogs() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestStreamTaskLogs_BoundsErrorResponseBody(t *testing.T) {
+	body := &taskLogTrackingReadCloser{reader: strings.NewReader(strings.Repeat("x", 1<<20))}
+	c := New("http://orka.test", "")
+	c.HTTPClient = &http.Client{Transport: taskLogRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Header:     make(http.Header),
+			Body:       body,
+		}, nil
+	})}
+
+	err := c.StreamTaskLogs(t.Context(), "task", StreamLogsOptions{})
+	if err == nil {
+		t.Fatal("StreamTaskLogs() error = nil, want status error")
+	}
+	if body.bytesRead > maxErrorResponseBodyBytes+maxResponseBodyDrainBytes {
+		t.Fatalf("error response bytes read = %d, want at most %d", body.bytesRead, maxErrorResponseBodyBytes+maxResponseBodyDrainBytes)
+	}
+	if !body.closed {
+		t.Fatal("error response body was not closed")
+	}
+}
+
+func TestStreamTaskLogs_ErrorBodyReadHasTimeBound(t *testing.T) {
+	body := newTaskLogBlockingReadCloser()
+	c := New("http://orka.test", "")
+	c.HTTPClient = &http.Client{Transport: taskLogRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		go func() {
+			<-req.Context().Done()
+			_ = body.Close()
+		}()
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Header:     make(http.Header),
+			Body:       body,
+		}, nil
+	})}
+
+	done := make(chan error, 1)
+	go func() { done <- c.StreamTaskLogs(t.Context(), "task", StreamLogsOptions{}) }()
+
+	select {
+	case <-body.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("stream error body read did not start")
+	}
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("StreamTaskLogs() error = nil, want status error")
+		}
+	case <-time.After(500 * time.Millisecond):
+		_ = body.Close()
+		<-done
+		t.Fatal("stream error body read did not return within a bounded interval")
+	}
+}
+
 func TestStreamTaskLogs_NilWriter(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("data: line\n")) //nolint:errcheck
+		w.Write([]byte("data: line\n\n")) //nolint:errcheck
 	}))
 	defer srv.Close()
 
@@ -1148,4 +1429,60 @@ func TestDoJSONAndTxnToken(t *testing.T) {
 	if gotNamespace != "team-a" {
 		t.Fatalf("namespace query = %q, want team-a", gotNamespace)
 	}
+}
+
+type taskLogRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f taskLogRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type taskLogErrorWriter struct {
+	err error
+}
+
+func (w taskLogErrorWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+type taskLogTrackingReadCloser struct {
+	reader    io.Reader
+	bytesRead int
+	closed    bool
+}
+
+func (r *taskLogTrackingReadCloser) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.bytesRead += n
+	return n, err
+}
+
+func (r *taskLogTrackingReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+type taskLogBlockingReadCloser struct {
+	readStarted chan struct{}
+	closed      chan struct{}
+	readOnce    sync.Once
+	closeOnce   sync.Once
+}
+
+func newTaskLogBlockingReadCloser() *taskLogBlockingReadCloser {
+	return &taskLogBlockingReadCloser{
+		readStarted: make(chan struct{}),
+		closed:      make(chan struct{}),
+	}
+}
+
+func (r *taskLogBlockingReadCloser) Read([]byte) (int, error) {
+	r.readOnce.Do(func() { close(r.readStarted) })
+	<-r.closed
+	return 0, io.ErrClosedPipe
+}
+
+func (r *taskLogBlockingReadCloser) Close() error {
+	r.closeOnce.Do(func() { close(r.closed) })
+	return nil
 }

--- a/internal/cli/client/sse.go
+++ b/internal/cli/client/sse.go
@@ -1,51 +1,148 @@
-/* Copyright (c) 2026. MIT License - see LICENSE file for details. */
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
 
 package client
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"strings"
 )
 
+const (
+	sseInitialBufferBytes = 256 * 1024
+	// Task-log producers accept log lines up to 1 MiB, so the client must
+	// also allow the SSE field prefix around a maximum-sized data line.
+	sseMaxDataBytes    = 1024 * 1024
+	sseMaxLineBytes    = len("data: ") + sseMaxDataBytes
+	sseScannerMaxBytes = sseMaxLineBytes + len("\ufeff") + 2
+)
+
 // SSEReader reads Server-Sent Events from a stream.
 type SSEReader struct {
-	scanner *bufio.Scanner
+	scanner   *bufio.Scanner
+	err       error
+	done      bool
+	firstLine bool
 }
 
 // NewSSEReader creates a new SSE reader from an io.Reader.
 func NewSSEReader(r io.Reader) *SSEReader {
 	s := bufio.NewScanner(r)
-	s.Buffer(make([]byte, 0, 256*1024), 1024*1024)
-	return &SSEReader{scanner: s}
+	s.Split(newSSELineSplitter())
+	s.Buffer(make([]byte, 0, sseInitialBufferBytes), sseScannerMaxBytes)
+	return &SSEReader{scanner: s, firstLine: true}
 }
 
 // Next reads the next SSE event from the stream.
 // Returns the event and true if an event was read, or a zero value and false at EOF.
 func (r *SSEReader) Next() (SSEEvent, bool) {
-	var evt SSEEvent
+	if r.done {
+		return SSEEvent{}, false
+	}
+
+	var eventType string
+	var data strings.Builder
+	dataLines := 0
+
 	for r.scanner.Scan() {
 		line := r.scanner.Text()
+		if r.firstLine {
+			line = strings.TrimPrefix(line, "\ufeff")
+			r.firstLine = false
+		}
+		if len(line) > sseMaxLineBytes {
+			r.err = fmt.Errorf("SSE line exceeds %d bytes", sseMaxLineBytes)
+			r.done = true
+			return SSEEvent{}, false
+		}
 
-		if after, ok := strings.CutPrefix(line, "event: "); ok {
-			evt.Event = after
+		if line == "" {
+			if dataLines == 0 {
+				eventType = ""
+				continue
+			}
+			return SSEEvent{Event: eventType, Data: data.String()}, true
+		}
+		if strings.HasPrefix(line, ":") {
 			continue
 		}
 
-		if after, ok := strings.CutPrefix(line, "data: "); ok {
-			evt.Data = after
-			return evt, true
+		field, value, found := strings.Cut(line, ":")
+		if !found {
+			value = ""
+		} else if strings.HasPrefix(value, " ") {
+			value = value[1:]
 		}
 
-		// blank line resets
-		if line == "" {
-			evt = SSEEvent{}
+		switch field {
+		case "event":
+			eventType = value
+		case "data":
+			additionalBytes := len(value)
+			if dataLines > 0 {
+				additionalBytes++
+			}
+			if data.Len()+additionalBytes > sseMaxDataBytes {
+				r.err = fmt.Errorf("SSE event data exceeds %d bytes", sseMaxDataBytes)
+				r.done = true
+				return SSEEvent{}, false
+			}
+			if dataLines > 0 {
+				data.WriteByte('\n')
+			}
+			data.WriteString(value)
+			dataLines++
 		}
 	}
+
+	if err := r.scanner.Err(); err != nil {
+		r.err = err
+	}
+	// The SSE parsing algorithm discards an event that was not terminated by
+	// a blank line before EOF.
+	r.done = true
 	return SSEEvent{}, false
 }
 
-// Err returns any error from the underlying scanner.
+// Err returns any error from the underlying scanner or SSE parser.
 func (r *SSEReader) Err() error {
+	if r.err != nil {
+		return r.err
+	}
 	return r.scanner.Err()
+}
+
+func newSSELineSplitter() bufio.SplitFunc {
+	skipLeadingLF := false
+	return func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		if skipLeadingLF && len(data) > 0 {
+			skipLeadingLF = false
+			if data[0] == '\n' {
+				return 1, nil, nil
+			}
+		}
+		for i, b := range data {
+			switch b {
+			case '\n':
+				return i + 1, data[:i], nil
+			case '\r':
+				if i+1 < len(data) && data[i+1] == '\n' {
+					return i + 2, data[:i], nil
+				}
+				if i+1 == len(data) && !atEOF {
+					skipLeadingLF = true
+				}
+				return i + 1, data[:i], nil
+			}
+		}
+		if atEOF && len(data) > 0 {
+			return len(data), data, nil
+		}
+		return 0, nil, nil
+	}
 }

--- a/internal/cli/client/sse_test.go
+++ b/internal/cli/client/sse_test.go
@@ -7,8 +7,10 @@ MIT License - see LICENSE file for details.
 package client
 
 import (
+	"io"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewSSEReader(t *testing.T) {
@@ -36,6 +38,20 @@ func TestSSEReader_Next(t *testing.T) {
 			input: "data: plain text\n\n",
 			wantEvents: []SSEEvent{
 				{Data: "plain text"},
+			},
+		},
+		{
+			name:  "multiline data",
+			input: "event: log\ndata: first\ndata: second\n\n",
+			wantEvents: []SSEEvent{
+				{Event: "log", Data: "first\nsecond"},
+			},
+		},
+		{
+			name:  "field values without optional space",
+			input: "event:error\ndata:{\"error\":\"boom\"}\n\n",
+			wantEvents: []SSEEvent{
+				{Event: "error", Data: `{"error":"boom"}`},
 			},
 		},
 		{
@@ -68,6 +84,25 @@ func TestSSEReader_Next(t *testing.T) {
 			input: "data: no-event\n\n",
 			wantEvents: []SSEEvent{
 				{Data: "no-event"},
+			},
+		},
+		{
+			name:       "unterminated event is discarded at EOF",
+			input:      "event: log\ndata: final line\n",
+			wantEvents: nil,
+		},
+		{
+			name:  "UTF-8 BOM is ignored",
+			input: "\ufeffevent: error\ndata: boom\n\n",
+			wantEvents: []SSEEvent{
+				{Event: "error", Data: "boom"},
+			},
+		},
+		{
+			name:  "lone carriage returns delimit fields",
+			input: "event: error\rdata: boom\r\r",
+			wantEvents: []SSEEvent{
+				{Event: "error", Data: "boom"},
 			},
 		},
 		{
@@ -122,7 +157,7 @@ func TestSSEReader_Err(t *testing.T) {
 
 func TestSSEReader_LargeData(t *testing.T) {
 	// Test that the reader can handle large data lines (buffer is configured for 1MB)
-	largeData := strings.Repeat("x", 100000)
+	largeData := strings.Repeat("x", sseMaxDataBytes)
 	input := "data: " + largeData + "\n\n"
 	r := NewSSEReader(strings.NewReader(input))
 
@@ -136,7 +171,7 @@ func TestSSEReader_LargeData(t *testing.T) {
 }
 
 func TestSSEReader_ConsecutiveEvents(t *testing.T) {
-	input := "event: a\ndata: 1\nevent: b\ndata: 2\n"
+	input := "event: a\ndata: 1\n\nevent: b\ndata: 2\n\n"
 	r := NewSSEReader(strings.NewReader(input))
 
 	evt1, ok := r.Next()
@@ -158,5 +193,57 @@ func TestSSEReader_ConsecutiveEvents(t *testing.T) {
 	_, ok = r.Next()
 	if ok {
 		t.Error("expected no more events")
+	}
+}
+
+func TestSSEReader_OversizedLine(t *testing.T) {
+	input := "data: " + strings.Repeat("x", sseMaxDataBytes+1) + "\n\n"
+	r := NewSSEReader(strings.NewReader(input))
+
+	if event, ok := r.Next(); ok {
+		t.Fatalf("Next() = %+v, true; want no event", event)
+	}
+	if err := r.Err(); err == nil || !strings.Contains(err.Error(), "SSE line exceeds") {
+		t.Fatalf("Err() = %v, want SSE line size error", err)
+	}
+}
+
+func TestSSEReader_OversizedMultilineEvent(t *testing.T) {
+	first := strings.Repeat("a", sseMaxDataBytes/2+1)
+	second := strings.Repeat("b", sseMaxDataBytes/2+1)
+	input := "data: " + first + "\ndata: " + second + "\n\n"
+	r := NewSSEReader(strings.NewReader(input))
+
+	if event, ok := r.Next(); ok {
+		t.Fatalf("Next() = %+v, true; want no event", event)
+	}
+	if err := r.Err(); err == nil || !strings.Contains(err.Error(), "SSE event data exceeds") {
+		t.Fatalf("Err() = %v, want aggregate SSE data size error", err)
+	}
+}
+
+func TestSSEReader_DispatchesLoneCREventBeforeEOF(t *testing.T) {
+	reader, writer := io.Pipe()
+	t.Cleanup(func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+	events := make(chan SSEEvent, 1)
+	go func() {
+		event, ok := NewSSEReader(reader).Next()
+		if ok {
+			events <- event
+		}
+	}()
+	if _, err := io.WriteString(writer, "event: log\rdata: live\r\r"); err != nil {
+		t.Fatalf("write SSE event: %v", err)
+	}
+	select {
+	case event := <-events:
+		if event.Event != "log" || event.Data != "live" {
+			t.Fatalf("event = %+v, want log/live", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("lone-CR SSE event was not dispatched before EOF")
 	}
 }


### PR DESCRIPTION
## Summary

Stacked salvage from #280. Base: #314 (`fix/kubernetes-inventory-pagination`).

- Add bounded task-log lines, heartbeats, safe CR/LF framing, terminal SSE errors, and writer/scanner error propagation.
- Hand established Kubernetes log streams off from Fiber safely while preserving request deadlines and cancellation ownership.
- Give CLI streaming a bounded response-header timeout, bounded error reads, and a size-limited SSE parser without imposing an overall stream timeout.

## Scope

This PR changes task-log follow streaming and the CLI SSE client only. It does not change backend inventory pagination; the stack base is used to keep the review diff to one commit.

## Verification

- `go test ./internal/api ./internal/cli/client ./cmd/cli -run 'TaskLog|SSE|StreamTaskLogs' -count=1`
- `make lint-fix && make test`
- Full required CI

After #314 merges, this PR should be retargeted to `main`.