### PR TITLE
fix(cli): complete namespace-scoped inventory pagination

### DIFF
--- a/cmd/cli/agent.go
+++ b/cmd/cli/agent.go
@@ -37,7 +37,7 @@ func newAgentListCmd() *cobra.Command {
 		Short: "List agents",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			c := newClientFromCmd(cmd)
-			agents, err := c.ListAgents(context.Background(), client.ListOptions{
+			agents, err := c.ListAgents(cmd.Context(), client.ListOptions{
 				Namespace: c.Namespace,
 			})
 			if err != nil {

--- a/cmd/cli/agent_test.go
+++ b/cmd/cli/agent_test.go
@@ -3,9 +3,13 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -107,6 +111,99 @@ func TestNewAgentListCmd_Execute(t *testing.T) {
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
+func TestNewAgentListCmdListsAllPagesAndForwardsNamespace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const (
+		namespace    = "inventory-ns"
+		continuation = "agent-cursor+/=? segment"
+	)
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if got := r.URL.Query().Get("namespace"); got != namespace {
+			t.Errorf("namespace query = %q, want %q", got, namespace)
+		}
+		if requests == 1 {
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"items":    []map[string]any{{"metadata": map[string]any{"name": "agent-1"}}},
+				"metadata": map[string]any{"continue": continuation},
+			})
+			return
+		}
+		if got := r.URL.Query().Get("continue"); got != continuation {
+			t.Errorf("continue query = %q, want %q", got, continuation)
+		}
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"items":    []map[string]any{{"metadata": map[string]any{"name": "agent-2"}}},
+			"metadata": map[string]any{},
+		})
+	}))
+	defer srv.Close()
+
+	root := newRootCmd()
+	root.SetArgs([]string{"agent", "list", "--server", srv.URL, "--namespace", namespace})
+	stdout, err := captureOutput(t, root.Execute)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+	if !strings.Contains(stdout, "agent-1") || !strings.Contains(stdout, "agent-2") {
+		t.Fatalf("stdout = %q, want agents from both pages", stdout)
+	}
+}
+
+func TestNewAgentListCmdReturnsUsefulPartialPageError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests == 1 {
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"items":    []map[string]any{{"metadata": map[string]any{"name": "agent-1"}}},
+				"metadata": map[string]any{"continue": "next"},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "later agent page failed") //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	root := newRootCmd()
+	root.SetArgs([]string{"agent", "list", "--server", srv.URL})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "after 1 items on page 2") {
+		t.Fatalf("Execute() error = %v, want partial-result page error", err)
+	}
+}
+
+func TestNewAgentListCmdHonorsCommandContextCancellation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		json.NewEncoder(w).Encode(map[string]any{"items": []any{}}) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	root := newRootCmd()
+	root.SetArgs([]string{"agent", "list", "--server", srv.URL})
+	if err := root.ExecuteContext(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ExecuteContext() error = %v, want context canceled", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
 	}
 }
 

--- a/cmd/cli/resource_commands.go
+++ b/cmd/cli/resource_commands.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -10,18 +11,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	toolResourceName    = "tool"
+	sessionResourceName = "session"
+)
+
 type crudResourceSpec struct {
-	Use       string
-	Short     string
-	BasePath  string
-	Name      string
-	ReadOnly  bool
-	NoGet     bool
-	NoCreate  bool
-	NoUpdate  bool
-	NoDelete  bool
-	ListFlags func(*cobra.Command)
-	ListQuery func(*cobra.Command) map[string]string
+	Use                     string
+	Short                   string
+	BasePath                string
+	Name                    string
+	ReadOnly                bool
+	NoGet                   bool
+	NoCreate                bool
+	NoUpdate                bool
+	NoDelete                bool
+	SurfaceListContinuation bool
+	ListFlags               func(*cobra.Command)
+	ListQuery               func(*cobra.Command) map[string]string
 }
 
 func newCRUDResourceCmd(spec crudResourceSpec) *cobra.Command {
@@ -65,11 +72,23 @@ func newCRUDListCmd(spec crudResourceSpec) *cobra.Command {
 					}
 				}
 			}
-			result, err := c.DoJSON(context.Background(), http.MethodGet, spec.BasePath, query, nil)
+			result, err := c.DoJSON(cmd.Context(), http.MethodGet, spec.BasePath, query, nil)
 			if err != nil {
 				return err
 			}
-			return printStructured(cmd, result)
+			if err := printStructured(cmd, result); err != nil {
+				return err
+			}
+			if spec.SurfaceListContinuation {
+				format, err := outputFormat(cmd)
+				if err != nil {
+					return err
+				}
+				if format == outputTable {
+					warnListContinuation(cmd, spec.Name, result)
+				}
+			}
+			return nil
 		},
 	}
 	addOutputFlag(cmd, outputTable)
@@ -80,6 +99,30 @@ func newCRUDListCmd(spec crudResourceSpec) *cobra.Command {
 		spec.ListFlags(cmd)
 	}
 	return cmd
+}
+
+func warnListContinuation(cmd *cobra.Command, resourceName string, result any) {
+	response, ok := result.(map[string]any)
+	if !ok {
+		return
+	}
+	metadata, ok := response["metadata"].(map[string]any)
+	if !ok {
+		return
+	}
+	continuation, _ := metadata["continue"].(string)
+	if continuation == "" {
+		return
+	}
+	encodedContinuation, _ := json.Marshal(continuation)
+	_, _ = fmt.Fprintf(
+		cmd.ErrOrStderr(),
+		"More %s resources are available; this command displays one page. "+
+			"Continuation token (JSON string, not shell syntax): %s. "+
+			"Use metadata.continue from -o json and pass its decoded value to --continue.\n",
+		resourceName,
+		encodedContinuation,
+	)
 }
 
 func newCRUDGetCmd(spec crudResourceSpec) *cobra.Command {
@@ -203,21 +246,23 @@ func newProviderCmd() *cobra.Command {
 
 func newToolCmd() *cobra.Command {
 	return newCRUDResourceCmd(crudResourceSpec{
-		Use:      "tool",
-		Short:    "Manage tools",
-		BasePath: "/api/v1/tools",
-		Name:     "tool",
+		Use:                     toolResourceName,
+		Short:                   "Manage tools",
+		BasePath:                "/api/v1/tools",
+		Name:                    toolResourceName,
+		SurfaceListContinuation: true,
 	})
 }
 
 func newSessionCmd() *cobra.Command {
 	cmd := newCRUDResourceCmd(crudResourceSpec{
-		Use:      "session",
-		Short:    "Manage sessions",
-		BasePath: "/api/v1/sessions",
-		Name:     "session",
-		NoCreate: true,
-		NoUpdate: true,
+		Use:                     sessionResourceName,
+		Short:                   "Manage sessions",
+		BasePath:                "/api/v1/sessions",
+		Name:                    sessionResourceName,
+		NoCreate:                true,
+		NoUpdate:                true,
+		SurfaceListContinuation: true,
 	})
 	cmd.AddCommand(newSessionEventsCmd())
 	cmd.AddCommand(newSessionFollowCmd())

--- a/cmd/cli/resource_commands_test.go
+++ b/cmd/cli/resource_commands_test.go
@@ -1,0 +1,79 @@
+/* Copyright (c) 2026. MIT License - see LICENSE file for details. */
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPagedGenericInventoryCommandsSurfaceOpaqueContinuation(t *testing.T) {
+	const (
+		requestedContinuation = "requested-cursor+/=? segment"
+		nextContinuation      = "$(touch should-not-run) $HOME ' opaque"
+	)
+
+	for _, tt := range []struct {
+		name string
+		path string
+	}{
+		{name: toolResourceName, path: "/api/v1/tools"},
+		{name: sessionResourceName, path: "/api/v1/sessions"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || r.URL.Path != tt.path {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				if got := r.URL.Query().Get("continue"); got != requestedContinuation {
+					t.Errorf("continue query = %q, want %q", got, requestedContinuation)
+				}
+				if got := r.URL.Query().Get("cursor"); got != requestedContinuation {
+					t.Errorf("cursor query = %q, want %q", got, requestedContinuation)
+				}
+				json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+					"items":    []map[string]any{{"name": tt.name + "-1"}},
+					"metadata": map[string]any{"continue": nextContinuation},
+				})
+			}))
+			defer srv.Close()
+
+			var stderr bytes.Buffer
+			root := newRootCmd()
+			root.SetOut(io.Discard)
+			root.SetErr(&stderr)
+			root.SetArgs([]string{
+				tt.name,
+				"list",
+				"--server",
+				srv.URL,
+				"--continue",
+				requestedContinuation,
+			})
+
+			if err := root.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			if !strings.Contains(stderr.String(), nextContinuation) {
+				t.Fatalf("stderr = %q, want continuation %q", stderr.String(), nextContinuation)
+			}
+			if !strings.Contains(stderr.String(), "--continue") {
+				t.Fatalf("stderr = %q, want --continue guidance", stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "not shell syntax") {
+				t.Fatalf("stderr = %q, want explicit non-shell warning", stderr.String())
+			}
+			if strings.Contains(stderr.String(), "Re-run with --continue") {
+				t.Fatalf("stderr = %q, must not present opaque server data as pasteable shell syntax", stderr.String())
+			}
+		})
+	}
+}

--- a/cmd/cli/skill.go
+++ b/cmd/cli/skill.go
@@ -43,7 +43,7 @@ func newSkillListCmd() *cobra.Command {
 		Short: "List skills",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			c := newClientFromCmd(cmd)
-			skills, err := c.ListSkills(context.Background(), client.ListOptions{
+			skills, err := c.ListSkills(cmd.Context(), client.ListOptions{
 				Namespace: c.Namespace,
 			})
 			if err != nil {

--- a/cmd/cli/skill_test.go
+++ b/cmd/cli/skill_test.go
@@ -1,0 +1,80 @@
+/* Copyright (c) 2026. MIT License - see LICENSE file for details. */
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewSkillListCmdListsAllPagesAndForwardsNamespace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const (
+		namespace    = "inventory-ns"
+		continuation = "skill-cursor+/=? segment"
+	)
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if got := r.URL.Query().Get("namespace"); got != namespace {
+			t.Errorf("namespace query = %q, want %q", got, namespace)
+		}
+		if requests == 1 {
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"items":    []map[string]any{{"name": "skill-1", "phase": "Ready"}},
+				"metadata": map[string]any{"continue": continuation},
+			})
+			return
+		}
+		if got := r.URL.Query().Get("continue"); got != continuation {
+			t.Errorf("continue query = %q, want %q", got, continuation)
+		}
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"items":    []map[string]any{{"name": "skill-2", "phase": "Ready"}},
+			"metadata": map[string]any{},
+		})
+	}))
+	defer srv.Close()
+
+	root := newRootCmd()
+	root.SetArgs([]string{"skill", "list", "--server", srv.URL, "--namespace", namespace})
+	stdout, err := captureOutput(t, root.Execute)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+	if !strings.Contains(stdout, "skill-1") || !strings.Contains(stdout, "skill-2") {
+		t.Fatalf("stdout = %q, want skills from both pages", stdout)
+	}
+}
+
+func TestNewSkillListCmdHonorsCommandContextCancellation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		json.NewEncoder(w).Encode(map[string]any{"items": []any{}}) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	root := newRootCmd()
+	root.SetArgs([]string{"skill", "list", "--server", srv.URL})
+	if err := root.ExecuteContext(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ExecuteContext() error = %v, want context canceled", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}

--- a/cmd/cli/status.go
+++ b/cmd/cli/status.go
@@ -9,7 +9,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -23,7 +22,7 @@ func newStatusCmd() *cobra.Command {
 		Short: "Show system overview (health, tasks, agents)",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			c := newClientFromCmd(cmd)
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 			defer cancel()
 
 			fmt.Println("Orka Status")
@@ -31,6 +30,9 @@ func newStatusCmd() *cobra.Command {
 
 			healthy, healthErr := c.HealthCheck(ctx)
 			if healthErr != nil {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
 				fmt.Printf("  Health:  ✗ Unreachable (%v)\n", healthErr)
 			} else if healthy {
 				fmt.Println("  Health:  ✓ Healthy")
@@ -40,6 +42,9 @@ func newStatusCmd() *cobra.Command {
 
 			ready, readyErr := c.ReadyCheck(ctx)
 			if readyErr != nil {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
 				fmt.Printf("  Ready:   ✗ Unreachable (%v)\n", readyErr)
 			} else if ready {
 				fmt.Println("  Ready:   ✓ Ready")
@@ -48,15 +53,18 @@ func newStatusCmd() *cobra.Command {
 			}
 
 			if healthErr != nil {
-				fmt.Fprintln(os.Stderr, "\nCannot reach the server. Skipping task and agent queries.")
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "\nCannot reach the server. Skipping task and agent queries.")
 				return nil
 			}
 
 			fmt.Println()
 
-			tasks, err := c.ListTasks(ctx, client.ListTasksOptions{Limit: 100})
+			tasks, _, err := listFilteredTasks(ctx, c, c.Namespace, 0, nil)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "  Tasks:   ✗ Error (%v)\n", err)
+				if contextErr := ctx.Err(); contextErr != nil {
+					return contextErr
+				}
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  Tasks:   ✗ Error (%v)\n", err)
 			} else {
 				counts := map[string]int{
 					"Pending": 0, "Running": 0, "Succeeded": 0, "Failed": 0, "Scheduled": 0,
@@ -91,9 +99,12 @@ func newStatusCmd() *cobra.Command {
 
 			fmt.Println()
 
-			agents, err := c.ListAgents(ctx, client.ListOptions{})
+			agents, err := c.ListAgents(ctx, client.ListOptions{Namespace: c.Namespace})
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "  Agents:  ✗ Error (%v)\n", err)
+				if contextErr := ctx.Err(); contextErr != nil {
+					return contextErr
+				}
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  Agents:  ✗ Error (%v)\n", err)
 			} else {
 				fmt.Printf("  Agents:    %d\n", len(agents))
 			}

--- a/cmd/cli/status_test.go
+++ b/cmd/cli/status_test.go
@@ -3,18 +3,24 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/orka-agents/orka/internal/cli/client"
 )
 
 const (
-	statusError  = "error"
-	tasksAPIPath = "/api/v1/tasks"
+	statusError      = "error"
+	statusHealthPath = "/healthz"
+	statusReadyPath  = "/readyz"
+	tasksAPIPath     = "/api/v1/tasks"
 )
 
 func TestNewStatusCmd_Structure(t *testing.T) {
@@ -31,13 +37,13 @@ func TestNewStatusCmd_Structure(t *testing.T) {
 func statusServer(healthy, ready bool, tasks []client.TaskSummary, agents []client.AgentSummary) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/healthz":
+		case statusHealthPath:
 			status := "ok"
 			if !healthy {
 				status = statusError
 			}
 			json.NewEncoder(w).Encode(map[string]any{"status": status}) //nolint:errcheck
-		case "/readyz":
+		case statusReadyPath:
 			status := "ok"
 			if !ready {
 				status = statusError
@@ -91,6 +97,157 @@ func TestNewStatusCmd_HealthyServer(t *testing.T) {
 	}
 }
 
+func TestNewStatusCmdCountsAllTaskAndAgentPagesInSelectedNamespace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const (
+		namespace         = "inventory-ns"
+		taskContinuation  = "task-cursor+/=? segment"
+		agentContinuation = "agent-cursor+/=? segment"
+	)
+	var taskRequests, agentRequests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case statusHealthPath, statusReadyPath:
+			json.NewEncoder(w).Encode(map[string]any{"status": "ok"}) //nolint:errcheck
+		case tasksAPIPath:
+			taskRequests++
+			if got := r.URL.Query().Get("namespace"); got != namespace {
+				t.Errorf("task namespace = %q, want %q", got, namespace)
+			}
+			if got := r.URL.Query().Get("limit"); got != "500" {
+				t.Errorf("task limit = %q, want 500", got)
+			}
+			if taskRequests == 1 {
+				json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+					"items": []map[string]any{{
+						"metadata": map[string]any{"name": "task-1", "namespace": namespace},
+						"status":   map[string]any{"phase": "Running"},
+					}},
+					"metadata": map[string]any{"continue": taskContinuation},
+				})
+				return
+			}
+			if got := r.URL.Query().Get("continue"); got != taskContinuation {
+				t.Errorf("task continue = %q, want %q", got, taskContinuation)
+			}
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"items": []map[string]any{{
+					"metadata": map[string]any{"name": "task-2", "namespace": namespace},
+					"status":   map[string]any{"phase": "Succeeded"},
+				}},
+				"metadata": map[string]any{},
+			})
+		case agentsAPIPath:
+			agentRequests++
+			if got := r.URL.Query().Get("namespace"); got != namespace {
+				t.Errorf("agent namespace = %q, want %q", got, namespace)
+			}
+			if agentRequests == 1 {
+				json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+					"items":    []map[string]any{{"metadata": map[string]any{"name": "agent-1"}}},
+					"metadata": map[string]any{"continue": agentContinuation},
+				})
+				return
+			}
+			if got := r.URL.Query().Get("continue"); got != agentContinuation {
+				t.Errorf("agent continue = %q, want %q", got, agentContinuation)
+			}
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"items":    []map[string]any{{"metadata": map[string]any{"name": "agent-2"}}},
+				"metadata": map[string]any{},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	root := newRootCmd()
+	root.SetArgs([]string{"status", "--server", srv.URL, "--namespace", namespace})
+
+	stdout, err := captureOutput(t, root.Execute)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if taskRequests != 2 || agentRequests != 2 {
+		t.Fatalf("task/agent requests = %d/%d, want 2/2", taskRequests, agentRequests)
+	}
+	for _, want := range []string{"Running:    1", "Succeeded:  1", "Agents:    2"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout = %q, want %q", stdout, want)
+		}
+	}
+}
+
+func TestNewStatusCmdReportsPartialInventoryErrorInsteadOfUndercount(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var taskRequests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case statusHealthPath, statusReadyPath:
+			json.NewEncoder(w).Encode(map[string]any{"status": "ok"}) //nolint:errcheck
+		case tasksAPIPath:
+			taskRequests++
+			if taskRequests == 1 {
+				json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+					"items": []map[string]any{{
+						"metadata": map[string]any{"name": "task-1"},
+						"status":   map[string]any{"phase": "Running"},
+					}},
+					"metadata": map[string]any{"continue": "next"},
+				})
+				return
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, "later task page failed") //nolint:errcheck
+		case agentsAPIPath:
+			json.NewEncoder(w).Encode(map[string]any{"items": []any{}}) //nolint:errcheck
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	var stderr bytes.Buffer
+	root := newRootCmd()
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"status", "--server", srv.URL})
+	if _, err := captureOutput(t, root.Execute); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(stderr.String(), "after 1 matching items on page 2") {
+		t.Fatalf("stderr = %q, want partial inventory error", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "Running:    1") {
+		t.Fatalf("stderr = %q, should not present partial inventory as a complete count", stderr.String())
+	}
+}
+
+func TestNewStatusCmdHonorsCommandContextCancellation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		json.NewEncoder(w).Encode(map[string]any{"status": "ok"}) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	root := newRootCmd()
+	root.SetArgs([]string{"status", "--server", srv.URL})
+	if err := root.ExecuteContext(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ExecuteContext() error = %v, want context canceled", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}
+
 func TestNewStatusCmd_UnhealthyServer(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
@@ -129,9 +286,9 @@ func TestNewStatusCmd_TaskErrors(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/healthz":
+		case statusHealthPath:
 			json.NewEncoder(w).Encode(map[string]any{"status": "ok"}) //nolint:errcheck
-		case "/readyz":
+		case statusReadyPath:
 			json.NewEncoder(w).Encode(map[string]any{"status": "ok"}) //nolint:errcheck
 		case tasksAPIPath:
 			w.WriteHeader(http.StatusInternalServerError)

--- a/cmd/cli/task.go
+++ b/cmd/cli/task.go
@@ -229,8 +229,7 @@ func newTaskListCmd() *cobra.Command {
 					warnFilteredTaskOutputLimited(limit)
 				}
 			} else {
-				var err error
-				tasks, err = c.ListTasks(ctx, client.ListTasksOptions{
+				page, err := c.ListTasksPage(ctx, client.ListTasksOptions{
 					Namespace: c.Namespace,
 					Limit:     limit,
 					Continue:  continueToken,
@@ -238,8 +237,11 @@ func newTaskListCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
+				tasks = page.Items
+				warnListContinuation(cmd, "task", map[string]any{
+					"metadata": map[string]any{"continue": page.Continue},
+				})
 			}
-
 			format, err := outputFormat(cmd)
 			if err != nil {
 				return err

--- a/cmd/cli/task.go
+++ b/cmd/cli/task.go
@@ -202,12 +202,13 @@ func newTaskListCmd() *cobra.Command {
 		Short:   "List tasks",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			c := newClientFromCmd(cmd)
+			ctx := cmd.Context()
 			var tasks []client.TaskSummary
 			if status != "" || transactionID != "" {
 				var truncated bool
 				var err error
 				tasks, truncated, err = listFilteredTasks(
-					context.Background(),
+					ctx,
 					c,
 					c.Namespace,
 					limit,
@@ -229,7 +230,7 @@ func newTaskListCmd() *cobra.Command {
 				}
 			} else {
 				var err error
-				tasks, err = c.ListTasks(context.Background(), client.ListTasksOptions{
+				tasks, err = c.ListTasks(ctx, client.ListTasksOptions{
 					Namespace: c.Namespace,
 					Limit:     limit,
 					Continue:  continueToken,

--- a/cmd/cli/task_pagination.go
+++ b/cmd/cli/task_pagination.go
@@ -15,7 +15,10 @@ import (
 	"github.com/orka-agents/orka/internal/cli/client"
 )
 
-const filteredTaskListPageSize = 500
+const (
+	filteredTaskListPageSize = 500
+	maxFilteredTaskListPages = 1000
+)
 
 func listFilteredTasks(
 	ctx context.Context,
@@ -40,21 +43,36 @@ func listFilteredTasksWithPagination(
 	}
 
 	var tasks []client.TaskSummary
-	continueToken := ""
-	for {
+	cursor := ""
+	seenContinuations := make(map[string]struct{})
+	for pageNumber := 1; pageNumber <= maxFilteredTaskListPages; pageNumber++ {
+		if err := ctx.Err(); err != nil {
+			return tasks, false, fmt.Errorf(
+				"listing tasks stopped after %d matching items before page %d: %w",
+				len(tasks),
+				pageNumber,
+				err,
+			)
+		}
+
 		opts := client.ListTasksOptions{Namespace: namespace}
 		if usePagination {
 			opts.Limit = filteredTaskListPageSize
-			opts.Continue = continueToken
+			opts.Continue = cursor
 		} else {
 			opts.All = true
 		}
 		page, err := c.ListTasksPage(ctx, opts)
 		if err != nil {
-			if usePagination && isCachePaginationUnsupported(err) {
+			if usePagination && ctx.Err() == nil && isCachePaginationUnsupported(err) {
 				return listFilteredTasksWithPagination(ctx, c, namespace, limit, match, false)
 			}
-			return nil, false, err
+			return tasks, false, fmt.Errorf(
+				"listing tasks stopped after %d matching items on page %d: %w",
+				len(tasks),
+				pageNumber,
+				err,
+			)
 		}
 
 		for _, task := range page.Items {
@@ -68,13 +86,42 @@ func listFilteredTasksWithPagination(
 		}
 
 		if !usePagination || page.Continue == "" {
+			if page.RemainingItemCount != nil && *page.RemainingItemCount > 0 {
+				return tasks, false, fmt.Errorf(
+					"listing tasks stopped after %d matching items: pagination ended with %d remaining items but no continuation",
+					len(tasks),
+					*page.RemainingItemCount,
+				)
+			}
 			return tasks, false, nil
+		}
+		if page.Continue == cursor {
+			return tasks, false, fmt.Errorf(
+				"listing tasks stopped after %d matching items: continuation did not advance",
+				len(tasks),
+			)
+		}
+		if _, seen := seenContinuations[page.Continue]; seen {
+			return tasks, false, fmt.Errorf(
+				"listing tasks stopped after %d matching items: continuation cycle detected",
+				len(tasks),
+			)
 		}
 		if limit > 0 && len(tasks) >= limit {
 			return tasks, true, nil
 		}
-		continueToken = page.Continue
+		if pageNumber == maxFilteredTaskListPages {
+			return tasks, false, fmt.Errorf(
+				"listing tasks stopped after %d matching items: pagination page limit (%d) reached",
+				len(tasks),
+				maxFilteredTaskListPages,
+			)
+		}
+		seenContinuations[page.Continue] = struct{}{}
+		cursor = page.Continue
 	}
+
+	return tasks, false, fmt.Errorf("listing tasks stopped: pagination terminated unexpectedly")
 }
 
 func isCachePaginationUnsupported(err error) bool {

--- a/cmd/cli/task_pagination_safety_test.go
+++ b/cmd/cli/task_pagination_safety_test.go
@@ -1,0 +1,115 @@
+/* Copyright (c) 2026. MIT License - see LICENSE file for details. */
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/orka-agents/orka/internal/cli/client"
+)
+
+func TestListFilteredTasksReturnsPartialResultsOnContinuationCycle(t *testing.T) {
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		continuation := r.URL.Query().Get("continue")
+		next := "a"
+		switch continuation {
+		case "a":
+			next = "b"
+		case "b":
+			next = "a"
+		}
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"items": []map[string]any{{
+				"metadata": map[string]any{"name": "task-" + strconv.Itoa(requests)},
+				"status":   map[string]any{"phase": "Running"},
+			}},
+			"metadata": map[string]any{"continue": next},
+		})
+	}))
+	defer srv.Close()
+
+	tasks, truncated, err := listFilteredTasks(
+		context.Background(),
+		client.New(srv.URL, ""),
+		"",
+		0,
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "continuation cycle detected") {
+		t.Fatalf("listFilteredTasks() error = %v, want continuation-cycle error", err)
+	}
+	if truncated {
+		t.Fatal("listFilteredTasks() truncated = true, want false on pagination failure")
+	}
+	if len(tasks) != 3 {
+		t.Fatalf("len(tasks) = %d, want 3 partial tasks", len(tasks))
+	}
+}
+
+func TestListFilteredTasksReturnsPartialResultsWhenLaterPageFails(t *testing.T) {
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests == 1 {
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"items": []map[string]any{{
+					"metadata": map[string]any{"name": "task-1"},
+					"status":   map[string]any{"phase": "Running"},
+				}},
+				"metadata": map[string]any{"continue": "next"},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	tasks, truncated, err := listFilteredTasks(
+		context.Background(),
+		client.New(srv.URL, ""),
+		"",
+		0,
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "after 1 matching items on page 2") {
+		t.Fatalf("listFilteredTasks() error = %v, want partial-result page error", err)
+	}
+	if truncated {
+		t.Fatal("listFilteredTasks() truncated = true, want false on page failure")
+	}
+	if len(tasks) != 1 || tasks[0].Name != "task-1" {
+		t.Fatalf("tasks = %#v, want first-page partial result", tasks)
+	}
+}
+
+func TestNewTaskListCmdHonorsCommandContextCancellation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		json.NewEncoder(w).Encode(map[string]any{"items": []any{}}) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	root := newRootCmd()
+	root.SetArgs([]string{"task", "list", "--server", srv.URL, "--status", "Running"})
+	if err := root.ExecuteContext(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ExecuteContext() error = %v, want context canceled", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}

--- a/internal/cli/client/client.go
+++ b/internal/cli/client/client.go
@@ -28,6 +28,7 @@ const (
 	maxErrorResponseBodyBytes    = 64 << 10
 	maxResponseBodyDrainBytes    = 64 << 10
 	responseBodyDrainTimeout     = 100 * time.Millisecond
+	maxAutoPaginationPages       = 1000
 )
 
 // Client is an HTTP client for the Orka API.
@@ -88,6 +89,97 @@ type ListOptions struct {
 	Namespace string
 }
 
+type listPage[T any] struct {
+	Items              []T
+	Continue           string
+	RemainingItemCount *int64
+}
+
+func collectAllPages[T any](
+	ctx context.Context,
+	resource string,
+	initialContinuation string,
+	fetch func(context.Context, string) (*listPage[T], error),
+) ([]T, error) {
+	items := make([]T, 0)
+	continuation := initialContinuation
+	seenContinuations := make(map[string]struct{})
+	if continuation != "" {
+		seenContinuations[continuation] = struct{}{}
+	}
+
+	for pageNumber := 1; pageNumber <= maxAutoPaginationPages; pageNumber++ {
+		if err := ctx.Err(); err != nil {
+			return items, fmt.Errorf(
+				"listing %s stopped after %d items before page %d: %w",
+				resource,
+				len(items),
+				pageNumber,
+				err,
+			)
+		}
+
+		page, err := fetch(ctx, continuation)
+		if err != nil {
+			return items, fmt.Errorf(
+				"listing %s stopped after %d items on page %d: %w",
+				resource,
+				len(items),
+				pageNumber,
+				err,
+			)
+		}
+		if page == nil {
+			return items, fmt.Errorf(
+				"listing %s stopped after %d items on page %d: empty page response",
+				resource,
+				len(items),
+				pageNumber,
+			)
+		}
+
+		items = append(items, page.Items...)
+		if page.Continue == "" {
+			if page.RemainingItemCount != nil && *page.RemainingItemCount > 0 {
+				return items, fmt.Errorf(
+					"listing %s stopped after %d items: pagination ended with %d remaining items but no continuation",
+					resource,
+					len(items),
+					*page.RemainingItemCount,
+				)
+			}
+			return items, nil
+		}
+		if page.Continue == continuation {
+			return items, fmt.Errorf(
+				"listing %s stopped after %d items: continuation did not advance",
+				resource,
+				len(items),
+			)
+		}
+		if _, seen := seenContinuations[page.Continue]; seen {
+			return items, fmt.Errorf(
+				"listing %s stopped after %d items: continuation cycle detected",
+				resource,
+				len(items),
+			)
+		}
+		if pageNumber == maxAutoPaginationPages {
+			return items, fmt.Errorf(
+				"listing %s stopped after %d items: pagination page limit (%d) reached",
+				resource,
+				len(items),
+				maxAutoPaginationPages,
+			)
+		}
+
+		seenContinuations[page.Continue] = struct{}{}
+		continuation = page.Continue
+	}
+
+	return items, fmt.Errorf("listing %s stopped: pagination terminated unexpectedly", resource)
+}
+
 // GetOptions contains options for get operations.
 type GetOptions struct {
 	Namespace string
@@ -115,6 +207,16 @@ type agentListResponse struct {
 
 // ListAgents returns all agents from the API.
 func (c *Client) ListAgents(ctx context.Context, opts ListOptions) ([]AgentSummary, error) {
+	return collectAllPages(ctx, "agents", "", func(ctx context.Context, continuation string) (*listPage[AgentSummary], error) {
+		return c.listAgentsPage(ctx, opts, continuation)
+	})
+}
+
+func (c *Client) listAgentsPage(
+	ctx context.Context,
+	opts ListOptions,
+	continuation string,
+) (*listPage[AgentSummary], error) {
 	u, err := url.Parse(c.BaseURL + "/api/v1/agents")
 	if err != nil {
 		return nil, fmt.Errorf("invalid base URL: %w", err)
@@ -122,6 +224,9 @@ func (c *Client) ListAgents(ctx context.Context, opts ListOptions) ([]AgentSumma
 	q := u.Query()
 	if opts.Namespace != "" {
 		q.Set("namespace", opts.Namespace)
+	}
+	if continuation != "" {
+		q.Set("continue", continuation)
 	}
 	u.RawQuery = q.Encode()
 
@@ -139,7 +244,11 @@ func (c *Client) ListAgents(ctx context.Context, opts ListOptions) ([]AgentSumma
 	for _, item := range resp.Items {
 		summaries = append(summaries, extractAgentSummary(item))
 	}
-	return summaries, nil
+	return &listPage[AgentSummary]{
+		Items:              summaries,
+		Continue:           resp.Metadata.Continue,
+		RemainingItemCount: resp.Metadata.RemainingItemCount,
+	}, nil
 }
 
 // GetAgent returns full details for a single agent.
@@ -709,6 +818,16 @@ type skillListResponse struct {
 
 // ListSkills returns all skills from the API.
 func (c *Client) ListSkills(ctx context.Context, opts ListOptions) ([]SkillSummary, error) {
+	return collectAllPages(ctx, "skills", "", func(ctx context.Context, continuation string) (*listPage[SkillSummary], error) {
+		return c.listSkillsPage(ctx, opts, continuation)
+	})
+}
+
+func (c *Client) listSkillsPage(
+	ctx context.Context,
+	opts ListOptions,
+	continuation string,
+) (*listPage[SkillSummary], error) {
 	u, err := url.Parse(c.BaseURL + "/api/v1/skills")
 	if err != nil {
 		return nil, fmt.Errorf("invalid base URL: %w", err)
@@ -716,6 +835,9 @@ func (c *Client) ListSkills(ctx context.Context, opts ListOptions) ([]SkillSumma
 	q := u.Query()
 	if opts.Namespace != "" {
 		q.Set("namespace", opts.Namespace)
+	}
+	if continuation != "" {
+		q.Set("continue", continuation)
 	}
 	u.RawQuery = q.Encode()
 
@@ -729,7 +851,11 @@ func (c *Client) ListSkills(ctx context.Context, opts ListOptions) ([]SkillSumma
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	return resp.Items, nil
+	return &listPage[SkillSummary]{
+		Items:              resp.Items,
+		Continue:           resp.Metadata.Continue,
+		RemainingItemCount: resp.Metadata.RemainingItemCount,
+	}, nil
 }
 
 // GetSkill returns full details for a single skill.

--- a/internal/cli/client/client.go
+++ b/internal/cli/client/client.go
@@ -668,8 +668,13 @@ func (c *Client) ListTasksPage(ctx context.Context, opts ListTasksOptions) (*Lis
 	}
 	if opts.All {
 		q.Set("limit", "0")
-	} else if opts.Limit > 0 {
-		q.Set("limit", strconv.Itoa(opts.Limit))
+	} else {
+		if opts.Limit > 0 {
+			q.Set("limit", strconv.Itoa(opts.Limit))
+		}
+		if opts.Limit > 0 || opts.Continue != "" {
+			q.Set("paginate", "true")
+		}
 	}
 	if opts.Continue != "" {
 		q.Set("continue", opts.Continue)

--- a/internal/cli/client/client_test.go
+++ b/internal/cli/client/client_test.go
@@ -429,6 +429,9 @@ func TestListTasksPageAllUsesLimitZero(t *testing.T) {
 	if !strings.Contains(capturedQuery, "limit=0") {
 		t.Fatalf("query %q missing limit=0", capturedQuery)
 	}
+	if strings.Contains(capturedQuery, "paginate=") {
+		t.Fatalf("query %q unexpectedly opts into pagination", capturedQuery)
+	}
 }
 
 func TestListTasksPageReturnsPaginationMetadata(t *testing.T) {
@@ -439,6 +442,9 @@ func TestListTasksPageReturnsPaginationMetadata(t *testing.T) {
 		}
 		if got := r.URL.Query().Get("continue"); got != "abc" {
 			t.Errorf("continue query = %q, want abc", got)
+		}
+		if got := r.URL.Query().Get("paginate"); got != "true" {
+			t.Errorf("paginate query = %q, want true", got)
 		}
 		json.NewEncoder(w).Encode(taskListResponse{ //nolint:errcheck
 			Items: []TaskDetail{

--- a/internal/cli/client/inventory_pagination_test.go
+++ b/internal/cli/client/inventory_pagination_test.go
@@ -1,0 +1,224 @@
+/* Copyright (c) 2026. MIT License - see LICENSE file for details. */
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestListAgentsFollowsOpaqueContinuationsAndNamespace(t *testing.T) {
+	const (
+		namespace    = "inventory-ns"
+		continuation = "agent-cursor+/=? segment"
+	)
+
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if got := r.URL.Query().Get("namespace"); got != namespace {
+			t.Errorf("namespace query = %q, want %q", got, namespace)
+		}
+
+		switch requests {
+		case 1:
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"items":    []map[string]any{{"metadata": map[string]any{"name": "agent-1"}}},
+				"metadata": map[string]any{"continue": continuation},
+			})
+		case 2:
+			if got := r.URL.Query().Get("continue"); got != continuation {
+				t.Errorf("continue query = %q, want %q", got, continuation)
+			}
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"items":    []map[string]any{{"metadata": map[string]any{"name": "agent-2"}}},
+				"metadata": map[string]any{},
+			})
+		default:
+			t.Errorf("unexpected request %d", requests)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	agents, err := New(srv.URL, "").ListAgents(context.Background(), ListOptions{Namespace: namespace})
+	if err != nil {
+		t.Fatalf("ListAgents() error = %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+	if len(agents) != 2 || agents[0].Name != "agent-1" || agents[1].Name != "agent-2" {
+		t.Fatalf("agents = %#v, want both pages", agents)
+	}
+}
+
+func TestListSkillsFollowsOpaqueContinuationsAndNamespace(t *testing.T) {
+	const (
+		namespace    = "inventory-ns"
+		continuation = "skill-cursor+/=? segment"
+	)
+
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if got := r.URL.Query().Get("namespace"); got != namespace {
+			t.Errorf("namespace query = %q, want %q", got, namespace)
+		}
+
+		switch requests {
+		case 1:
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"items":    []map[string]any{{"name": "skill-1"}},
+				"metadata": map[string]any{"continue": continuation},
+			})
+		case 2:
+			if got := r.URL.Query().Get("continue"); got != continuation {
+				t.Errorf("continue query = %q, want %q", got, continuation)
+			}
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"items":    []map[string]any{{"name": "skill-2"}},
+				"metadata": map[string]any{},
+			})
+		default:
+			t.Errorf("unexpected request %d", requests)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	skills, err := New(srv.URL, "").ListSkills(context.Background(), ListOptions{Namespace: namespace})
+	if err != nil {
+		t.Fatalf("ListSkills() error = %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+	if len(skills) != 2 || skills[0].Name != "skill-1" || skills[1].Name != "skill-2" {
+		t.Fatalf("skills = %#v, want both pages", skills)
+	}
+}
+
+func TestCollectAllPagesReturnsPartialResultsForUnsafePagination(t *testing.T) {
+	t.Run("later page failure", func(t *testing.T) {
+		wantErr := errors.New("later page failed")
+		calls := 0
+		items, err := collectAllPages(context.Background(), "widgets", "", func(
+			context.Context,
+			string,
+		) (*listPage[int], error) {
+			calls++
+			if calls == 1 {
+				return &listPage[int]{Items: []int{1}, Continue: "next"}, nil
+			}
+			return nil, wantErr
+		})
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("collectAllPages() error = %v, want wrapped later-page error", err)
+		}
+		if len(items) != 1 || items[0] != 1 {
+			t.Fatalf("items = %#v, want first-page partial result", items)
+		}
+		if !strings.Contains(err.Error(), "after 1 items on page 2") {
+			t.Fatalf("error = %q, want partial-result context", err)
+		}
+	})
+
+	t.Run("non advancing continuation", func(t *testing.T) {
+		items, err := collectAllPages(context.Background(), "widgets", "", func(
+			_ context.Context,
+			continuation string,
+		) (*listPage[int], error) {
+			if continuation == "" {
+				return &listPage[int]{Items: []int{1}, Continue: "same"}, nil
+			}
+			return &listPage[int]{Items: []int{2}, Continue: continuation}, nil
+		})
+		if err == nil || !strings.Contains(err.Error(), "continuation did not advance") {
+			t.Fatalf("collectAllPages() error = %v, want non-advancing continuation error", err)
+		}
+		if len(items) != 2 {
+			t.Fatalf("len(items) = %d, want 2 partial items", len(items))
+		}
+	})
+
+	t.Run("continuation cycle", func(t *testing.T) {
+		items, err := collectAllPages(context.Background(), "widgets", "", func(
+			_ context.Context,
+			continuation string,
+		) (*listPage[int], error) {
+			switch continuation {
+			case "":
+				return &listPage[int]{Items: []int{1}, Continue: "a"}, nil
+			case "a":
+				return &listPage[int]{Items: []int{2}, Continue: "b"}, nil
+			default:
+				return &listPage[int]{Items: []int{3}, Continue: "a"}, nil
+			}
+		})
+		if err == nil || !strings.Contains(err.Error(), "continuation cycle detected") {
+			t.Fatalf("collectAllPages() error = %v, want continuation cycle error", err)
+		}
+		if len(items) != 3 {
+			t.Fatalf("len(items) = %d, want 3 partial items", len(items))
+		}
+	})
+
+	t.Run("remaining items without continuation", func(t *testing.T) {
+		remaining := int64(1)
+		items, err := collectAllPages(context.Background(), "widgets", "", func(
+			context.Context,
+			string,
+		) (*listPage[int], error) {
+			return &listPage[int]{Items: []int{1}, RemainingItemCount: &remaining}, nil
+		})
+		if err == nil || !strings.Contains(err.Error(), "remaining items but no continuation") {
+			t.Fatalf("collectAllPages() error = %v, want remaining-items error", err)
+		}
+		if len(items) != 1 {
+			t.Fatalf("len(items) = %d, want one partial item", len(items))
+		}
+	})
+}
+
+func TestCollectAllPagesHonorsCancellationAndPageLimit(t *testing.T) {
+	t.Run("cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		items, err := collectAllPages(ctx, "widgets", "", func(
+			context.Context,
+			string,
+		) (*listPage[int], error) {
+			cancel()
+			return &listPage[int]{Items: []int{1}, Continue: "next"}, nil
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("collectAllPages() error = %v, want context canceled", err)
+		}
+		if len(items) != 1 {
+			t.Fatalf("len(items) = %d, want first-page partial item", len(items))
+		}
+	})
+
+	t.Run("page limit", func(t *testing.T) {
+		calls := 0
+		items, err := collectAllPages(context.Background(), "widgets", "", func(
+			context.Context,
+			string,
+		) (*listPage[int], error) {
+			calls++
+			return &listPage[int]{Items: []int{calls}, Continue: fmt.Sprintf("cursor-%d", calls)}, nil
+		})
+		if err == nil || !strings.Contains(err.Error(), "pagination page limit") {
+			t.Fatalf("collectAllPages() error = %v, want page-limit error", err)
+		}
+		if calls != maxAutoPaginationPages || len(items) != maxAutoPaginationPages {
+			t.Fatalf("calls/items = %d/%d, want %d", calls, len(items), maxAutoPaginationPages)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Stacked salvage from #280. Base: #318 (`fix/task-log-streaming`); functional dependency: #314.

- Follow opaque continuations for Agent, Skill, Task, and status inventory while forwarding the selected namespace and command context.
- Detect non-advancing or cyclic cursors, later-page failures, cancellation, and excessive page counts instead of silently reporting partial inventory.
- Keep Tool and Session generic inventory explicitly manual-page surfaces while exposing safe continuation guidance.

## Scope

This PR changes CLI-side inventory traversal only. It does not change Kubernetes cursor generation or task-log streaming; the latter remains in the stack because both slices touch the shared CLI client.

## Verification

- `go test ./cmd/cli ./internal/cli/client -run 'Pagination|List|Status|Continuation' -count=1`
- `make lint-fix && make test`
- Full required CI

After #318 and #314 merge, this PR should be retargeted to `main`.