### PR TITLE
fix(helm): harden release manifest rendering

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -89,10 +89,47 @@ jobs:
             echo "The raw installer must require a pre-created harness-wrapper-auth Secret, not embed one." >&2
             exit 1
           fi
+          if ! awk '
+            function finish_resource() {
+              if (kind == "ValidatingAdmissionPolicy" || kind == "ValidatingAdmissionPolicyBinding") {
+                count++
+                if (namespace != "") {
+                  printf "%s %s must not set metadata.namespace (%s)\n", kind, name, namespace > "/dev/stderr"
+                  invalid = 1
+                }
+              }
+            }
+            /^---$/ {
+              finish_resource()
+              kind = ""
+              name = ""
+              namespace = ""
+              next
+            }
+            /^kind: / { kind = $2; next }
+            /^  name: / && name == "" { name = $2; next }
+            /^  namespace: / { namespace = $2; next }
+            END {
+              finish_resource()
+              if (count != 8) {
+                printf "Expected 8 admission policies and bindings, found %d\n", count > "/dev/stderr"
+                invalid = 1
+              }
+              exit invalid
+            }
+          ' manifest_staging/deploy/orka.yaml; then
+            echo "Cluster-scoped admission resources in the raw installer are invalid." >&2
+            exit 1
+          fi
 
           go test ./cmd/build/helmify
           helm lint cmd/build/helmify/static
           helm lint manifest_staging/charts/orka
+          helm template legacy-values manifest_staging/charts/orka \
+            --namespace "${NAMESPACE}" \
+            --set-json controller.workspaceProvider=null \
+            --set-string workers.harnessWrapper.auth.token=mock-token \
+            > /dev/null
 
           fake_provider_render=$(mktemp)
           default_render=$(mktemp)
@@ -103,7 +140,8 @@ jobs:
           long_render=$(mktemp)
           long_wrapper_service=$(mktemp)
           long_wrapper_secret=$(mktemp)
-          trap 'rm -f "${fake_provider_render}" "${default_render}" "${secondary_render}" "${secondary_rbac}" "${secondary_serviceaccounts}" "${secondary_gateway_policy}" "${long_render}" "${long_wrapper_service}" "${long_wrapper_secret}"' EXIT
+          long_workspace_webhook=$(mktemp)
+          trap 'rm -f "${fake_provider_render}" "${default_render}" "${secondary_render}" "${secondary_rbac}" "${secondary_serviceaccounts}" "${secondary_gateway_policy}" "${long_render}" "${long_wrapper_service}" "${long_wrapper_secret}" "${long_workspace_webhook}"' EXIT
           "$(pwd)/bin/kustomize" build \
             --load-restrictor LoadRestrictionsNone \
             config/development/fake-workspace-provider \
@@ -154,6 +192,14 @@ jobs:
             --set-string workers.harnessWrapper.auth.token=mock-token \
             --show-only templates/harness-wrapper-secret.yaml \
             > "${long_wrapper_secret}"
+          helm template "${long_release}" manifest_staging/charts/orka \
+            --namespace "${NAMESPACE}" \
+            --set controller.workspaceProvider.classUseAdmission.enabled=true \
+            --set-string controller.workspaceProvider.classUseAdmission.existingSecret=workspace-webhook-tls \
+            --set-string controller.workspaceProvider.classUseAdmission.caBundle=Y2E= \
+            --set-string workers.harnessWrapper.auth.token=mock-token \
+            --show-only templates/workspace-class-use-webhook.yaml \
+            > "${long_workspace_webhook}"
 
           grep -Fq -- "--controller-url=http://orka.${NAMESPACE}.svc:8080" "${default_render}"
           grep -Fq -- "--controller-url=http://secondary-orka.${NAMESPACE}.svc:8080" "${secondary_render}"
@@ -167,11 +213,14 @@ jobs:
           done
           wrapper_name=$(awk '$1 == "name:" { print $2; exit }' "${long_wrapper_service}")
           wrapper_secret_name=$(awk '$1 == "name:" { print $2; exit }' "${long_wrapper_secret}")
+          workspace_webhook_name=$(awk '$1 == "name:" { print $2; exit }' "${long_workspace_webhook}")
           [[ -n "${wrapper_name}" && ${#wrapper_name} -le 63 ]]
           [[ -n "${wrapper_secret_name}" && ${#wrapper_secret_name} -le 63 ]]
+          [[ -n "${workspace_webhook_name}" && ${#workspace_webhook_name} -le 63 ]]
           grep -Fq -- "http://${wrapper_name}:8080" "${long_render}"
           grep -Fq -- "serviceAccountName: ${wrapper_name}" "${long_render}"
           grep -Fq -- "secretName: ${wrapper_secret_name}" "${long_render}"
+          test "$(grep -Fc -- "name: ${workspace_webhook_name}" "${long_workspace_webhook}")" -eq 3
 
           chart_version=$(awk '$1 == "version:" { print $2; exit }' manifest_staging/charts/orka/Chart.yaml)
           grep -Fq -- "--general-worker-image=ghcr.io/orka-agents/orka/general-worker:${chart_version}" "${secondary_render}"

--- a/cmd/build/helmify/static/templates/_helpers.tpl
+++ b/cmd/build/helmify/static/templates/_helpers.tpl
@@ -90,6 +90,14 @@ that must remain valid DNS labels (notably the Service name).
 {{- printf "%s-harness-wrapper-auth" (include "orka.fullname" . | trunc 42 | trimSuffix "-") | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{/*
+Create the workspace admission webhook Service name while reserving room for
+its suffix so long release names remain valid DNS labels.
+*/}}
+{{- define "orka.workspaceWebhookName" -}}
+{{- printf "%s-workspace-webhook" (include "orka.fullname" . | trunc 45 | trimSuffix "-") | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 
 {{/*
 Create the namespace for the chart-managed client ServiceAccount.

--- a/cmd/build/helmify/static/templates/deployment.yaml
+++ b/cmd/build/helmify/static/templates/deployment.yaml
@@ -1,12 +1,14 @@
-{{- if and .Values.controller.workspaceProvider.fakeProviderEnabled (not .Values.controller.workspaceProvider.apiEnabled) -}}
+{{- $workspaceProvider := .Values.controller.workspaceProvider | default dict -}}
+{{- $classUseAdmission := $workspaceProvider.classUseAdmission | default dict -}}
+{{- if and $workspaceProvider.fakeProviderEnabled (not $workspaceProvider.apiEnabled) -}}
 {{- fail "controller.workspaceProvider.fakeProviderEnabled requires controller.workspaceProvider.apiEnabled" -}}
 {{- end -}}
-{{- if and .Values.controller.workspaceProvider.apiEnabled (not .Values.controller.workspaceProvider.classUseAdmission.enabled) -}}
+{{- if and $workspaceProvider.apiEnabled (not $classUseAdmission.enabled) -}}
 {{- fail "controller.workspaceProvider.apiEnabled requires controller.workspaceProvider.classUseAdmission.enabled" -}}
 {{- end -}}
-{{- if .Values.controller.workspaceProvider.classUseAdmission.enabled -}}
-{{- $workspaceWebhookSecret := required "controller.workspaceProvider.classUseAdmission.existingSecret is required when class-use admission is enabled" .Values.controller.workspaceProvider.classUseAdmission.existingSecret -}}
-{{- $workspaceWebhookCA := required "controller.workspaceProvider.classUseAdmission.caBundle is required when class-use admission is enabled" .Values.controller.workspaceProvider.classUseAdmission.caBundle -}}
+{{- if $classUseAdmission.enabled -}}
+{{- $workspaceWebhookSecret := required "controller.workspaceProvider.classUseAdmission.existingSecret is required when class-use admission is enabled" $classUseAdmission.existingSecret -}}
+{{- $workspaceWebhookCA := required "controller.workspaceProvider.classUseAdmission.caBundle is required when class-use admission is enabled" $classUseAdmission.caBundle -}}
 {{- end -}}
 {{- $gatewayCRDsReady := false -}}
 {{- if and .Values.controller.gateway.enabled (not .Values.controller.gateway.crdsReadyOverride) -}}
@@ -250,7 +252,7 @@ spec:
             {{- if gt (int .Values.controller.maxTasksPerNamespace) 0 }}
             - --max-tasks-per-namespace={{ .Values.controller.maxTasksPerNamespace }}
             {{- end }}
-            {{- with .Values.controller.workspaceProvider }}
+            {{- with $workspaceProvider }}
             {{- if .apiEnabled }}
             - --enable-workspace-provider-api=true
             {{- end }}
@@ -368,7 +370,7 @@ spec:
             - name: health
               containerPort: {{ .Values.controller.healthPort }}
               protocol: TCP
-            {{- if .Values.controller.workspaceProvider.classUseAdmission.enabled }}
+            {{- if $classUseAdmission.enabled }}
             - name: webhook-server
               containerPort: 9443
               protocol: TCP
@@ -401,7 +403,7 @@ spec:
             - name: harness-wrapper-auth
               mountPath: /var/run/orka/harness-wrapper
               readOnly: true
-            {{- if .Values.controller.workspaceProvider.classUseAdmission.enabled }}
+            {{- if $classUseAdmission.enabled }}
             - name: workspace-webhook-certs
               mountPath: /var/run/orka/workspace-webhook
               readOnly: true
@@ -415,10 +417,10 @@ spec:
             items:
               - key: {{ .Values.workers.harnessWrapper.auth.tokenKey | default "token" }}
                 path: token
-        {{- if .Values.controller.workspaceProvider.classUseAdmission.enabled }}
+        {{- if $classUseAdmission.enabled }}
         - name: workspace-webhook-certs
           secret:
-            secretName: {{ .Values.controller.workspaceProvider.classUseAdmission.existingSecret | quote }}
+            secretName: {{ $classUseAdmission.existingSecret | quote }}
             defaultMode: 0400
             items:
               - key: tls.crt

--- a/cmd/build/helmify/static/templates/rbac.yaml
+++ b/cmd/build/helmify/static/templates/rbac.yaml
@@ -1,3 +1,4 @@
+{{- $workspaceProvider := .Values.controller.workspaceProvider | default dict -}}
 {{- if .Values.rbac.create -}}
 # Controller ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -542,7 +543,7 @@ aggregationRule:
     - matchLabels:
         workspace.orka.ai/aggregate-to-parameter-reader: "true"
 rules: []
-{{- if .Values.controller.workspaceProvider.fakeProviderEnabled }}
+{{- if $workspaceProvider.fakeProviderEnabled }}
 ---
 # Development-only fake provider parameters contribute to the aggregate reader.
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cmd/build/helmify/static/templates/workspace-class-use-webhook.yaml
+++ b/cmd/build/helmify/static/templates/workspace-class-use-webhook.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "orka.fullname" . }}-workspace-webhook
+  name: {{ include "orka.workspaceWebhookName" . }}
   labels:
     {{- include "orka.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
@@ -33,7 +33,7 @@ webhooks:
     timeoutSeconds: 10
     clientConfig:
       service:
-        name: {{ include "orka.fullname" . }}-workspace-webhook
+        name: {{ include "orka.workspaceWebhookName" . }}
         namespace: {{ .Release.Namespace }}
         path: /validate-core-orka-ai-v1alpha1-task-workspace-class-use
         port: 443
@@ -52,7 +52,7 @@ webhooks:
     timeoutSeconds: 10
     clientConfig:
       service:
-        name: {{ include "orka.fullname" . }}-workspace-webhook
+        name: {{ include "orka.workspaceWebhookName" . }}
         namespace: {{ .Release.Namespace }}
         path: /validate-core-orka-ai-v1alpha1-tool-workspace-class-use
         port: 443

--- a/config/default/remove_admission_policy_binding_namespace.yaml
+++ b/config/default/remove_admission_policy_binding_namespace.yaml
@@ -9,4 +9,3 @@ target:
   group: admissionregistration.k8s.io
   version: v1
   kind: ValidatingAdmissionPolicyBinding
-  name: gateway-task-protection

--- a/config/default/remove_admission_policy_namespace.yaml
+++ b/config/default/remove_admission_policy_namespace.yaml
@@ -9,4 +9,3 @@ target:
   group: admissionregistration.k8s.io
   version: v1
   kind: ValidatingAdmissionPolicy
-  name: gateway-task-protection

--- a/manifest_staging/charts/orka/templates/_helpers.tpl
+++ b/manifest_staging/charts/orka/templates/_helpers.tpl
@@ -90,6 +90,14 @@ that must remain valid DNS labels (notably the Service name).
 {{- printf "%s-harness-wrapper-auth" (include "orka.fullname" . | trunc 42 | trimSuffix "-") | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{/*
+Create the workspace admission webhook Service name while reserving room for
+its suffix so long release names remain valid DNS labels.
+*/}}
+{{- define "orka.workspaceWebhookName" -}}
+{{- printf "%s-workspace-webhook" (include "orka.fullname" . | trunc 45 | trimSuffix "-") | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 
 {{/*
 Create the namespace for the chart-managed client ServiceAccount.

--- a/manifest_staging/charts/orka/templates/deployment.yaml
+++ b/manifest_staging/charts/orka/templates/deployment.yaml
@@ -1,12 +1,14 @@
-{{- if and .Values.controller.workspaceProvider.fakeProviderEnabled (not .Values.controller.workspaceProvider.apiEnabled) -}}
+{{- $workspaceProvider := .Values.controller.workspaceProvider | default dict -}}
+{{- $classUseAdmission := $workspaceProvider.classUseAdmission | default dict -}}
+{{- if and $workspaceProvider.fakeProviderEnabled (not $workspaceProvider.apiEnabled) -}}
 {{- fail "controller.workspaceProvider.fakeProviderEnabled requires controller.workspaceProvider.apiEnabled" -}}
 {{- end -}}
-{{- if and .Values.controller.workspaceProvider.apiEnabled (not .Values.controller.workspaceProvider.classUseAdmission.enabled) -}}
+{{- if and $workspaceProvider.apiEnabled (not $classUseAdmission.enabled) -}}
 {{- fail "controller.workspaceProvider.apiEnabled requires controller.workspaceProvider.classUseAdmission.enabled" -}}
 {{- end -}}
-{{- if .Values.controller.workspaceProvider.classUseAdmission.enabled -}}
-{{- $workspaceWebhookSecret := required "controller.workspaceProvider.classUseAdmission.existingSecret is required when class-use admission is enabled" .Values.controller.workspaceProvider.classUseAdmission.existingSecret -}}
-{{- $workspaceWebhookCA := required "controller.workspaceProvider.classUseAdmission.caBundle is required when class-use admission is enabled" .Values.controller.workspaceProvider.classUseAdmission.caBundle -}}
+{{- if $classUseAdmission.enabled -}}
+{{- $workspaceWebhookSecret := required "controller.workspaceProvider.classUseAdmission.existingSecret is required when class-use admission is enabled" $classUseAdmission.existingSecret -}}
+{{- $workspaceWebhookCA := required "controller.workspaceProvider.classUseAdmission.caBundle is required when class-use admission is enabled" $classUseAdmission.caBundle -}}
 {{- end -}}
 {{- $gatewayCRDsReady := false -}}
 {{- if and .Values.controller.gateway.enabled (not .Values.controller.gateway.crdsReadyOverride) -}}
@@ -250,7 +252,7 @@ spec:
             {{- if gt (int .Values.controller.maxTasksPerNamespace) 0 }}
             - --max-tasks-per-namespace={{ .Values.controller.maxTasksPerNamespace }}
             {{- end }}
-            {{- with .Values.controller.workspaceProvider }}
+            {{- with $workspaceProvider }}
             {{- if .apiEnabled }}
             - --enable-workspace-provider-api=true
             {{- end }}
@@ -368,7 +370,7 @@ spec:
             - name: health
               containerPort: {{ .Values.controller.healthPort }}
               protocol: TCP
-            {{- if .Values.controller.workspaceProvider.classUseAdmission.enabled }}
+            {{- if $classUseAdmission.enabled }}
             - name: webhook-server
               containerPort: 9443
               protocol: TCP
@@ -401,7 +403,7 @@ spec:
             - name: harness-wrapper-auth
               mountPath: /var/run/orka/harness-wrapper
               readOnly: true
-            {{- if .Values.controller.workspaceProvider.classUseAdmission.enabled }}
+            {{- if $classUseAdmission.enabled }}
             - name: workspace-webhook-certs
               mountPath: /var/run/orka/workspace-webhook
               readOnly: true
@@ -415,10 +417,10 @@ spec:
             items:
               - key: {{ .Values.workers.harnessWrapper.auth.tokenKey | default "token" }}
                 path: token
-        {{- if .Values.controller.workspaceProvider.classUseAdmission.enabled }}
+        {{- if $classUseAdmission.enabled }}
         - name: workspace-webhook-certs
           secret:
-            secretName: {{ .Values.controller.workspaceProvider.classUseAdmission.existingSecret | quote }}
+            secretName: {{ $classUseAdmission.existingSecret | quote }}
             defaultMode: 0400
             items:
               - key: tls.crt

--- a/manifest_staging/charts/orka/templates/rbac.yaml
+++ b/manifest_staging/charts/orka/templates/rbac.yaml
@@ -1,3 +1,4 @@
+{{- $workspaceProvider := .Values.controller.workspaceProvider | default dict -}}
 {{- if .Values.rbac.create -}}
 # Controller ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -542,7 +543,7 @@ aggregationRule:
     - matchLabels:
         workspace.orka.ai/aggregate-to-parameter-reader: "true"
 rules: []
-{{- if .Values.controller.workspaceProvider.fakeProviderEnabled }}
+{{- if $workspaceProvider.fakeProviderEnabled }}
 ---
 # Development-only fake provider parameters contribute to the aggregate reader.
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifest_staging/charts/orka/templates/workspace-class-use-webhook.yaml
+++ b/manifest_staging/charts/orka/templates/workspace-class-use-webhook.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "orka.fullname" . }}-workspace-webhook
+  name: {{ include "orka.workspaceWebhookName" . }}
   labels:
     {{- include "orka.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
@@ -33,7 +33,7 @@ webhooks:
     timeoutSeconds: 10
     clientConfig:
       service:
-        name: {{ include "orka.fullname" . }}-workspace-webhook
+        name: {{ include "orka.workspaceWebhookName" . }}
         namespace: {{ .Release.Namespace }}
         path: /validate-core-orka-ai-v1alpha1-task-workspace-class-use
         port: 443
@@ -52,7 +52,7 @@ webhooks:
     timeoutSeconds: 10
     clientConfig:
       service:
-        name: {{ include "orka.fullname" . }}-workspace-webhook
+        name: {{ include "orka.workspaceWebhookName" . }}
         namespace: {{ .Release.Namespace }}
         path: /validate-core-orka-ai-v1alpha1-tool-workspace-class-use
         port: 443

--- a/manifest_staging/deploy/orka.yaml
+++ b/manifest_staging/deploy/orka.yaml
@@ -11459,7 +11459,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: orka-executionworkspace-core-admission.orka.ai
-  namespace: orka-system
 spec:
   failurePolicy: Fail
   matchConstraints:
@@ -11494,64 +11493,6 @@ spec:
         .check('admit').allowed()
     message: only the Orka core controller may establish or advance ExecutionWorkspace
       core admission
-    reason: Forbidden
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingAdmissionPolicy
-metadata:
-  name: orka-task-workspace-class-use.orka.ai
-  namespace: orka-system
-spec:
-  failurePolicy: Fail
-  matchConstraints:
-    resourceRules:
-    - apiGroups:
-      - core.orka.ai
-      apiVersions:
-      - v1alpha1
-      operations:
-      - CREATE
-      - UPDATE
-      resources:
-      - tasks
-  validations:
-  - expression: |-
-      !has(object.spec.execution) || !has(object.spec.execution.workspace) || !has(object.spec.execution.workspace.classRef) || authorizer.group('workspace.orka.ai')
-
-        .resource('executionworkspaceclasses')
-        .namespace(request.namespace)
-        .name(object.spec.execution.workspace.classRef.name)
-        .check('use').allowed()
-    message: caller is not authorized to use the selected ExecutionWorkspaceClass
-    reason: Forbidden
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingAdmissionPolicy
-metadata:
-  name: orka-tool-workspace-class-use.orka.ai
-  namespace: orka-system
-spec:
-  failurePolicy: Fail
-  matchConstraints:
-    resourceRules:
-    - apiGroups:
-      - core.orka.ai
-      apiVersions:
-      - v1alpha1
-      operations:
-      - CREATE
-      - UPDATE
-      resources:
-      - tools
-  validations:
-  - expression: |-
-      !has(object.spec.mcp) || !has(object.spec.mcp.workspace) || authorizer.group('workspace.orka.ai')
-
-        .resource('executionworkspaceclasses')
-        .namespace(request.namespace)
-        .name(object.spec.mcp.workspace.classRef.name)
-        .check('use').allowed()
-    message: caller is not authorized to use the selected ExecutionWorkspaceClass
     reason: Forbidden
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -11608,32 +11549,67 @@ spec:
     name: containerWorkerServiceAccount
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: orka-task-workspace-class-use.orka.ai
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - core.orka.ai
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - tasks
+  validations:
+  - expression: |-
+      !has(object.spec.execution) || !has(object.spec.execution.workspace) || !has(object.spec.execution.workspace.classRef) || authorizer.group('workspace.orka.ai')
+
+        .resource('executionworkspaceclasses')
+        .namespace(request.namespace)
+        .name(object.spec.execution.workspace.classRef.name)
+        .check('use').allowed()
+    message: caller is not authorized to use the selected ExecutionWorkspaceClass
+    reason: Forbidden
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: orka-tool-workspace-class-use.orka.ai
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - core.orka.ai
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - tools
+  validations:
+  - expression: |-
+      !has(object.spec.mcp) || !has(object.spec.mcp.workspace) || authorizer.group('workspace.orka.ai')
+
+        .resource('executionworkspaceclasses')
+        .namespace(request.namespace)
+        .name(object.spec.mcp.workspace.classRef.name)
+        .check('use').allowed()
+    message: caller is not authorized to use the selected ExecutionWorkspaceClass
+    reason: Forbidden
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: orka-executionworkspace-core-admission.orka.ai
-  namespace: orka-system
 spec:
   policyName: orka-executionworkspace-core-admission.orka.ai
-  validationActions:
-  - Deny
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingAdmissionPolicyBinding
-metadata:
-  name: orka-task-workspace-class-use.orka.ai
-  namespace: orka-system
-spec:
-  policyName: orka-task-workspace-class-use.orka.ai
-  validationActions:
-  - Deny
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingAdmissionPolicyBinding
-metadata:
-  name: orka-tool-workspace-class-use.orka.ai
-  namespace: orka-system
-spec:
-  policyName: orka-tool-workspace-class-use.orka.ai
   validationActions:
   - Deny
 ---
@@ -11643,5 +11619,23 @@ metadata:
   name: orka-gateway-task-protection
 spec:
   policyName: orka-gateway-task-protection
+  validationActions:
+  - Deny
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: orka-task-workspace-class-use.orka.ai
+spec:
+  policyName: orka-task-workspace-class-use.orka.ai
+  validationActions:
+  - Deny
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: orka-tool-workspace-class-use.orka.ai
+spec:
+  policyName: orka-tool-workspace-class-use.orka.ai
   validationActions:
   - Deny


### PR DESCRIPTION
## Summary

- strip metadata namespaces from every cluster-scoped admission policy and binding in the raw installer
- render safely when legacy Helm release values do not contain controller.workspaceProvider
- keep the workspace webhook Service and both webhook references within the DNS-label limit
- add regression coverage to the existing Helm validation workflow

## Verification

- make manifests
- go test ./cmd/build/helmify
- helm lint cmd/build/helmify/static
- helm lint manifest_staging/charts/orka
- legacy-values Helm render with controller.workspaceProvider set to null
- long-release webhook name/reference assertion
- actionlint on .github/workflows/helm-chart.yml

## Release coordination

Addresses the release review findings on #371. After this merges, rerun the v0.1.1 release-preparation workflow so the release branch and promoted snapshots include these regenerated staging outputs before #371 is merged and tagged.