### PR TITLE
fix(release): backport workflow action pins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,13 +268,13 @@ jobs:
         run: printf '%s' '${{ steps.build.outputs.digest }}' > digest-${{ matrix.image }}.txt
 
       - name: Upload image digest
-        uses: actions/upload-artifact@ea165f8d65b6db9a8b9c84b9ecb0b81bc0de3c06 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: digest-${{ matrix.image }}
           path: digest-${{ matrix.image }}.txt
 
       - name: Upload release tags
-        uses: actions/upload-artifact@ea165f8d65b6db9a8b9c84b9ecb0b81bc0de3c06 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: tags-${{ matrix.image }}
           path: tags-${{ matrix.image }}.txt
@@ -294,7 +294,7 @@ jobs:
           "${SYFT_CMD}" scan --platform linux/arm64 "${IMAGE_REF}@${IMAGE_DIGEST}" -o spdx-json="sbom-${{ matrix.image }}-linux-arm64.spdx.json"
 
       - name: Upload SBOMs
-        uses: actions/upload-artifact@ea165f8d65b6db9a8b9c84b9ecb0b81bc0de3c06 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sbom-${{ matrix.image }}
           path: sbom-${{ matrix.image }}-*.spdx.json
@@ -363,7 +363,7 @@ jobs:
         run: echo "value=$(cat digests/digest-${{ matrix.image }}.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947e0f18c8ea69db56b # v0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_PLATFORM: ${{ matrix.platform }}
         with:
@@ -374,7 +374,7 @@ jobs:
           exit-code: "1"
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@ff82a3f0d98ec3cdc78ee8e96ffa7b68c8f68367 # v3
+        uses: github/codeql-action/upload-sarif@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7
         with:
           sarif_file: trivy-${{ matrix.image }}-${{ matrix.platform_slug }}.sarif
           category: trivy-${{ matrix.image }}-${{ matrix.platform_slug }}


### PR DESCRIPTION
## Summary

Backport #375 to the `release-0.1` branch so tag-triggered publication can resolve every external action. This is an exact cherry-pick of `f02ffdb6`.

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/*.yml`
- every external workflow action uses a full commit SHA
- every pinned action commit resolves successfully
- source patch was already reviewed cleanly in #375

Unblocks preparation of `v0.1.2` after the failed `v0.1.1` release run.