### PR TITLE
chore(release): prepare v0.1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Current application release version. Chart.yaml has its own version and may
 # advance independently for chart-only changes. Release preparation aligns both
 # versions for a tagged application release.
-VERSION := v0.1.1
+VERSION := v0.1.2
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest

--- a/charts/orka/Chart.yaml
+++ b/charts/orka/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: orka
 description: Kubernetes-native task execution platform with AI agent support
 type: application
-version: 0.1.1
-appVersion: "v0.1.1"
+version: 0.1.2
+appVersion: "v0.1.2"
 keywords:
   - kubernetes
   - task-execution

--- a/charts/orka/values.yaml
+++ b/charts/orka/values.yaml
@@ -8,7 +8,7 @@ controller:
   # Controller image
   image:
     repository: ghcr.io/orka-agents/orka
-    tag: "0.1.1"
+    tag: "0.1.2"
     pullPolicy: IfNotPresent
 
   # Resource limits
@@ -206,18 +206,18 @@ workers:
   ai:
     image:
       repository: ghcr.io/orka-agents/orka/ai-worker
-      tag: "0.1.1"
+      tag: "0.1.2"
       pullPolicy: IfNotPresent
 
   general:
     image:
       repository: ghcr.io/orka-agents/orka/general-worker
-      tag: "0.1.1"
+      tag: "0.1.2"
 
   harnessWrapper:
     image:
       repository: ghcr.io/orka-agents/orka/agent-harness-wrapper
-      tag: "0.1.1"
+      tag: "0.1.2"
       pullPolicy: IfNotPresent
     auth:
       # Existing Secret containing the shared wrapper bearer token.

--- a/cmd/build/helmify/static/Chart.yaml
+++ b/cmd/build/helmify/static/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: orka
 description: Kubernetes-native task execution platform with AI agent support
 type: application
-version: 0.1.1
-appVersion: "v0.1.1"
+version: 0.1.2
+appVersion: "v0.1.2"
 keywords:
   - kubernetes
   - task-execution

--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -8,7 +8,7 @@ controller:
   # Controller image
   image:
     repository: ghcr.io/orka-agents/orka
-    tag: "0.1.1"
+    tag: "0.1.2"
     pullPolicy: IfNotPresent
 
   # Resource limits
@@ -206,18 +206,18 @@ workers:
   ai:
     image:
       repository: ghcr.io/orka-agents/orka/ai-worker
-      tag: "0.1.1"
+      tag: "0.1.2"
       pullPolicy: IfNotPresent
 
   general:
     image:
       repository: ghcr.io/orka-agents/orka/general-worker
-      tag: "0.1.1"
+      tag: "0.1.2"
 
   harnessWrapper:
     image:
       repository: ghcr.io/orka-agents/orka/agent-harness-wrapper
-      tag: "0.1.1"
+      tag: "0.1.2"
       pullPolicy: IfNotPresent
     auth:
       # Existing Secret containing the shared wrapper bearer token.

--- a/config/harness-wrapper/deployment.yaml
+++ b/config/harness-wrapper/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: wrapper
-        image: ghcr.io/orka-agents/orka/agent-harness-wrapper:0.1.1
+        image: ghcr.io/orka-agents/orka/agent-harness-wrapper:0.1.2
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,7 +5,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - newName: ghcr.io/orka-agents/orka
-  newTag: 0.1.1
+  newTag: 0.1.2
 - name: controller
   newName: ghcr.io/orka-agents/orka
-  newTag: 0.1.1
+  newTag: 0.1.2

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,8 +72,8 @@ spec:
           - --store-backend=sqlite
           - --store-path=/data/orka.db
           - --controller-url=http://orka-api.orka-system.svc:8080
-          - --ai-worker-image=ghcr.io/orka-agents/orka/ai-worker:0.1.1
-          - --general-worker-image=ghcr.io/orka-agents/orka/general-worker:0.1.1
+          - --ai-worker-image=ghcr.io/orka-agents/orka/ai-worker:0.1.2
+          - --general-worker-image=ghcr.io/orka-agents/orka/general-worker:0.1.2
           - --gateway-enabled=true
           - --gateway-pending-per-session=100
           - --gateway-max-records-per-gateway=1000

--- a/deploy/orka.yaml
+++ b/deploy/orka.yaml
@@ -11269,7 +11269,7 @@ spec:
           value: danger-full-access
         - name: ORKA_SA_TOKEN_PATH
           value: /var/run/orka/upload-token/token
-        image: ghcr.io/orka-agents/orka/agent-harness-wrapper:0.1.1
+        image: ghcr.io/orka-agents/orka/agent-harness-wrapper:0.1.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -11368,8 +11368,8 @@ spec:
         - --store-backend=sqlite
         - --store-path=/data/orka.db
         - --controller-url=http://orka-api.orka-system.svc:8080
-        - --ai-worker-image=ghcr.io/orka-agents/orka/ai-worker:0.1.1
-        - --general-worker-image=ghcr.io/orka-agents/orka/general-worker:0.1.1
+        - --ai-worker-image=ghcr.io/orka-agents/orka/ai-worker:0.1.2
+        - --general-worker-image=ghcr.io/orka-agents/orka/general-worker:0.1.2
         - --gateway-enabled=true
         - --gateway-pending-per-session=100
         - --gateway-max-records-per-gateway=1000
@@ -11401,7 +11401,7 @@ spec:
           value: /var/run/orka/harness-wrapper/token
         - name: ORKA_HARNESS_WRAPPER_SERVICE_ACCOUNT_NAME
           value: orka-agent-harness-wrapper
-        image: ghcr.io/orka-agents/orka:0.1.1
+        image: ghcr.io/orka-agents/orka:0.1.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/manifest_staging/charts/orka/Chart.yaml
+++ b/manifest_staging/charts/orka/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: orka
 description: Kubernetes-native task execution platform with AI agent support
 type: application
-version: 0.1.1
-appVersion: "v0.1.1"
+version: 0.1.2
+appVersion: "v0.1.2"
 keywords:
   - kubernetes
   - task-execution

--- a/manifest_staging/charts/orka/values.yaml
+++ b/manifest_staging/charts/orka/values.yaml
@@ -8,7 +8,7 @@ controller:
   # Controller image
   image:
     repository: ghcr.io/orka-agents/orka
-    tag: "0.1.1"
+    tag: "0.1.2"
     pullPolicy: IfNotPresent
 
   # Resource limits
@@ -206,18 +206,18 @@ workers:
   ai:
     image:
       repository: ghcr.io/orka-agents/orka/ai-worker
-      tag: "0.1.1"
+      tag: "0.1.2"
       pullPolicy: IfNotPresent
 
   general:
     image:
       repository: ghcr.io/orka-agents/orka/general-worker
-      tag: "0.1.1"
+      tag: "0.1.2"
 
   harnessWrapper:
     image:
       repository: ghcr.io/orka-agents/orka/agent-harness-wrapper
-      tag: "0.1.1"
+      tag: "0.1.2"
       pullPolicy: IfNotPresent
     auth:
       # Existing Secret containing the shared wrapper bearer token.

--- a/manifest_staging/deploy/orka.yaml
+++ b/manifest_staging/deploy/orka.yaml
@@ -11269,7 +11269,7 @@ spec:
           value: danger-full-access
         - name: ORKA_SA_TOKEN_PATH
           value: /var/run/orka/upload-token/token
-        image: ghcr.io/orka-agents/orka/agent-harness-wrapper:0.1.1
+        image: ghcr.io/orka-agents/orka/agent-harness-wrapper:0.1.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -11368,8 +11368,8 @@ spec:
         - --store-backend=sqlite
         - --store-path=/data/orka.db
         - --controller-url=http://orka-api.orka-system.svc:8080
-        - --ai-worker-image=ghcr.io/orka-agents/orka/ai-worker:0.1.1
-        - --general-worker-image=ghcr.io/orka-agents/orka/general-worker:0.1.1
+        - --ai-worker-image=ghcr.io/orka-agents/orka/ai-worker:0.1.2
+        - --general-worker-image=ghcr.io/orka-agents/orka/general-worker:0.1.2
         - --gateway-enabled=true
         - --gateway-pending-per-session=100
         - --gateway-max-records-per-gateway=1000
@@ -11401,7 +11401,7 @@ spec:
           value: /var/run/orka/harness-wrapper/token
         - name: ORKA_HARNESS_WRAPPER_SERVICE_ACCOUNT_NAME
           value: orka-agent-harness-wrapper
-        image: ghcr.io/orka-agents/orka:0.1.1
+        image: ghcr.io/orka-agents/orka:0.1.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## Summary

- bump Orka release metadata from v0.1.1 to v0.1.2
- update controller and harness-wrapper image tags
- promote the reviewed v0.1.2 manifests and Helm chart snapshot

## Validation

- release preparation workflow generation passed
- Helm chart validation passed
- `git diff --check origin/release-0.1...origin/release-v0.1.2` passed

No release tag is created by this PR.