### PR TITLE
chore(release): prepare v0.1.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Current application release version. Chart.yaml has its own version and may
 # advance independently for chart-only changes. Release preparation aligns both
 # versions for a tagged application release.
-VERSION := v0.1.2
+VERSION := v0.1.3
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest

--- a/charts/orka/Chart.yaml
+++ b/charts/orka/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: orka
 description: Kubernetes-native task execution platform with AI agent support
 type: application
-version: 0.1.2
-appVersion: "v0.1.2"
+version: 0.1.3
+appVersion: "v0.1.3"
 keywords:
   - kubernetes
   - task-execution

--- a/charts/orka/values.yaml
+++ b/charts/orka/values.yaml
@@ -8,7 +8,7 @@ controller:
   # Controller image
   image:
     repository: ghcr.io/orka-agents/orka
-    tag: "0.1.2"
+    tag: "0.1.3"
     pullPolicy: IfNotPresent
 
   # Resource limits
@@ -206,18 +206,18 @@ workers:
   ai:
     image:
       repository: ghcr.io/orka-agents/orka/ai-worker
-      tag: "0.1.2"
+      tag: "0.1.3"
       pullPolicy: IfNotPresent
 
   general:
     image:
       repository: ghcr.io/orka-agents/orka/general-worker
-      tag: "0.1.2"
+      tag: "0.1.3"
 
   harnessWrapper:
     image:
       repository: ghcr.io/orka-agents/orka/agent-harness-wrapper
-      tag: "0.1.2"
+      tag: "0.1.3"
       pullPolicy: IfNotPresent
     auth:
       # Existing Secret containing the shared wrapper bearer token.

--- a/cmd/build/helmify/static/Chart.yaml
+++ b/cmd/build/helmify/static/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: orka
 description: Kubernetes-native task execution platform with AI agent support
 type: application
-version: 0.1.2
-appVersion: "v0.1.2"
+version: 0.1.3
+appVersion: "v0.1.3"
 keywords:
   - kubernetes
   - task-execution

--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -8,7 +8,7 @@ controller:
   # Controller image
   image:
     repository: ghcr.io/orka-agents/orka
-    tag: "0.1.2"
+    tag: "0.1.3"
     pullPolicy: IfNotPresent
 
   # Resource limits
@@ -206,18 +206,18 @@ workers:
   ai:
     image:
       repository: ghcr.io/orka-agents/orka/ai-worker
-      tag: "0.1.2"
+      tag: "0.1.3"
       pullPolicy: IfNotPresent
 
   general:
     image:
       repository: ghcr.io/orka-agents/orka/general-worker
-      tag: "0.1.2"
+      tag: "0.1.3"
 
   harnessWrapper:
     image:
       repository: ghcr.io/orka-agents/orka/agent-harness-wrapper
-      tag: "0.1.2"
+      tag: "0.1.3"
       pullPolicy: IfNotPresent
     auth:
       # Existing Secret containing the shared wrapper bearer token.

--- a/config/harness-wrapper/deployment.yaml
+++ b/config/harness-wrapper/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: wrapper
-        image: ghcr.io/orka-agents/orka/agent-harness-wrapper:0.1.2
+        image: ghcr.io/orka-agents/orka/agent-harness-wrapper:0.1.3
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,7 +5,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - newName: ghcr.io/orka-agents/orka
-  newTag: 0.1.2
+  newTag: 0.1.3
 - name: controller
   newName: ghcr.io/orka-agents/orka
-  newTag: 0.1.2
+  newTag: 0.1.3

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,8 +72,8 @@ spec:
           - --store-backend=sqlite
           - --store-path=/data/orka.db
           - --controller-url=http://orka-api.orka-system.svc:8080
-          - --ai-worker-image=ghcr.io/orka-agents/orka/ai-worker:0.1.2
-          - --general-worker-image=ghcr.io/orka-agents/orka/general-worker:0.1.2
+          - --ai-worker-image=ghcr.io/orka-agents/orka/ai-worker:0.1.3
+          - --general-worker-image=ghcr.io/orka-agents/orka/general-worker:0.1.3
           - --gateway-enabled=true
           - --gateway-pending-per-session=100
           - --gateway-max-records-per-gateway=1000

--- a/deploy/orka.yaml
+++ b/deploy/orka.yaml
@@ -11269,7 +11269,7 @@ spec:
           value: danger-full-access
         - name: ORKA_SA_TOKEN_PATH
           value: /var/run/orka/upload-token/token
-        image: ghcr.io/orka-agents/orka/agent-harness-wrapper:0.1.2
+        image: ghcr.io/orka-agents/orka/agent-harness-wrapper:0.1.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -11368,8 +11368,8 @@ spec:
         - --store-backend=sqlite
         - --store-path=/data/orka.db
         - --controller-url=http://orka-api.orka-system.svc:8080
-        - --ai-worker-image=ghcr.io/orka-agents/orka/ai-worker:0.1.2
-        - --general-worker-image=ghcr.io/orka-agents/orka/general-worker:0.1.2
+        - --ai-worker-image=ghcr.io/orka-agents/orka/ai-worker:0.1.3
+        - --general-worker-image=ghcr.io/orka-agents/orka/general-worker:0.1.3
         - --gateway-enabled=true
         - --gateway-pending-per-session=100
         - --gateway-max-records-per-gateway=1000
@@ -11401,7 +11401,7 @@ spec:
           value: /var/run/orka/harness-wrapper/token
         - name: ORKA_HARNESS_WRAPPER_SERVICE_ACCOUNT_NAME
           value: orka-agent-harness-wrapper
-        image: ghcr.io/orka-agents/orka:0.1.2
+        image: ghcr.io/orka-agents/orka:0.1.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/manifest_staging/charts/orka/Chart.yaml
+++ b/manifest_staging/charts/orka/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: orka
 description: Kubernetes-native task execution platform with AI agent support
 type: application
-version: 0.1.2
-appVersion: "v0.1.2"
+version: 0.1.3
+appVersion: "v0.1.3"
 keywords:
   - kubernetes
   - task-execution

--- a/manifest_staging/charts/orka/values.yaml
+++ b/manifest_staging/charts/orka/values.yaml
@@ -8,7 +8,7 @@ controller:
   # Controller image
   image:
     repository: ghcr.io/orka-agents/orka
-    tag: "0.1.2"
+    tag: "0.1.3"
     pullPolicy: IfNotPresent
 
   # Resource limits
@@ -206,18 +206,18 @@ workers:
   ai:
     image:
       repository: ghcr.io/orka-agents/orka/ai-worker
-      tag: "0.1.2"
+      tag: "0.1.3"
       pullPolicy: IfNotPresent
 
   general:
     image:
       repository: ghcr.io/orka-agents/orka/general-worker
-      tag: "0.1.2"
+      tag: "0.1.3"
 
   harnessWrapper:
     image:
       repository: ghcr.io/orka-agents/orka/agent-harness-wrapper
-      tag: "0.1.2"
+      tag: "0.1.3"
       pullPolicy: IfNotPresent
     auth:
       # Existing Secret containing the shared wrapper bearer token.

--- a/manifest_staging/deploy/orka.yaml
+++ b/manifest_staging/deploy/orka.yaml
@@ -11269,7 +11269,7 @@ spec:
           value: danger-full-access
         - name: ORKA_SA_TOKEN_PATH
           value: /var/run/orka/upload-token/token
-        image: ghcr.io/orka-agents/orka/agent-harness-wrapper:0.1.2
+        image: ghcr.io/orka-agents/orka/agent-harness-wrapper:0.1.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -11368,8 +11368,8 @@ spec:
         - --store-backend=sqlite
         - --store-path=/data/orka.db
         - --controller-url=http://orka-api.orka-system.svc:8080
-        - --ai-worker-image=ghcr.io/orka-agents/orka/ai-worker:0.1.2
-        - --general-worker-image=ghcr.io/orka-agents/orka/general-worker:0.1.2
+        - --ai-worker-image=ghcr.io/orka-agents/orka/ai-worker:0.1.3
+        - --general-worker-image=ghcr.io/orka-agents/orka/general-worker:0.1.3
         - --gateway-enabled=true
         - --gateway-pending-per-session=100
         - --gateway-max-records-per-gateway=1000
@@ -11401,7 +11401,7 @@ spec:
           value: /var/run/orka/harness-wrapper/token
         - name: ORKA_HARNESS_WRAPPER_SERVICE_ACCOUNT_NAME
           value: orka-agent-harness-wrapper
-        image: ghcr.io/orka-agents/orka:0.1.2
+        image: ghcr.io/orka-agents/orka:0.1.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## Release preparation

This PR prepares Orka `v0.1.3` using the staged release flow:

- updates release versions in the canonical and static generator inputs
- regenerates `manifest_staging/`
- promotes the staging installer and chart into `deploy/` and `charts/`

Merge this PR before creating the matching `v0.1.3` tag. The tag workflow publishes the reviewed root chart snapshot without regenerating it.