### PR TITLE
fix(acp): default agent task timeout

### DIFF
--- a/internal/controller/acp_dispatcher.go
+++ b/internal/controller/acp_dispatcher.go
@@ -36,6 +36,7 @@ const (
 	DefaultACPIdlePoolTTL                                = 15 * time.Minute
 	DefaultACPRuntimePoolReservationTTL                  = 2 * time.Minute
 	DefaultACPRateLimitReconcileInterval                 = time.Second
+	defaultACPTaskTimeout                                = 30 * time.Minute
 	acpSucceededOperation                                = "succeeded"
 	acpCredentialBlockedOperation                        = "credential-blocked"
 	acpCredentialBlockedMessage                          = "workspace credential changed or became unavailable after queue; refusing to change frozen authority"
@@ -2517,8 +2518,15 @@ func runtimeSessionCreateTimeout(target acpDispatchTarget) time.Duration {
 }
 
 func acpTaskDeadline(task *corev1alpha1.Task, now time.Time) (time.Time, bool) {
-	if task == nil || task.Spec.Timeout == nil || task.Spec.Timeout.Duration <= 0 {
+	if task == nil {
 		return time.Time{}, false
+	}
+	timeout := defaultACPTaskTimeout
+	if task.Spec.Timeout != nil {
+		if task.Spec.Timeout.Duration <= 0 {
+			return time.Time{}, false
+		}
+		timeout = task.Spec.Timeout.Duration
 	}
 	now = now.UTC()
 	var startedAt time.Time
@@ -2530,7 +2538,7 @@ func acpTaskDeadline(task *corev1alpha1.Task, now time.Time) (time.Time, bool) {
 			startedAt = now
 		}
 	}
-	return startedAt.Add(task.Spec.Timeout.Duration), true
+	return startedAt.Add(timeout), true
 }
 
 func (d *ACPDispatcher) settleQueuedTaskBeforeAdmission(ctx context.Context, queued *corev1alpha1.Task) (bool, error) {

--- a/internal/controller/acp_dispatcher.go
+++ b/internal/controller/acp_dispatcher.go
@@ -2523,10 +2523,7 @@ func acpTaskDeadline(task *corev1alpha1.Task, now time.Time) (time.Time, bool) {
 	}
 	timeout := defaultACPTaskTimeout
 	switch {
-	case task.Spec.Timeout != nil:
-		if task.Spec.Timeout.Duration <= 0 {
-			return time.Time{}, false
-		}
+	case task.Spec.Timeout != nil && task.Spec.Timeout.Duration > 0:
 		timeout = task.Spec.Timeout.Duration
 	case task.Status.AgentExecutionBinding == nil ||
 		task.Status.AgentExecutionBinding.ContractVersion != corev1alpha1.AgentRuntimeContractHarnessV2:

--- a/internal/controller/acp_dispatcher.go
+++ b/internal/controller/acp_dispatcher.go
@@ -2522,11 +2522,15 @@ func acpTaskDeadline(task *corev1alpha1.Task, now time.Time) (time.Time, bool) {
 		return time.Time{}, false
 	}
 	timeout := defaultACPTaskTimeout
-	if task.Spec.Timeout != nil {
+	switch {
+	case task.Spec.Timeout != nil:
 		if task.Spec.Timeout.Duration <= 0 {
 			return time.Time{}, false
 		}
 		timeout = task.Spec.Timeout.Duration
+	case task.Status.AgentExecutionBinding == nil ||
+		task.Status.AgentExecutionBinding.ContractVersion != corev1alpha1.AgentRuntimeContractHarnessV2:
+		return time.Time{}, false
 	}
 	now = now.UTC()
 	var startedAt time.Time

--- a/internal/controller/acp_dispatcher.go
+++ b/internal/controller/acp_dispatcher.go
@@ -37,6 +37,7 @@ const (
 	DefaultACPRuntimePoolReservationTTL                  = 2 * time.Minute
 	DefaultACPRateLimitReconcileInterval                 = time.Second
 	defaultACPTaskTimeout                                = 30 * time.Minute
+	acpTaskTimeoutReason                                 = "TaskTimeout"
 	acpSucceededOperation                                = "succeeded"
 	acpCredentialBlockedOperation                        = "credential-blocked"
 	acpCredentialBlockedMessage                          = "workspace credential changed or became unavailable after queue; refusing to change frozen authority"
@@ -781,7 +782,7 @@ func (d *ACPDispatcher) executeReservedTask(ctx context.Context, task *corev1alp
 				return errors.Join(err, cleanupErr)
 			}
 			if settleErr := d.settlePreSubmissionCancellation(
-				ctx, task, attemptID, fence, "timeout-before-submission", "TaskTimeout", "task deadline exceeded before prompt submission",
+				ctx, task, attemptID, fence, "timeout-before-submission", acpTaskTimeoutReason, "task deadline exceeded before prompt submission",
 			); settleErr != nil {
 				return errors.Join(err, settleErr)
 			}
@@ -2529,6 +2530,10 @@ func acpTaskDeadline(task *corev1alpha1.Task, now time.Time) (time.Time, bool) {
 		task.Status.AgentExecutionBinding.ContractVersion != corev1alpha1.AgentRuntimeContractHarnessV2:
 		return time.Time{}, false
 	}
+	return taskDeadlineFromTimeout(task, now, timeout), true
+}
+
+func taskDeadlineFromTimeout(task *corev1alpha1.Task, now time.Time, timeout time.Duration) time.Time {
 	now = now.UTC()
 	var startedAt time.Time
 	if !task.CreationTimestamp.IsZero() {
@@ -2539,7 +2544,7 @@ func acpTaskDeadline(task *corev1alpha1.Task, now time.Time) (time.Time, bool) {
 			startedAt = now
 		}
 	}
-	return startedAt.Add(timeout), true
+	return startedAt.Add(timeout)
 }
 
 func (d *ACPDispatcher) settleQueuedTaskBeforeAdmission(ctx context.Context, queued *corev1alpha1.Task) (bool, error) {
@@ -2581,7 +2586,7 @@ func (d *ACPDispatcher) settleTaskBeforeRuntimeAdmission(ctx context.Context, ta
 	case !task.DeletionTimestamp.IsZero() || task.Status.Phase == corev1alpha1.TaskPhaseCancelled:
 		operation, reason, message = "cancelled-before-admission", "Cancelled", "task cancelled before runtime admission"
 	case hasDeadline && !now.Before(deadline):
-		operation, reason, message = "timeout-before-admission", "TaskTimeout", "task deadline exceeded before runtime admission"
+		operation, reason, message = "timeout-before-admission", acpTaskTimeoutReason, "task deadline exceeded before runtime admission"
 	default:
 		return false, nil
 	}
@@ -2645,7 +2650,7 @@ func (d *ACPDispatcher) settleTaskBeforeRuntimeAdmission(ctx context.Context, ta
 		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), acpPreSubmissionCleanupTimeout)
 		defer cancel()
 		var terminalErr = context.Canceled
-		if reason == corev1alpha1.TaskExecutionReason("TaskTimeout") {
+		if reason == corev1alpha1.TaskExecutionReason(acpTaskTimeoutReason) {
 			terminalErr = context.DeadlineExceeded
 		}
 		if err := d.reconcileUnfinalizedTaskSession(cleanupCtx, task, fence, recoveredSession, terminalErr); err != nil {
@@ -2914,7 +2919,7 @@ func (d *ACPDispatcher) handlePreSubmissionContextDone(
 		return false, nil
 	}
 	return true, d.settlePreSubmissionCancellation(
-		ctx, task, attemptID, fence, "timeout-before-submission", "TaskTimeout", "task deadline exceeded before prompt submission",
+		ctx, task, attemptID, fence, "timeout-before-submission", acpTaskTimeoutReason, "task deadline exceeded before prompt submission",
 	)
 }
 
@@ -3746,15 +3751,23 @@ func (d *ACPDispatcher) handlePromptStreamError(
 	)
 	if runtimeContextErr != nil {
 		if !accepted && writeEvidence.SafeToResendSameIdentity() {
-			if transitionErr := d.transitionAttemptToTerminal(ctx, attemptID, fence, store.PromptExecutionCancelled, "cancelled-before-acceptance"); transitionErr != nil {
+			operation, terminalReason, message := "cancelled-before-acceptance", corev1alpha1.TaskExecutionReason("Cancelled"), "prompt cancelled before acceptance"
+			if errors.Is(runtimeContextErr, context.DeadlineExceeded) {
+				operation, terminalReason, message = "timeout-before-acceptance", acpTaskTimeoutReason, "task deadline exceeded before prompt acceptance"
+			}
+			if transitionErr := d.transitionAttemptToTerminal(ctx, attemptID, fence, store.PromptExecutionCancelled, operation); transitionErr != nil {
 				return transitionErr
 			}
-			return d.failTask(ctx, task, corev1alpha1.TaskExecutionStateCancelled, corev1alpha1.TaskExecutionOutcomeCancelled, "Cancelled", "prompt cancelled before acceptance")
+			return d.failTask(ctx, task, corev1alpha1.TaskExecutionStateCancelled, corev1alpha1.TaskExecutionOutcomeCancelled, terminalReason, message)
 		}
 		now := time.Now().UTC()
 		reason := harnessv2.CancelReasonControllerShutdown
+		terminalReason := corev1alpha1.TaskExecutionReason("Cancelled")
+		terminalMessage := "prompt cancellation settled"
 		if errors.Is(runtimeContextErr, context.DeadlineExceeded) {
 			reason = harnessv2.CancelReasonTaskTimeout
+			terminalReason = acpTaskTimeoutReason
+			terminalMessage = "task deadline cancellation settled"
 		}
 		cancelRequest := harnessv2.CancelPromptRequest{
 			Protocol: harnessv2.ProtocolVersion,
@@ -3768,10 +3781,14 @@ func (d *ACPDispatcher) handlePromptStreamError(
 			if cancelErr == nil && response.SettlementProven {
 				switch response.Settlement.TerminalEvent {
 				case harnessv2.EventCancelled:
-					if transitionErr := d.transitionAttemptToTerminal(ctx, attemptID, fence, store.PromptExecutionCancelled, "cancelled"); transitionErr != nil {
+					operation := "cancelled"
+					if terminalReason == corev1alpha1.TaskExecutionReason(acpTaskTimeoutReason) {
+						operation = "timeout-cancelled"
+					}
+					if transitionErr := d.transitionAttemptToTerminal(ctx, attemptID, fence, store.PromptExecutionCancelled, operation); transitionErr != nil {
 						return transitionErr
 					}
-					return d.failTask(ctx, task, corev1alpha1.TaskExecutionStateCancelled, corev1alpha1.TaskExecutionOutcomeCancelled, "Cancelled", "prompt cancellation settled")
+					return d.failTask(ctx, task, corev1alpha1.TaskExecutionStateCancelled, corev1alpha1.TaskExecutionOutcomeCancelled, terminalReason, terminalMessage)
 				case harnessv2.EventFailed:
 					if transitionErr := d.transitionAttemptToTerminal(ctx, attemptID, fence, store.PromptExecutionFailed, "cancel-failed"); transitionErr != nil {
 						return transitionErr

--- a/internal/controller/acp_dispatcher_test.go
+++ b/internal/controller/acp_dispatcher_test.go
@@ -1282,7 +1282,9 @@ func TestACPDispatcherDeletesTaskScopedRuntimeSessionAfterTimeoutCancellation(t 
 	if err := kubeClient.Get(ctx, types.NamespacedName{Namespace: task.Namespace, Name: task.Name}, completed); err != nil {
 		t.Fatal(err)
 	}
-	if completed.Status.Phase != corev1alpha1.TaskPhaseCancelled || completed.Status.Execution == nil || completed.Status.Execution.Outcome != corev1alpha1.TaskExecutionOutcomeCancelled {
+	if completed.Status.Phase != corev1alpha1.TaskPhaseCancelled || completed.Status.Execution == nil ||
+		completed.Status.Execution.Outcome != corev1alpha1.TaskExecutionOutcomeCancelled ||
+		completed.Status.Execution.Reason != corev1alpha1.TaskExecutionReason("TaskTimeout") {
 		t.Fatalf("unexpected timeout status: %#v", completed.Status)
 	}
 	if got := deleteCalls.Load(); got != 1 {

--- a/internal/controller/acp_dispatcher_test.go
+++ b/internal/controller/acp_dispatcher_test.go
@@ -207,6 +207,16 @@ func TestACPTaskDeadlineIncludesTimeBeforeRuntimeAdmission(t *testing.T) {
 	}
 
 	task.Spec.Timeout = nil
+	if deadline, ok = acpTaskDeadline(task, now); ok || !deadline.IsZero() {
+		t.Fatalf("unbound default deadline = %s, %v; want zero, false", deadline, ok)
+	}
+	task.Status.AgentExecutionBinding = &corev1alpha1.AgentExecutionBinding{
+		ContractVersion: corev1alpha1.AgentRuntimeContractHarnessV1,
+	}
+	if deadline, ok = acpTaskDeadline(task, now); ok || !deadline.IsZero() {
+		t.Fatalf("harness v1 default deadline = %s, %v; want zero, false", deadline, ok)
+	}
+	task.Status.AgentExecutionBinding = testACPExecuteBindingForDispatcher()
 	deadline, ok = acpTaskDeadline(task, now)
 	if !ok || !deadline.Equal(now.Add(defaultACPTaskTimeout-time.Minute)) {
 		t.Fatalf("default deadline = %s, %v; want %s, true", deadline, ok, now.Add(defaultACPTaskTimeout-time.Minute))
@@ -216,7 +226,12 @@ func TestACPTaskDeadlineIncludesTimeBeforeRuntimeAdmission(t *testing.T) {
 func TestACPTaskRuntimeContextUsesDefaultDeadline(t *testing.T) {
 	t.Parallel()
 	createdAt := time.Now().UTC().Add(-time.Minute)
-	task := &corev1alpha1.Task{ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(createdAt)}}
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(createdAt)},
+		Status: corev1alpha1.TaskStatus{
+			AgentExecutionBinding: testACPExecuteBindingForDispatcher(),
+		},
+	}
 	runtimeCtx, cancel := (&ACPDispatcher{}).newTaskRuntimeContext(context.Background(), task)
 	defer cancel()
 

--- a/internal/controller/acp_dispatcher_test.go
+++ b/internal/controller/acp_dispatcher_test.go
@@ -205,6 +205,29 @@ func TestACPTaskDeadlineIncludesTimeBeforeRuntimeAdmission(t *testing.T) {
 	if !ok || !deadline.Equal(now.Add(4*time.Minute)) {
 		t.Fatalf("queue-derived deadline = %s, %v; want %s, true", deadline, ok, now.Add(4*time.Minute))
 	}
+
+	task.Spec.Timeout = nil
+	deadline, ok = acpTaskDeadline(task, now)
+	if !ok || !deadline.Equal(now.Add(defaultACPTaskTimeout-time.Minute)) {
+		t.Fatalf("default deadline = %s, %v; want %s, true", deadline, ok, now.Add(defaultACPTaskTimeout-time.Minute))
+	}
+}
+
+func TestACPTaskRuntimeContextUsesDefaultDeadline(t *testing.T) {
+	t.Parallel()
+	createdAt := time.Now().UTC().Add(-time.Minute)
+	task := &corev1alpha1.Task{ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(createdAt)}}
+	runtimeCtx, cancel := (&ACPDispatcher{}).newTaskRuntimeContext(context.Background(), task)
+	defer cancel()
+
+	deadline, ok := runtimeCtx.Deadline()
+	want := createdAt.Add(defaultACPTaskTimeout)
+	if !ok || !deadline.Equal(want) {
+		t.Fatalf("runtime context deadline = %s, %v; want %s, true", deadline, ok, want)
+	}
+	if err := runtimeCtx.Err(); err != nil {
+		t.Fatalf("runtime context expired before the default deadline: %v", err)
+	}
 }
 
 func TestRuntimeSessionStartFailureMessageAllowsOnlyKnownStages(t *testing.T) {
@@ -2458,6 +2481,12 @@ func TestACPDispatcherSettlesExpiredTaskBeforeRuntimePoolAdmission(t *testing.T)
 	runACPDispatcherPreAdmissionSettlementTest(t, func(task *corev1alpha1.Task) {
 		task.CreationTimestamp = metav1.NewTime(time.Now().UTC().Add(-2 * time.Minute))
 		task.Spec.Timeout = &timeout
+	}, corev1alpha1.TaskExecutionReason("TaskTimeout"), "task deadline exceeded before runtime admission", false)
+}
+
+func TestACPDispatcherSettlesDefaultExpiredTaskBeforeRuntimePoolAdmission(t *testing.T) {
+	runACPDispatcherPreAdmissionSettlementTest(t, func(task *corev1alpha1.Task) {
+		task.CreationTimestamp = metav1.NewTime(time.Now().UTC().Add(-defaultACPTaskTimeout - time.Minute))
 	}, corev1alpha1.TaskExecutionReason("TaskTimeout"), "task deadline exceeded before runtime admission", false)
 }
 

--- a/internal/controller/acp_dispatcher_test.go
+++ b/internal/controller/acp_dispatcher_test.go
@@ -221,6 +221,13 @@ func TestACPTaskDeadlineIncludesTimeBeforeRuntimeAdmission(t *testing.T) {
 	if !ok || !deadline.Equal(now.Add(defaultACPTaskTimeout-time.Minute)) {
 		t.Fatalf("default deadline = %s, %v; want %s, true", deadline, ok, now.Add(defaultACPTaskTimeout-time.Minute))
 	}
+	for _, duration := range []time.Duration{0, -time.Minute} {
+		task.Spec.Timeout = &metav1.Duration{Duration: duration}
+		deadline, ok = acpTaskDeadline(task, now)
+		if !ok || !deadline.Equal(now.Add(defaultACPTaskTimeout-time.Minute)) {
+			t.Fatalf("nonpositive %s deadline = %s, %v; want %s, true", duration, deadline, ok, now.Add(defaultACPTaskTimeout-time.Minute))
+		}
+	}
 }
 
 func TestACPTaskRuntimeContextUsesDefaultDeadline(t *testing.T) {

--- a/internal/controller/acp_task_queue.go
+++ b/internal/controller/acp_task_queue.go
@@ -506,7 +506,7 @@ func (r *TaskReconciler) cancelACPTaskBeforeDurableAttempt(ctx context.Context, 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	nowUTC := time.Now().UTC()
-	deadline, expired := acpTaskDeadline(latest, nowUTC)
+	deadline, expired := r.pendingAgentTaskDeadline(ctx, latest, nowUTC)
 	if latest.UID != task.UID || latest.Spec.Type != corev1alpha1.TaskTypeAgent || !expired || nowUTC.Before(deadline) {
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
@@ -549,7 +549,7 @@ func (r *TaskReconciler) cancelACPTaskBeforeDurableAttempt(ctx context.Context, 
 				attempt, err = r.DurableControlStore.TransitionPromptAttemptExecution(ctx, store.PromptAttemptExecutionTransition{
 					ID: attempt.ID, Fence: fence, ExpectedVersion: attempt.Version, ExpectedState: store.PromptExecutionQueued,
 					NewState: store.PromptExecutionCancelled, OperationID: operationID, OperationDigest: digest,
-					TerminalReason: "TaskTimeout", OutcomeMarker: message, UpdatedAt: time.Now().UTC(),
+					TerminalReason: acpTaskTimeoutReason, OutcomeMarker: message, UpdatedAt: time.Now().UTC(),
 				})
 				if err != nil {
 					return ctrl.Result{}, err
@@ -568,7 +568,7 @@ func (r *TaskReconciler) cancelACPTaskBeforeDurableAttempt(ctx context.Context, 
 			return err
 		}
 		currentNow := time.Now().UTC()
-		currentDeadline, currentHasDeadline := acpTaskDeadline(current, currentNow)
+		currentDeadline, currentHasDeadline := r.pendingAgentTaskDeadline(ctx, current, currentNow)
 		if current.UID != task.UID || current.Spec.Type != corev1alpha1.TaskTypeAgent ||
 			!currentHasDeadline || currentNow.Before(currentDeadline) {
 			statusBound = true
@@ -584,7 +584,7 @@ func (r *TaskReconciler) cancelACPTaskBeforeDurableAttempt(ctx context.Context, 
 		current.Status.Message = message
 		current.Status.Execution = &corev1alpha1.TaskExecutionStatus{
 			State: corev1alpha1.TaskExecutionStateCancelled, Outcome: corev1alpha1.TaskExecutionOutcomeCancelled,
-			Reason: "TaskTimeout", Message: message, LastTransitionTime: &now,
+			Reason: acpTaskTimeoutReason, Message: message, LastTransitionTime: &now,
 		}
 		if attempt != nil {
 			if current.Status.Attempts < int32(attempt.Key.Attempt) {

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -782,6 +782,12 @@ func (r *TaskReconciler) handleBoundAgentTaskPending(
 		}
 		return r.queueHarnessV1Task(ctx, task)
 	case corev1alpha1.AgentRuntimeContractHarnessV2:
+		if task.Status.Execution == nil {
+			now := time.Now().UTC()
+			if deadline, ok := acpTaskDeadline(task, now); ok && !now.Before(deadline) {
+				return r.cancelACPTaskBeforeDurableAttempt(ctx, task, "task deadline exceeded before runtime admission")
+			}
+		}
 		if result, err, handled := r.ensureAgentExecutionBinding(ctx, task, nil); handled {
 			return result, err
 		}

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -667,7 +667,7 @@ func (r *TaskReconciler) handlePending(ctx context.Context, task *corev1alpha1.T
 	}
 	if task.Spec.Type == corev1alpha1.TaskTypeAgent && task.Status.Execution == nil {
 		now := time.Now().UTC()
-		if deadline, ok := acpTaskDeadline(task, now); ok && !now.Before(deadline) {
+		if deadline, ok := r.pendingAgentTaskDeadline(ctx, task, now); ok && !now.Before(deadline) {
 			return r.cancelACPTaskBeforeDurableAttempt(ctx, task, "task deadline exceeded before runtime admission")
 		}
 	}
@@ -765,6 +765,28 @@ func (r *TaskReconciler) handlePending(ctx context.Context, task *corev1alpha1.T
 	}
 
 	return r.createTaskJob(ctx, task, agent, provider)
+}
+
+func (r *TaskReconciler) pendingAgentTaskDeadline(
+	ctx context.Context,
+	task *corev1alpha1.Task,
+	now time.Time,
+) (time.Time, bool) {
+	if deadline, ok := acpTaskDeadline(task, now); ok {
+		return deadline, true
+	}
+	if task == nil || task.Spec.Type != corev1alpha1.TaskTypeAgent || task.Status.AgentExecutionBinding != nil {
+		return time.Time{}, false
+	}
+	deadline := taskDeadlineFromTimeout(task, now, defaultACPTaskTimeout)
+	if now.Before(deadline) {
+		return time.Time{}, false
+	}
+	agent, err := r.resolveAgent(ctx, task)
+	if err != nil || r.planAgentExecution(ctx, task, agent).path != agentExecutionPathACP {
+		return time.Time{}, false
+	}
+	return deadline, true
 }
 
 func (r *TaskReconciler) handleBoundAgentTaskPending(

--- a/internal/controller/task_controller_unit_test.go
+++ b/internal/controller/task_controller_unit_test.go
@@ -7167,6 +7167,93 @@ func TestHandlePending_BoundV2AgentExpiresAtDefaultDeadlineBeforeQueue(t *testin
 	}
 }
 
+func TestHandlePending_UnboundV2AgentExpiresAtDefaultDeadlineAtNamespaceLimit(t *testing.T) {
+	scheme := newTestScheme()
+	agent := &corev1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "default"},
+		Spec: corev1alpha1.AgentSpec{Runtime: &corev1alpha1.AgentCLIRuntime{
+			Type: corev1alpha1.AgentRuntimeCodex, ContractVersion: ptr.To(corev1alpha1.AgentRuntimeContractHarnessV2),
+		}},
+	}
+	active := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "active", Namespace: "default"},
+		Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeContainer},
+		Status:     corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseRunning},
+	}
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "unbound-v2-default-timeout", Namespace: "default", UID: "12345678-abcd-efgh-ijkl-1234567890b1",
+			CreationTimestamp: metav1.NewTime(time.Now().UTC().Add(-defaultACPTaskTimeout - time.Minute)),
+		},
+		Spec: corev1alpha1.TaskSpec{
+			Type: corev1alpha1.TaskTypeAgent, AgentRef: &corev1alpha1.AgentReference{Name: agent.Name}, Prompt: "expired at namespace limit",
+		},
+		Status: corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhasePending},
+	}
+	r := newUnitReconciler(scheme, task, agent, active)
+	r.ACPRuntimeEnabled = true
+	r.MaxTasksPerNamespace = 1
+
+	result, err := r.handlePending(context.Background(), task)
+	if err != nil {
+		t.Fatalf("handlePending() error = %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Fatalf("result = %#v, want terminal result", result)
+	}
+	updated := &corev1alpha1.Task{}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(task), updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status.Phase != corev1alpha1.TaskPhaseCancelled || updated.Status.Execution == nil ||
+		updated.Status.Execution.Reason != corev1alpha1.TaskExecutionReason("TaskTimeout") {
+		t.Fatalf("expired unbound v2 Task status = %#v", updated.Status)
+	}
+}
+
+func TestHandlePending_UnboundV1AgentRetainsBindingRelativeDefaultAtNamespaceLimit(t *testing.T) {
+	scheme := newTestScheme()
+	agent := &corev1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "default"},
+		Spec: corev1alpha1.AgentSpec{Runtime: &corev1alpha1.AgentCLIRuntime{
+			Type: corev1alpha1.AgentRuntimeCodex, ContractVersion: ptr.To(corev1alpha1.AgentRuntimeContractHarnessV1),
+		}},
+	}
+	active := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "active", Namespace: "default"},
+		Spec:       corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeContainer},
+		Status:     corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseRunning},
+	}
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "unbound-v1-default-timeout", Namespace: "default", UID: "12345678-abcd-efgh-ijkl-1234567890b2",
+			CreationTimestamp: metav1.NewTime(time.Now().UTC().Add(-defaultACPTaskTimeout - time.Minute)),
+		},
+		Spec: corev1alpha1.TaskSpec{
+			Type: corev1alpha1.TaskTypeAgent, AgentRef: &corev1alpha1.AgentReference{Name: agent.Name}, Prompt: "wait at namespace limit",
+		},
+		Status: corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhasePending},
+	}
+	r := newUnitReconciler(scheme, task, agent, active)
+	r.HarnessV1Enabled = true
+	r.MaxTasksPerNamespace = 1
+
+	result, err := r.handlePending(context.Background(), task)
+	if err != nil {
+		t.Fatalf("handlePending() error = %v", err)
+	}
+	if result.RequeueAfter != 10*time.Second {
+		t.Fatalf("RequeueAfter = %v, want 10s", result.RequeueAfter)
+	}
+	updated := &corev1alpha1.Task{}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(task), updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status.Phase != corev1alpha1.TaskPhasePending || updated.Status.Execution != nil {
+		t.Fatalf("queued unbound v1 Task status = %#v", updated.Status)
+	}
+}
+
 func TestHandlePending_ExpiredAgentSettlesDurableAttemptBeforeStatusBinding(t *testing.T) {
 	scheme := newTestScheme()
 	timeout := metav1.Duration{Duration: time.Minute}

--- a/internal/controller/task_controller_unit_test.go
+++ b/internal/controller/task_controller_unit_test.go
@@ -7132,6 +7132,41 @@ func TestHandlePending_AgentSessionWaitExpiresAtAbsoluteDeadline(t *testing.T) {
 	}
 }
 
+func TestHandlePending_BoundV2AgentExpiresAtDefaultDeadlineBeforeQueue(t *testing.T) {
+	scheme := newTestScheme()
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bound-v2-default-timeout", Namespace: "default", UID: "12345678-abcd-efgh-ijkl-1234567890b0",
+			CreationTimestamp: metav1.NewTime(time.Now().UTC().Add(-defaultACPTaskTimeout - time.Minute)),
+		},
+		Spec: corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeAgent, Prompt: "expired before ACP queueing"},
+		Status: corev1alpha1.TaskStatus{
+			Phase: corev1alpha1.TaskPhasePending,
+			AgentExecutionBinding: &corev1alpha1.AgentExecutionBinding{
+				ContractVersion: corev1alpha1.AgentRuntimeContractHarnessV2,
+			},
+		},
+	}
+	r := newUnitReconciler(scheme, task)
+	result, err := r.handlePending(context.Background(), task)
+	if err != nil {
+		t.Fatalf("handlePending() error = %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Fatalf("result = %#v, want terminal result", result)
+	}
+	updated := &corev1alpha1.Task{}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(task), updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status.Phase != corev1alpha1.TaskPhaseCancelled || updated.Status.Execution == nil ||
+		updated.Status.Execution.State != corev1alpha1.TaskExecutionStateCancelled ||
+		updated.Status.Execution.Outcome != corev1alpha1.TaskExecutionOutcomeCancelled ||
+		updated.Status.Execution.Reason != corev1alpha1.TaskExecutionReason("TaskTimeout") {
+		t.Fatalf("expired bound v2 Task status = %#v", updated.Status)
+	}
+}
+
 func TestHandlePending_ExpiredAgentSettlesDurableAttemptBeforeStatusBinding(t *testing.T) {
 	scheme := newTestScheme()
 	timeout := metav1.Duration{Duration: time.Minute}

--- a/website/docs/reference/api-reference.md
+++ b/website/docs/reference/api-reference.md
@@ -74,6 +74,7 @@ The controller requires `ORKA_GITHUB_WEBHOOK_SECRET` and verifies the `X-Hub-Sig
 | `spec.agentRuntime.maxTurns` | integer | Agent default | Per-Task prompt-loop limit. |
 | `spec.agentRuntime.allowedTools` / `disallowedTools` | list | Agent defaults | Per-Task tool policy override. |
 | `spec.agentRuntime.allowBash` | boolean | Agent default | Per-Task bash policy override. |
+| `spec.timeout` | duration | `30m` for ACP v2 agent Tasks | Maximum wall-clock duration measured from Task creation, including queue, runtime admission, and prompt execution time. An explicit positive value overrides the default. |
 
 Source read, target read, target write, and forge references are distinct
 credential roles. The selected Secret UID/resourceVersion is frozen for the


### PR DESCRIPTION
## Summary

- apply a 30-minute effective deadline to ACP v2 agent Tasks when spec.timeout is omitted
- preserve explicit positive timeouts and the existing bounded cancellation/settlement path
- document the default and cover runtime-context and pre-admission expiry behavior

## Testing

- make lint-fix
- make test
- .agents/skills/autoreview/scripts/autoreview --mode local (clean)

Closes #385