### PR TITLE
fix(ci): stabilize security scan e2e

### DIFF
--- a/.github/workflows/security-scan-e2e.yml
+++ b/.github/workflows/security-scan-e2e.yml
@@ -88,4 +88,15 @@ jobs:
           bash scripts/tests/security-scan-e2e-test.sh
 
       - name: Run security scan e2e
+        env:
+          ORKA_SECURITY_SCAN_DIAGNOSTICS_DIR: ${{ runner.temp }}/security-scan-e2e-diagnostics
         run: bash scripts/security-scan-e2e.sh
+
+      - name: Upload security scan failure diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: security-scan-e2e-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/security-scan-e2e-diagnostics
+          if-no-files-found: warn
+          retention-days: 14

--- a/internal/api/acp_artifact_authorization.go
+++ b/internal/api/acp_artifact_authorization.go
@@ -24,7 +24,10 @@ import (
 
 const acpArtifactAuthorizationPath = "/internal/v2/acp/artifact-authorizations"
 
-var errPublisherArtifactAuthorizationUnavailable = errors.New("publisher artifact authorization authority is unavailable")
+var (
+	errPublisherArtifactAuthorizationUnavailable = errors.New("publisher artifact authorization authority is unavailable")
+	errPublisherAuthorizationObjectNotFound      = errors.New("publisher authorization object not found")
+)
 
 type acpArtifactAuthorizationRequest struct {
 	Namespace string                      `json:"namespace"`
@@ -190,7 +193,7 @@ func findTaskByUIDWithReader(ctx context.Context, reader client.Reader, namespac
 			return tasks.Items[i].DeepCopy(), nil
 		}
 	}
-	return nil, fmt.Errorf("task not found")
+	return nil, fmt.Errorf("%w: Task", errPublisherAuthorizationObjectNotFound)
 }
 
 func readACPArtifactCapabilitySecret() ([]byte, error) {
@@ -241,6 +244,9 @@ func (s *Server) issuePublisherArtifactAuthorization(c fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid_request"})
 	}
 	if err := s.authorizePublisherArtifactRequest(c.Context(), request); err != nil {
+		if errors.Is(err, errPublisherArtifactAuthorizationUnavailable) {
+			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "artifact_authorization_unavailable"})
+		}
 		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "authorization_failed"})
 	}
 	if err := s.authorizePublisherParentEffect(c.Context(), request.ParentOperation, request.Metadata); err != nil {
@@ -296,6 +302,10 @@ func (s *Server) authorizePublisherWorkspaceUpload(ctx context.Context, request 
 		return fmt.Errorf("workspace artifact identity is invalid")
 	}
 	task, err := s.findTaskByUID(ctx, request.Metadata.Namespace, request.Metadata.TaskID)
+	if err != nil && !errors.Is(err, errPublisherAuthorizationObjectNotFound) {
+		log.Info("publisher artifact authorization denied", "reason", "workspace_task_read_failed", "parentOperation", request.ParentOperation, "namespace", request.Metadata.Namespace, "operationID", request.Metadata.OperationID, "error", err)
+		return fmt.Errorf("%w: workspace Task could not be read", errPublisherArtifactAuthorizationUnavailable)
+	}
 	if err != nil || task.Status.Execution == nil {
 		log.Info("publisher artifact authorization denied", "reason", "workspace_task_unavailable", "parentOperation", request.ParentOperation, "namespace", request.Metadata.Namespace, "operationID", request.Metadata.OperationID)
 		return fmt.Errorf("workspace Task is unavailable")
@@ -314,6 +324,9 @@ func (s *Server) authorizePublisherDeltaDownload(ctx context.Context, request pu
 		return fmt.Errorf("publication artifact identity is invalid")
 	}
 	publication, err := s.findPublicationByID(ctx, request.Metadata.Namespace, request.Metadata.PublicationID)
+	if err != nil && !errors.Is(err, errPublisherAuthorizationObjectNotFound) {
+		return fmt.Errorf("%w: Publication could not be read", errPublisherArtifactAuthorizationUnavailable)
+	}
 	if err != nil || string(publication.Status.State) != string(store.PublicationPreparing) {
 		return fmt.Errorf("publication is not preparing")
 	}
@@ -332,6 +345,9 @@ func (s *Server) authorizePublisherBundleUpload(ctx context.Context, request pub
 		return fmt.Errorf("prepared bundle upload identity is invalid")
 	}
 	publication, err := s.findPublicationByID(ctx, request.Metadata.Namespace, request.Metadata.PublicationID)
+	if err != nil && !errors.Is(err, errPublisherAuthorizationObjectNotFound) {
+		return fmt.Errorf("%w: Publication could not be read", errPublisherArtifactAuthorizationUnavailable)
+	}
 	if err != nil || string(publication.Status.State) != string(store.PublicationPreparing) || publication.Status.PreparedReceipt != nil {
 		return fmt.Errorf("publication is not accepting a prepared bundle")
 	}
@@ -344,6 +360,9 @@ func (s *Server) authorizePublisherBundleDownload(ctx context.Context, request p
 		return fmt.Errorf("prepared bundle download identity is invalid")
 	}
 	publication, err := s.findPublicationByID(ctx, request.Metadata.Namespace, request.Metadata.PublicationID)
+	if err != nil && !errors.Is(err, errPublisherAuthorizationObjectNotFound) {
+		return fmt.Errorf("%w: Publication could not be read", errPublisherArtifactAuthorizationUnavailable)
+	}
 	if err != nil || publication.Status.PreparedReceipt == nil {
 		return fmt.Errorf("publication prepared receipt is unavailable")
 	}
@@ -370,7 +389,7 @@ func (s *Server) findPublicationByID(ctx context.Context, namespace, id string) 
 			return publications.Items[i].DeepCopy(), nil
 		}
 	}
-	return nil, fmt.Errorf("publication not found")
+	return nil, fmt.Errorf("%w: Publication", errPublisherAuthorizationObjectNotFound)
 }
 
 func readSecretAtEnvPath(name string, minimum int) ([]byte, error) {

--- a/internal/api/acp_artifact_authorization.go
+++ b/internal/api/acp_artifact_authorization.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gofiber/fiber/v3"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
 	"github.com/orka-agents/orka/internal/artifactcap"
@@ -297,6 +298,7 @@ func (s *Server) authorizePublisherArtifactRequest(ctx context.Context, request 
 }
 
 func (s *Server) authorizePublisherWorkspaceUpload(ctx context.Context, request publisherservice.ArtifactAuthorizationRequest) error {
+	log := logf.FromContext(ctx)
 	if request.ArtifactOperation != artifactcap.OperationUpload || request.Metadata.TaskID == "" || request.Metadata.PublicationID != "" {
 		log.Info("publisher artifact authorization denied", "reason", "workspace_identity_invalid", "parentOperation", request.ParentOperation, "namespace", request.Metadata.Namespace, "operationID", request.Metadata.OperationID)
 		return fmt.Errorf("workspace artifact identity is invalid")
@@ -413,6 +415,7 @@ func (s *Server) authorizePublisherParentEffect(
 	operation publisherservice.Operation,
 	metadata publisherservice.OperationMetadata,
 ) error {
+	log := logf.FromContext(ctx)
 	if s.config.ControllerEpochs == nil {
 		log.Info("publisher artifact authorization denied", "reason", "parent_epoch_authority_unavailable", "parentOperation", operation, "namespace", metadata.Namespace, "operationID", metadata.OperationID)
 		return errPublisherArtifactAuthorizationUnavailable

--- a/internal/api/acp_artifact_authorization.go
+++ b/internal/api/acp_artifact_authorization.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -22,6 +23,8 @@ import (
 )
 
 const acpArtifactAuthorizationPath = "/internal/v2/acp/artifact-authorizations"
+
+var errPublisherArtifactAuthorizationUnavailable = errors.New("publisher artifact authorization authority is unavailable")
 
 type acpArtifactAuthorizationRequest struct {
 	Namespace string                      `json:"namespace"`
@@ -241,6 +244,9 @@ func (s *Server) issuePublisherArtifactAuthorization(c fiber.Ctx) error {
 		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "authorization_failed"})
 	}
 	if err := s.authorizePublisherParentEffect(c.Context(), request.ParentOperation, request.Metadata); err != nil {
+		if errors.Is(err, errPublisherArtifactAuthorizationUnavailable) {
+			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "artifact_authorization_unavailable"})
+		}
 		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "authorization_failed"})
 	}
 	artifactSecret, err := readACPArtifactCapabilitySecret()
@@ -286,15 +292,18 @@ func (s *Server) authorizePublisherArtifactRequest(ctx context.Context, request 
 
 func (s *Server) authorizePublisherWorkspaceUpload(ctx context.Context, request publisherservice.ArtifactAuthorizationRequest) error {
 	if request.ArtifactOperation != artifactcap.OperationUpload || request.Metadata.TaskID == "" || request.Metadata.PublicationID != "" {
+		log.Info("publisher artifact authorization denied", "reason", "workspace_identity_invalid", "parentOperation", request.ParentOperation, "namespace", request.Metadata.Namespace, "operationID", request.Metadata.OperationID)
 		return fmt.Errorf("workspace artifact identity is invalid")
 	}
 	task, err := s.findTaskByUID(ctx, request.Metadata.Namespace, request.Metadata.TaskID)
 	if err != nil || task.Status.Execution == nil {
+		log.Info("publisher artifact authorization denied", "reason", "workspace_task_unavailable", "parentOperation", request.ParentOperation, "namespace", request.Metadata.Namespace, "operationID", request.Metadata.OperationID)
 		return fmt.Errorf("workspace Task is unavailable")
 	}
 	execution := task.Status.Execution
 	if execution.State != corev1alpha1.TaskExecutionStatePlanned || execution.PromptID == "" ||
 		request.Metadata.OperationID != "workspace-prepare-"+execution.PromptID {
+		log.Info("publisher artifact authorization denied", "reason", "workspace_task_state_mismatch", "parentOperation", request.ParentOperation, "namespace", request.Metadata.Namespace, "operationID", request.Metadata.OperationID, "executionState", execution.State, "promptIDMatches", request.Metadata.OperationID == "workspace-prepare-"+execution.PromptID)
 		return fmt.Errorf("workspace Task is not in the exact preparation state")
 	}
 	return nil
@@ -386,11 +395,13 @@ func (s *Server) authorizePublisherParentEffect(
 	metadata publisherservice.OperationMetadata,
 ) error {
 	if s.config.ControllerEpochs == nil {
-		return fmt.Errorf("publisher controller epoch authority is unavailable")
+		log.Info("publisher artifact authorization denied", "reason", "parent_epoch_authority_unavailable", "parentOperation", operation, "namespace", metadata.Namespace, "operationID", metadata.OperationID)
+		return errPublisherArtifactAuthorizationUnavailable
 	}
 	currentFence, err := s.config.ControllerEpochs.CurrentFence(ctx)
 	if err != nil || strings.TrimSpace(currentFence.Name) == "" || currentFence.Epoch <= 0 || strings.TrimSpace(currentFence.HolderID) == "" {
-		return fmt.Errorf("publisher controller epoch authority is unavailable")
+		log.Info("publisher artifact authorization denied", "reason", "parent_epoch_unavailable", "parentOperation", operation, "namespace", metadata.Namespace, "operationID", metadata.OperationID, "error", err)
+		return fmt.Errorf("%w: controller epoch could not be read", errPublisherArtifactAuthorizationUnavailable)
 	}
 	kind := ""
 	aggregateID := metadata.PublicationID
@@ -413,11 +424,13 @@ func (s *Server) authorizePublisherParentEffect(
 		return fmt.Errorf("unsupported Publisher parent operation")
 	}
 	if aggregateID == "" || metadata.OperationID == "" {
+		log.Info("publisher artifact authorization denied", "reason", "parent_identity_incomplete", "parentOperation", operation, "namespace", metadata.Namespace, "operationID", metadata.OperationID)
 		return fmt.Errorf("publisher parent effect identity is incomplete")
 	}
 	var effects corev1alpha1.ExternalEffectList
 	if err := s.authorizationReader().List(ctx, &effects, client.InNamespace(metadata.Namespace)); err != nil {
-		return err
+		log.Info("publisher artifact authorization denied", "reason", "parent_effect_read_failed", "parentOperation", operation, "namespace", metadata.Namespace, "operationID", metadata.OperationID, "error", err)
+		return fmt.Errorf("%w: parent effect could not be read", errPublisherArtifactAuthorizationUnavailable)
 	}
 	now := time.Now().UTC()
 	matches := 0
@@ -431,6 +444,7 @@ func (s *Server) authorizePublisherParentEffect(
 		}
 	}
 	if matches != 1 {
+		log.Info("publisher artifact authorization denied", "reason", "parent_effect_not_uniquely_in_flight", "parentOperation", operation, "namespace", metadata.Namespace, "operationID", metadata.OperationID, "matches", matches, "controllerEpoch", currentFence.Epoch)
 		return fmt.Errorf("publisher parent effect is not uniquely in flight")
 	}
 	return nil

--- a/internal/api/acp_artifact_authorization_test.go
+++ b/internal/api/acp_artifact_authorization_test.go
@@ -396,6 +396,7 @@ func TestPublisherArtifactAuthorizationBrokerBindsTaskAndPublicationState(t *tes
 	tests := []struct {
 		name        string
 		request     publisherservice.ArtifactAuthorizationRequest
+		apiReader   client.Reader
 		epochSource ControllerEpochFenceSource
 		wantStatus  int
 	}{
@@ -451,6 +452,42 @@ func TestPublisherArtifactAuthorizationBrokerBindsTaskAndPublicationState(t *tes
 			epochSource: fixedControllerEpochFenceSource{err: context.DeadlineExceeded},
 			wantStatus:  http.StatusServiceUnavailable,
 		},
+		{
+			name: "transient task state read failure",
+			request: publisherservice.ArtifactAuthorizationRequest{
+				ParentOperation:   publisherservice.OperationWorkspacePrepare,
+				Metadata:          publisherservice.OperationMetadata{Namespace: "default", TaskID: string(taskUID), OperationID: "workspace-prepare-prompt-publisher"},
+				ArtifactOperation: artifactcap.OperationUpload,
+				Artifact:          harnessv2.ArtifactReference{ArtifactID: harnessv2.ArtifactID(workspaceID), Digest: workspaceDigest, SizeBytes: int64(len(workspace)), MediaType: artifactcap.MediaTypeWorkspaceTar},
+				Attempt:           1,
+			},
+			apiReader:  failingPublisherAuthorizationReader{err: context.DeadlineExceeded},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name: "missing task remains denied",
+			request: publisherservice.ArtifactAuthorizationRequest{
+				ParentOperation:   publisherservice.OperationWorkspacePrepare,
+				Metadata:          publisherservice.OperationMetadata{Namespace: "default", TaskID: string(taskUID), OperationID: "workspace-prepare-prompt-publisher"},
+				ArtifactOperation: artifactcap.OperationUpload,
+				Artifact:          harnessv2.ArtifactReference{ArtifactID: harnessv2.ArtifactID(workspaceID), Digest: workspaceDigest, SizeBytes: int64(len(workspace)), MediaType: artifactcap.MediaTypeWorkspaceTar},
+				Attempt:           1,
+			},
+			apiReader:  fake.NewClientBuilder().WithScheme(scheme).Build(),
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name: "transient publication state read failure",
+			request: publisherservice.ArtifactAuthorizationRequest{
+				ParentOperation:   publisherservice.OperationPublicationPrepare,
+				Metadata:          publisherservice.OperationMetadata{Namespace: "default", PublicationID: publication.Spec.ID, OperationID: "prepare-operation"},
+				ArtifactOperation: artifactcap.OperationUpload,
+				Artifact:          harnessv2.ArtifactReference{ArtifactID: harnessv2.ArtifactID(bundleID), Digest: bundleDigest, SizeBytes: int64(len(bundle)), MediaType: artifactcap.MediaTypeGitBundle},
+				Attempt:           1,
+			},
+			apiReader:  failingPublisherAuthorizationReader{err: context.DeadlineExceeded},
+			wantStatus: http.StatusServiceUnavailable,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -467,6 +504,7 @@ func TestPublisherArtifactAuthorizationBrokerBindsTaskAndPublicationState(t *tes
 				app: app, client: kubeClient,
 				config: ServerConfig{
 					ArtifactReservations: &recordingCapabilityReservations{},
+					APIReader:            test.apiReader,
 					ControllerEpochs:     epochSource,
 				},
 			}
@@ -827,6 +865,18 @@ func publisherEffectForTest(name, kind, aggregateID, operationID string) *corev1
 type fixedControllerEpochFenceSource struct {
 	fence store.ControllerEpochFence
 	err   error
+}
+
+type failingPublisherAuthorizationReader struct {
+	err error
+}
+
+func (r failingPublisherAuthorizationReader) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	return r.err
+}
+
+func (r failingPublisherAuthorizationReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	return r.err
 }
 
 type fixedControllerEpochStore struct {

--- a/internal/api/acp_artifact_authorization_test.go
+++ b/internal/api/acp_artifact_authorization_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -393,8 +394,10 @@ func TestPublisherArtifactAuthorizationBrokerBindsTaskAndPublicationState(t *tes
 		t.Fatal(err)
 	}
 	tests := []struct {
-		name    string
-		request publisherservice.ArtifactAuthorizationRequest
+		name        string
+		request     publisherservice.ArtifactAuthorizationRequest
+		epochSource ControllerEpochFenceSource
+		wantStatus  int
 	}{
 		{
 			name: "workspace upload",
@@ -436,15 +439,35 @@ func TestPublisherArtifactAuthorizationBrokerBindsTaskAndPublicationState(t *tes
 				Attempt:           1,
 			},
 		},
+		{
+			name: "transient controller epoch read failure",
+			request: publisherservice.ArtifactAuthorizationRequest{
+				ParentOperation:   publisherservice.OperationWorkspacePrepare,
+				Metadata:          publisherservice.OperationMetadata{Namespace: "default", TaskID: string(taskUID), OperationID: "workspace-prepare-prompt-publisher"},
+				ArtifactOperation: artifactcap.OperationUpload,
+				Artifact:          harnessv2.ArtifactReference{ArtifactID: harnessv2.ArtifactID(workspaceID), Digest: workspaceDigest, SizeBytes: int64(len(workspace)), MediaType: artifactcap.MediaTypeWorkspaceTar},
+				Attempt:           1,
+			},
+			epochSource: fixedControllerEpochFenceSource{err: context.DeadlineExceeded},
+			wantStatus:  http.StatusServiceUnavailable,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			epochSource := test.epochSource
+			if epochSource == nil {
+				epochSource = publisherEpochSourceForTest()
+			}
+			wantStatus := test.wantStatus
+			if wantStatus == 0 {
+				wantStatus = http.StatusOK
+			}
 			app := fiber.New()
 			server := &Server{
 				app: app, client: kubeClient,
 				config: ServerConfig{
 					ArtifactReservations: &recordingCapabilityReservations{},
-					ControllerEpochs:     publisherEpochSourceForTest(),
+					ControllerEpochs:     epochSource,
 				},
 			}
 			server.installACPArtifactAuthorizationBroker()
@@ -459,8 +482,11 @@ func TestPublisherArtifactAuthorizationBrokerBindsTaskAndPublicationState(t *tes
 			if err != nil {
 				t.Fatal(err)
 			}
-			if response.StatusCode != http.StatusOK {
-				t.Fatalf("status=%d", response.StatusCode)
+			if response.StatusCode != wantStatus {
+				t.Fatalf("status=%d, want %d", response.StatusCode, wantStatus)
+			}
+			if wantStatus != http.StatusOK {
+				return
 			}
 			var issued publisherservice.ArtifactAuthorizationResponse
 			if err := json.NewDecoder(response.Body).Decode(&issued); err != nil {
@@ -695,10 +721,11 @@ func TestAuthorizePublisherParentEffectRequiresLiveLease(t *testing.T) {
 		return publisherEffectForTest("workspace-effect", "workspace.prepare", metadata.TaskID, metadata.OperationID)
 	}
 	tests := []struct {
-		name        string
-		mutate      func(*corev1alpha1.ExternalEffect)
-		epochSource ControllerEpochFenceSource
-		wantErr     bool
+		name            string
+		mutate          func(*corev1alpha1.ExternalEffect)
+		epochSource     ControllerEpochFenceSource
+		wantErr         bool
+		wantUnavailable bool
 	}{
 		{name: "live lease authorizes", mutate: func(*corev1alpha1.ExternalEffect) {}, epochSource: publisherEpochSourceForTest()},
 		{
@@ -735,7 +762,7 @@ func TestAuthorizePublisherParentEffectRequiresLiveLease(t *testing.T) {
 		},
 		{
 			name: "unavailable controller authority is rejected", mutate: func(*corev1alpha1.ExternalEffect) {},
-			epochSource: fixedControllerEpochFenceSource{err: context.Canceled}, wantErr: true,
+			epochSource: fixedControllerEpochFenceSource{err: context.Canceled}, wantErr: true, wantUnavailable: true,
 		},
 	}
 	for _, test := range tests {
@@ -755,12 +782,15 @@ func TestAuthorizePublisherParentEffectRequiresLiveLease(t *testing.T) {
 			if !test.wantErr && err != nil {
 				t.Fatalf("expected authorization to succeed: %v", err)
 			}
+			if got := errors.Is(err, errPublisherArtifactAuthorizationUnavailable); got != test.wantUnavailable {
+				t.Fatalf("unavailable classification = %t, want %t (error %v)", got, test.wantUnavailable, err)
+			}
 		})
 	}
 }
 
 func TestControllerEpochStoreFenceSourceReadsDurableAuthority(t *testing.T) {
-	epochStore := &fixedControllerEpochStore{epoch: &store.ControllerEpoch{
+	epochStore := &fixedControllerEpochStore{fence: store.ControllerEpochFence{
 		Name: store.DefaultControllerEpochName, Epoch: 7, HolderID: "controller-7",
 	}}
 	source := NewControllerEpochStoreFenceSource(epochStore)
@@ -800,14 +830,14 @@ type fixedControllerEpochFenceSource struct {
 }
 
 type fixedControllerEpochStore struct {
-	epoch         *store.ControllerEpoch
+	fence         store.ControllerEpochFence
 	err           error
 	requestedName string
 }
 
-func (s *fixedControllerEpochStore) GetControllerEpoch(_ context.Context, name string) (*store.ControllerEpoch, error) {
+func (s *fixedControllerEpochStore) GetControllerEpochFence(_ context.Context, name string) (store.ControllerEpochFence, error) {
 	s.requestedName = name
-	return s.epoch, s.err
+	return s.fence, s.err
 }
 
 func (s fixedControllerEpochFenceSource) CurrentFence(context.Context) (store.ControllerEpochFence, error) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -42,7 +42,7 @@ type ControllerEpochFenceSource interface {
 }
 
 type ControllerEpochReader interface {
-	GetControllerEpoch(context.Context, string) (*store.ControllerEpoch, error)
+	GetControllerEpochFence(context.Context, string) (store.ControllerEpochFence, error)
 }
 
 // ControllerEpochStoreFenceSource reads the current fence directly from the
@@ -60,14 +60,7 @@ func (s *ControllerEpochStoreFenceSource) CurrentFence(ctx context.Context) (sto
 	if s == nil || s.epochs == nil {
 		return store.ControllerEpochFence{}, fmt.Errorf("controller epoch store is unavailable")
 	}
-	epoch, err := s.epochs.GetControllerEpoch(ctx, store.DefaultControllerEpochName)
-	if err != nil {
-		return store.ControllerEpochFence{}, err
-	}
-	if epoch == nil {
-		return store.ControllerEpochFence{}, fmt.Errorf("controller epoch is unavailable")
-	}
-	return store.ControllerEpochFence{Name: epoch.Name, Epoch: epoch.Epoch, HolderID: epoch.HolderID}, nil
+	return s.epochs.GetControllerEpochFence(ctx, store.DefaultControllerEpochName)
 }
 
 // ServerConfig holds configuration for the API server

--- a/internal/publisher/service/artifact_authorization_test.go
+++ b/internal/publisher/service/artifact_authorization_test.go
@@ -91,12 +91,15 @@ func TestArtifactClientPreservesBrokerAuthorizationClassification(t *testing.T) 
 	}
 	metadata := OperationMetadata{Namespace: "default", TaskID: "task", OperationID: "workspace-prepare-prompt"}
 	tests := []struct {
-		name      string
-		status    int
-		retryable bool
+		name          string
+		status        int
+		retryable     bool
+		wantStatus    int
+		wantRetryable bool
 	}{
-		{name: "transient broker outage", status: http.StatusServiceUnavailable, retryable: true},
-		{name: "broker authorization denial", status: http.StatusForbidden, retryable: false},
+		{name: "transient broker outage", status: http.StatusServiceUnavailable, retryable: true, wantStatus: http.StatusServiceUnavailable, wantRetryable: true},
+		{name: "broker authorization denial", status: http.StatusForbidden, retryable: false, wantStatus: http.StatusForbidden, wantRetryable: false},
+		{name: "successful status error is normalized", status: http.StatusOK, retryable: false, wantStatus: http.StatusBadGateway, wantRetryable: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -113,8 +116,8 @@ func TestArtifactClientPreservesBrokerAuthorizationClassification(t *testing.T) 
 			if !errors.As(err, &operationErr) {
 				t.Fatalf("upload error = %v, want operationError", err)
 			}
-			if operationErr.status != test.status || operationErr.retryable != test.retryable || operationErr.code != "artifact_authorization_failed" {
-				t.Fatalf("upload authorization classification = status %d retryable %t code %q, want %d/%t/artifact_authorization_failed", operationErr.status, operationErr.retryable, operationErr.code, test.status, test.retryable)
+			if operationErr.status != test.wantStatus || operationErr.retryable != test.wantRetryable || operationErr.code != "artifact_authorization_failed" {
+				t.Fatalf("upload authorization classification = status %d retryable %t code %q, want %d/%t/artifact_authorization_failed", operationErr.status, operationErr.retryable, operationErr.code, test.wantStatus, test.wantRetryable)
 			}
 		})
 	}

--- a/internal/publisher/service/artifact_authorization_test.go
+++ b/internal/publisher/service/artifact_authorization_test.go
@@ -100,6 +100,7 @@ func TestArtifactClientPreservesBrokerAuthorizationClassification(t *testing.T) 
 		{name: "transient broker outage", status: http.StatusServiceUnavailable, retryable: true, wantStatus: http.StatusServiceUnavailable, wantRetryable: true},
 		{name: "broker authorization denial", status: http.StatusForbidden, retryable: false, wantStatus: http.StatusForbidden, wantRetryable: false},
 		{name: "successful status error is normalized", status: http.StatusOK, retryable: false, wantStatus: http.StatusBadGateway, wantRetryable: true},
+		{name: "redirect status error is normalized", status: http.StatusTemporaryRedirect, retryable: false, wantStatus: http.StatusBadGateway, wantRetryable: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/publisher/service/artifact_authorization_test.go
+++ b/internal/publisher/service/artifact_authorization_test.go
@@ -1,8 +1,10 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -74,6 +76,56 @@ func TestBrokerArtifactAuthorizerRequestsExactCapability(t *testing.T) {
 	if _, err := artifactcap.Verify(secret, issued.Capability, presented, time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestArtifactClientPreservesBrokerAuthorizationClassification(t *testing.T) {
+	data := []byte("workspace")
+	digest := artifactcap.DigestBytes(data)
+	artifactID, err := artifactcap.ArtifactIDForDigest(digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reference := harnessv2.ArtifactReference{
+		ArtifactID: harnessv2.ArtifactID(artifactID), Digest: digest,
+		SizeBytes: int64(len(data)), MediaType: artifactcap.MediaTypeWorkspaceTar,
+	}
+	metadata := OperationMetadata{Namespace: "default", TaskID: "task", OperationID: "workspace-prepare-prompt"}
+	tests := []struct {
+		name      string
+		status    int
+		retryable bool
+	}{
+		{name: "transient broker outage", status: http.StatusServiceUnavailable, retryable: true},
+		{name: "broker authorization denial", status: http.StatusForbidden, retryable: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			authorizer := failingArtifactAuthorizerForTest{err: apiError(
+				ErrArtifactTransport, "artifact_authorization_rejected", "broker rejected authorization",
+				test.status, test.retryable, nil,
+			)}
+			client, err := newArtifactClient("http://artifact.example", nil, authorizer, time.Second)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = client.upload(context.Background(), OperationWorkspacePrepare, metadata, 1, reference, bytes.NewReader(data))
+			var operationErr *operationError
+			if !errors.As(err, &operationErr) {
+				t.Fatalf("upload error = %v, want operationError", err)
+			}
+			if operationErr.status != test.status || operationErr.retryable != test.retryable || operationErr.code != "artifact_authorization_failed" {
+				t.Fatalf("upload authorization classification = status %d retryable %t code %q, want %d/%t/artifact_authorization_failed", operationErr.status, operationErr.retryable, operationErr.code, test.status, test.retryable)
+			}
+		})
+	}
+}
+
+type failingArtifactAuthorizerForTest struct {
+	err error
+}
+
+func (a failingArtifactAuthorizerForTest) Authorize(context.Context, ArtifactAuthorizationRequest) (artifactcap.Authorization, error) {
+	return artifactcap.Authorization{}, a.err
 }
 
 func TestLoadConfigFromEnvUsesArtifactBrokerWithoutSigningKey(t *testing.T) {

--- a/internal/publisher/service/artifact_client.go
+++ b/internal/publisher/service/artifact_client.go
@@ -145,6 +145,9 @@ func (c *artifactClient) download(ctx context.Context, parent Operation, metadat
 func artifactAuthorizationErrorClassification(err error) (int, bool) {
 	var typed *operationError
 	if errors.As(err, &typed) {
+		if typed.status >= http.StatusOK && typed.status < http.StatusMultipleChoices {
+			return http.StatusBadGateway, true
+		}
 		return typed.status, typed.retryable
 	}
 	return http.StatusServiceUnavailable, false

--- a/internal/publisher/service/artifact_client.go
+++ b/internal/publisher/service/artifact_client.go
@@ -145,7 +145,7 @@ func (c *artifactClient) download(ctx context.Context, parent Operation, metadat
 func artifactAuthorizationErrorClassification(err error) (int, bool) {
 	var typed *operationError
 	if errors.As(err, &typed) {
-		if typed.status >= http.StatusOK && typed.status < http.StatusMultipleChoices {
+		if typed.status < http.StatusBadRequest || typed.status >= 600 {
 			return http.StatusBadGateway, true
 		}
 		return typed.status, typed.retryable

--- a/internal/publisher/service/artifact_client.go
+++ b/internal/publisher/service/artifact_client.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -66,7 +67,8 @@ func (c *artifactClient) upload(
 		Artifact: reference, Attempt: attempt,
 	})
 	if err != nil {
-		return apiError(ErrArtifactTransport, "artifact_authorization_failed", "artifact upload could not be authorized", 503, false, err)
+		status, retryable := artifactAuthorizationErrorClassification(err)
+		return apiError(ErrArtifactTransport, "artifact_authorization_failed", "artifact upload could not be authorized", status, retryable, err)
 	}
 	request, err := c.request(ctx, http.MethodPut, reference, authorization, body)
 	if err != nil {
@@ -109,7 +111,8 @@ func (c *artifactClient) download(ctx context.Context, parent Operation, metadat
 		Artifact: reference, Attempt: attempt,
 	})
 	if err != nil {
-		return nil, apiError(ErrArtifactTransport, "artifact_authorization_failed", "artifact download could not be authorized", 503, false, err)
+		status, retryable := artifactAuthorizationErrorClassification(err)
+		return nil, apiError(ErrArtifactTransport, "artifact_authorization_failed", "artifact download could not be authorized", status, retryable, err)
 	}
 	request, err := c.request(ctx, http.MethodGet, reference, authorization, nil)
 	if err != nil {
@@ -137,6 +140,14 @@ func (c *artifactClient) download(ctx context.Context, parent Operation, metadat
 		return nil, apiError(ErrArtifactTransport, "artifact_digest_mismatch", "artifact download digest did not match", 502, false, nil)
 	}
 	return data, nil
+}
+
+func artifactAuthorizationErrorClassification(err error) (int, bool) {
+	var typed *operationError
+	if errors.As(err, &typed) {
+		return typed.status, typed.retryable
+	}
+	return http.StatusServiceUnavailable, false
 }
 
 func (c *artifactClient) request(ctx context.Context, method string, reference harnessv2.ArtifactReference, authorization artifactcap.Authorization, body io.Reader) (*http.Request, error) {

--- a/internal/store/kube/controller_epoch.go
+++ b/internal/store/kube/controller_epoch.go
@@ -91,6 +91,17 @@ func (s *Store) GetControllerEpochFence(ctx context.Context, name string) (store
 	if err := validateControllerEpochObjectForLease(object, epoch, lease.Name); err != nil {
 		return store.ControllerEpochFence{}, err
 	}
+	latestLease := &coordinationv1.Lease{}
+	if err := s.readClient().Get(ctx, key, latestLease); err != nil {
+		return store.ControllerEpochFence{}, mapKubernetesError("revalidate controller epoch fence Lease", err)
+	}
+	latestEpoch, err := controllerEpochFromLease(normalized, latestLease)
+	if err != nil {
+		return store.ControllerEpochFence{}, err
+	}
+	if latestLease.UID != lease.UID || latestEpoch != epoch {
+		return store.ControllerEpochFence{}, controlConflict("controller epoch authority changed during fence read")
+	}
 	return store.ControllerEpochFence{Name: epoch.Name, Epoch: epoch.Epoch, HolderID: epoch.HolderID}, nil
 }
 

--- a/internal/store/kube/controller_epoch.go
+++ b/internal/store/kube/controller_epoch.go
@@ -54,6 +54,46 @@ func (s *Store) GetControllerEpoch(ctx context.Context, name string) (*store.Con
 	return &result, nil
 }
 
+// GetControllerEpochFence reads and validates the current authoritative fence
+// without synchronizing the inspection mirror. Broker authorization paths use
+// this read-only form because unrelated control-store mutations legitimately
+// change the Lease resourceVersion while leaving its epoch authority intact.
+func (s *Store) GetControllerEpochFence(ctx context.Context, name string) (store.ControllerEpochFence, error) {
+	if err := s.requireClient(); err != nil {
+		return store.ControllerEpochFence{}, err
+	}
+	normalized, err := normalizeControllerEpochName(name)
+	if err != nil {
+		return store.ControllerEpochFence{}, err
+	}
+	lease := &coordinationv1.Lease{}
+	key := types.NamespacedName{Namespace: s.controlNamespace, Name: controllerEpochLeaseName(normalized)}
+	if err := s.readClient().Get(ctx, key, lease); err != nil {
+		return store.ControllerEpochFence{}, mapKubernetesError("get controller epoch fence Lease", err)
+	}
+	epoch, err := controllerEpochFromLease(normalized, lease)
+	if err != nil {
+		return store.ControllerEpochFence{}, err
+	}
+	object, err := s.getControllerEpochObject(ctx, normalized)
+	if errors.Is(err, store.ErrNotFound) {
+		return store.ControllerEpochFence{}, controlConflict(
+			"controller epoch object %q is missing while authoritative Lease %q exists",
+			controllerEpochObjectName(normalized), lease.Name,
+		)
+	}
+	if err != nil {
+		return store.ControllerEpochFence{}, err
+	}
+	if err := validateControllerEpochObjectLeaseUID(object, lease); err != nil {
+		return store.ControllerEpochFence{}, err
+	}
+	if err := validateControllerEpochObjectForLease(object, epoch, lease.Name); err != nil {
+		return store.ControllerEpochFence{}, err
+	}
+	return store.ControllerEpochFence{Name: epoch.Name, Epoch: epoch.Epoch, HolderID: epoch.HolderID}, nil
+}
+
 // CompareAndSwapControllerEpoch creates or advances the authoritative Lease.
 // A same-holder, same-digest retry of an already committed target epoch is
 // idempotent even when the caller's expected values are stale.

--- a/internal/store/kube/store_test.go
+++ b/internal/store/kube/store_test.go
@@ -145,6 +145,42 @@ func TestControllerEpochLeaseCAS(t *testing.T) {
 	}
 }
 
+func TestControllerEpochFenceReadToleratesLeaseMutationResourceVersionChurn(t *testing.T) {
+	ctx := context.Background()
+	kubeStore, kubeClient, want := newTestStoreWithEpoch(t)
+	name := controlstore.DefaultControllerEpochName
+	objectKey := client.ObjectKey{Namespace: testControlNamespace, Name: controllerEpochObjectName(name)}
+	before := &corev1alpha1.ControllerEpoch{}
+	if err := kubeClient.Get(ctx, objectKey, before); err != nil {
+		t.Fatalf("get controller epoch mirror before fence read: %v", err)
+	}
+	lease := &coordinationv1.Lease{}
+	leaseKey := client.ObjectKey{Namespace: testControlNamespace, Name: controllerEpochLeaseName(name)}
+	if err := kubeClient.Get(ctx, leaseKey, lease); err != nil {
+		t.Fatalf("get controller epoch Lease before mutation churn: %v", err)
+	}
+	lease.Annotations[annotationMutationToken] = "concurrent-control-store-mutation"
+	lease.Annotations[annotationMutationExpiresAt] = formatTime(time.Now().UTC().Add(time.Minute))
+	if err := kubeClient.Update(ctx, lease); err != nil {
+		t.Fatalf("change controller epoch Lease resourceVersion: %v", err)
+	}
+
+	got, err := kubeStore.GetControllerEpochFence(ctx, name)
+	if err != nil {
+		t.Fatalf("read controller epoch fence during mutation churn: %v", err)
+	}
+	if got != want {
+		t.Fatalf("controller epoch fence = %#v, want %#v", got, want)
+	}
+	after := &corev1alpha1.ControllerEpoch{}
+	if err := kubeClient.Get(ctx, objectKey, after); err != nil {
+		t.Fatalf("get controller epoch mirror after fence read: %v", err)
+	}
+	if after.ResourceVersion != before.ResourceVersion {
+		t.Fatalf("read-only fence lookup changed mirror resourceVersion from %q to %q", before.ResourceVersion, after.ResourceVersion)
+	}
+}
+
 func TestControllerEpochAuthorityRejectsRecreatedLeaseIncarnation(t *testing.T) {
 	ctx := context.Background()
 	kubeStore, kubeClient, fence := newTestStoreWithEpoch(t)
@@ -184,6 +220,9 @@ func TestControllerEpochAuthorityRejectsRecreatedLeaseIncarnation(t *testing.T) 
 	}
 	if _, err := kubeStore.GetControllerEpoch(ctx, name); !errors.Is(err, controlstore.ErrConflict) || !strings.Contains(err.Error(), "bound to Lease UID") {
 		t.Fatalf("recreated Lease read error = %v, want UID conflict", err)
+	}
+	if _, err := kubeStore.GetControllerEpochFence(ctx, name); !errors.Is(err, controlstore.ErrConflict) || !strings.Contains(err.Error(), "bound to Lease UID") {
+		t.Fatalf("recreated Lease fence read error = %v, want UID conflict", err)
 	}
 	if _, _, err := kubeStore.requireControllerEpoch(ctx, fence); !errors.Is(err, controlstore.ErrConflict) || !strings.Contains(err.Error(), "bound to Lease UID") {
 		t.Fatalf("recreated Lease mutation-fence error = %v, want UID conflict", err)

--- a/internal/store/kube/store_test.go
+++ b/internal/store/kube/store_test.go
@@ -181,6 +181,46 @@ func TestControllerEpochFenceReadToleratesLeaseMutationResourceVersionChurn(t *t
 	}
 }
 
+func TestControllerEpochFenceReadRejectsConcurrentAuthorityChange(t *testing.T) {
+	ctx := context.Background()
+	kubeStore, rawClient, _ := newTestStoreWithEpoch(t)
+	withWatch, ok := rawClient.(client.WithWatch)
+	if !ok {
+		t.Fatal("fake client does not implement client.WithWatch")
+	}
+	name := controlstore.DefaultControllerEpochName
+	leaseKey := client.ObjectKey{Namespace: testControlNamespace, Name: controllerEpochLeaseName(name)}
+	var leaseReads atomic.Int64
+	kubeStore.reader = interceptor.NewClient(withWatch, interceptor.Funcs{
+		Get: func(ctx context.Context, delegate client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+			if _, isLease := object.(*coordinationv1.Lease); !isLease || key != leaseKey {
+				return delegate.Get(ctx, key, object, options...)
+			}
+			if leaseReads.Add(1) == 2 {
+				latest := &coordinationv1.Lease{}
+				if err := delegate.Get(ctx, key, latest, options...); err != nil {
+					return err
+				}
+				setControllerEpochLease(latest, controlstore.ControllerEpochCAS{
+					Name: name, NewEpoch: 2, HolderID: testControllerSecond,
+					RequestDigest: testDigest("concurrent-fence-read"), UpdatedAt: testNow.Add(time.Minute),
+				}, 2, "")
+				if err := delegate.Update(ctx, latest); err != nil {
+					return err
+				}
+			}
+			return delegate.Get(ctx, key, object, options...)
+		},
+	})
+
+	if _, err := kubeStore.GetControllerEpochFence(ctx, name); !errors.Is(err, controlstore.ErrConflict) || !strings.Contains(err.Error(), "changed during fence read") {
+		t.Fatalf("concurrent controller epoch fence read error = %v, want authority-change conflict", err)
+	}
+	if got := leaseReads.Load(); got != 2 {
+		t.Fatalf("controller epoch fence Lease reads = %d, want 2", got)
+	}
+}
+
 func TestControllerEpochAuthorityRejectsRecreatedLeaseIncarnation(t *testing.T) {
 	ctx := context.Background()
 	kubeStore, kubeClient, fence := newTestStoreWithEpoch(t)

--- a/scripts/security-scan-e2e.sh
+++ b/scripts/security-scan-e2e.sh
@@ -55,6 +55,8 @@ general_worker_image="${ORKA_GENERAL_WORKER_IMAGE:-orka-general-worker:security-
 fake_runtime_image="${ORKA_SECURITY_SCAN_FAKE_RUNTIME_IMAGE:-orka-acp-security-fixture:security-scan-e2e-${e2e_run_id}}"
 
 work_dir="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/security-scan-e2e.XXXXXX")"
+diagnostics_root="${ORKA_SECURITY_SCAN_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/security-scan-e2e-diagnostics}"
+diagnostics_dir="${diagnostics_root}/${e2e_run_id}"
 kind_config="${ORKA_SECURITY_SCAN_KIND_CONFIG:-${work_dir}/kind-config.yaml}"
 manager_kustomization="${repo_root}/config/manager/kustomization.yaml"
 manager_kustomization_backup="${work_dir}/manager-kustomization.yaml.bak"
@@ -64,6 +66,7 @@ api_auth_header_file="${work_dir}/api-auth-header"
 kubeconfig_file="${work_dir}/kubeconfig"
 kind_lock_dir=""
 registry_owner="security-scan-e2e-${e2e_run_id}"
+diagnostics_collected="0"
 
 run() {
   printf '+ ' >&2
@@ -86,10 +89,267 @@ restore_manager_kustomization() {
   fi
 }
 
+capture_redacted() {
+  local output_file="$1"
+  shift
+  "$@" 2>&1 | redact >"${output_file}" || true
+}
+
+collect_security_scan_diagnostics() {
+  if [[ "${diagnostics_collected}" == "1" ]]; then
+    return 0
+  fi
+  diagnostics_collected="1"
+
+  mkdir -p "${diagnostics_dir}/jobs" "${diagnostics_dir}/runtime"
+  chmod 700 "${diagnostics_root}" "${diagnostics_dir}" "${diagnostics_dir}/jobs" "${diagnostics_dir}/runtime" 2>/dev/null || true
+  log "Collecting redacted SecurityScan diagnostics in ${diagnostics_dir}"
+
+  jq -n \
+    --arg collectedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg runID "${e2e_run_id}" \
+    --arg cluster "${kind_cluster}" \
+    --arg namespace "${test_namespace}" \
+    '{collectedAt:$collectedAt,runID:$runID,cluster:$cluster,namespace:$namespace}' \
+    >"${diagnostics_dir}/metadata.json"
+
+  kubectl -n "${test_namespace}" get repositoryscans -o json 2>/dev/null |
+    jq '{items: [.items[] | {
+      metadata: {
+        name: .metadata.name,
+        namespace: .metadata.namespace,
+        uid: .metadata.uid,
+        generation: .metadata.generation,
+        creationTimestamp: .metadata.creationTimestamp,
+        labels: .metadata.labels
+      },
+      spec: {
+        provider: .spec.provider,
+        repoURL: .spec.repoURL,
+        owner: .spec.owner,
+        repository: .spec.repository,
+        branch: .spec.branch,
+        ref: .spec.ref,
+        subPath: .spec.subPath,
+        analysisAgentRef: .spec.analysisAgentRef
+      },
+      status: .status
+    }]}' | redact >"${diagnostics_dir}/repository-scans.json" || true
+
+  kubectl -n "${test_namespace}" get tasks \
+    -l "orka.ai/security-target in (${scan_name},${bad_scan_name})" -o json 2>/dev/null |
+    jq '{items: [.items[] | {
+      metadata: {
+        name: .metadata.name,
+        namespace: .metadata.namespace,
+        uid: .metadata.uid,
+        generation: .metadata.generation,
+        creationTimestamp: .metadata.creationTimestamp,
+        labels: .metadata.labels,
+        ownerReferences: .metadata.ownerReferences
+      },
+      spec: {
+        type: .spec.type,
+        image: .spec.image,
+        command: .spec.command,
+        timeout: .spec.timeout,
+        priority: .spec.priority,
+        agentRef: .spec.agentRef,
+        workspace: (if .spec.workspace == null then null else {
+          intent: .spec.workspace.intent,
+          gitRepo: .spec.workspace.gitRepo,
+          branch: .spec.workspace.branch,
+          ref: .spec.workspace.ref
+        } end)
+      },
+      status: .status
+    }]}' | redact >"${diagnostics_dir}/tasks.json" || true
+
+  kubectl -n "${test_namespace}" get agents -o json 2>/dev/null |
+    jq '{items: [.items[] | {
+      metadata: {name: .metadata.name, namespace: .metadata.namespace, uid: .metadata.uid, generation: .metadata.generation},
+      spec: {runtime: .spec.runtime, model: .spec.model},
+      status: .status
+    }]}' | redact >"${diagnostics_dir}/agents.json" || true
+
+  kubectl -n "${test_namespace}" get runtimepools -o json 2>/dev/null |
+    jq '{items: [.items[] | {
+      metadata: {
+        name: .metadata.name,
+        namespace: .metadata.namespace,
+        uid: .metadata.uid,
+        generation: .metadata.generation,
+        creationTimestamp: .metadata.creationTimestamp,
+        labels: .metadata.labels,
+        ownerReferences: .metadata.ownerReferences
+      },
+      spec: {
+        trustDomain: .spec.trustDomain,
+        runtimeNamespace: .spec.runtimeNamespace,
+        runtime: (if .spec.runtime == null then null else {
+          image: .spec.runtime.image,
+          profile: (if .spec.runtime.profile == null then null else {
+            protocolVersion: .spec.runtime.profile.protocolVersion,
+            digest: .spec.runtime.profile.digest,
+            digestSchemaVersion: .spec.runtime.profile.digestSchemaVersion,
+            acpProfile: .spec.runtime.profile.acpProfile,
+            providerKind: .spec.runtime.profile.providerKind,
+            model: .spec.runtime.profile.model,
+            modelLimits: .spec.runtime.profile.modelLimits,
+            agentConfigurationDigest: .spec.runtime.profile.agentConfigurationDigest,
+            toolPolicyDigest: .spec.runtime.profile.toolPolicyDigest,
+            approvalPolicyDigest: .spec.runtime.profile.approvalPolicyDigest,
+            mcpConfigurationDigest: .spec.runtime.profile.mcpConfigurationDigest,
+            workspaceIntent: .spec.runtime.profile.workspaceIntent,
+            proxyCredentialRole: .spec.runtime.profile.proxyCredentialRole,
+            proxyCredentialScope: .spec.runtime.profile.proxyCredentialScope,
+            resourceClass: .spec.runtime.profile.resourceClass
+          } end)
+        } end),
+        desiredReplicas: .spec.desiredReplicas,
+        capacity: .spec.capacity,
+        coldStartTimeoutSeconds: .spec.coldStartTimeoutSeconds
+      },
+      status: .status
+    }]}' | redact >"${diagnostics_dir}/runtime-pools.json" || true
+
+  kubectl -n "${test_namespace}" get promptattempts -o json 2>/dev/null |
+    jq '{items: [.items[] | {
+      metadata: {name: .metadata.name, namespace: .metadata.namespace, uid: .metadata.uid, labels: .metadata.labels},
+      spec: {
+        id: .spec.id,
+        taskUid: .spec.taskUid,
+        attempt: .spec.attempt,
+        promptId: .spec.promptId,
+        requestDigest: .spec.requestDigest,
+        bindingDigest: .spec.bindingDigest,
+        snapshotDigest: .spec.snapshotDigest
+      },
+      status: .status
+    }]}' | redact >"${diagnostics_dir}/prompt-attempts.json" || true
+
+  kubectl -n "${test_namespace}" get externaleffects -o json 2>/dev/null |
+    jq '{items: [.items[] | {
+      metadata: {
+        name: .metadata.name,
+        namespace: .metadata.namespace,
+        uid: .metadata.uid,
+        creationTimestamp: .metadata.creationTimestamp,
+        labels: .metadata.labels
+      },
+      spec: {
+        id: .spec.id,
+        kind: .spec.kind,
+        identityNamespace: .spec.identityNamespace,
+        aggregateId: .spec.aggregateId,
+        operationId: .spec.operationId,
+        requestDigest: .spec.requestDigest
+      },
+      status: {
+        state: .status.state,
+        responseDigest: .status.responseDigest,
+        leaseOwner: .status.leaseOwner,
+        leaseExpiresAt: .status.leaseExpiresAt,
+        attempts: .status.attempts,
+        controllerEpochName: .status.controllerEpochName,
+        controllerEpoch: .status.controllerEpoch,
+        controllerEpochLeaseResourceVersion: .status.controllerEpochLeaseResourceVersion,
+        version: .status.version,
+        createdAt: .status.createdAt,
+        updatedAt: .status.updatedAt
+      }
+    }]}' | redact >"${diagnostics_dir}/external-effects.json" || true
+
+  kubectl -n "${test_namespace}" get runtimesessioncontrols -o json 2>/dev/null |
+    jq '{items: [.items[] | {
+      metadata: {name: .metadata.name, namespace: .metadata.namespace, uid: .metadata.uid, labels: .metadata.labels},
+      spec: {
+        sessionUid: .spec.sessionUid,
+        requestDigest: .spec.requestDigest,
+        owner: .spec.owner,
+        runtimePoolRef: .spec.runtimePoolRef,
+        runtimePoolUid: .spec.runtimePoolUid,
+        runtimeProfileDigest: .spec.runtimeProfileDigest,
+        profileDigestSchemaVersion: .spec.profileDigestSchemaVersion
+      },
+      status: {
+        generation: .status.generation,
+        lifecycle: .status.lifecycle,
+        availability: .status.availability,
+        mutationLeaseGeneration: .status.mutationLeaseGeneration,
+        mutationLease: .status.mutationLease,
+        blockedReason: .status.blockedReason,
+        relatedPromptAttemptId: .status.relatedPromptAttemptId,
+        relatedPublicationId: .status.relatedPublicationId,
+        lineage: .status.lineage,
+        controllerEpochName: .status.controllerEpochName,
+        controllerEpoch: .status.controllerEpoch,
+        controllerEpochLeaseResourceVersion: .status.controllerEpochLeaseResourceVersion,
+        lastOperationId: .status.lastOperationId,
+        lastOperationDigest: .status.lastOperationDigest,
+        version: .status.version,
+        createdAt: .status.createdAt,
+        updatedAt: .status.updatedAt
+      }
+    }]}' | redact >"${diagnostics_dir}/runtime-session-controls.json" || true
+
+  capture_redacted "${diagnostics_dir}/cluster-resources.txt" kubectl get nodes,pods -A -o wide
+  capture_redacted "${diagnostics_dir}/namespace-resources.txt" kubectl -n "${test_namespace}" \
+    get deployments,pods,services,jobs,agents,tasks,runtimepools,promptattempts,externaleffects,runtimesessioncontrols -o wide
+  capture_redacted "${diagnostics_dir}/events.txt" kubectl -n "${test_namespace}" \
+    get events --sort-by=.metadata.creationTimestamp
+  capture_redacted "${diagnostics_dir}/controller.log" kubectl -n "${orka_namespace}" \
+    logs deployment/"${orka_controller_deployment}" --all-containers=true --timestamps=true --tail=2000
+  capture_redacted "${diagnostics_dir}/controller-describe.txt" kubectl -n "${orka_namespace}" \
+    describe deployment/"${orka_controller_deployment}"
+
+  local job_name
+  while IFS= read -r job_name; do
+    [[ -n "${job_name}" ]] || continue
+    capture_redacted "${diagnostics_dir}/jobs/${job_name}.log" kubectl -n "${test_namespace}" \
+      logs job/"${job_name}" --all-containers=true --timestamps=true --tail=2000
+    capture_redacted "${diagnostics_dir}/jobs/${job_name}.describe.txt" kubectl -n "${test_namespace}" \
+      describe job/"${job_name}"
+  done < <(kubectl -n "${test_namespace}" get jobs -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+
+  local runtime_namespace runtime_pod
+  while IFS= read -r runtime_namespace; do
+    [[ -n "${runtime_namespace}" ]] || continue
+    capture_redacted "${diagnostics_dir}/runtime/${runtime_namespace}-resources.txt" kubectl -n "${runtime_namespace}" \
+      get deployments,pods,services,networkpolicies,poddisruptionbudgets -o wide
+    capture_redacted "${diagnostics_dir}/runtime/${runtime_namespace}-events.txt" kubectl -n "${runtime_namespace}" \
+      get events --sort-by=.metadata.creationTimestamp
+    while IFS= read -r runtime_pod; do
+      [[ -n "${runtime_pod}" ]] || continue
+      capture_redacted "${diagnostics_dir}/runtime/${runtime_namespace}-${runtime_pod}.log" kubectl -n "${runtime_namespace}" \
+        logs pod/"${runtime_pod}" --all-containers=true --timestamps=true --tail=2000
+      capture_redacted "${diagnostics_dir}/runtime/${runtime_namespace}-${runtime_pod}.previous.log" kubectl -n "${runtime_namespace}" \
+        logs pod/"${runtime_pod}" --all-containers=true --timestamps=true --tail=2000 --previous
+      capture_redacted "${diagnostics_dir}/runtime/${runtime_namespace}-${runtime_pod}.describe.txt" kubectl -n "${runtime_namespace}" \
+        describe pod/"${runtime_pod}"
+    done < <(kubectl -n "${runtime_namespace}" get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+  done < <(
+    {
+      printf '%s\n' "${orka_namespace}" "orka-runtimes"
+      kubectl -n "${test_namespace}" get runtimepools \
+        -o jsonpath='{range .items[*]}{.spec.runtimeNamespace}{"\n"}{end}' 2>/dev/null || true
+    } | LC_ALL=C sort -u
+  )
+
+  if [[ -f "${api_forward_log}" ]]; then
+    redact <"${api_forward_log}" >"${diagnostics_dir}/api-port-forward.log"
+  fi
+  log "Redacted SecurityScan diagnostics are ready at ${diagnostics_dir}"
+}
+
 on_exit() {
   local status="$1"
   local cleanup_status=0
   set +e
+  if [[ "${status}" -ne 0 ]] &&
+    [[ "$(kubectl config current-context 2>/dev/null || true)" == "kind-${kind_cluster}" ]]; then
+    collect_security_scan_diagnostics || warn "SecurityScan diagnostic collection was incomplete"
+  fi
   stop_api_forward
   if [[ "$(kubectl config current-context 2>/dev/null || true)" == "kind-${kind_cluster}" ]]; then
     kubectl -n "${test_namespace}" delete serviceaccount "${api_identity_name}" \
@@ -434,7 +694,7 @@ wait_repo_phase() {
   local timeout_seconds
   timeout_seconds="$(duration_to_seconds "${wait_timeout}")"
   local deadline=$((SECONDS + timeout_seconds))
-  local phase
+  local phase message
 
   log "Waiting for RepositoryScan/${name} phase ${expected}"
   while (( SECONDS < deadline )); do
@@ -442,6 +702,16 @@ wait_repo_phase() {
     if [[ "${phase}" == "${expected}" ]]; then
       return 0
     fi
+    case "${phase}" in
+      Ready|Error|Suspended)
+        message="$(
+          kubectl -n "${test_namespace}" get repositoryscan "${name}" -o json 2>/dev/null |
+            jq -r '[.status.conditions[]? | select(.type == "Ready")][-1].message // empty' |
+            redact
+        )"
+        die "RepositoryScan/${name} entered terminal phase ${phase} while waiting for ${expected}${message:+: ${message}}"
+        ;;
+    esac
     sleep 5
   done
   die "RepositoryScan/${name} did not reach phase ${expected}; current phase ${phase:-<empty>}"

--- a/scripts/tests/security-scan-e2e-test.sh
+++ b/scripts/tests/security-scan-e2e-test.sh
@@ -3,6 +3,7 @@ set -Eeuo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 security_script="${root}/scripts/security-scan-e2e.sh"
+security_workflow="${root}/.github/workflows/security-scan-e2e.yml"
 
 for command in cmp jq; do
   command -v "${command}" >/dev/null 2>&1 || {
@@ -47,6 +48,28 @@ apply_repository_scan "${scan_name}"
 grep -F 'repoURL: https://github.com/sozercan/vekil' "${manifest_capture}" >/dev/null
 grep -F 'owner: sozercan' "${manifest_capture}" >/dev/null
 grep -F 'repository: vekil' "${manifest_capture}" >/dev/null
+
+repository_phase="Error"
+kubectl() {
+  if [[ "$*" == *"get repositoryscan ${scan_name} -o jsonpath={.status.phase}"* ]]; then
+    printf '%s' "${repository_phase}"
+    return 0
+  fi
+  if [[ "$*" == *"get repositoryscan ${scan_name} -o json"* ]]; then
+    jq -n '{status:{conditions:[{type:"Ready",message:"runtime pool degraded"}]}}'
+    return 0
+  fi
+  return 1
+}
+set +e
+terminal_wait_error="$(wait_repo_phase "${scan_name}" "Ready" 2>&1)"
+terminal_wait_status=$?
+set -e
+[[ "${terminal_wait_status}" -eq 1 ]]
+grep -Fq 'entered terminal phase Error while waiting for Ready: runtime pool degraded' <<<"${terminal_wait_error}"
+
+repository_phase="Ready"
+wait_repo_phase "${scan_name}" "Ready"
 
 positive="${work_dir}/positive"
 malformed="${work_dir}/malformed"
@@ -441,6 +464,129 @@ set -e
   exit 1
 }
 [[ ! -e "${cleanup_precedence_dir}" ]]
+
+diagnostics_root="${test_root}/diagnostics"
+diagnostics_dir="${diagnostics_root}/fixture-run"
+diagnostics_collected="0"
+api_forward_log="${test_root}/diagnostic-api-forward.log"
+printf '%s\n' 'Authorization: Bearer diagnostic-secret' >"${api_forward_log}"
+kubectl() {
+  case "$*" in
+    *"get repositoryscans -o json"*)
+      jq -n '{items:[{
+        metadata:{name:"security-goof",namespace:"orka-system",uid:"scan-uid",generation:1,annotations:{debug:"must-not-be-captured"}},
+        spec:{repoURL:"https://github.com/sozercan/vekil",branch:"main",ref:"abc",analysisAgentRef:{name:"fixture-agent"},readCredentialRef:{name:"must-not-be-captured"}},
+        status:{phase:"Error",conditions:[{type:"Ready",message:"failed safely"}]}
+      }]}'
+      ;;
+    *"get tasks "*" -o json"*)
+      jq -n '{items:[{
+        metadata:{name:"threat-task",namespace:"orka-system",uid:"task-uid",labels:{"orka.ai/security-target":"security-goof"},annotations:{debug:"must-not-be-captured"}},
+        spec:{type:"agent",prompt:"sensitive prompt",env:[{name:"API_KEY",value:"diagnostic-secret"}],agentRef:{name:"fixture-agent"},workspace:{intent:"read",gitRepo:"https://github.com/sozercan/vekil",branch:"main",ref:"abc",readCredentialRef:{name:"must-not-be-captured"}}},
+        status:{phase:"Failed",message:"runtime failed"}
+      }]}'
+      ;;
+    *"get agents -o json"*)
+      jq -n '{items:[]}'
+      ;;
+    *"get runtimepools -o jsonpath="*)
+      printf '%s\n' 'orka-runtimes'
+      ;;
+    *"get runtimepools -o json"*)
+      jq -n '{items:[{
+        metadata:{name:"pool",namespace:"orka-system",uid:"pool-uid"},
+        spec:{
+          trustDomain:{namespace:"orka-system",identity:"fixture"},
+          runtimeNamespace:"orka-runtimes",
+          runtime:{image:"example.invalid/runtime@sha256:test",profile:{protocolVersion:"orka.harness.v2",digest:"sha256:test",providerKind:"codex",model:"fixture"}},
+          desiredReplicas:1,
+          capacity:{maxResidentSessions:10,maxRunningPrompts:4},
+          credential:"must-not-be-captured"
+        },
+        status:{lifecycle:"Degraded"}
+      }]}'
+      ;;
+    *"get promptattempts -o json"*)
+      jq -n '{items:[{metadata:{name:"attempt"},spec:{id:"attempt-id",taskUid:"task-uid",attempt:1,promptId:"prompt-id",requestDigest:"sha256:test",credentialBindings:[{secretName:"must-not-be-captured",secretKey:"token"}]},status:{executionState:"Failed"}}]}'
+      ;;
+    *"get externaleffects -o json"*)
+      jq -n '{items:[{
+        metadata:{name:"effect",namespace:"orka-system",uid:"effect-uid"},
+        spec:{id:"effect-id",kind:"workspace.prepare",identityNamespace:"orka-system",aggregateId:"task-uid",operationId:"workspace-prepare-prompt-id",requestDigest:"sha256:test",response:{capability:"must-not-be-captured"}},
+        status:{state:"OutcomeUnknown",attempts:1,controllerEpochName:"orka-controller",controllerEpoch:2,version:3,response:{capability:"must-not-be-captured"}}
+      }]}'
+      ;;
+    *"get runtimesessioncontrols -o json"*)
+      jq -n '{items:[{
+        metadata:{name:"session",namespace:"orka-system",uid:"session-object-uid"},
+        spec:{sessionName:"must-not-be-captured",sessionUid:"session-uid",requestDigest:"sha256:test",owner:{kind:"Task",uid:"task-uid"},runtimePoolRef:"pool",credential:"must-not-be-captured"},
+        status:{lifecycle:"Poisoned",availability:"ReconciliationBlocked",blockedReason:"fixture blocked",version:2}
+      }]}'
+      ;;
+    *"get jobs -o jsonpath="*)
+      printf '%s\n' 'mapper-job'
+      ;;
+    *"get pods -o jsonpath="*)
+      printf '%s\n' 'runtime-pod'
+      ;;
+    *"logs "*)
+      printf '%s\n' 'Authorization: Bearer diagnostic-secret'
+      ;;
+    *)
+      printf '%s\n' 'diagnostic fixture output'
+      ;;
+  esac
+}
+
+collect_security_scan_diagnostics
+for expected_file in \
+  metadata.json repository-scans.json tasks.json agents.json runtime-pools.json prompt-attempts.json \
+  external-effects.json runtime-session-controls.json cluster-resources.txt namespace-resources.txt events.txt controller.log \
+  controller-describe.txt api-port-forward.log jobs/mapper-job.log runtime/orka-runtimes-runtime-pod.log; do
+  [[ -f "${diagnostics_dir}/${expected_file}" ]] || {
+    echo "SecurityScan diagnostics omitted ${expected_file}" >&2
+    exit 1
+  }
+done
+if grep -R -Fq 'diagnostic-secret' "${diagnostics_dir}"; then
+  echo "SecurityScan diagnostics retained a credential value" >&2
+  exit 1
+fi
+jq -e '
+  .items[0].status.phase == "Failed" and
+  (.items[0].metadata | has("annotations") | not) and
+  (.items[0].spec | has("prompt") | not) and
+  (.items[0].spec | has("env") | not) and
+  (.items[0].spec.workspace | has("readCredentialRef") | not)
+' "${diagnostics_dir}/tasks.json" >/dev/null
+jq -e '
+  (.items[0].metadata | has("annotations") | not) and
+  (.items[0].spec | has("readCredentialRef") | not)
+' "${diagnostics_dir}/repository-scans.json" >/dev/null
+jq -e '
+  .items[0].spec.runtimeNamespace == "orka-runtimes" and
+  .items[0].spec.runtime.profile.providerKind == "codex" and
+  (.items[0].spec | has("credential") | not)
+' "${diagnostics_dir}/runtime-pools.json" >/dev/null
+jq -e '(.items[0].spec | has("credentialBindings") | not)' \
+  "${diagnostics_dir}/prompt-attempts.json" >/dev/null
+jq -e '
+  .items[0].spec.kind == "workspace.prepare" and
+  .items[0].status.state == "OutcomeUnknown" and
+  (.items[0].spec | has("response") | not) and
+  (.items[0].status | has("response") | not)
+' "${diagnostics_dir}/external-effects.json" >/dev/null
+jq -e '
+  .items[0].spec.sessionUid == "session-uid" and
+  .items[0].status.lifecycle == "Poisoned" and
+  (.items[0].spec | has("sessionName") | not) and
+  (.items[0].spec | has("credential") | not)
+' "${diagnostics_dir}/runtime-session-controls.json" >/dev/null
+
+grep -Fq 'ORKA_SECURITY_SCAN_DIAGNOSTICS_DIR: ${{ runner.temp }}/security-scan-e2e-diagnostics' "${security_workflow}"
+grep -Fq 'if: ${{ failure() }}' "${security_workflow}"
+grep -Fq 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' "${security_workflow}"
+grep -Fq 'path: ${{ runner.temp }}/security-scan-e2e-diagnostics' "${security_workflow}"
 
 preflight_root="${test_root}/preflight-cleanup"
 preflight_bin="${test_root}/preflight-bin"


### PR DESCRIPTION
## Summary

- read the authoritative controller epoch fence without mutating its inspection mirror, avoiding transient resource-version conflicts
- preserve broker retry classification so temporary artifact-authorization outages remain retryable while authorization stays fail-closed
- fail fast on terminal RepositoryScan phases and upload strictly redacted failure diagnostics

## Testing

- `make lint-fix`
- `go test ./internal/api ./internal/publisher/service ./internal/store/kube`
- `make test`
- `bash -n scripts/*.sh`
- `bash scripts/tests/security-scan-e2e-test.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/security-scan-e2e.yml`

Closes #382