### PR TITLE
fix(api): retry resource updates on conflicts

### DIFF
--- a/internal/api/resource_handlers.go
+++ b/internal/api/resource_handlers.go
@@ -317,7 +317,8 @@ func (h *Handlers) UpdateProvider(c fiber.Ctx) error {
 	if err := rejectContextTokenResourceMutation(c, "provider"); err != nil {
 		return err
 	}
-	provider, err := h.fetchProvider(c, c.Params("name"))
+	name := c.Params("name")
+	namespace, err := h.resolveNamespace(c, c.Query("namespace", ""))
 	if err != nil {
 		return err
 	}
@@ -325,14 +326,62 @@ func (h *Handlers) UpdateProvider(c fiber.Ctx) error {
 	if err := c.Bind().JSON(&req); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
 	}
-	if err := validateProviderRESTUpdate(req.Spec, provider.Spec); err != nil {
-		return err
+
+	reader := h.apiReader
+	if reader == nil {
+		reader = h.client
 	}
-	// REST updates cannot set protected routing fields, but they also must not
-	// clear values that were created through the Kubernetes API/RBAC path.
-	req.Spec.BaseURL = provider.Spec.BaseURL
-	provider.Spec = req.Spec
-	if err := h.client.Update(c.Context(), provider); err != nil {
+	ctx := c.Context()
+	key := types.NamespacedName{Name: name, Namespace: namespace}
+	var (
+		provider          *corev1alpha1.Provider
+		initialGeneration int64
+		initialSpec       *corev1alpha1.ProviderSpec
+		initialUID        types.UID
+	)
+	errProviderSpecChanged := errors.New("provider spec changed concurrently")
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		current := &corev1alpha1.Provider{}
+		if err := reader.Get(ctx, key, current); err != nil {
+			return err
+		}
+		if initialSpec == nil {
+			initialGeneration = current.Generation
+			initialSpec = current.Spec.DeepCopy()
+			initialUID = current.UID
+		} else if current.UID != initialUID ||
+			current.Generation != initialGeneration ||
+			!apiequality.Semantic.DeepEqual(current.Spec, *initialSpec) {
+			return errProviderSpecChanged
+		}
+		if err := validateProviderRESTUpdate(req.Spec, current.Spec); err != nil {
+			return err
+		}
+		// REST updates cannot set protected routing fields, but they also must
+		// not clear values that were created through the Kubernetes API/RBAC path.
+		desiredSpec := req.Spec.DeepCopy()
+		desiredSpec.BaseURL = current.Spec.BaseURL
+		current.Spec = *desiredSpec
+		if err := h.client.Update(ctx, current); err != nil {
+			return err
+		}
+		provider = current
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, errProviderSpecChanged) {
+			return fiber.NewError(fiber.StatusConflict, "provider spec was modified concurrently")
+		}
+		var fiberErr *fiber.Error
+		if errors.As(err, &fiberErr) {
+			return err
+		}
+		if apierrors.IsNotFound(err) {
+			return fiber.NewError(fiber.StatusNotFound, "provider not found")
+		}
+		if apierrors.IsConflict(err) {
+			return fiber.NewError(fiber.StatusConflict, "provider was modified concurrently")
+		}
 		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("failed to update provider: %v", err))
 	}
 	return c.JSON(provider)

--- a/internal/api/resource_handlers_test.go
+++ b/internal/api/resource_handlers_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -22,13 +23,13 @@ import (
 	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
 )
 
-type recordingToolReader struct {
+type recordingResourceReader struct {
 	client.Reader
 	getCalls         int
 	resourceVersions []string
 }
 
-func (r *recordingToolReader) Get(
+func (r *recordingResourceReader) Get(
 	ctx context.Context,
 	key client.ObjectKey,
 	obj client.Object,
@@ -128,6 +129,146 @@ func TestHandlers_ProviderUpdatePreservesExistingBaseURL(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
+func TestHandlers_UpdateProviderRetriesStatusOnlyConflictWithFreshRead(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1alpha1.AddToScheme(scheme))
+
+	provider := &corev1alpha1.Provider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "proxy-provider",
+			Namespace:  "default",
+			UID:        types.UID("provider-uid"),
+			Generation: 1,
+		},
+		Spec: corev1alpha1.ProviderSpec{
+			Type:         corev1alpha1.ProviderTypeOpenAI,
+			BaseURL:      "https://proxy.example/v1",
+			DefaultModel: "gpt-4o-mini",
+		},
+	}
+	updateCalls := 0
+	var updateVersions []string
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&corev1alpha1.Provider{}).
+		WithObjects(provider).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				updateCalls++
+				updateVersions = append(updateVersions, obj.GetResourceVersion())
+				if updateCalls == 1 {
+					current := &corev1alpha1.Provider{}
+					if err := c.Get(ctx, client.ObjectKeyFromObject(obj), current); err != nil {
+						return err
+					}
+					current.Status.Ready = true
+					current.Status.Message = "credentials validated"
+					if err := c.Status().Update(ctx, current); err != nil {
+						return err
+					}
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: corev1alpha1.GroupVersion.Group, Resource: "providers"},
+						obj.GetName(),
+						errors.New("status update advanced resource version"),
+					)
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	reader := &recordingResourceReader{Reader: kubeClient}
+	handlers := NewHandlers(HandlersConfig{Client: kubeClient, APIReader: reader})
+	app := fiber.New()
+	app.Put("/providers/:name", handlers.UpdateProvider)
+
+	resp := testJSONRequest(t, app, http.MethodPut, "/providers/proxy-provider", map[string]any{
+		"spec": map[string]any{
+			"type":         "openai",
+			"defaultModel": "gpt-4.1",
+		},
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 2, updateCalls)
+	require.Equal(t, 2, reader.getCalls)
+	require.Len(t, reader.resourceVersions, 2)
+	require.NotEqual(t, reader.resourceVersions[0], reader.resourceVersions[1])
+	require.Equal(t, reader.resourceVersions, updateVersions)
+
+	updated := &corev1alpha1.Provider{}
+	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(provider), updated))
+	require.Equal(t, "gpt-4.1", updated.Spec.DefaultModel)
+	require.Equal(t, "https://proxy.example/v1", updated.Spec.BaseURL)
+	require.True(t, updated.Status.Ready)
+	require.Equal(t, "credentials validated", updated.Status.Message)
+}
+
+func TestHandlers_UpdateProviderRejectsConcurrentSpecEdit(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1alpha1.AddToScheme(scheme))
+
+	provider := &corev1alpha1.Provider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "proxy-provider",
+			Namespace:  "default",
+			UID:        types.UID("provider-uid"),
+			Generation: 1,
+		},
+		Spec: corev1alpha1.ProviderSpec{
+			Type:         corev1alpha1.ProviderTypeOpenAI,
+			BaseURL:      "https://proxy.example/v1",
+			DefaultModel: "gpt-4o-mini",
+		},
+	}
+	updateCalls := 0
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(provider).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				updateCalls++
+				if updateCalls == 1 {
+					current := &corev1alpha1.Provider{}
+					if err := c.Get(ctx, client.ObjectKeyFromObject(obj), current); err != nil {
+						return err
+					}
+					current.Generation++
+					current.Spec.BaseURL = "https://concurrent-proxy.example/v1"
+					current.Spec.DefaultModel = "gpt-4.1-mini"
+					if err := c.Update(ctx, current, opts...); err != nil {
+						return err
+					}
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: corev1alpha1.GroupVersion.Group, Resource: "providers"},
+						obj.GetName(),
+						errors.New("spec update advanced resource version"),
+					)
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	reader := &recordingResourceReader{Reader: kubeClient}
+	handlers := NewHandlers(HandlersConfig{Client: kubeClient, APIReader: reader})
+	app := fiber.New()
+	app.Put("/providers/:name", handlers.UpdateProvider)
+
+	resp := testJSONRequest(t, app, http.MethodPut, "/providers/proxy-provider", map[string]any{
+		"spec": map[string]any{
+			"type":         "openai",
+			"defaultModel": "gpt-4.1",
+		},
+	})
+	require.Equal(t, http.StatusConflict, resp.StatusCode)
+	require.Equal(t, 1, updateCalls)
+	require.Equal(t, 2, reader.getCalls)
+
+	updated := &corev1alpha1.Provider{}
+	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(provider), updated))
+	require.Equal(t, int64(2), updated.Generation)
+	require.Equal(t, "gpt-4.1-mini", updated.Spec.DefaultModel)
+	require.Equal(t, "https://concurrent-proxy.example/v1", updated.Spec.BaseURL)
+}
+
 func TestHandlers_ToolWriteRejectsBuiltInAndCRUD(t *testing.T) {
 	handlers, app := setupTestHandlers()
 	app.Post("/tools", handlers.CreateTool)
@@ -214,7 +355,7 @@ func TestHandlers_UpdateToolRetriesStatusOnlyConflictWithFreshRead(t *testing.T)
 			},
 		}).
 		Build()
-	reader := &recordingToolReader{Reader: kubeClient}
+	reader := &recordingResourceReader{Reader: kubeClient}
 	handlers := NewHandlers(HandlersConfig{Client: kubeClient, APIReader: reader})
 	app := fiber.New()
 	app.Put("/tools/:name", handlers.UpdateTool)
@@ -282,7 +423,7 @@ func TestHandlers_UpdateToolRejectsConcurrentSpecEdit(t *testing.T) {
 			},
 		}).
 		Build()
-	reader := &recordingToolReader{Reader: kubeClient}
+	reader := &recordingResourceReader{Reader: kubeClient}
 	handlers := NewHandlers(HandlersConfig{Client: kubeClient, APIReader: reader})
 	app := fiber.New()
 	app.Put("/tools/:name", handlers.UpdateTool)
@@ -304,6 +445,89 @@ func TestHandlers_UpdateToolRejectsConcurrentSpecEdit(t *testing.T) {
 	require.Equal(t, int64(2), updated.Generation)
 	require.Equal(t, "concurrent edit", updated.Spec.Description)
 	require.Equal(t, "https://example.com/concurrent", updated.Spec.HTTP.URL)
+}
+
+func TestHandlers_ResourceUpdateExhaustedConflictReturnsConflict(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		resource string
+		object   client.Object
+		body     map[string]any
+		register func(*fiber.App, *Handlers)
+	}{
+		{
+			name:     "provider",
+			path:     "/providers/openai",
+			resource: "providers",
+			object: &corev1alpha1.Provider{
+				ObjectMeta: metav1.ObjectMeta{Name: "openai", Namespace: "default"},
+				Spec: corev1alpha1.ProviderSpec{
+					Type:         corev1alpha1.ProviderTypeOpenAI,
+					DefaultModel: "gpt-4o-mini",
+				},
+			},
+			body: map[string]any{
+				"spec": map[string]any{"type": "openai", "defaultModel": "gpt-4.1"},
+			},
+			register: func(app *fiber.App, handlers *Handlers) {
+				app.Put("/providers/:name", handlers.UpdateProvider)
+			},
+		},
+		{
+			name:     "tool",
+			path:     "/tools/http-tool",
+			resource: "tools",
+			object: &corev1alpha1.Tool{
+				ObjectMeta: metav1.ObjectMeta{Name: "http-tool", Namespace: "default"},
+				Spec: corev1alpha1.ToolSpec{
+					Description: "original",
+					HTTP:        &corev1alpha1.HTTPExecution{URL: "https://example.com/original"},
+				},
+			},
+			body: map[string]any{
+				"spec": map[string]any{
+					"description": "updated",
+					"http":        map[string]any{"url": "https://example.com/updated"},
+				},
+			},
+			register: func(app *fiber.App, handlers *Handlers) {
+				app.Put("/tools/:name", handlers.UpdateTool)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, corev1alpha1.AddToScheme(scheme))
+
+			updateCalls := 0
+			kubeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.object).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Update: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.UpdateOption) error {
+						updateCalls++
+						return apierrors.NewConflict(
+							schema.GroupResource{Group: corev1alpha1.GroupVersion.Group, Resource: tt.resource},
+							obj.GetName(),
+							errors.New("resource remains busy"),
+						)
+					},
+				}).
+				Build()
+			reader := &recordingResourceReader{Reader: kubeClient}
+			handlers := NewHandlers(HandlersConfig{Client: kubeClient, APIReader: reader})
+			app := fiber.New()
+			tt.register(app, handlers)
+
+			resp := testJSONRequest(t, app, http.MethodPut, tt.path, tt.body)
+			require.Equal(t, http.StatusConflict, resp.StatusCode)
+			require.Greater(t, updateCalls, 1)
+			require.Equal(t, updateCalls, reader.getCalls)
+		})
+	}
 }
 
 func TestHandlers_SubstrateActorPoolCRUD(t *testing.T) {


### PR DESCRIPTION
## Summary

- retry Provider and Tool updates from fresh reads after Kubernetes resourceVersion conflicts
- preserve protected fields and reject concurrent spec edits instead of overwriting them
- return HTTP 409 for exhausted conflicts and add deterministic regression coverage

## Verification

- `go test ./internal/api/ -run 'TestHandlers_(UpdateProvider|UpdateTool|ResourceUpdate)' -count=1 -v`\n- `make lint-fix`\n- `make test`\n- `autoreview` clean\n\nCloses #379