### PR TITLE
fix(harness): synchronize CLI wrapper persistence with shutdown

### DIFF
--- a/workers/harness/cliwrapper/server.go
+++ b/workers/harness/cliwrapper/server.go
@@ -58,6 +58,7 @@ type Server struct {
 	configuredExactRedactionValues []string
 
 	turnRegistry *turnRegistry
+	ledgerMu     sync.RWMutex
 	ledger       *ledger.Ledger
 
 	healthMu           sync.RWMutex
@@ -182,7 +183,12 @@ func (s *Server) reclaimSettledTurns(ctx context.Context) error {
 // Close releases the durable wrapper admission ledger. The HTTP server must be
 // stopped before calling Close.
 func (s *Server) Close() error {
-	if s == nil || s.ledger == nil {
+	if s == nil {
+		return nil
+	}
+	s.ledgerMu.Lock()
+	defer s.ledgerMu.Unlock()
+	if s.ledger == nil {
 		return nil
 	}
 	err := s.ledger.Close()
@@ -231,6 +237,17 @@ func (s *Server) finishTurn(turn *turnState) {
 	if !s.childCredentialProcessesHealthy() {
 		return
 	}
+	if !s.persistTurnTerminal(turn) {
+		return
+	}
+	turn.close()
+	s.turnRegistry.finishActive()
+	s.scheduleTurnEviction(turn)
+}
+
+func (s *Server) persistTurnTerminal(turn *turnState) bool {
+	s.ledgerMu.RLock()
+	defer s.ledgerMu.RUnlock()
 	if s.ledger != nil {
 		receipt, outcomeUnknown := s.durableTerminalReceipt(turn)
 		var durableOutput *ledger.TurnOutput
@@ -241,7 +258,7 @@ func (s *Server) finishTurn(turn *turnState) {
 					err = errors.New("terminal output payload is missing")
 				}
 				s.setTerminalLedgerError(err)
-				return
+				return false
 			}
 			durableOutput = &ledger.TurnOutput{Ref: localOutputRef, Data: data}
 		}
@@ -253,13 +270,11 @@ func (s *Server) finishTurn(turn *turnState) {
 			// unhealthy readiness response surfaces the failure without leaking
 			// ledger details; an operator can restart into conservative recovery.
 			s.setTerminalLedgerError(err)
-			return
+			return false
 		}
 		s.setTerminalLedgerError(nil)
 	}
-	turn.close()
-	s.turnRegistry.finishActive()
-	s.scheduleTurnEviction(turn)
+	return true
 }
 
 func (s *Server) markDurableTurnAccepted(ctx context.Context, turn *turnState) error {

--- a/workers/harness/cliwrapper/server_test.go
+++ b/workers/harness/cliwrapper/server_test.go
@@ -139,6 +139,93 @@ func TestServerReceiptPersistenceFailureRetainsTurnAndClosesReadiness(t *testing
 	}
 }
 
+func TestServerCloseWaitsForTerminalReceiptPersistence(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.AllowUnauthenticated = true
+	cfg.AdmissionLedgerPath = filepath.Join(t.TempDir(), "admission-ledger.db")
+	server, err := NewServer(cfg, NewFakeAdapter(FakeBehaviorSuccess))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	request := validWrapperStartTurnRequest()
+	durable, err := validateDurableTurnAdmission(request)
+	if err != nil {
+		t.Fatalf("validate durable admission: %v", err)
+	}
+	if _, _, err := server.ledger.AdmitTurn(
+		context.Background(), string(request.TurnID), durable.taskUID, durable.attempt, durable.requestDigest,
+		string(request.RuntimeSessionID), request.CorrelationID,
+	); err != nil {
+		t.Fatalf("admit durable turn: %v", err)
+	}
+	if err := server.ledger.MarkTurnAccepted(context.Background(), string(request.TurnID)); err != nil {
+		t.Fatalf("mark durable turn accepted: %v", err)
+	}
+	turn, err := server.turnRegistry.admit(request, server.now)
+	if err != nil {
+		t.Fatalf("admit active turn: %v", err)
+	}
+	turn.appendFrame(server.frame(
+		turn, harness.FrameTurnCompleted, "turn completed", &harness.TurnCompleted{Result: "ok"},
+	))
+
+	turn.mu.Lock()
+	turnLocked := true
+	defer func() {
+		if turnLocked {
+			turn.mu.Unlock()
+		}
+	}()
+	finishDone := make(chan struct{})
+	go func() {
+		defer close(finishDone)
+		server.finishTurn(turn)
+	}()
+	eventually(t, 2*time.Second, func() bool {
+		if server.ledgerMu.TryLock() {
+			server.ledgerMu.Unlock()
+			return false
+		}
+		return true
+	})
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- server.Close()
+	}()
+	eventually(t, 2*time.Second, func() bool {
+		if server.ledgerMu.TryRLock() {
+			server.ledgerMu.RUnlock()
+			return false
+		}
+		return true
+	})
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close completed before terminal persistence was released: %v", err)
+	default:
+	}
+
+	turn.mu.Unlock()
+	turnLocked = false
+	select {
+	case <-finishDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("finishTurn did not complete after terminal persistence was released")
+	}
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not complete after terminal persistence finished")
+	}
+	if server.ledger != nil {
+		t.Fatal("Close retained the admission ledger")
+	}
+}
+
 func TestServerAcceptanceFailureReconcilesAdmissionWithIndependentContext(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.AllowUnauthenticated = true


### PR DESCRIPTION
## Summary

- prevent detached `finishTurn` persistence from racing `Server.Close` as it closes the SQLite admission ledger
- guard the ledger lifecycle through terminal receipt and output persistence
- preserve persistence failure behavior and add deterministic coverage proving `Close` waits

## Verification

- `go test ./workers/harness/cliwrapper -run '^TestServerCloseWaitsForTerminalReceiptPersistence$' -count=1 -v`
- `go test -race ./workers/harness/cliwrapper -run '^TestServerCloseWaitsForTerminalReceiptPersistence$' -count=20`
- `go test -race ./workers/harness/cliwrapper -count=1`
- `make lint`
- canonical autoreview completed with no actionable findings

`make test` passes `workers/harness/cliwrapper`; the repository run currently fails in untouched `internal/tools` because `TestCodeExecTool_Execute_Node` receives empty output instead of `node-test\n`.

Closes #443
