### PR TITLE
fix(security): make scan task ingestion durable

### DIFF
--- a/internal/controller/repositoryscan_controller.go
+++ b/internal/controller/repositoryscan_controller.go
@@ -1836,6 +1836,12 @@ func (r *RepositoryScanReconciler) refreshScanRunStatus(
 	scanID string,
 	updateStatus bool,
 ) error {
+	if terminalScanRunPhase(run.Phase) {
+		if updateStatus && r.Client != nil {
+			return r.publishScanRunStatus(ctx, scan, run)
+		}
+		return nil
+	}
 	if r.Client == nil {
 		if run.ErrorMessage != "" {
 			run.Phase = scanRunPhaseFailed
@@ -1887,6 +1893,10 @@ func (r *RepositoryScanReconciler) refreshScanRunStatus(
 		return nil
 	}
 
+	return r.publishScanRunStatus(ctx, scan, run)
+}
+
+func (r *RepositoryScanReconciler) publishScanRunStatus(ctx context.Context, scan *corev1alpha1.RepositoryScan, run *store.ScanRun) error {
 	counts, err := r.SecurityStore.GetFindingCounts(ctx, scan.Namespace, scan.Name)
 	if err != nil {
 		return err
@@ -1970,13 +1980,16 @@ func (r *RepositoryScanReconciler) keepScanRunningForPendingReviewSlices(
 	if err != nil {
 		return err
 	}
-	if len(reviewSlices) == 0 {
+	// Kubernetes success precedes ingestion. In particular, the mapper may not
+	// have persisted any slices yet when all Tasks are first observed terminal.
+	pending := max(len(reviewSlices), progress.reviewCount-run.ReviewedSliceCount)
+	if pending == 0 {
 		return nil
 	}
 	run.Phase = scanRunPhaseRunning
 	run.CompletedAt = nil
 	run.ErrorMessage = ""
-	run.Summary = fmt.Sprintf("Threat model generated; %d review slices remain pending", len(reviewSlices))
+	run.Summary = fmt.Sprintf("Threat model generated; %d review slices remain pending", pending)
 	return nil
 }
 
@@ -2105,7 +2118,16 @@ func (r *RepositoryScanReconciler) createValidationTask(ctx context.Context, sca
 		return err
 	}
 	if err := r.Create(ctx, task); err != nil {
-		return err
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		existing := &corev1alpha1.Task{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(task), existing); err != nil {
+			return err
+		}
+		if !matchingRepositoryScanTask(existing, task) {
+			return fmt.Errorf("%w: validation Task does not match the recorded scan finding", store.ErrConflict)
+		}
 	}
 
 	finding.ValidationStatus = findingValidationStatusPending
@@ -3001,14 +3023,14 @@ func (r *RepositoryScanReconciler) persistDroppedFindingDiagnostics(
 	task *corev1alpha1.Task,
 	run *store.ScanRun,
 	diagnostics []security.DroppedFindingDiagnostic,
-) error {
+) (string, error) {
 	if len(diagnostics) == 0 {
-		return nil
+		return "", nil
 	}
 	sliceID := strings.TrimSpace(task.Labels[labels.LabelSecuritySliceID])
 	for _, diagnostic := range diagnostics {
 		dropped := &store.DroppedFinding{
-			ID:             "drop_" + security.FindingID(strings.Join([]string{run.ID, task.Name, sliceID, fmt.Sprint(diagnostic.Index), diagnostic.Reason}, "|")),
+			ID:             "drop_" + security.FindingID(strings.Join([]string{run.ID, task.Name, string(task.UID), sliceID, fmt.Sprint(diagnostic.Index), diagnostic.Reason}, "|")),
 			Namespace:      scan.Namespace,
 			RepositoryScan: scan.Name,
 			ScanRunID:      run.ID,
@@ -3019,23 +3041,15 @@ func (r *RepositoryScanReconciler) persistDroppedFindingDiagnostics(
 			SampleJSON:     security.DroppedFindingSampleJSON(diagnostic),
 		}
 		if err := r.SecurityStore.CreateDroppedFinding(ctx, dropped); err != nil {
-			return err
+			return "", err
 		}
 	}
-	if r.ArtifactStore != nil {
-		artifact := security.DroppedFindingArtifact{
-			SchemaVersion: 1,
-			Dropped:       diagnostics,
-		}
-		data, err := json.MarshalIndent(artifact, "", "  ")
-		if err != nil {
-			return err
-		}
-		if err := r.ArtifactStore.SaveArtifact(ctx, task.Namespace, task.Name, security.ArtifactDroppedFindings, "application/json", data); err != nil {
-			return err
-		}
+	artifact := security.DroppedFindingArtifact{SchemaVersion: 1, Dropped: diagnostics}
+	data, err := json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		return "", err
 	}
-	return nil
+	return string(data), nil
 }
 
 func (r *RepositoryScanReconciler) validationTaskCountForScanRun(ctx context.Context, scan *corev1alpha1.RepositoryScan, scanRunID string) (int, error) {
@@ -3134,11 +3148,10 @@ func clearReviewRunError(run *store.ScanRun, sliceID string) {
 }
 
 func (r *RepositoryScanReconciler) ingestThreatModelTask(ctx context.Context, scan *corev1alpha1.RepositoryScan, task *corev1alpha1.Task, run *store.ScanRun) error {
-	run.TaskName = task.Name
-	if mode := task.Labels[labels.LabelSecurityMode]; mode != "" {
-		run.Mode = mode
+	if terminalScanRunPhase(run.Phase) {
+		return nil
 	}
-
+	var threatModel, failure string
 	if task.Status.Phase == corev1alpha1.TaskPhaseSucceeded {
 		if err := r.ensureActiveScanRunPolicyCurrent(ctx, scan, run); err != nil {
 			return err
@@ -3147,35 +3160,40 @@ func (r *RepositoryScanReconciler) ingestThreatModelTask(ctx context.Context, sc
 		if err != nil {
 			return err
 		}
-		var threatModel string
 		if validationProblem == "" {
 			threatModel, err = security.ParseThreatModelResult(result, security.AgentResultBinding{
-				RepositoryScan: scan.Name,
-				ScanID:         run.ID,
-				PolicyDigest:   run.PolicyDigest,
+				RepositoryScan: scan.Name, ScanID: run.ID, PolicyDigest: run.PolicyDigest,
 			})
 			if err != nil {
 				validationProblem = err.Error()
 			}
 		}
-		if validationProblem == "" {
-			if err := r.persistThreatModelIfChanged(ctx, scan, run.ID, run.StartedAt, threatModel); err != nil {
-				return err
-			}
-			clearThreatModelRunError(run)
-			run.Summary = scanSummaryThreatModelPending
-		} else {
-			run.ErrorMessage = "threat model terminal result is missing or invalid: " + validationProblem
+		if validationProblem != "" {
+			failure = "threat model terminal result is missing or invalid: " + validationProblem
 		}
 	} else {
-		run.ErrorMessage = r.pipelineTaskFailureSummary(ctx, task)
+		failure = r.pipelineTaskFailureSummary(ctx, task)
 	}
-
-	return r.refreshScanRunStatus(ctx, scan, run, run.ID, false)
+	return r.applyScanTaskIngestion(ctx, scan, task, run, func(tx *RepositoryScanReconciler, current *store.ScanRun, _ *store.ScanTaskIngestion) error {
+		current.TaskName = task.Name
+		if mode := task.Labels[labels.LabelSecurityMode]; mode != "" {
+			current.Mode = mode
+		}
+		if failure != "" {
+			current.ErrorMessage = failure
+			return nil
+		}
+		if err := tx.persistThreatModelIfChanged(ctx, scan, current.ID, current.StartedAt, threatModel); err != nil {
+			return err
+		}
+		clearThreatModelRunError(current)
+		current.Summary = scanSummaryThreatModelPending
+		return nil
+	})
 }
 
 func (r *RepositoryScanReconciler) ingestReviewTask(ctx context.Context, scan *corev1alpha1.RepositoryScan, task *corev1alpha1.Task, run *store.ScanRun) error {
-	if run.Phase == scanRunPhaseFailed {
+	if terminalScanRunPhase(run.Phase) {
 		return nil
 	}
 	sliceID := strings.TrimSpace(task.Labels[labels.LabelSecuritySliceID])
@@ -3194,16 +3212,16 @@ func (r *RepositoryScanReconciler) ingestReviewTask(ctx context.Context, scan *c
 	if !validAttempt ||
 		(attempt == securityReviewRetryAttempt && task.Name != retryTaskName) ||
 		(attempt == securityReviewInitialAttempt && task.Name == retryTaskName) {
-		return r.failReviewTask(ctx, scan, run, sliceID, "invalid security review attempt identity")
+		return r.failReviewTask(ctx, scan, task, run, sliceID, "invalid security review attempt identity")
 	}
 
 	if task.Status.Phase != corev1alpha1.TaskPhaseSucceeded {
-		return r.failReviewTask(ctx, scan, run, sliceID, r.pipelineTaskFailureSummary(ctx, task))
+		return r.failReviewTask(ctx, scan, task, run, sliceID, r.pipelineTaskFailureSummary(ctx, task))
 	}
 
 	trustedRepository, targetProblem := trustedFindingsRepositoryForRunTask(scan, run, task)
 	if targetProblem != "" {
-		return r.failReviewTask(ctx, scan, run, sliceID, targetProblem)
+		return r.failReviewTask(ctx, scan, task, run, sliceID, targetProblem)
 	}
 	manifest, findingsV2, validationProblem, retryableResult, err := r.validateReviewTaskResult(ctx, scan, task, run, reviewSlice, sliceID, trustedRepository)
 	if err != nil {
@@ -3216,18 +3234,20 @@ func (r *RepositoryScanReconciler) ingestReviewTask(ctx context.Context, scan *c
 				return retryErr
 			}
 			if retried {
-				run.Phase = scanRunPhaseRunning
-				run.CompletedAt = nil
-				run.ErrorMessage = ""
-				run.Summary = fmt.Sprintf("Retrying review slice %s after an invalid terminal result", sliceID)
-				return r.SecurityStore.UpdateScanRun(ctx, run)
+				return r.applyScanTaskIngestion(ctx, scan, task, run, func(_ *RepositoryScanReconciler, current *store.ScanRun, _ *store.ScanTaskIngestion) error {
+					current.Phase = scanRunPhaseRunning
+					current.CompletedAt = nil
+					current.ErrorMessage = ""
+					current.Summary = fmt.Sprintf("Retrying review slice %s after an invalid terminal result", sliceID)
+					return nil
+				})
 			}
 		}
 		message := validationProblem
 		if sliceID != "" {
 			message = fmt.Sprintf("slice %s: %s", sliceID, validationProblem)
 		}
-		return r.failReviewTask(ctx, scan, run, sliceID, message)
+		return r.failReviewTask(ctx, scan, task, run, sliceID, message)
 	}
 
 	clearReviewRunError(run, sliceID)
@@ -3250,55 +3270,67 @@ func (r *RepositoryScanReconciler) ingestReviewTask(ctx context.Context, scan *c
 	})
 	partition.Accepted = filterResult.Kept
 	partition.Dropped = append(partition.Dropped, filterResult.Dropped...)
-	var capDrops []security.DroppedFindingDiagnostic
-	partition.Accepted, capDrops = capAcceptedFindingsForRun(scan, run, partition.Accepted)
-	partition.Dropped = append(partition.Dropped, capDrops...)
-	if err := r.persistDroppedFindingDiagnostics(ctx, scan, task, run, partition.Dropped); err != nil {
-		return err
-	}
-	run.AcceptedFindings += len(partition.Accepted)
-	run.DroppedFindings += len(partition.Dropped)
-	run.ReviewedSliceCount++
-	if findingsV2.Scan.Summary != "" {
-		run.Summary = findingsV2.Scan.Summary
-	} else if sliceID != "" {
-		run.Summary = fmt.Sprintf("Reviewed slice %s", sliceID)
-	}
-	upserted := make([]*store.Finding, 0, len(partition.Accepted))
-	for _, finding := range partition.Accepted {
-		if err := r.mergeExistingFindingForTarget(ctx, scan, trustedRepository, finding); err != nil {
+	return r.applyScanTaskIngestion(ctx, scan, task, run, func(tx *RepositoryScanReconciler, current *store.ScanRun, ingestion *store.ScanTaskIngestion) error {
+		// Recheck ownership inside the transaction. A failed or missing slice
+		// update must roll back findings, diagnostics, counters, and the receipt.
+		owned, err := tx.SecurityStore.GetReviewSlice(ctx, scan.Namespace, scan.Name, sliceID)
+		if err != nil {
 			return err
 		}
-		if err := r.SecurityStore.UpsertObservedFinding(ctx, finding); err != nil {
+		if owned.LastScanRunID != current.ID || owned.ReviewContextHash != reviewSlice.ReviewContextHash {
+			return fmt.Errorf("%w: review slice ownership or context changed before ingestion", store.ErrConflict)
+		}
+		if owned.Status == reviewSliceStatusReviewed {
+			return nil
+		}
+		if err := tx.SecurityStore.UpdateReviewSliceStatus(ctx, scan.Namespace, scan.Name, sliceID, current.ID, reviewSliceStatusReviewed); err != nil {
 			return err
 		}
-		upserted = append(upserted, finding)
-	}
-	if err := r.enqueueAutoValidationTasks(ctx, scan, upserted); err != nil {
-		return err
-	}
-	if sliceID != "" {
-		if err := r.SecurityStore.UpdateReviewSliceStatus(ctx, scan.Namespace, scan.Name, sliceID, run.ID, reviewSliceStatusReviewed); err != nil && !errors.Is(err, store.ErrNotFound) {
+		accepted, capDrops := capAcceptedFindingsForRun(scan, current, partition.Accepted)
+		dropped := append(partition.Dropped, capDrops...)
+		ingestion.DroppedFindingsJSON, err = tx.persistDroppedFindingDiagnostics(ctx, scan, task, current, dropped)
+		if err != nil {
 			return err
 		}
-	}
-	return r.refreshScanRunStatus(ctx, scan, run, run.ID, false)
+		for _, finding := range accepted {
+			if err := tx.mergeExistingFindingForTarget(ctx, scan, trustedRepository, finding); err != nil {
+				return err
+			}
+			if err := tx.SecurityStore.UpsertObservedFinding(ctx, finding); err != nil {
+				return err
+			}
+			ingestion.FindingIDs = append(ingestion.FindingIDs, finding.ID)
+		}
+		clearReviewRunError(current, sliceID)
+		current.AcceptedFindings += len(accepted)
+		current.DroppedFindings += len(dropped)
+		current.ReviewedSliceCount++
+		current.Summary = findingsV2.Scan.Summary
+		if current.Summary == "" {
+			current.Summary = fmt.Sprintf("Reviewed slice %s", sliceID)
+		}
+		ingestion.Completed = false
+		return nil
+	})
 }
 
 func (r *RepositoryScanReconciler) failReviewTask(
 	ctx context.Context,
 	scan *corev1alpha1.RepositoryScan,
+	task *corev1alpha1.Task,
 	run *store.ScanRun,
 	sliceID string,
 	message string,
 ) error {
-	run.ErrorMessage = message
-	if sliceID != "" {
-		if err := r.SecurityStore.UpdateReviewSliceStatus(ctx, scan.Namespace, scan.Name, sliceID, run.ID, reviewSliceStatusFailed); err != nil && !errors.Is(err, store.ErrNotFound) {
-			return err
+	return r.applyScanTaskIngestion(ctx, scan, task, run, func(tx *RepositoryScanReconciler, current *store.ScanRun, _ *store.ScanTaskIngestion) error {
+		if sliceID != "" {
+			if err := tx.SecurityStore.UpdateReviewSliceStatus(ctx, scan.Namespace, scan.Name, sliceID, current.ID, reviewSliceStatusFailed); err != nil {
+				return err
+			}
 		}
-	}
-	return r.refreshScanRunStatus(ctx, scan, run, run.ID, false)
+		current.ErrorMessage = message
+		return nil
+	})
 }
 
 func (r *RepositoryScanReconciler) validateReviewTaskResult(
@@ -3447,6 +3479,13 @@ func reviewResultRetryEligible(
 }
 
 func matchingReviewRetryTask(existing, desired *corev1alpha1.Task) bool {
+	if existing == nil || existing.Annotations[labels.AnnotationSecurityReviewAttempt] != strconv.Itoa(securityReviewRetryAttempt) {
+		return false
+	}
+	return matchingRepositoryScanTask(existing, desired)
+}
+
+func matchingRepositoryScanTask(existing, desired *corev1alpha1.Task) bool {
 	if existing == nil || desired == nil || existing.Namespace != desired.Namespace || existing.Name != desired.Name {
 		return false
 	}
@@ -3454,9 +3493,6 @@ func matchingReviewRetryTask(existing, desired *corev1alpha1.Task) bool {
 		if existing.Labels[key] != value {
 			return false
 		}
-	}
-	if existing.Annotations[labels.AnnotationSecurityReviewAttempt] != strconv.Itoa(securityReviewRetryAttempt) {
-		return false
 	}
 	existingOwner := metav1.GetControllerOf(existing)
 	desiredOwner := metav1.GetControllerOf(desired)
@@ -3521,9 +3557,6 @@ func (r *RepositoryScanReconciler) reviewSliceForTaskRun(
 		return nil, false, nil
 	}
 	reviewSlice, err := r.SecurityStore.GetReviewSlice(ctx, scan.Namespace, scan.Name, sliceID)
-	if errors.Is(err, store.ErrNotFound) {
-		return nil, false, nil
-	}
 	if err != nil {
 		return nil, false, err
 	}
@@ -3534,95 +3567,102 @@ func (r *RepositoryScanReconciler) reviewSliceForTaskRun(
 }
 
 func (r *RepositoryScanReconciler) ingestMapperTask(ctx context.Context, scan *corev1alpha1.RepositoryScan, task *corev1alpha1.Task, run *store.ScanRun) error {
-	if run.Phase == scanRunPhaseFailed {
+	if terminalScanRunPhase(run.Phase) {
 		return nil
 	}
-	if task.Status.Phase == corev1alpha1.TaskPhaseSucceeded {
-		artifact, validationProblem, err := r.loadReviewSlicesArtifact(ctx, task)
+	fail := func(message string) error {
+		return r.applyScanTaskIngestion(ctx, scan, task, run, func(_ *RepositoryScanReconciler, current *store.ScanRun, _ *store.ScanTaskIngestion) error {
+			current.ErrorMessage = message
+			return nil
+		})
+	}
+	if task.Status.Phase != corev1alpha1.TaskPhaseSucceeded {
+		return fail(r.pipelineTaskFailureSummary(ctx, task))
+	}
+	artifact, validationProblem, err := r.loadReviewSlicesArtifact(ctx, task)
+	if err != nil {
+		return err
+	}
+	if validationProblem != "" {
+		return fail("mapper stage failed: " + validationProblem)
+	}
+	if artifact == nil {
+		return fail("mapper stage failed: " + repositoryScanArtifactStoreNotConfigured)
+	}
+	changedFiles := changedFileSet(artifact.ChangedFiles)
+	incrementalSelection := run.Mode == scanModeIncremental && artifact.ChangedFilesComputed
+	annotateChangedMetadata := artifact.ChangedFilesComputed && (run.Mode == scanModeIncremental || run.Mode == scanModeManual)
+	skippedSlices := 0
+	preparedSlices := make([]store.ReviewSlice, 0, len(artifact.Slices))
+	for i := range artifact.Slices {
+		slice := artifact.Slices[i]
+		slice.Namespace = scan.Namespace
+		slice.RepositoryScan = scan.Name
+		slice.LastScanRunID = run.ID
+		if annotateChangedMetadata {
+			attachChangedMetadataToReviewSlice(&slice, artifact.ChangedFiles, artifact.ChangedLineRanges)
+		}
+		if incrementalSelection {
+			if reviewSliceMatchesChangedFiles(slice, changedFiles) {
+				slice.Status = reviewSliceStatusPending
+			} else {
+				slice.Status = reviewSliceStatusSkipped
+				skippedSlices++
+			}
+		}
+		contextJSON, contextHash, contextProblem, err := r.loadMapperReviewContext(ctx, task, slice.ID)
 		if err != nil {
 			return err
 		}
-		if validationProblem != "" {
-			run.ErrorMessage = "mapper stage failed: " + validationProblem
-		} else if artifact != nil {
-			changedFiles := changedFileSet(artifact.ChangedFiles)
-			incrementalSelection := run.Mode == scanModeIncremental && artifact.ChangedFilesComputed
-			annotateChangedMetadata := artifact.ChangedFilesComputed && (run.Mode == scanModeIncremental || run.Mode == scanModeManual)
-			skippedSlices := 0
-			preparedSlices := make([]store.ReviewSlice, 0, len(artifact.Slices))
-			for i := range artifact.Slices {
-				slice := artifact.Slices[i]
-				slice.Namespace = scan.Namespace
-				slice.RepositoryScan = scan.Name
-				slice.LastScanRunID = run.ID
-				if annotateChangedMetadata {
-					attachChangedMetadataToReviewSlice(&slice, artifact.ChangedFiles, artifact.ChangedLineRanges)
-				}
-				if incrementalSelection {
-					if reviewSliceMatchesChangedFiles(slice, changedFiles) {
-						slice.Status = reviewSliceStatusPending
-					} else {
-						slice.Status = reviewSliceStatusSkipped
-						skippedSlices++
-					}
-				}
-				contextJSON, contextHash, contextProblem, err := r.loadMapperReviewContext(ctx, task, slice.ID)
-				if err != nil {
-					return err
-				}
-				if contextProblem != "" {
-					run.ErrorMessage = "mapper stage failed: " + contextProblem
-					return r.refreshScanRunStatus(ctx, scan, run, run.ID, false)
-				}
-				slice.ReviewContextJSON = contextJSON
-				slice.ReviewContextHash = contextHash
-				preparedSlices = append(preparedSlices, slice)
+		if contextProblem != "" {
+			return fail("mapper stage failed: " + contextProblem)
+		}
+		slice.ReviewContextJSON = contextJSON
+		slice.ReviewContextHash = contextHash
+		preparedSlices = append(preparedSlices, slice)
+	}
+	return r.applyScanTaskIngestion(ctx, scan, task, run, func(tx *RepositoryScanReconciler, current *store.ScanRun, _ *store.ScanTaskIngestion) error {
+		for i := range preparedSlices {
+			slice := &preparedSlices[i]
+			if err := tx.preserveCurrentRunReviewSliceTerminalState(ctx, scan, slice); err != nil {
+				return err
 			}
-			for i := range preparedSlices {
-				slice := &preparedSlices[i]
-				if err := r.preserveCurrentRunReviewSliceTerminalState(ctx, scan, slice); err != nil {
-					return err
-				}
-				if err := r.SecurityStore.UpsertReviewSlice(ctx, slice); err != nil {
-					return err
-				}
-			}
-			clearRunError(run)
-			if artifact.BaseCommit != "" {
-				run.BaseCommit = artifact.BaseCommit
-			}
-			if artifact.HeadCommit != "" {
-				run.HeadCommit = artifact.HeadCommit
-			}
-			if run.PolicyDigest == "" {
-				run.PolicyDigest = security.ScannerPolicyDigest(security.ScannerPolicy{})
-			}
-			if run.IdempotencyKey == "" {
-				run.IdempotencyKey = security.ScanRunIdempotencyKey(scan.Namespace, scan.Name, run.Mode, run.BaseCommit, run.HeadCommit, scan.Spec.SubPath, run.PolicyDigest)
-			}
-			run.SliceCount = len(artifact.Slices)
-			run.SkippedSliceCount = skippedSlices
-			switch {
-			case incrementalSelection && skippedSlices == len(artifact.Slices):
-				run.Summary = fmt.Sprintf("Threat model generated; no review slices matched %d changed files", len(artifact.ChangedFiles))
-			case incrementalSelection:
-				run.Summary = fmt.Sprintf(
-					"Threat model generated; deterministic mapper selected %d/%d review slices from %d changed files",
-					len(artifact.Slices)-skippedSlices,
-					len(artifact.Slices),
-					len(artifact.ChangedFiles),
-				)
-			case run.Mode == scanModeIncremental && artifact.ChangedFilesError != "":
-				run.Summary = fmt.Sprintf("Threat model generated; deterministic mapper produced %d review slices after changed-file selection failed", len(artifact.Slices))
-			default:
-				run.Summary = fmt.Sprintf("Threat model generated; deterministic mapper produced %d review slices", len(artifact.Slices))
+			if err := tx.SecurityStore.UpsertReviewSlice(ctx, slice); err != nil {
+				return err
 			}
 		}
-	} else {
-		run.ErrorMessage = r.pipelineTaskFailureSummary(ctx, task)
-	}
-
-	return r.refreshScanRunStatus(ctx, scan, run, run.ID, false)
+		clearRunError(current)
+		if artifact.BaseCommit != "" {
+			current.BaseCommit = artifact.BaseCommit
+		}
+		if artifact.HeadCommit != "" {
+			current.HeadCommit = artifact.HeadCommit
+		}
+		if current.PolicyDigest == "" {
+			current.PolicyDigest = security.ScannerPolicyDigest(security.ScannerPolicy{})
+		}
+		if current.IdempotencyKey == "" {
+			current.IdempotencyKey = security.ScanRunIdempotencyKey(scan.Namespace, scan.Name, current.Mode, current.BaseCommit, current.HeadCommit, scan.Spec.SubPath, current.PolicyDigest)
+		}
+		current.SliceCount = len(artifact.Slices)
+		current.SkippedSliceCount = skippedSlices
+		switch {
+		case incrementalSelection && skippedSlices == len(artifact.Slices):
+			current.Summary = fmt.Sprintf("Threat model generated; no review slices matched %d changed files", len(artifact.ChangedFiles))
+		case incrementalSelection:
+			current.Summary = fmt.Sprintf(
+				"Threat model generated; deterministic mapper selected %d/%d review slices from %d changed files",
+				len(artifact.Slices)-skippedSlices,
+				len(artifact.Slices),
+				len(artifact.ChangedFiles),
+			)
+		case current.Mode == scanModeIncremental && artifact.ChangedFilesError != "":
+			current.Summary = fmt.Sprintf("Threat model generated; deterministic mapper produced %d review slices after changed-file selection failed", len(artifact.Slices))
+		default:
+			current.Summary = fmt.Sprintf("Threat model generated; deterministic mapper produced %d review slices", len(artifact.Slices))
+		}
+		return nil
+	})
 }
 
 func (r *RepositoryScanReconciler) preserveCurrentRunReviewSliceTerminalState(ctx context.Context, scan *corev1alpha1.RepositoryScan, slice *store.ReviewSlice) error {
@@ -3657,6 +3697,18 @@ func (r *RepositoryScanReconciler) ingestScanTask(ctx context.Context, scan *cor
 	run, err := r.getOrCreateScanRun(ctx, scan, task)
 	if err != nil {
 		return err
+	}
+
+	identity := scanTaskIngestionIdentity(scan, task)
+	ingestion, err := r.SecurityStore.GetScanTaskIngestion(ctx, identity)
+	if err == nil {
+		return r.finishScanTaskIngestion(ctx, scan, ingestion)
+	}
+	if !errors.Is(err, store.ErrNotFound) {
+		return err
+	}
+	if terminalScanRunPhase(run.Phase) {
+		return nil
 	}
 
 	switch taskSecurityStage(task) {

--- a/internal/controller/repositoryscan_controller.go
+++ b/internal/controller/repositoryscan_controller.go
@@ -2024,9 +2024,9 @@ func (r *RepositoryScanReconciler) shouldAutoValidateFinding(scan *corev1alpha1.
 	}
 }
 
-func (r *RepositoryScanReconciler) hasActiveValidationTask(ctx context.Context, scan *corev1alpha1.RepositoryScan, findingID, scanRunID string) (bool, error) {
+func (r *RepositoryScanReconciler) validationTaskForFinding(ctx context.Context, scan *corev1alpha1.RepositoryScan, findingID, scanRunID string) (*corev1alpha1.Task, error) {
 	if r.Client == nil {
-		return false, nil
+		return nil, nil
 	}
 	selector := map[string]string{
 		labels.LabelSecurityTarget:    labels.SelectorValue(scan.Name),
@@ -2041,17 +2041,19 @@ func (r *RepositoryScanReconciler) hasActiveValidationTask(ctx context.Context, 
 		client.InNamespace(scan.Namespace),
 		client.MatchingLabels(selector),
 	); err != nil {
-		return false, err
+		return nil, err
 	}
+	var latest *corev1alpha1.Task
 	for i := range tasks.Items {
-		if isActiveTaskPhase(tasks.Items[i].Status.Phase) {
-			return true, nil
+		task := &tasks.Items[i]
+		if latest == nil || latest.CreationTimestamp.Before(&task.CreationTimestamp) {
+			latest = task
 		}
 	}
-	return false, nil
+	return latest, nil
 }
 
-func (r *RepositoryScanReconciler) createValidationTask(ctx context.Context, scan *corev1alpha1.RepositoryScan, finding *store.Finding) error {
+func (r *RepositoryScanReconciler) ensureValidationTask(ctx context.Context, scan *corev1alpha1.RepositoryScan, finding *store.Finding, existing *corev1alpha1.Task) error {
 	if r.Client == nil {
 		return nil
 	}
@@ -2080,11 +2082,7 @@ func (r *RepositoryScanReconciler) createValidationTask(ctx context.Context, sca
 	}
 	timeout := metav1.Duration{Duration: 90 * time.Minute}
 	priority := int32(725)
-	taskScope := finding.ID
-	if scanRunID := strings.TrimSpace(finding.ScanRunID); scanRunID != "" {
-		taskScope += "-" + scanRunID
-	}
-	taskName := security.ScanStageTaskName(scan.Name, "validation", security.StageValidation, taskScope)
+	taskName := security.AutoValidationTaskName(scan.Name, finding.ID, finding.ScanRunID)
 	resultBinding := security.AgentResultBinding{
 		RepositoryScan: scan.Name,
 		ScanID:         finding.ScanRunID,
@@ -2117,17 +2115,23 @@ func (r *RepositoryScanReconciler) createValidationTask(ctx context.Context, sca
 	if err := controllerutil.SetControllerReference(scan, task, r.Scheme); err != nil {
 		return err
 	}
-	if err := r.Create(ctx, task); err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return err
+	if existing != nil {
+		// Recover older timestamp-named Tasks and manually requested validation
+		// for this occurrence using the same identity and spec checks.
+		task.Name = existing.Name
+	} else {
+		if err := r.Create(ctx, task); err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+			existing = &corev1alpha1.Task{}
+			if err := r.Get(ctx, client.ObjectKeyFromObject(task), existing); err != nil {
+				return err
+			}
 		}
-		existing := &corev1alpha1.Task{}
-		if err := r.Get(ctx, client.ObjectKeyFromObject(task), existing); err != nil {
-			return err
-		}
-		if !matchingRepositoryScanTask(existing, task) {
-			return fmt.Errorf("%w: validation Task does not match the recorded scan finding", store.ErrConflict)
-		}
+	}
+	if existing != nil && !matchingRepositoryScanTask(existing, task) {
+		return fmt.Errorf("%w: validation Task does not match the recorded scan finding", store.ErrConflict)
 	}
 
 	finding.ValidationStatus = findingValidationStatusPending
@@ -3073,7 +3077,8 @@ func (r *RepositoryScanReconciler) validationTaskCountForScanRun(ctx context.Con
 func (r *RepositoryScanReconciler) enqueueAutoValidationTasks(ctx context.Context, scan *corev1alpha1.RepositoryScan, findings []*store.Finding) error {
 	createdByRun := map[string]int{}
 	for _, finding := range findings {
-		if finding == nil {
+		if finding == nil || finding.ValidationStatus == findingValidationStatusValidated ||
+			finding.ValidationStatus == findingValidationStatusPending {
 			continue
 		}
 		created, ok := createdByRun[finding.ScanRunID]
@@ -3083,27 +3088,23 @@ func (r *RepositoryScanReconciler) enqueueAutoValidationTasks(ctx context.Contex
 				return err
 			}
 			created = existing
-		}
-		if !r.shouldAutoValidateFinding(scan, finding, created) {
 			createdByRun[finding.ScanRunID] = created
-			continue
 		}
-		if finding.ValidationStatus == findingValidationStatusValidated ||
-			finding.ValidationStatus == findingValidationStatusPending {
-			continue
-		}
-		active, err := r.hasActiveValidationTask(ctx, scan, finding.ID, finding.ScanRunID)
+		existing, err := r.validationTaskForFinding(ctx, scan, finding.ID, finding.ScanRunID)
 		if err != nil {
 			return err
 		}
-		if active {
+		// Creation may have succeeded before its response or the finding update
+		// was lost. Recover it in any phase, even if it already consumed the cap.
+		if existing == nil && !r.shouldAutoValidateFinding(scan, finding, created) {
 			continue
 		}
-		if err := r.createValidationTask(ctx, scan, finding); err != nil {
+		if err := r.ensureValidationTask(ctx, scan, finding, existing); err != nil {
 			return err
 		}
-		created++
-		createdByRun[finding.ScanRunID] = created
+		if existing == nil {
+			createdByRun[finding.ScanRunID] = created + 1
+		}
 	}
 	return nil
 }
@@ -3503,7 +3504,23 @@ func matchingRepositoryScanTask(existing, desired *corev1alpha1.Task) bool {
 		existingOwner.UID != desiredOwner.UID {
 		return false
 	}
-	return apiequality.Semantic.DeepEqual(existing.Spec, desired.Spec)
+	return apiequality.Semantic.DeepEqual(comparableRepositoryScanTaskSpec(existing.Spec), comparableRepositoryScanTaskSpec(desired.Spec))
+}
+
+func comparableRepositoryScanTaskSpec(spec corev1alpha1.TaskSpec) corev1alpha1.TaskSpec {
+	// Admission owns provenance. Scheduler defaults do not affect these
+	// unscheduled Tasks; retain every execution field for the comparison.
+	spec.RequestedBy = nil
+	spec.Transaction = nil
+	if spec.Schedule == "" {
+		spec.TimeZone = nil
+		spec.ConcurrencyPolicy = ""
+		spec.StartingDeadlineSeconds = nil
+		spec.SuccessfulRunsHistoryLimit = nil
+		spec.FailedRunsHistoryLimit = nil
+		spec.Suspend = nil
+	}
+	return spec
 }
 
 func capAcceptedFindingsForRun(scan *corev1alpha1.RepositoryScan, run *store.ScanRun, accepted []*store.Finding) ([]*store.Finding, []security.DroppedFindingDiagnostic) {

--- a/internal/controller/repositoryscan_controller_test.go
+++ b/internal/controller/repositoryscan_controller_test.go
@@ -5976,8 +5976,8 @@ func TestRepositoryScanPolicyDigestDriftFailsValidationTaskCreationWithoutRequeu
 	}
 	finding := &storepkg.Finding{ID: "finding_policy", Namespace: defaultNS, RepositoryScan: "kaset", ScanRunID: run.ID, Severity: "high", Confidence: "high"}
 
-	if err := reconciler.createValidationTask(ctx, scan, finding); err == nil || !strings.Contains(err.Error(), "scanner policy digest changed") {
-		t.Fatalf("createValidationTask() error = %v, want policy drift propagated", err)
+	if err := reconciler.ensureValidationTask(ctx, scan, finding, nil); err == nil || !strings.Contains(err.Error(), "scanner policy digest changed") {
+		t.Fatalf("ensureValidationTask() error = %v, want policy drift propagated", err)
 	}
 	storedRun, err := store.GetScanRun(ctx, defaultNS, run.ID)
 	if err != nil {

--- a/internal/controller/repositoryscan_ingestion.go
+++ b/internal/controller/repositoryscan_ingestion.go
@@ -1,0 +1,104 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+	"github.com/orka-agents/orka/internal/labels"
+	"github.com/orka-agents/orka/internal/security"
+	"github.com/orka-agents/orka/internal/store"
+)
+
+func scanTaskIngestionIdentity(scan *corev1alpha1.RepositoryScan, task *corev1alpha1.Task) store.ScanTaskIdentity {
+	return store.ScanTaskIdentity{
+		Namespace: scan.Namespace, RepositoryScan: scan.Name, ScanRunID: scanTaskRunID(task),
+		TaskName: task.Name, TaskUID: string(task.UID), Stage: taskSecurityStage(task),
+		SliceID: strings.TrimSpace(task.Labels[labels.LabelSecuritySliceID]),
+	}
+}
+
+func terminalScanRunPhase(phase string) bool {
+	return phase == scanRunPhaseSucceeded || phase == scanRunPhaseFailed
+}
+
+func (r *RepositoryScanReconciler) applyScanTaskIngestion(
+	ctx context.Context, scan *corev1alpha1.RepositoryScan, task *corev1alpha1.Task, run *store.ScanRun,
+	apply func(*RepositoryScanReconciler, *store.ScanRun, *store.ScanTaskIngestion) error,
+) error {
+	ingestion := &store.ScanTaskIngestion{ScanTaskIdentity: scanTaskIngestionIdentity(scan, task), Completed: true}
+	applied, err := r.SecurityStore.ApplyScanTaskIngestion(ctx, ingestion, func(tx store.SecurityStore, current *store.ScanRun) error {
+		transactional := *r
+		transactional.SecurityStore = tx
+		if current.PolicyDigest == "" {
+			current.PolicyDigest = run.PolicyDigest
+		}
+		if err := apply(&transactional, current, ingestion); err != nil {
+			return err
+		}
+		if current.ErrorMessage != "" {
+			current.Phase = scanRunPhaseFailed
+			current.Summary = current.ErrorMessage
+			if current.CompletedAt == nil && task.Status.CompletionTime != nil {
+				completed := task.Status.CompletionTime.Time
+				current.CompletedAt = &completed
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	current, err := r.SecurityStore.GetScanRun(ctx, scan.Namespace, run.ID)
+	if err != nil {
+		return err
+	}
+	*run = *current
+	log.FromContext(ctx).V(1).Info("Reconciled scan Task ingestion",
+		"task", task.Name, "taskUID", task.UID, "recordedRun", ingestion.ScanRunID,
+		"selectedRun", run.ID, "stage", ingestion.Stage, "slice", ingestion.SliceID,
+		"applied", applied, "reviewed", run.ReviewedSliceCount,
+		"accepted", run.AcceptedFindings, "dropped", run.DroppedFindings)
+	if applied {
+		if err := r.finishScanTaskIngestion(ctx, scan, ingestion); err != nil {
+			return err
+		}
+	}
+	return r.refreshScanRunStatus(ctx, scan, run, run.ID, false)
+}
+
+// SQLite results commit before Kubernetes validation Tasks or diagnostic
+// artifacts are published. A pending receipt retries only that follow-up work.
+func (r *RepositoryScanReconciler) finishScanTaskIngestion(ctx context.Context, scan *corev1alpha1.RepositoryScan, ingestion *store.ScanTaskIngestion) error {
+	if ingestion.Completed {
+		return nil
+	}
+	if ingestion.DroppedFindingsJSON != "" && r.ArtifactStore != nil {
+		if err := r.ArtifactStore.SaveArtifact(ctx, ingestion.Namespace, ingestion.TaskName,
+			security.ArtifactDroppedFindings, "application/json", []byte(ingestion.DroppedFindingsJSON)); err != nil {
+			return err
+		}
+	}
+	findings := make([]*store.Finding, 0, len(ingestion.FindingIDs))
+	for _, id := range ingestion.FindingIDs {
+		finding, err := r.SecurityStore.GetFinding(ctx, ingestion.Namespace, id)
+		if errors.Is(err, store.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		// A later scan may already have observed this canonical finding.
+		if finding.RepositoryScan == ingestion.RepositoryScan && finding.ScanRunID == ingestion.ScanRunID {
+			finding.ScanTaskName = ingestion.TaskName
+			findings = append(findings, finding)
+		}
+	}
+	if err := r.enqueueAutoValidationTasks(ctx, scan, findings); err != nil {
+		return err
+	}
+	return r.SecurityStore.CompleteScanTaskIngestion(ctx, ingestion.ScanTaskIdentity)
+}

--- a/internal/controller/repositoryscan_ingestion_test.go
+++ b/internal/controller/repositoryscan_ingestion_test.go
@@ -1,0 +1,406 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+	"github.com/orka-agents/orka/internal/labels"
+	"github.com/orka-agents/orka/internal/security"
+	"github.com/orka-agents/orka/internal/store"
+	sqlitestore "github.com/orka-agents/orka/internal/store/sqlite"
+)
+
+// Exercise the real collection order: retained threat-model, mapper, and review
+// Tasks from the first run precede the same stages from the next run. The old
+// mapper used to reclaim shared slices, letting both runs count reviews again.
+func TestRepositoryScanRetainedPipelineTasks(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "scans.db")
+	db, err := sqlitestore.NewDB(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	s := sqlitestore.NewStore(db, path)
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1alpha1.AddToScheme(scheme))
+	scan := &corev1alpha1.RepositoryScan{
+		ObjectMeta: metav1.ObjectMeta{Name: "kaset", Namespace: defaultNS, UID: "scan-uid"},
+		Spec: corev1alpha1.RepositoryScanSpec{
+			RepoURL: "https://github.com/example/repo", ValidationMode: "off",
+			MaxFindingsPerRun: new(int32(14)), Suspend: new(true),
+		},
+		Status: corev1alpha1.RepositoryScanStatus{Phase: repositoryScanPhaseScanning},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&corev1alpha1.RepositoryScan{}, &corev1alpha1.Task{}).
+		WithObjects(scan).Build()
+	r := &RepositoryScanReconciler{Client: cl, Scheme: scheme, SecurityStore: s, ArtifactStore: s, ResultStore: s}
+	reconcile := func() {
+		t.Helper()
+		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(scan)})
+		require.NoError(t, err)
+	}
+	completedRuns := map[string]*store.ScanRun{}
+	for runIndex := range 2 {
+		runID := fmt.Sprintf("scan_retained_%d", runIndex)
+		started := time.Now().UTC().Add(time.Duration(runIndex-1) * time.Hour)
+		tasks := seedRetainedScanPipeline(t, s, cl, scan, runID, started, 14)
+		finishScanTask(t, cl, tasks[0])
+		finishScanTask(t, cl, tasks[1])
+		reconcile()
+		// Keep the last review active while terminal Tasks are reconciled again.
+		for _, task := range tasks[2 : len(tasks)-1] {
+			finishScanTask(t, cl, task)
+		}
+		reconcile()
+		before, err := s.GetScanRun(ctx, defaultNS, runID)
+		require.NoError(t, err)
+		require.Equal(t, scanRunPhaseRunning, before.Phase, "run: %#v", before)
+		require.Equal(t, 13, before.ReviewedSliceCount)
+		for repeat := range 3 {
+			reconcile()
+			after, err := s.GetScanRun(ctx, defaultNS, runID)
+			require.NoError(t, err)
+			require.Equal(t, before.ReviewedSliceCount, after.ReviewedSliceCount, "run %s changed on replay %d", runID, repeat)
+			require.Equal(t, before.AcceptedFindings, after.AcceptedFindings)
+			require.Equal(t, before.DroppedFindings, after.DroppedFindings)
+			for oldID, oldRun := range completedRuns {
+				got, err := s.GetScanRun(ctx, defaultNS, oldID)
+				require.NoError(t, err)
+				require.Equal(t, oldRun, got, "retained Tasks changed completed run %s", oldID)
+			}
+		}
+		finishScanTask(t, cl, tasks[len(tasks)-1])
+		reconcile()
+		run, err := s.GetScanRun(ctx, defaultNS, runID)
+		require.NoError(t, err)
+		require.Equal(t, scanRunPhaseSucceeded, run.Phase)
+		require.Equal(t, 14, run.SliceCount)
+		require.Equal(t, 14, run.ReviewedSliceCount)
+		require.Equal(t, 14, run.AcceptedFindings)
+		require.Equal(t, 14, run.DroppedFindings)
+		completedRuns[runID] = run
+		dropped, _, err := s.ListDroppedFindings(ctx, store.DroppedFindingFilter{
+			Namespace: defaultNS, RepositoryScan: scan.Name, ScanRunID: runID, Limit: 100,
+		})
+		require.NoError(t, err)
+		require.Len(t, dropped, 14)
+		findings, _, err := s.ListFindings(ctx, store.FindingFilter{Namespace: defaultNS, RepositoryScan: scan.Name, Limit: 100})
+		require.NoError(t, err)
+		require.Len(t, findings, 14)
+		for _, finding := range findings {
+			require.Equal(t, runID, finding.ScanRunID)
+		}
+		reviewSlices, _, err := s.ListReviewSlices(ctx, store.ReviewSliceFilter{Namespace: defaultNS, RepositoryScan: scan.Name, Limit: 100})
+		require.NoError(t, err)
+		for _, slice := range reviewSlices {
+			require.Equal(t, runID, slice.LastScanRunID)
+			require.Equal(t, reviewSliceStatusReviewed, slice.Status)
+		}
+		model, err := s.GetLatestThreatModel(ctx, defaultNS, scan.Name)
+		require.NoError(t, err)
+		require.Equal(t, runID, model.GeneratedByScan)
+		for _, task := range tasks {
+			receipt, err := s.GetScanTaskIngestion(ctx, scanTaskIngestionIdentity(scan, task))
+			require.NoError(t, err)
+			require.True(t, receipt.Completed)
+		}
+		// Reopen SQLite and rebuild the reconciler, retaining the same Tasks.
+		require.NoError(t, db.Close())
+		db, err = sqlitestore.NewDB(path)
+		require.NoError(t, err)
+		s = sqlitestore.NewStore(db, path)
+		r = &RepositoryScanReconciler{Client: cl, Scheme: scheme, SecurityStore: s, ArtifactStore: s, ResultStore: s}
+		reconcile()
+		got, err := s.GetScanRun(ctx, defaultNS, runID)
+		require.NoError(t, err)
+		require.Equal(t, run, got, "restart changed completed ingestion")
+		gotModel, err := s.GetLatestThreatModel(ctx, defaultNS, scan.Name)
+		require.NoError(t, err)
+		require.Equal(t, model, gotModel)
+		gotFindings, _, err := s.ListFindings(ctx, store.FindingFilter{Namespace: defaultNS, RepositoryScan: scan.Name, Limit: 100})
+		require.NoError(t, err)
+		require.Equal(t, findings, gotFindings)
+		gotDropped, _, err := s.ListDroppedFindings(ctx, store.DroppedFindingFilter{Namespace: defaultNS, RepositoryScan: scan.Name, ScanRunID: runID, Limit: 100})
+		require.NoError(t, err)
+		require.Equal(t, dropped, gotDropped)
+		gotSlices, _, err := s.ListReviewSlices(ctx, store.ReviewSliceFilter{Namespace: defaultNS, RepositoryScan: scan.Name, Limit: 100})
+		require.NoError(t, err)
+		require.Equal(t, reviewSlices, gotSlices)
+		var retained corev1alpha1.TaskList
+		require.NoError(t, cl.List(ctx, &retained))
+		require.Len(t, retained.Items, (runIndex+1)*16, "ingestion must not delete retained Tasks")
+	}
+	// Task history cleanup can remove old Tasks and their artifacts without
+	// deleting ingestion receipts or changing the completed run history.
+	var oldTasks corev1alpha1.TaskList
+	require.NoError(t, cl.List(ctx, &oldTasks, client.MatchingLabels{labels.LabelSecurityScanID: "scan_retained_0"}))
+	for i := range oldTasks.Items {
+		task := &oldTasks.Items[i]
+		require.NoError(t, cl.Delete(ctx, task))
+		require.NoError(t, s.DeleteResult(ctx, task.Namespace, task.Name))
+		require.NoError(t, s.DeleteArtifacts(ctx, task.Namespace, task.Name))
+	}
+	reconcile()
+	for id, before := range completedRuns {
+		after, err := s.GetScanRun(ctx, defaultNS, id)
+		require.NoError(t, err)
+		require.Equal(t, before, after)
+	}
+}
+
+func TestRepositoryScanIngestsTerminalPipelineOnRestart(t *testing.T) {
+	ctx := context.Background()
+	s := setupControllerSQLiteStore(t)
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1alpha1.AddToScheme(scheme))
+	scan := &corev1alpha1.RepositoryScan{
+		ObjectMeta: metav1.ObjectMeta{Name: "kaset", Namespace: defaultNS, UID: "scan-uid"},
+		Spec:       corev1alpha1.RepositoryScanSpec{RepoURL: "https://github.com/example/repo", ValidationMode: "off", Suspend: new(true)},
+		Status:     corev1alpha1.RepositoryScanStatus{Phase: repositoryScanPhaseScanning},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&corev1alpha1.RepositoryScan{}, &corev1alpha1.Task{}).WithObjects(scan).Build()
+	tasks := seedRetainedScanPipeline(t, s, cl, scan, "scan_restart", time.Now().UTC(), 2)
+	for _, task := range tasks {
+		finishScanTask(t, cl, task)
+	}
+	r := &RepositoryScanReconciler{Client: cl, Scheme: scheme, SecurityStore: s, ResultStore: s, ArtifactStore: s}
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(scan)})
+	require.NoError(t, err)
+	run, err := s.GetScanRun(ctx, defaultNS, "scan_restart")
+	require.NoError(t, err)
+	require.Equal(t, scanRunPhaseSucceeded, run.Phase)
+	require.Equal(t, 2, run.ReviewedSliceCount)
+	require.Equal(t, 2, run.AcceptedFindings)
+	require.Equal(t, 2, run.DroppedFindings)
+}
+
+func seedRetainedScanPipeline(t *testing.T, s *sqlitestore.Store, cl client.Client, scan *corev1alpha1.RepositoryScan, runID string, started time.Time, sliceCount int) []*corev1alpha1.Task {
+	t.Helper()
+	ctx := context.Background()
+	policyDigest := security.ScannerPolicyDigest(security.ScannerPolicy{})
+	run := &store.ScanRun{ID: runID, Namespace: scan.Namespace, RepositoryScan: scan.Name,
+		Mode: scanModeManual, Phase: scanRunPhaseRunning, PolicyDigest: policyDigest, StartedAt: started,
+		HeadCommit: "head-" + runID}
+	require.NoError(t, s.CreateScanRun(ctx, run))
+	newTask := func(stage, sliceID string, index int) *corev1alpha1.Task {
+		name := security.ScanStageTaskName(scan.Name, runID, stage, sliceID)
+		return &corev1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: scan.Namespace, UID: types.UID(name + "-uid"),
+				CreationTimestamp: metav1.NewTime(started.Add(time.Duration(index) * time.Second)),
+				Labels: map[string]string{
+					labels.LabelSecurityTarget: scan.Name, labels.LabelSecurityScanID: runID,
+					labels.LabelSecurityStage: stage, labels.LabelSecuritySliceID: sliceID, labels.LabelSecurityMode: scanModeManual,
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: corev1alpha1.GroupVersion.String(), Kind: "RepositoryScan", Name: scan.Name, UID: scan.UID, Controller: new(true)}},
+			},
+			Spec:   corev1alpha1.TaskSpec{Workspace: repositoryScanTaskWorkspace(scan, corev1alpha1.WorkspaceIntentRead)},
+			Status: corev1alpha1.TaskStatus{Phase: corev1alpha1.TaskPhaseRunning, ResultRef: &corev1alpha1.ResultReference{Available: true}},
+		}
+	}
+	threatTask := newTask(security.StageThreatModel, "", 0)
+	mapperTask := newTask(security.StageMapper, "", 1)
+	threatResult, err := json.Marshal(security.ThreatModelResultEnvelope{
+		SchemaVersion: security.AgentResultSchemaVersion, Kind: security.AgentResultKindThreatModel,
+		RepositoryScan: scan.Name, ScanID: runID, PolicyDigest: policyDigest, ThreatModel: "# Threat model for " + runID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, s.SaveResult(ctx, scan.Namespace, threatTask.Name, threatResult))
+	tasks := make([]*corev1alpha1.Task, 0, 2+sliceCount)
+	tasks = append(tasks, threatTask, mapperTask)
+	mapperArtifact := security.ReviewSlicesArtifact{SchemaVersion: security.SchemaVersionReviewSlices, HeadCommit: run.HeadCommit}
+	for i := range sliceCount {
+		sliceID := fmt.Sprintf("slice_%02d", i)
+		path := fmt.Sprintf("src/file_%02d.go", i)
+		slice := store.ReviewSlice{ID: sliceID, RepositoryScan: scan.Name, Source: "deterministic", Title: sliceID,
+			Kind: "package", Status: reviewSliceStatusPending, OwnedFiles: []store.ReviewSliceFile{{Path: path}}}
+		bindReviewSliceContext(t, &slice)
+		mapperArtifact.Slices = append(mapperArtifact.Slices, slice)
+		task := newTask(security.StageReview, sliceID, i+2)
+		findings := security.FindingsV2Artifact{
+			SchemaVersion: security.SchemaVersionFindingsV2,
+			Repository:    trustedFindingsRepository(scan, run),
+			Scan:          security.FindingsV2Scan{Mode: run.Mode, SliceID: sliceID},
+			Findings: []security.FindingsV2Finding{
+				{Title: "Authorization missing in " + path, Category: "authz", Severity: "high", Confidence: "high",
+					Summary: "The handler permits access to another user's data.", Remediation: "Check ownership.",
+					Evidence: []security.FindingsV2EvidenceRef{{Path: path, StartLine: 5, EndLine: 8}}},
+				{Title: "Unsubstantiated issue", Category: "authz", Severity: "high", Confidence: "low",
+					Summary: "Evidence is outside the review context.", Remediation: "Check ownership.",
+					Evidence: []security.FindingsV2EvidenceRef{{Path: "omitted.go", StartLine: 1, EndLine: 1}}},
+			},
+		}
+		saveFindingsTaskResult(t, s, task, scan.Name, runID, policyDigest, slice.ReviewContextHash, sliceID, findings)
+		tasks = append(tasks, task)
+	}
+	saveMapperArtifactWithContexts(t, s, mapperTask, mapperArtifact)
+	for _, task := range tasks {
+		require.NoError(t, cl.Create(ctx, task))
+	}
+	return tasks
+}
+
+func finishScanTask(t *testing.T, cl client.Client, task *corev1alpha1.Task) {
+	t.Helper()
+	task.Status.Phase = corev1alpha1.TaskPhaseSucceeded
+	completed := metav1.NewTime(task.CreationTimestamp.Add(time.Minute))
+	task.Status.CompletionTime = &completed
+	require.NoError(t, cl.Status().Update(context.Background(), task))
+}
+
+type scanIngestionFaultStore struct{ store.SecurityStore }
+
+func (s *scanIngestionFaultStore) ApplyScanTaskIngestion(ctx context.Context, receipt *store.ScanTaskIngestion, apply func(store.SecurityStore, *store.ScanRun) error) (bool, error) {
+	return s.SecurityStore.ApplyScanTaskIngestion(ctx, receipt, func(tx store.SecurityStore, run *store.ScanRun) error {
+		return apply(&scanIngestionFaultStore{SecurityStore: tx}, run)
+	})
+}
+
+func (s *scanIngestionFaultStore) UpdateReviewSliceStatus(context.Context, string, string, string, string, string) error {
+	return store.ErrNotFound
+}
+
+func TestReviewIngestionRequiresSliceUpdate(t *testing.T) {
+	for _, fault := range []string{"missing row", "unassigned row", "failed update"} {
+		t.Run(fault, func(t *testing.T) {
+			f := newReviewIngestionFixture(t)
+			switch fault {
+			case "missing row":
+				f.sourceTask.Labels[labels.LabelSecuritySliceID] = "missing"
+			case "unassigned row":
+				f.slice.LastScanRunID = ""
+				require.NoError(t, f.store.UpsertReviewSlice(f.ctx, f.slice))
+			case "failed update":
+				f.reconciler.SecurityStore = &scanIngestionFaultStore{SecurityStore: f.store}
+			}
+			err := f.reconciler.ingestScanTask(f.ctx, f.scan, f.sourceTask)
+			require.Error(t, err)
+			run, err := f.store.GetScanRun(f.ctx, defaultNS, f.run.ID)
+			require.NoError(t, err)
+			require.Zero(t, run.ReviewedSliceCount)
+			require.Zero(t, run.AcceptedFindings)
+			require.Zero(t, run.DroppedFindings)
+			findings, _, err := f.store.ListFindings(f.ctx, store.FindingFilter{Namespace: defaultNS, RepositoryScan: f.scan.Name})
+			require.NoError(t, err)
+			require.Empty(t, findings)
+			dropped, _, err := f.store.ListDroppedFindings(f.ctx, store.DroppedFindingFilter{Namespace: defaultNS, ScanRunID: f.run.ID})
+			require.NoError(t, err)
+			require.Empty(t, dropped)
+			_, err = f.store.GetScanTaskIngestion(f.ctx, scanTaskIngestionIdentity(f.scan, f.sourceTask))
+			require.ErrorIs(t, err, store.ErrNotFound)
+			// Repair the missing ownership/update and retry the same Task.
+			f.sourceTask.Labels[labels.LabelSecuritySliceID] = f.slice.ID
+			f.slice.LastScanRunID = f.run.ID
+			require.NoError(t, f.store.UpsertReviewSlice(f.ctx, f.slice))
+			f.reconciler.SecurityStore = f.store
+			require.NoError(t, f.reconciler.ingestScanTask(f.ctx, f.scan, f.sourceTask))
+			run, err = f.store.GetScanRun(f.ctx, defaultNS, f.run.ID)
+			require.NoError(t, err)
+			require.Equal(t, 1, run.ReviewedSliceCount)
+		})
+	}
+}
+
+var errScanIngestionFollowup = errors.New("injected scan follow-up failure")
+
+type failingScanArtifactStore struct{ store.ArtifactStore }
+
+func (s *failingScanArtifactStore) SaveArtifact(context.Context, string, string, string, string, []byte) error {
+	return errScanIngestionFollowup
+}
+
+type lostValidationCreateResponse struct{ client.Client }
+
+func (c *lostValidationCreateResponse) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if err := c.Client.Create(ctx, obj, opts...); err != nil {
+		return err
+	}
+	return errScanIngestionFollowup
+}
+
+func TestReviewIngestionResumesFollowupWithoutRecounting(t *testing.T) {
+	for _, fault := range []string{"artifact", "validation create response"} {
+		t.Run(fault, func(t *testing.T) {
+			f := newReviewIngestionFixture(t)
+			if fault == "artifact" {
+				f.reconciler.ArtifactStore = &failingScanArtifactStore{ArtifactStore: f.store}
+			} else {
+				f.scan.Spec.ValidationMode = "full"
+				f.reconciler.Client = &lostValidationCreateResponse{Client: f.client}
+			}
+			require.ErrorIs(t, f.reconciler.ingestScanTask(f.ctx, f.scan, f.sourceTask), errScanIngestionFollowup)
+			identity := scanTaskIngestionIdentity(f.scan, f.sourceTask)
+			receipt, err := f.store.GetScanTaskIngestion(f.ctx, identity)
+			require.NoError(t, err)
+			require.False(t, receipt.Completed)
+			before, err := f.store.GetScanRun(f.ctx, defaultNS, f.run.ID)
+			require.NoError(t, err)
+			require.Equal(t, 1, before.ReviewedSliceCount)
+			require.Equal(t, 1, before.AcceptedFindings)
+			require.Equal(t, 1, before.DroppedFindings)
+			// Recovery must use the receipt even when original Task results have
+			// already been cleaned up, or the source slice now has another owner.
+			require.NoError(t, f.store.DeleteResult(f.ctx, defaultNS, f.sourceTask.Name))
+			f.slice.LastScanRunID = "later-run"
+			require.NoError(t, f.store.UpsertReviewSlice(f.ctx, f.slice))
+			restarted := &RepositoryScanReconciler{Client: f.client, Scheme: f.reconciler.Scheme, SecurityStore: f.store, ArtifactStore: f.store}
+			for range 3 {
+				require.NoError(t, restarted.ingestScanTask(f.ctx, f.scan, f.sourceTask))
+			}
+			after, err := f.store.GetScanRun(f.ctx, defaultNS, f.run.ID)
+			require.NoError(t, err)
+			require.Equal(t, before, after)
+			receipt, err = f.store.GetScanTaskIngestion(f.ctx, identity)
+			require.NoError(t, err)
+			require.True(t, receipt.Completed)
+			dropped, _, err := f.store.ListDroppedFindings(f.ctx, store.DroppedFindingFilter{Namespace: defaultNS, ScanRunID: f.run.ID})
+			require.NoError(t, err)
+			require.Len(t, dropped, 1)
+			data, _, err := f.store.GetArtifact(f.ctx, defaultNS, f.sourceTask.Name, security.ArtifactDroppedFindings)
+			require.NoError(t, err)
+			require.JSONEq(t, receipt.DroppedFindingsJSON, string(data))
+			var tasks corev1alpha1.TaskList
+			require.NoError(t, f.client.List(f.ctx, &tasks, client.MatchingLabels{labels.LabelSecurityStage: security.StageValidation}))
+			if fault == "validation create response" {
+				require.Len(t, tasks.Items, 1)
+			} else {
+				require.Empty(t, tasks.Items)
+			}
+		})
+	}
+}
+
+func newReviewIngestionFixture(t *testing.T) *reviewResultRetryFixture {
+	t.Helper()
+	f := newReviewResultRetryFixture(t)
+	f.scan.Spec.ValidationMode = "off"
+	f.reconciler.ArtifactStore = f.store
+	findings := security.FindingsV2Artifact{
+		SchemaVersion: security.SchemaVersionFindingsV2, Repository: trustedFindingsRepository(f.scan, f.run),
+		Scan: security.FindingsV2Scan{Mode: f.run.Mode, SliceID: f.slice.ID},
+		Findings: []security.FindingsV2Finding{
+			{Title: "Missing authorization", Category: "authz", Severity: "high", Confidence: "high",
+				Summary: "The handler permits access to another user's data.", Remediation: "Check ownership.",
+				Evidence: []security.FindingsV2EvidenceRef{{Path: "internal/api/security.go", StartLine: 5, EndLine: 8}}},
+			{Title: "Unsubstantiated issue", Category: "authz", Severity: "high", Confidence: "low",
+				Summary: "Evidence is outside the review context.", Remediation: "Check ownership.",
+				Evidence: []security.FindingsV2EvidenceRef{{Path: "omitted.go", StartLine: 1, EndLine: 1}}},
+		},
+	}
+	saveFindingsTaskResult(t, f.store, f.sourceTask, f.scan.Name, f.run.ID, f.run.PolicyDigest, f.slice.ReviewContextHash, f.slice.ID, findings)
+	return f
+}

--- a/internal/controller/repositoryscan_ingestion_test.go
+++ b/internal/controller/repositoryscan_ingestion_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -323,30 +324,89 @@ func (s *failingScanArtifactStore) SaveArtifact(context.Context, string, string,
 	return errScanIngestionFollowup
 }
 
-type lostValidationCreateResponse struct{ client.Client }
+type lostValidationCreateResponse struct {
+	client.Client
+	legacyName bool
+}
 
 func (c *lostValidationCreateResponse) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if c.legacyName {
+		task := obj.(*corev1alpha1.Task)
+		task.Name = security.ScanStageTaskName(task.Labels[labels.LabelSecurityTarget], "validation", security.StageValidation,
+			task.Labels[labels.LabelSecurityFindingID]+"-"+task.Labels[labels.LabelSecurityScanID])
+	}
 	if err := c.Client.Create(ctx, obj, opts...); err != nil {
 		return err
 	}
 	return errScanIngestionFollowup
 }
 
+type missingValidationTaskList struct{ client.Client }
+
+func (c *missingValidationTaskList) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if err := c.Client.List(ctx, list, opts...); err != nil {
+		return err
+	}
+	if tasks, ok := list.(*corev1alpha1.TaskList); ok {
+		tasks.Items = slices.DeleteFunc(tasks.Items, func(task corev1alpha1.Task) bool {
+			return taskSecurityStage(&task) == security.StageValidation
+		})
+	}
+	return nil
+}
+
+func defaultRecoveredScanTask(task *corev1alpha1.Task) {
+	task.Spec.ConcurrencyPolicy = corev1alpha1.ForbidConcurrent
+	task.Spec.StartingDeadlineSeconds = new(int64(100))
+	task.Spec.SuccessfulRunsHistoryLimit = new(int32(3))
+	task.Spec.FailedRunsHistoryLimit = new(int32(1))
+	task.Spec.RequestedBy = &corev1alpha1.RequestedBy{Subject: "controller"}
+	task.Spec.Transaction = &corev1alpha1.TaskTransaction{ID: "test-transaction-metadata"}
+}
+
 func TestReviewIngestionResumesFollowupWithoutRecounting(t *testing.T) {
-	for _, fault := range []string{"artifact", "validation create response"} {
-		t.Run(fault, func(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		validationMode string
+		phase          corev1alpha1.TaskPhase
+		delayedCache   bool
+		legacyName     bool
+	}{
+		{name: "artifact"},
+		{name: "validation unobserved", validationMode: "full"},
+		{name: "validation pending", validationMode: "full", phase: corev1alpha1.TaskPhasePending},
+		{name: "validation running at cap", validationMode: "light", phase: corev1alpha1.TaskPhaseRunning},
+		{name: "validation succeeded at cap", validationMode: "light", phase: corev1alpha1.TaskPhaseSucceeded},
+		{name: "validation defaulted after delayed cache", validationMode: "full", phase: corev1alpha1.TaskPhaseSucceeded, delayedCache: true},
+		{name: "timestamp-named validation", validationMode: "full", phase: corev1alpha1.TaskPhasePending, legacyName: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
 			f := newReviewIngestionFixture(t)
-			if fault == "artifact" {
+			if tt.validationMode == "" {
 				f.reconciler.ArtifactStore = &failingScanArtifactStore{ArtifactStore: f.store}
 			} else {
-				f.scan.Spec.ValidationMode = "full"
-				f.reconciler.Client = &lostValidationCreateResponse{Client: f.client}
+				f.scan.Spec.ValidationMode = tt.validationMode
+				f.scan.Spec.ValidationMaxFindingsPerRun = new(int32(1))
+				f.reconciler.Client = &lostValidationCreateResponse{Client: f.client, legacyName: tt.legacyName}
 			}
 			require.ErrorIs(t, f.reconciler.ingestScanTask(f.ctx, f.scan, f.sourceTask), errScanIngestionFollowup)
 			identity := scanTaskIngestionIdentity(f.scan, f.sourceTask)
 			receipt, err := f.store.GetScanTaskIngestion(f.ctx, identity)
 			require.NoError(t, err)
 			require.False(t, receipt.Completed)
+			require.Len(t, receipt.FindingIDs, 1)
+			finding, err := f.store.GetFinding(f.ctx, defaultNS, receipt.FindingIDs[0])
+			require.NoError(t, err)
+			require.Equal(t, "unvalidated", finding.ValidationStatus)
+			if tt.validationMode != "" {
+				var tasks corev1alpha1.TaskList
+				require.NoError(t, f.client.List(f.ctx, &tasks, client.MatchingLabels{labels.LabelSecurityStage: security.StageValidation}))
+				require.Len(t, tasks.Items, 1)
+				task := &tasks.Items[0]
+				defaultRecoveredScanTask(task)
+				task.Status.Phase = tt.phase
+				require.NoError(t, f.client.Update(f.ctx, task))
+			}
 			before, err := f.store.GetScanRun(f.ctx, defaultNS, f.run.ID)
 			require.NoError(t, err)
 			require.Equal(t, 1, before.ReviewedSliceCount)
@@ -357,7 +417,13 @@ func TestReviewIngestionResumesFollowupWithoutRecounting(t *testing.T) {
 			require.NoError(t, f.store.DeleteResult(f.ctx, defaultNS, f.sourceTask.Name))
 			f.slice.LastScanRunID = "later-run"
 			require.NoError(t, f.store.UpsertReviewSlice(f.ctx, f.slice))
-			restarted := &RepositoryScanReconciler{Client: f.client, Scheme: f.reconciler.Scheme, SecurityStore: f.store, ArtifactStore: f.store}
+			restarted := &RepositoryScanReconciler{Client: f.client, Scheme: f.reconciler.Scheme, SecurityStore: f.store, ArtifactStore: f.store, ResultStore: f.store}
+			if tt.delayedCache {
+				// Lists can lag a successful creation. Retrying after the old
+				// timestamp name would change must still hit AlreadyExists.
+				restarted.Client = &missingValidationTaskList{Client: f.client}
+				time.Sleep(time.Second)
+			}
 			for range 3 {
 				require.NoError(t, restarted.ingestScanTask(f.ctx, f.scan, f.sourceTask))
 			}
@@ -375,11 +441,69 @@ func TestReviewIngestionResumesFollowupWithoutRecounting(t *testing.T) {
 			require.JSONEq(t, receipt.DroppedFindingsJSON, string(data))
 			var tasks corev1alpha1.TaskList
 			require.NoError(t, f.client.List(f.ctx, &tasks, client.MatchingLabels{labels.LabelSecurityStage: security.StageValidation}))
-			if fault == "validation create response" {
+			if tt.validationMode != "" {
 				require.Len(t, tasks.Items, 1)
+				finding, err = f.store.GetFinding(f.ctx, defaultNS, receipt.FindingIDs[0])
+				require.NoError(t, err)
+				require.Equal(t, findingValidationStatusPending, finding.ValidationStatus)
+				if tt.phase == corev1alpha1.TaskPhaseSucceeded {
+					task := &tasks.Items[0]
+					saveValidationTaskResult(t, f.store, task, f.scan.Name, f.run.ID, f.run.PolicyDigest, security.ValidationArtifact{
+						Version: 1, FindingID: finding.ID, Status: findingValidationStatusValidated,
+						Summary: "Confirmed missing ownership check", ValidationSteps: []string{"Trace the request to the handler"},
+						AttackPathAnalysis: "An authenticated caller supplies another user's record ID to the handler.",
+					})
+					require.NoError(t, restarted.ingestValidationTask(f.ctx, f.scan, task))
+					require.NoError(t, restarted.ingestScanTask(f.ctx, f.scan, f.sourceTask))
+					finding, err = f.store.GetFinding(f.ctx, defaultNS, finding.ID)
+					require.NoError(t, err)
+					require.Equal(t, findingValidationStatusValidated, finding.ValidationStatus)
+				}
 			} else {
 				require.Empty(t, tasks.Items)
 			}
+		})
+	}
+}
+
+func TestReviewIngestionRejectsConflictingValidationTask(t *testing.T) {
+	for name, mutate := range map[string]func(*corev1alpha1.Task){
+		"owner": func(task *corev1alpha1.Task) { task.OwnerReferences[0].UID = "another-scan" },
+		"run": func(task *corev1alpha1.Task) {
+			task.Labels[labels.LabelSecurityScanID] = "another-run"
+		},
+		"prompt":    func(task *corev1alpha1.Task) { task.Spec.Prompt = "different instructions" },
+		"workspace": func(task *corev1alpha1.Task) { task.Spec.Workspace.GitRepo = "https://github.com/example/other" },
+		"agent":     func(task *corev1alpha1.Task) { task.Spec.AgentRef.Name = "other-agent" },
+		"schedule":  func(task *corev1alpha1.Task) { task.Spec.Schedule = "0 * * * *" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := newReviewIngestionFixture(t)
+			f.scan.Spec.ValidationMode = "full"
+			f.reconciler.Client = &lostValidationCreateResponse{Client: f.client}
+			require.ErrorIs(t, f.reconciler.ingestScanTask(f.ctx, f.scan, f.sourceTask), errScanIngestionFollowup)
+			var tasks corev1alpha1.TaskList
+			require.NoError(t, f.client.List(f.ctx, &tasks, client.MatchingLabels{labels.LabelSecurityStage: security.StageValidation}))
+			require.Len(t, tasks.Items, 1)
+			task := &tasks.Items[0]
+			defaultRecoveredScanTask(task)
+			mutate(task)
+			require.NoError(t, f.client.Update(f.ctx, task))
+			before, err := f.store.GetScanRun(f.ctx, defaultNS, f.run.ID)
+			require.NoError(t, err)
+			f.reconciler.Client = f.client
+			require.ErrorIs(t, f.reconciler.ingestScanTask(f.ctx, f.scan, f.sourceTask), store.ErrConflict)
+			receipt, err := f.store.GetScanTaskIngestion(f.ctx, scanTaskIngestionIdentity(f.scan, f.sourceTask))
+			require.NoError(t, err)
+			require.False(t, receipt.Completed)
+			finding, err := f.store.GetFinding(f.ctx, defaultNS, receipt.FindingIDs[0])
+			require.NoError(t, err)
+			require.Equal(t, "unvalidated", finding.ValidationStatus)
+			after, err := f.store.GetScanRun(f.ctx, defaultNS, f.run.ID)
+			require.NoError(t, err)
+			require.Equal(t, before, after)
+			require.NoError(t, f.client.List(f.ctx, &tasks, client.MatchingLabels{labels.LabelSecurityStage: security.StageValidation}))
+			require.Len(t, tasks.Items, 1)
 		})
 	}
 }

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -357,6 +357,17 @@ func ScanStageRetryTaskName(repositoryScanName, scanRunID, stage, scope string, 
 	return boundedTaskName(parts...)
 }
 
+// AutoValidationTaskName binds automatic validation to one finding occurrence
+// so a delayed retry cannot create another Task after a lost creation response.
+func AutoValidationTaskName(repositoryScanName, findingID, scanRunID string) string {
+	return boundedTaskName(
+		sanitizeName(repositoryScanName),
+		"auto-validation",
+		sanitizeName(findingID),
+		sanitizeName(scanRunID),
+	)
+}
+
 // PatchTaskName returns a task name for a patch proposal bound to one finding
 // occurrence.
 func PatchTaskName(repositoryScanName, findingID, scanRunID string) string {

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -494,6 +494,7 @@ func TestGeneratedSecurityTaskNamesStayLabelSafe(t *testing.T) {
 		ScanStageTaskName(scanName, "initial", "discovery", "ci-cd-supply-chain"),
 		ScanStageTaskName(scanName, "initial", "discovery", "ci-cd-supply-chain-4"),
 		ScanStageRetryTaskName(scanName, "scan_1234567890abcdef", StageReview, "ci-cd-supply-chain", 1),
+		AutoValidationTaskName(scanName, "fnd_1234567890abcdef", "scan_1234567890abcdef"),
 		PatchTaskName(scanName, "fnd_1234567890abcdef", "scan_1234567890abcdef"),
 	}
 

--- a/internal/store/security_types.go
+++ b/internal/store/security_types.go
@@ -2,6 +2,27 @@ package store
 
 import "time"
 
+// ScanTaskIdentity binds ingestion to one Kubernetes Task incarnation and run.
+type ScanTaskIdentity struct {
+	Namespace      string
+	RepositoryScan string
+	ScanRunID      string
+	TaskName       string
+	TaskUID        string
+	Stage          string
+	SliceID        string
+}
+
+// ScanTaskIngestion is committed with the Task's results and run counters.
+// Follow-up work uses this receipt instead of parsing and counting results again.
+type ScanTaskIngestion struct {
+	ScanTaskIdentity
+	FindingIDs          []string
+	DroppedFindingsJSON string
+	Completed           bool
+	IngestedAt          time.Time
+}
+
 // ScanRun represents a single repository security scan execution.
 type ScanRun struct {
 	ID                   string     `json:"id"`

--- a/internal/store/sqlite/scan_task_ingestion.go
+++ b/internal/store/sqlite/scan_task_ingestion.go
@@ -1,0 +1,129 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/orka-agents/orka/internal/store"
+)
+
+type securityDB interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func (s *Store) securityDB() securityDB {
+	if s.securityTx != nil {
+		return s.securityTx
+	}
+	return s.db
+}
+
+func (s *Store) withSecurityTransaction(ctx context.Context, apply func(*Store) error) error {
+	if s.securityTx != nil {
+		return apply(s)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := apply(&Store{db: s.db, securityTx: tx}); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) GetScanTaskIngestion(ctx context.Context, task store.ScanTaskIdentity) (*store.ScanTaskIngestion, error) {
+	ingestion := &store.ScanTaskIngestion{ScanTaskIdentity: task}
+	var findingIDs string
+	err := s.securityDB().QueryRowContext(ctx, `SELECT repository_scan, stage, slice_id,
+		finding_ids_json, dropped_findings_json, completed, ingested_at
+		FROM security_scan_task_ingestions
+		WHERE namespace = ? AND scan_run_id = ? AND task_name = ? AND task_uid = ?`,
+		task.Namespace, task.ScanRunID, task.TaskName, task.TaskUID,
+	).Scan(&ingestion.RepositoryScan, &ingestion.Stage, &ingestion.SliceID,
+		&findingIDs, &ingestion.DroppedFindingsJSON, &ingestion.Completed, &ingestion.IngestedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if ingestion.ScanTaskIdentity != task {
+		return nil, fmt.Errorf("%w: scan Task ingestion identity changed", store.ErrConflict)
+	}
+	if err := unmarshalSecurityJSON(findingIDs, &ingestion.FindingIDs); err != nil {
+		return nil, err
+	}
+	return ingestion, nil
+}
+
+func (s *Store) ApplyScanTaskIngestion(ctx context.Context, ingestion *store.ScanTaskIngestion, apply func(store.SecurityStore, *store.ScanRun) error) (bool, error) {
+	if ingestion == nil || ingestion.Namespace == "" || ingestion.RepositoryScan == "" ||
+		ingestion.ScanRunID == "" || ingestion.TaskName == "" || ingestion.Stage == "" || apply == nil {
+		return false, store.ValidationErrorf("scan Task ingestion requires a run, Task identity, and apply callback")
+	}
+	applied := false
+	err := s.withSecurityTransaction(ctx, func(tx *Store) error {
+		if _, err := tx.GetScanTaskIngestion(ctx, ingestion.ScanTaskIdentity); err == nil {
+			return nil
+		} else if !errors.Is(err, store.ErrNotFound) {
+			return err
+		}
+		run, err := tx.GetScanRun(ctx, ingestion.Namespace, ingestion.ScanRunID)
+		if err != nil {
+			return err
+		}
+		if run.RepositoryScan != ingestion.RepositoryScan {
+			return fmt.Errorf("%w: scan Task belongs to a different RepositoryScan", store.ErrConflict)
+		}
+		if run.Phase == "succeeded" || run.Phase == "failed" {
+			return nil
+		}
+		if err := apply(tx, run); err != nil {
+			return err
+		}
+		if err := tx.UpdateScanRun(ctx, run); err != nil {
+			return err
+		}
+		findingIDs, err := marshalSecurityJSON(ingestion.FindingIDs)
+		if err != nil {
+			return err
+		}
+		ingestion.IngestedAt = time.Now().UTC()
+		if _, err := tx.securityDB().ExecContext(ctx, `INSERT INTO security_scan_task_ingestions
+			(namespace, repository_scan, scan_run_id, task_name, task_uid, stage, slice_id,
+			 finding_ids_json, dropped_findings_json, completed, ingested_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			ingestion.Namespace, ingestion.RepositoryScan, ingestion.ScanRunID, ingestion.TaskName,
+			ingestion.TaskUID, ingestion.Stage, ingestion.SliceID, findingIDs,
+			ingestion.DroppedFindingsJSON, ingestion.Completed, ingestion.IngestedAt); err != nil {
+			return err
+		}
+		applied = true
+		return nil
+	})
+	return applied && err == nil, err
+}
+
+func (s *Store) CompleteScanTaskIngestion(ctx context.Context, task store.ScanTaskIdentity) error {
+	result, err := s.securityDB().ExecContext(ctx, `UPDATE security_scan_task_ingestions SET completed = TRUE
+		WHERE namespace = ? AND scan_run_id = ? AND task_name = ? AND task_uid = ? AND repository_scan = ? AND stage = ? AND slice_id = ?`,
+		task.Namespace, task.ScanRunID, task.TaskName, task.TaskUID, task.RepositoryScan, task.Stage, task.SliceID)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}

--- a/internal/store/sqlite/scan_task_ingestion_test.go
+++ b/internal/store/sqlite/scan_task_ingestion_test.go
@@ -1,0 +1,171 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/orka-agents/orka/internal/store"
+)
+
+func TestScanTaskIngestionRollsBackAndRetries(t *testing.T) {
+	for _, failure := range []struct{ name, trigger string }{
+		{"finding", "BEFORE INSERT ON security_findings WHEN NEW.id = 'finding-2'"},
+		{"counters", "BEFORE UPDATE ON security_scan_runs"},
+		{"receipt", "BEFORE INSERT ON security_scan_task_ingestions"},
+	} {
+		t.Run(failure.name, func(t *testing.T) {
+			ctx := context.Background()
+			s := setupTestStore(t)
+			identity := store.ScanTaskIdentity{Namespace: "ns", RepositoryScan: "repo", ScanRunID: "run", TaskName: "review", TaskUID: "task-uid", Stage: "review", SliceID: "slice"}
+			run := &store.ScanRun{ID: identity.ScanRunID, Namespace: identity.Namespace, RepositoryScan: identity.RepositoryScan, Phase: "running"}
+			require.NoError(t, s.CreateScanRun(ctx, run))
+			slice := &store.ReviewSlice{Namespace: "ns", RepositoryScan: "repo", ID: "slice", LastScanRunID: "run", Status: "pending"}
+			require.NoError(t, s.UpsertReviewSlice(ctx, slice))
+			_, err := s.db.Exec("CREATE TRIGGER fail_ingestion " + failure.trigger + " BEGIN SELECT RAISE(ABORT, 'injected ingestion failure'); END")
+			require.NoError(t, err)
+			apply := func(tx store.SecurityStore, current *store.ScanRun) error {
+				if err := tx.SaveThreatModel(ctx, &store.ThreatModel{Namespace: "ns", RepositoryScan: "repo", Content: "# Model", GeneratedByScan: "run"}); err != nil {
+					return err
+				}
+				if err := tx.UpdateReviewSliceStatus(ctx, "ns", "repo", "slice", "run", "reviewed"); err != nil {
+					return err
+				}
+				if err := tx.CreateDroppedFinding(ctx, &store.DroppedFinding{ID: "drop", Namespace: "ns", RepositoryScan: "repo", ScanRunID: "run", TaskName: "review", Reason: "missing evidence"}); err != nil {
+					return err
+				}
+				for i := 1; i <= 2; i++ {
+					id := fmt.Sprintf("finding-%d", i)
+					if err := tx.UpsertObservedFinding(ctx, &store.Finding{ID: id, Namespace: "ns", RepositoryScan: "repo", ScanRunID: "run", Fingerprint: id}); err != nil {
+						return err
+					}
+				}
+				if err := tx.MarkFindingDuplicate(ctx, "ns", "finding-2", "finding-1"); err != nil {
+					return err
+				}
+				current.ReviewedSliceCount++
+				current.AcceptedFindings += 2
+				current.DroppedFindings++
+				return nil
+			}
+			applied, err := s.ApplyScanTaskIngestion(ctx, &store.ScanTaskIngestion{ScanTaskIdentity: identity}, apply)
+			require.ErrorContains(t, err, "injected ingestion failure")
+			require.False(t, applied)
+			gotRun, err := s.GetScanRun(ctx, "ns", "run")
+			require.NoError(t, err)
+			require.Equal(t, run, gotRun)
+			gotSlice, err := s.GetReviewSlice(ctx, "ns", "repo", "slice")
+			require.NoError(t, err)
+			require.Equal(t, slice, gotSlice)
+			findings, _, err := s.ListFindings(ctx, store.FindingFilter{Namespace: "ns", RepositoryScan: "repo", IncludeDuplicates: true})
+			require.NoError(t, err)
+			require.Empty(t, findings)
+			dropped, _, err := s.ListDroppedFindings(ctx, store.DroppedFindingFilter{Namespace: "ns", ScanRunID: "run"})
+			require.NoError(t, err)
+			require.Empty(t, dropped)
+			_, err = s.GetLatestThreatModel(ctx, "ns", "repo")
+			require.ErrorIs(t, err, store.ErrNotFound)
+			_, err = s.GetScanTaskIngestion(ctx, identity)
+			require.ErrorIs(t, err, store.ErrNotFound)
+
+			_, err = s.db.Exec("DROP TRIGGER fail_ingestion")
+			require.NoError(t, err)
+			ingestion := &store.ScanTaskIngestion{ScanTaskIdentity: identity, FindingIDs: []string{"finding-1"}, DroppedFindingsJSON: `{"schemaVersion":1,"dropped":[]}`}
+			applied, err = s.ApplyScanTaskIngestion(ctx, ingestion, apply)
+			require.NoError(t, err)
+			require.True(t, applied)
+			gotRun, err = s.GetScanRun(ctx, "ns", "run")
+			require.NoError(t, err)
+			require.Equal(t, 1, gotRun.ReviewedSliceCount)
+			require.Equal(t, 2, gotRun.AcceptedFindings)
+			require.Equal(t, 1, gotRun.DroppedFindings)
+			gotReceipt, err := s.GetScanTaskIngestion(ctx, identity)
+			require.NoError(t, err)
+			require.Equal(t, ingestion, gotReceipt)
+			model, err := s.GetLatestThreatModel(ctx, "ns", "repo")
+			require.NoError(t, err)
+			require.EqualValues(t, 1, model.Version)
+			alias, err := s.GetFinding(ctx, "ns", "finding-2")
+			require.NoError(t, err)
+			require.Equal(t, "finding-1", alias.DuplicateOf)
+
+			applied, err = s.ApplyScanTaskIngestion(ctx, ingestion, func(store.SecurityStore, *store.ScanRun) error {
+				t.Fatal("replay invoked result ingestion")
+				return nil
+			})
+			require.NoError(t, err)
+			require.False(t, applied)
+			require.NoError(t, s.CompleteScanTaskIngestion(ctx, identity))
+			gotReceipt, err = s.GetScanTaskIngestion(ctx, identity)
+			require.NoError(t, err)
+			require.True(t, gotReceipt.Completed)
+			require.Equal(t, ingestion.IngestedAt, gotReceipt.IngestedAt)
+		})
+	}
+}
+
+func TestScanTaskIngestionFencesRunAndTaskIdentity(t *testing.T) {
+	ctx := context.Background()
+	s := setupTestStore(t)
+	identity := store.ScanTaskIdentity{Namespace: "ns", RepositoryScan: "repo", ScanRunID: "run", TaskName: "mapper", TaskUID: "uid-1", Stage: "mapper"}
+	run := &store.ScanRun{ID: "run", Namespace: "ns", RepositoryScan: "repo", Phase: "running"}
+	require.NoError(t, s.CreateScanRun(ctx, run))
+	apply := func(_ store.SecurityStore, run *store.ScanRun) error { run.SliceCount++; return nil }
+	applied, err := s.ApplyScanTaskIngestion(ctx, &store.ScanTaskIngestion{ScanTaskIdentity: identity}, apply)
+	require.NoError(t, err)
+	require.True(t, applied)
+	changed := identity
+	changed.Stage = "review"
+	_, err = s.GetScanTaskIngestion(ctx, changed)
+	assertIngestionConflict := func(task store.ScanTaskIdentity) {
+		t.Helper()
+		applied, err := s.ApplyScanTaskIngestion(ctx, &store.ScanTaskIngestion{ScanTaskIdentity: task}, apply)
+		require.ErrorIs(t, err, store.ErrConflict)
+		require.False(t, applied)
+	}
+	require.ErrorIs(t, err, store.ErrConflict)
+	assertIngestionConflict(changed)
+	changed = identity
+	changed.TaskUID = "uid-2"
+	_, err = s.GetScanTaskIngestion(ctx, changed)
+	require.ErrorIs(t, err, store.ErrNotFound, "Task name reuse must not reuse the old receipt")
+	changed.RepositoryScan = "another-repo"
+	assertIngestionConflict(changed)
+	for _, phase := range []string{"succeeded", "failed"} {
+		run.Phase = phase
+		require.NoError(t, s.UpdateScanRun(ctx, run))
+		identity.TaskUID = "unseen-task"
+		applied, err := s.ApplyScanTaskIngestion(ctx, &store.ScanTaskIngestion{ScanTaskIdentity: identity}, func(store.SecurityStore, *store.ScanRun) error {
+			t.Fatal("terminal run invoked result ingestion")
+			return nil
+		})
+		require.NoError(t, err)
+		require.False(t, applied)
+	}
+}
+
+func TestScanTaskIngestionConcurrentReplay(t *testing.T) {
+	ctx := context.Background()
+	s := setupTestStore(t)
+	identity := store.ScanTaskIdentity{Namespace: "ns", RepositoryScan: "repo", ScanRunID: "run", TaskName: "review", TaskUID: "uid", Stage: "review"}
+	require.NoError(t, s.CreateScanRun(ctx, &store.ScanRun{ID: "run", Namespace: "ns", RepositoryScan: "repo", Phase: "running"}))
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			_, err := s.ApplyScanTaskIngestion(ctx, &store.ScanTaskIngestion{ScanTaskIdentity: identity}, func(_ store.SecurityStore, run *store.ScanRun) error {
+				run.ReviewedSliceCount++
+				return nil
+			})
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+	wg.Wait()
+	run, err := s.GetScanRun(ctx, "ns", "run")
+	require.NoError(t, err)
+	require.Equal(t, 1, run.ReviewedSliceCount)
+}

--- a/internal/store/sqlite/security_store.go
+++ b/internal/store/sqlite/security_store.go
@@ -108,7 +108,7 @@ func (s *Store) CreateScanRun(ctx context.Context, run *store.ScanRun) error {
 		 )`
 		args = append(args, run.Namespace, run.RepositoryScan)
 	}
-	result, err := s.db.ExecContext(ctx, query, args...)
+	result, err := s.securityDB().ExecContext(ctx, query, args...)
 	if err != nil && isSQLiteConstraintError(err) {
 		return fmt.Errorf("%w: active security scan run already exists", store.ErrConflict)
 	}
@@ -129,7 +129,7 @@ func (s *Store) CreateScanRun(ctx context.Context, run *store.ScanRun) error {
 func (s *Store) UpdateScanRun(ctx context.Context, run *store.ScanRun) error {
 	run.StartedAt = utcTime(run.StartedAt)
 	run.CompletedAt = utcTimePtr(run.CompletedAt)
-	_, err := s.db.ExecContext(ctx,
+	_, err := s.securityDB().ExecContext(ctx,
 		`UPDATE security_scan_runs
 		 SET task_name = ?, mode = ?, phase = ?, base_commit = ?, head_commit = ?, commit_count = ?,
 		     slice_count = ?, reviewed_slice_count = ?, skipped_slice_count = ?, accepted_findings = ?, dropped_findings = ?,
@@ -147,7 +147,7 @@ func (s *Store) UpdateScanRun(ctx context.Context, run *store.ScanRun) error {
 // GetScanRun fetches a scan run by ID.
 func (s *Store) GetScanRun(ctx context.Context, namespace, id string) (*store.ScanRun, error) {
 	var run store.ScanRun
-	err := s.db.QueryRowContext(ctx,
+	err := s.securityDB().QueryRowContext(ctx,
 		`SELECT id, namespace, repository_scan, task_name, mode, phase, started_at, completed_at,
 		        base_commit, head_commit, commit_count, slice_count, reviewed_slice_count, skipped_slice_count,
 		        accepted_findings, dropped_findings, scanner_policy_version, policy_digest, idempotency_key,
@@ -180,7 +180,7 @@ func (s *Store) ListScanRuns(ctx context.Context, namespace, repositoryScan stri
 		limit = 20
 	}
 
-	rows, err := s.db.QueryContext(ctx,
+	rows, err := s.securityDB().QueryContext(ctx,
 		`SELECT id, namespace, repository_scan, task_name, mode, phase, started_at, completed_at,
 		        base_commit, head_commit, commit_count, slice_count, reviewed_slice_count, skipped_slice_count,
 		        accepted_findings, dropped_findings, scanner_policy_version, policy_digest, idempotency_key,
@@ -273,7 +273,7 @@ func (s *Store) UpsertReviewSlice(ctx context.Context, slice *store.ReviewSlice)
 	}
 	slice.UpdatedAt = now
 
-	_, err = s.db.ExecContext(ctx,
+	_, err = s.securityDB().ExecContext(ctx,
 		`INSERT INTO security_review_slices
 		 (id, namespace, repository_scan, source, title, summary, kind, confidence, status,
 		  entrypoints_json, owned_files_json, context_files_json, tests_json, tags_json,
@@ -389,7 +389,7 @@ func (s *Store) ListReviewSlices(ctx context.Context, filter store.ReviewSliceFi
 	query.WriteString(` ORDER BY updated_at DESC, id DESC LIMIT ? OFFSET ?`)
 	args = append(args, filter.Limit, offset)
 
-	rows, err := s.db.QueryContext(ctx, query.String(), args...)
+	rows, err := s.securityDB().QueryContext(ctx, query.String(), args...)
 	if err != nil {
 		return nil, "", err
 	}
@@ -411,7 +411,7 @@ func (s *Store) ListReviewSlices(ctx context.Context, filter store.ReviewSliceFi
 
 // GetReviewSlice returns one review slice.
 func (s *Store) GetReviewSlice(ctx context.Context, namespace, repositoryScan, id string) (*store.ReviewSlice, error) {
-	row := s.db.QueryRowContext(ctx,
+	row := s.securityDB().QueryRowContext(ctx,
 		`SELECT id, namespace, repository_scan, source, title, summary, kind, confidence, status,
 		        entrypoints_json, owned_files_json, context_files_json, tests_json, tags_json, trust_boundaries_json,
 		        changed_files_json, changed_line_ranges_json, review_context_json, review_context_hash,
@@ -433,7 +433,7 @@ func (s *Store) GetReviewSlice(ctx context.Context, namespace, repositoryScan, i
 // UpdateReviewSliceStatus updates slice status and review timestamp.
 func (s *Store) UpdateReviewSliceStatus(ctx context.Context, namespace, repositoryScan, id, lastScanRunID, status string) error {
 	now := time.Now().UTC()
-	res, err := s.db.ExecContext(ctx,
+	res, err := s.securityDB().ExecContext(ctx,
 		`UPDATE security_review_slices
 		 SET status = ?, last_reviewed_at = CASE WHEN ? IN ('reviewed', 'completed') THEN ? ELSE last_reviewed_at END,
 		     updated_at = ?
@@ -456,7 +456,7 @@ func (s *Store) UpdateReviewSliceStatus(ctx context.Context, namespace, reposito
 // GetLatestThreatModel returns the current threat model for a repository.
 func (s *Store) GetLatestThreatModel(ctx context.Context, namespace, repositoryScan string) (*store.ThreatModel, error) {
 	var model store.ThreatModel
-	err := s.db.QueryRowContext(ctx,
+	err := s.securityDB().QueryRowContext(ctx,
 		`SELECT namespace, repository_scan, version, content, source, generated_by_scan, created_at, updated_at
 		 FROM security_threat_models
 		 WHERE namespace = ? AND repository_scan = ?
@@ -479,14 +479,15 @@ func (s *Store) GetLatestThreatModel(ctx context.Context, namespace, repositoryS
 // SaveThreatModel stores the current threat model, replacing any older copies for the repository.
 // When Version is zero, the revision number is incremented from the latest stored model.
 func (s *Store) SaveThreatModel(ctx context.Context, model *store.ThreatModel) error {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = tx.Rollback() }()
+	return s.withSecurityTransaction(ctx, func(tx *Store) error {
+		return tx.saveThreatModel(ctx, model)
+	})
+}
+
+func (s *Store) saveThreatModel(ctx context.Context, model *store.ThreatModel) error {
 
 	var latestVersion int64
-	err = tx.QueryRowContext(ctx,
+	err := s.securityDB().QueryRowContext(ctx,
 		`SELECT version FROM security_threat_models WHERE namespace = ? AND repository_scan = ? ORDER BY version DESC LIMIT 1`,
 		model.Namespace, model.RepositoryScan,
 	).Scan(&latestVersion)
@@ -508,14 +509,14 @@ func (s *Store) SaveThreatModel(ctx context.Context, model *store.ThreatModel) e
 	}
 	model.UpdatedAt = now
 
-	if _, err := tx.ExecContext(ctx,
+	if _, err := s.securityDB().ExecContext(ctx,
 		`DELETE FROM security_threat_models WHERE namespace = ? AND repository_scan = ?`,
 		model.Namespace, model.RepositoryScan,
 	); err != nil {
 		return err
 	}
 
-	if _, err := tx.ExecContext(ctx,
+	if _, err := s.securityDB().ExecContext(ctx,
 		`INSERT INTO security_threat_models
 		 (namespace, repository_scan, version, content, source, generated_by_scan, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -525,7 +526,7 @@ func (s *Store) SaveThreatModel(ctx context.Context, model *store.ThreatModel) e
 		return err
 	}
 
-	return tx.Commit()
+	return nil
 }
 
 func marshalEvidence(evidence []store.FindingEvidenceRef) (string, error) {
@@ -583,7 +584,7 @@ func (s *Store) upsertFinding(ctx context.Context, finding *store.Finding, obser
 	}
 	finding.UpdatedAt = now
 
-	_, err = s.db.ExecContext(ctx,
+	_, err = s.securityDB().ExecContext(ctx,
 		`INSERT INTO security_findings
 		 (id, namespace, repository_scan, scan_run_id, slice_id, fingerprint, target_key, title, category, summary, severity, confidence, triage,
 			  validation_status, state, decision_at, duplicate_of, file_path, line, commit_sha, root_cause, reproduction, remediation, suggested_action,
@@ -784,7 +785,7 @@ func scanFinding(scanner interface {
 
 // GetFinding returns a finding by ID.
 func (s *Store) GetFinding(ctx context.Context, namespace, id string) (*store.Finding, error) {
-	row := s.db.QueryRowContext(ctx,
+	row := s.securityDB().QueryRowContext(ctx,
 		`SELECT id, namespace, repository_scan, scan_run_id, slice_id, fingerprint, target_key, title, category, summary, severity,
 		        confidence, triage, validation_status, state, decision_at, duplicate_of, file_path, line, commit_sha, root_cause, reproduction,
 		        remediation, suggested_action, why_tests_do_not_cover, suggested_regression_test, minimum_fix_scope,
@@ -883,7 +884,7 @@ func (s *Store) ListFindings(ctx context.Context, filter store.FindingFilter) ([
 	query.WriteString(` LIMIT ? OFFSET ?`)
 	args = append(args, filter.Limit, offset)
 
-	rows, err := s.db.QueryContext(ctx, query.String(), args...)
+	rows, err := s.securityDB().QueryContext(ctx, query.String(), args...)
 	if err != nil {
 		return nil, "", err
 	}
@@ -906,7 +907,7 @@ func (s *Store) ListFindings(ctx context.Context, filter store.FindingFilter) ([
 
 // GetFindingCounts returns current open finding counts by severity.
 func (s *Store) GetFindingCounts(ctx context.Context, namespace, repositoryScan string) (store.FindingCounts, error) {
-	row := s.db.QueryRowContext(ctx,
+	row := s.securityDB().QueryRowContext(ctx,
 		`SELECT
 			COUNT(*),
 			COALESCE(SUM(CASE WHEN severity = 'critical' THEN 1 ELSE 0 END), 0),
@@ -927,7 +928,7 @@ func (s *Store) GetFindingCounts(ctx context.Context, namespace, repositoryScan 
 // UpdateFindingState updates the user-visible finding state.
 func (s *Store) UpdateFindingState(ctx context.Context, namespace, id, state string) error {
 	now := time.Now().UTC()
-	res, err := s.db.ExecContext(ctx,
+	res, err := s.securityDB().ExecContext(ctx,
 		`WITH RECURSIVE canonical(id, duplicate_of) AS (
 			SELECT id, duplicate_of FROM security_findings WHERE namespace = ? AND id = ?
 			UNION ALL
@@ -959,7 +960,7 @@ func (s *Store) UpdateFindingState(ctx context.Context, namespace, id, state str
 // ResolveFindingIfCurrent resolves only the pr_open occurrence and PR selected by the caller.
 func (s *Store) ResolveFindingIfCurrent(ctx context.Context, namespace, id, scanRunID string, prNumber int) (bool, error) {
 	now := time.Now().UTC()
-	res, err := s.db.ExecContext(ctx,
+	res, err := s.securityDB().ExecContext(ctx,
 		`UPDATE security_findings
 		 SET state = 'resolved', decision_at = NULL, updated_at = ?
 		 WHERE namespace = ? AND id = ? AND scan_run_id = ? AND pr_number = ? AND state = 'pr_open' AND duplicate_of = ''`,
@@ -990,20 +991,21 @@ func (s *Store) MarkFindingDuplicate(ctx context.Context, namespace, id, canonic
 	if strings.TrimSpace(namespace) == "" || strings.TrimSpace(id) == "" || strings.TrimSpace(canonicalID) == "" || id == canonicalID {
 		return store.ValidationErrorf("duplicate finding namespace, ID, and distinct canonical ID are required")
 	}
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = tx.Rollback() }()
+	return s.withSecurityTransaction(ctx, func(tx *Store) error {
+		return tx.markFindingDuplicate(ctx, namespace, id, canonicalID)
+	})
+}
+
+func (s *Store) markFindingDuplicate(ctx context.Context, namespace, id, canonicalID string) error {
 	var sourceRepo, sourceState, canonicalRepo, canonicalDuplicate, canonicalState string
 	var sourceDecision, canonicalDecision sql.NullTime
-	if err := tx.QueryRowContext(ctx, `SELECT repository_scan, state, decision_at FROM security_findings WHERE namespace = ? AND id = ?`, namespace, id).Scan(&sourceRepo, &sourceState, &sourceDecision); err != nil {
+	if err := s.securityDB().QueryRowContext(ctx, `SELECT repository_scan, state, decision_at FROM security_findings WHERE namespace = ? AND id = ?`, namespace, id).Scan(&sourceRepo, &sourceState, &sourceDecision); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return store.ErrNotFound
 		}
 		return err
 	}
-	if err := tx.QueryRowContext(ctx, `SELECT repository_scan, duplicate_of, state, decision_at FROM security_findings WHERE namespace = ? AND id = ?`, namespace, canonicalID).Scan(&canonicalRepo, &canonicalDuplicate, &canonicalState, &canonicalDecision); err != nil {
+	if err := s.securityDB().QueryRowContext(ctx, `SELECT repository_scan, duplicate_of, state, decision_at FROM security_findings WHERE namespace = ? AND id = ?`, namespace, canonicalID).Scan(&canonicalRepo, &canonicalDuplicate, &canonicalState, &canonicalDecision); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return store.ErrNotFound
 		}
@@ -1014,14 +1016,14 @@ func (s *Store) MarkFindingDuplicate(ctx context.Context, namespace, id, canonic
 	}
 	newerSourceDecision := sourceDecision.Valid && (!canonicalDecision.Valid || sourceDecision.Time.After(canonicalDecision.Time))
 	if findingUserFinalState(sourceState) && (!findingUserFinalState(canonicalState) || newerSourceDecision) {
-		if _, err := tx.ExecContext(ctx,
+		if _, err := s.securityDB().ExecContext(ctx,
 			`UPDATE security_findings SET state = ?, decision_at = ?, updated_at = ? WHERE namespace = ? AND id = ?`,
 			sourceState, sourceDecision, time.Now().UTC(), namespace, canonicalID,
 		); err != nil {
 			return err
 		}
 	}
-	if _, err := tx.ExecContext(ctx, `WITH RECURSIVE descendants(id) AS (
+	if _, err := s.securityDB().ExecContext(ctx, `WITH RECURSIVE descendants(id) AS (
 		SELECT id FROM security_findings
 		 WHERE namespace = ? AND repository_scan = ? AND duplicate_of = ?
 		UNION
@@ -1035,10 +1037,10 @@ func (s *Store) MarkFindingDuplicate(ctx context.Context, namespace, id, canonic
 		namespace, sourceRepo, id, namespace, sourceRepo, canonicalID, namespace, sourceRepo); err != nil {
 		return err
 	}
-	if _, err := tx.ExecContext(ctx, `UPDATE security_findings SET duplicate_of = ?, updated_at = CURRENT_TIMESTAMP WHERE namespace = ? AND id = ?`, canonicalID, namespace, id); err != nil {
+	if _, err := s.securityDB().ExecContext(ctx, `UPDATE security_findings SET duplicate_of = ?, updated_at = CURRENT_TIMESTAMP WHERE namespace = ? AND id = ?`, canonicalID, namespace, id); err != nil {
 		return err
 	}
-	return tx.Commit()
+	return nil
 }
 
 // CreatePatchProposal inserts a new patch proposal.
@@ -1053,7 +1055,7 @@ func (s *Store) CreatePatchProposal(ctx context.Context, proposal *store.PatchPr
 	}
 	proposal.UpdatedAt = now
 
-	_, err := s.db.ExecContext(ctx,
+	_, err := s.securityDB().ExecContext(ctx,
 		`INSERT INTO security_patch_proposals
 		 (id, namespace, repository_scan, finding_id, task_name, branch, diff_artifact, summary_artifact, status, reason, pr_number, pr_url, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1268,7 +1270,7 @@ func (s *Store) UpdatePatchProposal(ctx context.Context, proposal *store.PatchPr
 		return store.ValidationErrorf("patch proposal publication evidence must be bound with BindPatchProposalPublicationEvidence")
 	}
 	now := time.Now().UTC()
-	result, err := s.db.ExecContext(ctx,
+	result, err := s.securityDB().ExecContext(ctx,
 		`UPDATE security_patch_proposals
 		 SET task_name = ?, branch = ?, diff_artifact = ?, summary_artifact = ?, status = ?, reason = ?, pr_number = ?, pr_url = ?, updated_at = ?
 		 WHERE namespace = ? AND id = ? AND publication_evidence_json = ''`,
@@ -1309,14 +1311,14 @@ func (s *Store) UpdatePatchProposal(ctx context.Context, proposal *store.PatchPr
 func (s *Store) ListPatchProposals(ctx context.Context, namespace, findingID string) ([]store.PatchProposal, error) {
 	canonicalID := findingID
 	var duplicateOf string
-	if err := s.db.QueryRowContext(ctx, `SELECT duplicate_of FROM security_findings WHERE namespace = ? AND id = ?`, namespace, findingID).Scan(&duplicateOf); err == nil {
+	if err := s.securityDB().QueryRowContext(ctx, `SELECT duplicate_of FROM security_findings WHERE namespace = ? AND id = ?`, namespace, findingID).Scan(&duplicateOf); err == nil {
 		if strings.TrimSpace(duplicateOf) != "" {
 			canonicalID = duplicateOf
 		}
 	} else if !errors.Is(err, sql.ErrNoRows) {
 		return nil, err
 	}
-	rows, err := s.db.QueryContext(ctx,
+	rows, err := s.securityDB().QueryContext(ctx,
 		`SELECT id, namespace, repository_scan, finding_id, task_name, branch, diff_artifact, summary_artifact,
 		        status, reason, pr_number, pr_url, publication_evidence_json, created_at, updated_at
 		 FROM security_patch_proposals
@@ -1374,7 +1376,7 @@ func (s *Store) CreateDroppedFinding(ctx context.Context, dropped *store.Dropped
 	if dropped.CreatedAt.IsZero() {
 		dropped.CreatedAt = time.Now().UTC()
 	}
-	_, err := s.db.ExecContext(ctx,
+	_, err := s.securityDB().ExecContext(ctx,
 		`INSERT OR IGNORE INTO security_dropped_findings
 		 (id, namespace, repository_scan, scan_run_id, task_name, slice_id, reason, layer, sample_json, created_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1425,7 +1427,7 @@ func (s *Store) ListDroppedFindings(ctx context.Context, filter store.DroppedFin
 	query.WriteString(` ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?`)
 	args = append(args, filter.Limit, offset)
 
-	rows, err := s.db.QueryContext(ctx, query.String(), args...)
+	rows, err := s.securityDB().QueryContext(ctx, query.String(), args...)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -310,6 +310,20 @@ func migrate(db *sql.DB) error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_security_scan_runs_repo
 			ON security_scan_runs(namespace, repository_scan, started_at DESC)`,
+		`CREATE TABLE IF NOT EXISTS security_scan_task_ingestions (
+			namespace TEXT NOT NULL,
+			repository_scan TEXT NOT NULL,
+			scan_run_id TEXT NOT NULL,
+			task_name TEXT NOT NULL,
+			task_uid TEXT NOT NULL,
+			stage TEXT NOT NULL,
+			slice_id TEXT NOT NULL,
+			finding_ids_json TEXT NOT NULL DEFAULT '[]',
+			dropped_findings_json TEXT NOT NULL DEFAULT '',
+			completed BOOLEAN NOT NULL DEFAULT FALSE,
+			ingested_at TIMESTAMP NOT NULL,
+			PRIMARY KEY (namespace, scan_run_id, task_name, task_uid)
+		)`,
 		`CREATE TABLE IF NOT EXISTS security_threat_models (
 			namespace         TEXT NOT NULL,
 			repository_scan   TEXT NOT NULL,
@@ -1322,6 +1336,7 @@ func sqlitePrimaryKeyColumns(db *sql.DB, table string) ([]string, error) {
 // Store implements both store.ResultStore and store.SessionStore.
 type Store struct {
 	db               *sql.DB
+	securityTx       *sql.Tx
 	dbPath           string
 	processLock      io.Closer
 	executionEventMu sync.Mutex

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -185,6 +185,13 @@ type ArtifactStore interface {
 
 // SecurityStore handles repository security scanning persistence.
 type SecurityStore interface {
+	GetScanTaskIngestion(ctx context.Context, task ScanTaskIdentity) (*ScanTaskIngestion, error)
+	// ApplyScanTaskIngestion atomically applies results, updates the current run,
+	// and records the receipt. It skips already ingested Tasks and terminal runs.
+	// The callback must use the supplied store and must not perform external mutations.
+	ApplyScanTaskIngestion(ctx context.Context, ingestion *ScanTaskIngestion, apply func(SecurityStore, *ScanRun) error) (bool, error)
+	CompleteScanTaskIngestion(ctx context.Context, task ScanTaskIdentity) error
+
 	CreateScanRun(ctx context.Context, run *ScanRun) error
 	UpdateScanRun(ctx context.Context, run *ScanRun) error
 	GetScanRun(ctx context.Context, namespace, id string) (*ScanRun, error)


### PR DESCRIPTION
Retained terminal mapper Tasks could reclaim shared slice rows. The current mapper then reset those rows, allowing completed reviews to be counted again. The regression reproduced a reviewed count increasing from 13 to 26 on one reconcile without another model review.

Persist a receipt for each Task incarnation and run in the same transaction as its results and counters. Completed runs cannot replay pipeline results, and missing or failed slice updates abort ingestion. Diagnostic artifacts and automatic validation Tasks recover from the committed receipt without counting the review again. Automatic validation uses stable names and recovers existing Tasks despite Kubernetes defaults or an already consumed run cap.

Validation covers two successive 14-slice runs with all 32 pipeline Tasks retained, repeated reconciles, reopening SQLite, Task history cleanup, all-terminal pipeline recovery, transaction rollback, concurrent replay, delayed or lost validation Task creation responses, defaulted and active Task recovery, validation caps, and conflicting Task rejection.

- `make lint-fix`
- `make test`

Depends on #456.

Fixes #470.
