### PR TITLE
fix(security): redact stored threat-model content

### DIFF
--- a/internal/api/security_handlers.go
+++ b/internal/api/security_handlers.go
@@ -751,6 +751,7 @@ func (h *Handlers) UpdateThreatModel(c fiber.Ctx) error {
 	if err := c.Bind().JSON(&req); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
 	}
+	req.Content = security.SanitizeThreatModel(req.Content)
 	if strings.TrimSpace(req.Content) == "" {
 		return fiber.NewError(fiber.StatusBadRequest, "content is required")
 	}

--- a/internal/api/security_handlers_test.go
+++ b/internal/api/security_handlers_test.go
@@ -938,6 +938,47 @@ func TestThreatModelRedactsEditedContent(t *testing.T) {
 	}
 }
 
+func TestThreatModelRejectsBlankSanitizedEdit(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+	ctxTokenConfig := testContextTokenConfig(t, provider, "")
+	app, handlers := setupSecurityHandlersWithAuthzFixture(
+		t, ctxTokenConfig, ContextTokenAuthorizationModeEnforce,
+		securityAuthzTestRepositoryScan("scan-1", securityTestRepoURL),
+	)
+	ctx := context.Background()
+	const content = "Existing threat-model notes."
+	require.NoError(t, handlers.securityStore.SaveThreatModel(ctx, &store.ThreatModel{
+		Namespace: "demo", RepositoryScan: "scan-1", Content: content, Source: "edited",
+	}))
+	token := issueTestContextToken(t, provider, nil, map[string]any{
+		"scope": ContextTokenScopeSecurityWrite,
+		"tctx":  securityAuthzTestTctx(securityTestRepoURL),
+	})
+	for name, input := range map[string]string{
+		"empty":         "",
+		"whitespace":    " \n\t",
+		"format runes":  "\u200b\u202e",
+		"control runes": "\x00\x1b",
+		"mixed":         " \n\t\u200b\x00",
+	} {
+		t.Run(name, func(t *testing.T) {
+			body, err := json.Marshal(UpdateThreatModelRequest{Content: input})
+			require.NoError(t, err)
+			req := httptest.NewRequest(http.MethodPut, "/security/repositories/scan-1/threat-model?namespace=demo", strings.NewReader(string(body)))
+			req.Header.Set(TransactionTokenHeaderName, token)
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			model, err := handlers.securityStore.GetLatestThreatModel(ctx, "demo", "scan-1")
+			require.NoError(t, err)
+			require.Equal(t, content, model.Content)
+			require.Equal(t, int64(1), model.Version)
+		})
+	}
+}
+
 func TestThreatModel_ContextTokenRepositoryScanAuthorizationDenials(t *testing.T) {
 	provider := newTestOIDCProvider(t)
 	ctxTokenConfig := testContextTokenConfig(t, provider, "")

--- a/internal/api/security_handlers_test.go
+++ b/internal/api/security_handlers_test.go
@@ -903,6 +903,41 @@ func TestRepositoryScanReadDelete_ContextTokenObjectAuthorizationDenials(t *test
 	}
 }
 
+func TestThreatModelRedactsEditedContent(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+	ctxTokenConfig := testContextTokenConfig(t, provider, "")
+	app, _ := setupSecurityHandlersWithAuthzFixture(
+		t, ctxTokenConfig, ContextTokenAuthorizationModeEnforce,
+		securityAuthzTestRepositoryScan("scan-1", securityTestRepoURL),
+	)
+	credential := "ghp_" + strings.Repeat("a", 36)
+	body, err := json.Marshal(UpdateThreatModelRequest{
+		Content: "Notes for `config/auth.go:12`.\n\n\t" + credential[:2] + "\u200b" + credential[2:] + "\n\nRotate keys.",
+	})
+	require.NoError(t, err)
+	const want = "Notes for `config/auth.go:12`.\n\n\t[REDACTED]\n\nRotate keys."
+	token := issueTestContextToken(t, provider, nil, map[string]any{
+		"scope": ContextTokenScopeSecurityRead + " " + ContextTokenScopeSecurityWrite,
+		"tctx":  securityAuthzTestTctx(securityTestRepoURL),
+	})
+	for _, method := range []string{http.MethodPut, http.MethodGet} {
+		req := httptest.NewRequest(method, "/security/repositories/scan-1/threat-model?namespace=demo", strings.NewReader(string(body)))
+		req.Header.Set(TransactionTokenHeaderName, token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		var model store.ThreatModel
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&model))
+		require.NoError(t, resp.Body.Close())
+		if model.Content != want {
+			t.Fatalf("%s returned unsanitized threat-model content", method)
+		}
+		require.Equal(t, "edited", model.Source)
+		require.Equal(t, int64(1), model.Version)
+	}
+}
+
 func TestThreatModel_ContextTokenRepositoryScanAuthorizationDenials(t *testing.T) {
 	provider := newTestOIDCProvider(t)
 	ctxTokenConfig := testContextTokenConfig(t, provider, "")

--- a/internal/controller/repositoryscan_controller_test.go
+++ b/internal/controller/repositoryscan_controller_test.go
@@ -2621,6 +2621,40 @@ func TestIngestReviewTaskSkipsStaleSliceRun(t *testing.T) {
 	}
 }
 
+func TestPersistThreatModelIfChangedDeduplicatesRedactedResult(t *testing.T) {
+	ctx := context.Background()
+	store := setupControllerSQLiteStore(t)
+	reconciler := &RepositoryScanReconciler{SecurityStore: store}
+	scan := &corev1alpha1.RepositoryScan{
+		ObjectMeta: metav1.ObjectMeta{Name: "kaset", Namespace: defaultNS},
+	}
+	const scanID = "scan_current"
+	data, err := json.Marshal(security.ThreatModelResultEnvelope{
+		SchemaVersion: security.AgentResultSchemaVersion, Kind: security.AgentResultKindThreatModel,
+		RepositoryScan: scan.Name, ScanID: scanID,
+		ThreatModel: "# Threat model\n\nEnvironment assignment `API_KEY=\"" + strings.Repeat("a", 32) + "\"`.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, err := security.ParseThreatModelResult(data, security.AgentResultBinding{RepositoryScan: scan.Name, ScanID: scanID})
+	if err != nil {
+		t.Fatalf("ParseThreatModelResult() error = %v", err)
+	}
+	for range 2 {
+		if err := reconciler.persistThreatModelIfChanged(ctx, scan, scanID, time.Time{}, content); err != nil {
+			t.Fatalf("persistThreatModelIfChanged() error = %v", err)
+		}
+	}
+	latest, err := store.GetLatestThreatModel(ctx, scan.Namespace, scan.Name)
+	if err != nil {
+		t.Fatalf("GetLatestThreatModel() error = %v", err)
+	}
+	if latest.Version != 1 || latest.Content != content {
+		t.Fatal("identical sanitized threat-model results were not deduplicated")
+	}
+}
+
 func TestPersistThreatModelIfChangedSkipsOlderGeneratedRun(t *testing.T) {
 	ctx := context.Background()
 	store := setupControllerSQLiteStore(t)

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -15,7 +15,7 @@ var (
 	// redactor must never leave a recoverable credential tail behind a
 	// comma or semicolon, and over-redacting a following word in prose is
 	// the safe direction.
-	sensitiveAssignmentRe   = regexp.MustCompile(`(?i)(["']?)([A-Z0-9_.-]*(?:api[-_]?key|token|secret|password|passwd|pwd|credential|private[-_]?key|client[-_]?secret|access[-_]?token|refresh[-_]?token)[A-Z0-9_.-]*)(["']?)(\s*[:=]\s*)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"']+)`)
+	sensitiveAssignmentRe   = regexp.MustCompile(`(?i)(["']?)([A-Z0-9_.-]*(?:api[-_]?key|token|secret|password|passwd|pwd|credential|private[-_]?key|client[-_]?secret|access[-_]?token|refresh[-_]?token)[A-Z0-9_.-]*)(["']?)(\s*[:=]\s*)("[^"\r\n]*"|'[^'\r\n]*'|[^\s"']+)`)
 	naturalLanguageSecretRe = regexp.MustCompile(`(?i)\b((?:api\s+key|token|secret|password|credential)\s+is\s+)([^\s]+)`) // e.g. "token is abc123"
 	wellKnownTokenRe        = regexp.MustCompile(`\b(?:sk-[A-Za-z0-9_-]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{30,}|xox[baprs]-[A-Za-z0-9-]{20,})\b`)
 	jwtRe                   = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b`)
@@ -38,7 +38,16 @@ func SensitiveText(s string) string {
 	s = authorizationHeaderRe.ReplaceAllString(s, `${1}`+redactedValue)
 	s = txnTokenHeaderRe.ReplaceAllString(s, `${1}`+redactedValue)
 	s = cookieHeaderRe.ReplaceAllString(s, `${1}`+redactedValue)
-	s = sensitiveAssignmentRe.ReplaceAllString(s, `${1}${2}${3}${4}`+redactedValue)
+	s = sensitiveAssignmentRe.ReplaceAllStringFunc(s, func(match string) string {
+		parts := sensitiveAssignmentRe.FindStringSubmatch(match)
+		replacement := redactedValue
+		// Keep quoted values quoted so another pass cannot consume Markdown
+		// delimiters or punctuation outside the original value.
+		if quote := parts[5][:1]; quote == "\"" || quote == "'" {
+			replacement = quote + replacement + quote
+		}
+		return parts[1] + parts[2] + parts[3] + parts[4] + replacement
+	})
 	s = naturalLanguageSecretRe.ReplaceAllString(s, `${1}`+redactedValue)
 	s = urlCredentialRe.ReplaceAllString(s, `${1}`+redactedValue+`@`)
 	s = signedURLQueryRe.ReplaceAllString(s, `${1}`+redactedValue)

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -11,6 +11,23 @@ import (
 	"testing"
 )
 
+func TestSensitiveTextPreservesRedactedMarkdown(t *testing.T) {
+	value := strings.Repeat("a", 32)
+	for input, want := range map[string]string{
+		"Environment assignment `API_KEY=\"" + value + "\"`.": "Environment assignment `API_KEY=\"[REDACTED]\"`.",
+		"Environment assignment `API_KEY='" + value + "'`.":   "Environment assignment `API_KEY='[REDACTED]'`.",
+		`{"api_key":"` + value + `","line":12}`:               `{"api_key":"[REDACTED]","line":12}`,
+	} {
+		if got := SensitiveText(input); got != want || SensitiveText(got) != got {
+			t.Fatal("redaction changed delimiters outside the credential or was not stable on a second pass")
+		}
+	}
+	input := "API_KEY=" + redactedValue + strings.Repeat("a", 32)
+	if got := SensitiveText(input); got != "API_KEY="+redactedValue {
+		t.Fatal("a credential using the redaction marker as a prefix was not fully redacted")
+	}
+}
+
 func TestSensitiveTextRedactsTxnTokenHeader(t *testing.T) {
 	input := `curl -H "Txn-Token: opaque-secret-token" https://orka.example.test`
 	got := SensitiveText(input)

--- a/internal/security/results.go
+++ b/internal/security/results.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/orka-agents/orka/internal/redact"
 	"github.com/orka-agents/orka/internal/store"
 )
 
@@ -160,11 +161,13 @@ func ParseThreatModelResult(data []byte, expected AgentResultBinding) (string, e
 		return "", err
 	}
 	content := strings.TrimSpace(result.ThreatModel)
-	if content == "" {
-		return "", fmt.Errorf("threatModel is required")
-	}
 	if len(content) > maxThreatModelBytes {
 		return "", fmt.Errorf("threatModel exceeds %d bytes", maxThreatModelBytes)
+	}
+	// Validate visible markdown before redaction can hide transcript markers.
+	content = strings.TrimSpace(stripUnsafeTextRunes(content))
+	if content == "" {
+		return "", fmt.Errorf("threatModel is required")
 	}
 	if !strings.HasPrefix(content, "#") {
 		return "", fmt.Errorf("threatModel must be markdown beginning with a heading")
@@ -172,7 +175,18 @@ func ParseThreatModelResult(data []byte, expected AgentResultBinding) (string, e
 	if securityResultLooksLikeToolTranscript(content) {
 		return "", fmt.Errorf("threatModel looks like a tool transcript")
 	}
+	content = SanitizeThreatModel(content)
+	if len(content) > maxThreatModelBytes {
+		return "", fmt.Errorf("threatModel exceeds %d bytes", maxThreatModelBytes)
+	}
 	return content, nil
+}
+
+// SanitizeThreatModel redacts common credential shapes in generated and edited
+// threat models. Strip invisible runes first so they cannot split a credential
+// past the redactor; preserve newlines and tabs for markdown structure.
+func SanitizeThreatModel(content string) string {
+	return redact.SensitiveText(stripUnsafeTextRunes(content))
 }
 
 func securityResultLooksLikeToolTranscript(content string) bool {

--- a/internal/security/results_test.go
+++ b/internal/security/results_test.go
@@ -43,6 +43,86 @@ func TestParseThreatModelResultRequiresExactEnvelopeAndBinding(t *testing.T) {
 	}
 }
 
+func TestParseThreatModelResultRedactsCredentials(t *testing.T) {
+	expected := AgentResultBinding{RepositoryScan: "repo", ScanID: "scan_123", PolicyDigest: "sha256:policy"}
+	// Synthetic values are assembled here so the fixtures cannot be mistaken
+	// for credentials copied from a repository.
+	token := "ghp_" + strings.Repeat("a", 36)
+	value := strings.Repeat("b", 32)
+	const prefix = "# Threat model\n\nCredential handling in `config/auth.go:12`.\n\n"
+	tests := []struct {
+		name, content, want string
+	}{
+		{name: "token", content: "Found `" + token + "`.", want: "Found `[REDACTED]`."},
+		{name: "assignment", content: "```\nAPI_KEY=\"" + value + "\"\n```", want: "```\nAPI_KEY=\"[REDACTED]\"\n```"},
+		{name: "inline assignment", content: "Environment assignment `API_KEY=\"" + value + "\"`.", want: "Environment assignment `API_KEY=\"[REDACTED]\"`."},
+		{name: "bearer header", content: "Authorization: Bearer " + value, want: "Authorization: [REDACTED]"},
+		{name: "transaction header", content: "Txn-Token: " + value, want: "Txn-Token: [REDACTED]"},
+		{name: "URL credentials", content: "https://user:" + value + "@example.test/repo", want: "https://[REDACTED]@example.test/repo"},
+		{name: "signed URL", content: "https://example.test/file?sig=" + value + "&page=1", want: "https://example.test/file?sig=[REDACTED]&page=1"},
+		{name: "prose", content: "The token is " + value, want: "The token is [REDACTED]"},
+		{name: "NUL", content: token[:2] + "\x00" + token[2:], want: "[REDACTED]"},
+		{name: "escape", content: token[:2] + "\x1b" + token[2:], want: "[REDACTED]"},
+		{name: "delete", content: token[:2] + "\x7f" + token[2:], want: "[REDACTED]"},
+		{name: "C1 control", content: token[:2] + "\u0085" + token[2:], want: "[REDACTED]"},
+		{name: "zero-width space", content: token[:2] + "\u200b" + token[2:], want: "[REDACTED]"},
+		{name: "zero-width joiner", content: token[:2] + "\u200d" + token[2:], want: "[REDACTED]"},
+		{name: "directional override", content: token[:2] + "\u202e" + token[2:], want: "[REDACTED]"},
+		{
+			name:    "ordinary markdown",
+			content: "Credentials come from Kubernetes Secrets.\n\n## 認証\n\n```go\n\tloadCredentials()\n```\n\n- Rotate keys regularly.",
+			want:    "Credentials come from Kubernetes Secrets.\n\n## 認証\n\n```go\n\tloadCredentials()\n```\n\n- Rotate keys regularly.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ThreatModelResultEnvelope{
+				SchemaVersion: AgentResultSchemaVersion, Kind: AgentResultKindThreatModel,
+				RepositoryScan: expected.RepositoryScan, ScanID: expected.ScanID, PolicyDigest: expected.PolicyDigest,
+				ThreatModel: prefix + tt.content,
+			}
+			got, err := ParseThreatModelResult(mustMarshalSecurityResult(t, result), expected)
+			if err != nil {
+				t.Fatalf("ParseThreatModelResult() error = %v", err)
+			}
+			if got != prefix+tt.want {
+				t.Fatal("threat model did not redact the credential while preserving surrounding markdown")
+			}
+			result.ThreatModel = got
+			again, err := ParseThreatModelResult(mustMarshalSecurityResult(t, result), expected)
+			if err != nil || again != got {
+				t.Fatalf("sanitized threat model is not stable on reprocessing: %v", err)
+			}
+		})
+	}
+}
+
+func TestParseThreatModelResultValidatesSanitizedContent(t *testing.T) {
+	tests := []struct {
+		name, content, wantError string
+	}{
+		{name: "empty", content: " \n\t", wantError: "threatModel is required"},
+		{name: "only invisible runes", content: "\x00\u200b", wantError: "threatModel is required"},
+		{name: "missing heading", content: "Trusted boundaries.", wantError: "beginning with a heading"},
+		{name: "transcript", content: "# Model\n<tool_call>read</tool_call>", wantError: "tool transcript"},
+		{name: "hidden transcript", content: "# Model\n<tool_\u200bcall>read</tool_\u200bcall>", wantError: "tool transcript"},
+		{name: "oversized before stripping", content: "# " + strings.Repeat("a", maxThreatModelBytes-2) + "\x00", wantError: "threatModel exceeds"},
+		{name: "oversized after redaction", content: "# Model\n" + strings.Repeat("pwd=x\n", maxThreatModelBytes/10), wantError: "threatModel exceeds"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ThreatModelResultEnvelope{
+				SchemaVersion: AgentResultSchemaVersion, Kind: AgentResultKindThreatModel,
+				ThreatModel: tt.content,
+			}
+			got, err := ParseThreatModelResult(mustMarshalSecurityResult(t, result), AgentResultBinding{})
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) || got != "" {
+				t.Fatalf("ParseThreatModelResult() error = %v, want %q and no content", err, tt.wantError)
+			}
+		})
+	}
+}
+
 func TestParseFindingsResultRequiresExactRepositoryAndContext(t *testing.T) {
 	repository := FindingsV2Repository{
 		RepoURL: "https://github.com/sozercan/vekil",

--- a/internal/store/sqlite/security_store.go
+++ b/internal/store/sqlite/security_store.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/orka-agents/orka/internal/security"
 	"github.com/orka-agents/orka/internal/store"
 )
 
@@ -479,6 +480,8 @@ func (s *Store) GetLatestThreatModel(ctx context.Context, namespace, repositoryS
 // SaveThreatModel stores the current threat model, replacing any older copies for the repository.
 // When Version is zero, the revision number is incremented from the latest stored model.
 func (s *Store) SaveThreatModel(ctx context.Context, model *store.ThreatModel) error {
+	model.Content = security.SanitizeThreatModel(model.Content)
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err

--- a/internal/store/sqlite/security_store_test.go
+++ b/internal/store/sqlite/security_store_test.go
@@ -354,6 +354,44 @@ func TestSaveThreatModelReplacesCurrentModel(t *testing.T) {
 	}
 }
 
+func TestSaveThreatModelRedactsContent(t *testing.T) {
+	for _, source := range []string{"generated", "edited"} {
+		t.Run(source, func(t *testing.T) {
+			s := setupTestStore(t)
+			ctx := context.Background()
+			token := "ghp_" + strings.Repeat("a", 36)
+			model := &store.ThreatModel{
+				Namespace: "ns1", RepositoryScan: "repo1", Source: source,
+				Content: "Notes for `config/auth.go:12`.\n\n\t" + token[:2] + "\u200b" + token[2:] + "\n\nRotate keys.",
+			}
+			const want = "Notes for `config/auth.go:12`.\n\n\t[REDACTED]\n\nRotate keys."
+			if err := s.SaveThreatModel(ctx, model); err != nil {
+				t.Fatalf("SaveThreatModel() error = %v", err)
+			}
+			if model.Content != want {
+				t.Fatal("SaveThreatModel() left unsanitized content in the returned model")
+			}
+			var persisted string
+			if err := s.db.QueryRowContext(ctx,
+				`SELECT content FROM security_threat_models WHERE namespace = ? AND repository_scan = ?`,
+				model.Namespace, model.RepositoryScan,
+			).Scan(&persisted); err != nil {
+				t.Fatalf("read stored threat model: %v", err)
+			}
+			if persisted != want {
+				t.Fatal("SaveThreatModel() persisted unsanitized content")
+			}
+			got, err := s.GetLatestThreatModel(ctx, model.Namespace, model.RepositoryScan)
+			if err != nil {
+				t.Fatalf("GetLatestThreatModel() error = %v", err)
+			}
+			if got.Content != want || got.Source != source || got.Version != 1 {
+				t.Fatal("GetLatestThreatModel() did not preserve the sanitized content and metadata")
+			}
+		})
+	}
+}
+
 func TestSaveThreatModelCollapsesExistingVersions(t *testing.T) {
 	s := setupTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
Threat-model generation and manual saves now strip unsafe control and format runes, then redact credential-shaped content with the existing `redact.SensitiveText` policy before canonical storage. Manual edits that sanitize to blank are rejected without replacing the current model. Generated results retain envelope and identity validation, heading and transcript checks, and size limits. Existing stored rows are not rewritten.

Preserve quoted assignment values during redaction so repeated sanitization keeps surrounding Markdown and JSON punctuation. This also prevents identical generated models from incrementing the stored version on every ingestion.

Regression coverage exercises parsing, raw SQLite persistence, authenticated PUT/GET responses, and controller deduplication.

The existing detector can miss PEM/AWS and multiline/wrapped credentials, and can redact line numbers in credential-named source citations. Detector changes and generic task result/receipt sanitization are separate follow-ups.

Validation:

- `make lint-fix && make test`
- Focused regressions in `internal/redact`, `internal/security`, `internal/store/sqlite`, `internal/api`, and `internal/controller`

Fixes #457
