### PR TITLE
fix(api): advertise only executable compatibility tools

### DIFF
--- a/internal/api/anthropic_compat.go
+++ b/internal/api/anthropic_compat.go
@@ -303,8 +303,7 @@ func (h *AnthropicCompatHandler) HandleMessages(c fiber.Ctx) error {
 
 	// Inject Orka tools and run the server-side agentic loop by default.
 	// Set X-Orka-Tools: disabled to use as a transparent proxy instead.
-	orkaToolsEnabled, err := prepareCompatCoordinatorTools(c, ctx, compReq, compatCoordinatorSetup{
-		Client:              newExternalToolClient(h.client, h.kubeClient, userInfo, namespace, h.watchNamespace, h.enforceNamespaceIsolation, h.gatewayEventStore),
+	orkaToolsEnabled, err := prepareCompatCoordinatorTools(c, compReq, compatCoordinatorSetup{
 		Namespace:           namespace,
 		ToolUseAction:       "anthropicTools",
 		AuthorizationConfig: h.contextTokenAuthorization,

--- a/internal/api/anthropic_compat_test.go
+++ b/internal/api/anthropic_compat_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1541,9 +1540,8 @@ func TestHandleStreamingMessages_DoesNotStreamPrematureCoordinatorText(t *testin
 // --- Tests: injectOrkaTools ---
 
 func TestInjectOrkaTools_BuiltinTools(t *testing.T) {
-	handler, _ := setupTestAnthropicHandler()
 	req := &llm.CompletionRequest{}
-	injectOrkaTools(context.Background(), handler.client, req, "default")
+	injectOrkaTools(req)
 
 	if len(req.Tools) < len(builtinProxyTools) {
 		t.Fatalf("expected at least %d tools, got %d", len(builtinProxyTools), len(req.Tools))
@@ -1561,7 +1559,6 @@ func TestInjectOrkaTools_BuiltinTools(t *testing.T) {
 }
 
 func TestInjectOrkaTools_PreservesClientTools(t *testing.T) {
-	handler, _ := setupTestAnthropicHandler()
 	clientTool := llm.Tool{
 		Name:        "my_custom_tool",
 		Description: "A client-provided tool",
@@ -1569,7 +1566,7 @@ func TestInjectOrkaTools_PreservesClientTools(t *testing.T) {
 	}
 	req := &llm.CompletionRequest{Tools: []llm.Tool{clientTool}}
 
-	injectOrkaTools(context.Background(), handler.client, req, "default")
+	injectOrkaTools(req)
 
 	// Client tool should still be first
 	if req.Tools[0].Name != "my_custom_tool" {
@@ -1591,34 +1588,6 @@ func TestInjectOrkaTools_PreservesClientTools(t *testing.T) {
 	}
 }
 
-func TestInjectOrkaTools_WithToolCRDs(t *testing.T) {
-	toolCRD := &corev1alpha1.Tool{
-		ObjectMeta: metav1.ObjectMeta{Name: "custom-tool", Namespace: "default"},
-		Spec: corev1alpha1.ToolSpec{
-			Description: "A custom tool",
-			Parameters:  &apiextensionsv1.JSON{Raw: json.RawMessage(`{"type":"object"}`)},
-			HTTP:        &corev1alpha1.HTTPExecution{URL: "http://example.com/tool"},
-		},
-	}
-
-	handler, _ := setupTestAnthropicHandler(toolCRD)
-	req := &llm.CompletionRequest{}
-	injectOrkaTools(context.Background(), handler.client, req, "default")
-
-	names := map[string]bool{}
-	for _, tool := range req.Tools {
-		names[tool.Name] = true
-	}
-	if !names["custom-tool"] {
-		t.Error("expected Tool CRD 'custom-tool' not found in injected tools")
-	}
-	for _, expected := range builtinProxyTools {
-		if !names[expected] {
-			t.Errorf("expected built-in tool %q not found", expected)
-		}
-	}
-}
-
 // TestInjectOrkaTools_CoordinatorToolsAllRegistered guards against a class of
 // outages where coordinatorProxyTools lists a tool name that is not registered
 // in DefaultRegistry. When that happens ToLLMTools silently drops the tool, the
@@ -1635,7 +1604,7 @@ func TestInjectOrkaTools_CoordinatorToolsAllRegistered(t *testing.T) {
 	tools.RegisterProxyPRTools(handler.client)
 
 	req := &llm.CompletionRequest{}
-	injectOrkaTools(context.Background(), handler.client, req, "default")
+	injectOrkaTools(req)
 
 	names := map[string]bool{}
 	for _, tool := range req.Tools {

--- a/internal/api/anthropic_tool_loop.go
+++ b/internal/api/anthropic_tool_loop.go
@@ -14,10 +14,8 @@ import (
 	"strings"
 	"time"
 
-	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
 	"github.com/orka-agents/orka/internal/llm"
 	"github.com/orka-agents/orka/internal/tools"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // goalStateSentinel is the literal tag the coordinator MUST include in its
@@ -606,28 +604,14 @@ var coordinatorProxyTools = []string{
 	"list_tasks",
 }
 
-// injectOrkaTools appends Orka's built-in tools, coordinator tools, and namespace Tool CRDs
-// to the completion request. Client-provided tools (if any) are preserved.
-func injectOrkaTools(ctx context.Context, k8sClient client.Client, req *llm.CompletionRequest, namespace string) {
+// injectOrkaTools appends the built-in and coordinator tools that the registry can execute.
+// Kubernetes Tool resources are not supported by the compatibility tool loop.
+func injectOrkaTools(req *llm.CompletionRequest) {
 	builtinTools := tools.DefaultRegistry.ToLLMTools(builtinProxyTools)
 	req.Tools = append(req.Tools, builtinTools...)
 
 	coordinatorTools := tools.DefaultRegistry.ToLLMTools(coordinatorProxyTools)
 	req.Tools = append(req.Tools, coordinatorTools...)
-
-	// Load Tool CRDs from namespace for custom HTTP tools
-	var toolList corev1alpha1.ToolList
-	if err := k8sClient.List(ctx, &toolList, client.InNamespace(namespace)); err == nil {
-		for _, t := range toolList.Items {
-			if t.Spec.Parameters != nil {
-				req.Tools = append(req.Tools, llm.Tool{
-					Name:        t.Name,
-					Description: t.Spec.Description,
-					Parameters:  t.Spec.Parameters.Raw,
-				})
-			}
-		}
-	}
 }
 
 // executeToolCall executes a single tool call via the default registry with a timeout.

--- a/internal/api/compat_coordinator.go
+++ b/internal/api/compat_coordinator.go
@@ -7,16 +7,12 @@ MIT License - see LICENSE file for details.
 package api
 
 import (
-	"context"
-
 	"github.com/gofiber/fiber/v3"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/orka-agents/orka/internal/llm"
 )
 
 type compatCoordinatorSetup struct {
-	Client              client.Client
 	Namespace           string
 	ToolUseAction       string
 	AuthorizationConfig ContextTokenAuthorizationConfig
@@ -28,7 +24,6 @@ type compatCoordinatorSetup struct {
 // order so OpenAI and Anthropic do not drift.
 func prepareCompatCoordinatorTools(
 	c fiber.Ctx,
-	ctx context.Context,
 	req *llm.CompletionRequest,
 	setup compatCoordinatorSetup,
 ) (bool, error) {
@@ -36,7 +31,7 @@ func prepareCompatCoordinatorTools(
 		return false, nil
 	}
 	req.Tools = nil
-	injectOrkaTools(ctx, setup.Client, req, setup.Namespace)
+	injectOrkaTools(req)
 	req.Tools = filterCompletionToolsForContextToken(c, setup.AuthorizationConfig, req.Tools)
 	if err := authorizeContextTokenToolUse(c, setup.AuthorizationConfig, setup.ToolUseAction, completionToolNames(req.Tools)); err != nil {
 		return false, err

--- a/internal/api/compat_coordinator_test.go
+++ b/internal/api/compat_coordinator_test.go
@@ -7,7 +7,6 @@ MIT License - see LICENSE file for details.
 package api
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -20,7 +19,6 @@ import (
 )
 
 func TestPrepareCompatCoordinatorToolsDisabledPreservesRequest(t *testing.T) {
-	handler, _ := setupTestAnthropicHandler()
 	clientTool := llm.Tool{Name: "client_tool"}
 	req := &llm.CompletionRequest{
 		Tools:        []llm.Tool{clientTool},
@@ -34,8 +32,7 @@ func TestPrepareCompatCoordinatorToolsDisabledPreservesRequest(t *testing.T) {
 	var setupErr error
 	app := fiber.New()
 	app.Post("/", func(c fiber.Ctx) error {
-		enabled, setupErr = prepareCompatCoordinatorTools(c, context.Background(), req, compatCoordinatorSetup{
-			Client:              handler.client,
+		enabled, setupErr = prepareCompatCoordinatorTools(c, req, compatCoordinatorSetup{
 			Namespace:           "default",
 			ToolUseAction:       "testTools",
 			AuthorizationConfig: ContextTokenAuthorizationConfig{},
@@ -63,7 +60,6 @@ func TestPrepareCompatCoordinatorToolsDisabledPreservesRequest(t *testing.T) {
 }
 
 func TestPrepareCompatCoordinatorToolsEnabledInjectsPromptToolsAndStripsClientToolMessages(t *testing.T) {
-	handler, _ := setupTestAnthropicHandler()
 	req := &llm.CompletionRequest{
 		Tools:        []llm.Tool{{Name: "client_tool"}},
 		SystemPrompt: "original prompt",
@@ -77,8 +73,7 @@ func TestPrepareCompatCoordinatorToolsEnabledInjectsPromptToolsAndStripsClientTo
 	var setupErr error
 	app := fiber.New()
 	app.Post("/", func(c fiber.Ctx) error {
-		enabled, setupErr = prepareCompatCoordinatorTools(c, context.Background(), req, compatCoordinatorSetup{
-			Client:              handler.client,
+		enabled, setupErr = prepareCompatCoordinatorTools(c, req, compatCoordinatorSetup{
 			Namespace:           "default",
 			ToolUseAction:       "testTools",
 			AuthorizationConfig: ContextTokenAuthorizationConfig{},
@@ -111,7 +106,6 @@ func TestPrepareCompatCoordinatorToolsEnabledInjectsPromptToolsAndStripsClientTo
 }
 
 func TestPrepareCompatCoordinatorToolsPropagatesToolAuthorizationAction(t *testing.T) {
-	handler, _ := setupTestAnthropicHandler()
 	authz, err := NewContextTokenAuthorizationConfig(ContextTokenAuthorizationConfigOptions{Mode: ContextTokenAuthorizationModeEnforce})
 	if err != nil {
 		t.Fatalf("NewContextTokenAuthorizationConfig: %v", err)
@@ -121,8 +115,7 @@ func TestPrepareCompatCoordinatorToolsPropagatesToolAuthorizationAction(t *testi
 	app := fiber.New()
 	app.Post("/", func(c fiber.Ctx) error {
 		c.Locals(UserInfoContextKey, &UserInfo{AuthType: AuthTypeContextToken, ContextToken: &ContextToken{Scopes: []string{}}})
-		_, setupErr = prepareCompatCoordinatorTools(c, context.Background(), req, compatCoordinatorSetup{
-			Client:              handler.client,
+		_, setupErr = prepareCompatCoordinatorTools(c, req, compatCoordinatorSetup{
 			Namespace:           "default",
 			ToolUseAction:       "openAITools",
 			AuthorizationConfig: authz,
@@ -142,7 +135,6 @@ func TestPrepareCompatCoordinatorToolsPropagatesToolAuthorizationAction(t *testi
 }
 
 func TestPrepareCompatCoordinatorToolsFiltersAllowedToolsBeforeAuthorizing(t *testing.T) {
-	handler, _ := setupTestAnthropicHandler()
 	authz, err := NewContextTokenAuthorizationConfig(ContextTokenAuthorizationConfigOptions{Mode: ContextTokenAuthorizationModeEnforce})
 	if err != nil {
 		t.Fatalf("NewContextTokenAuthorizationConfig: %v", err)
@@ -155,8 +147,7 @@ func TestPrepareCompatCoordinatorToolsFiltersAllowedToolsBeforeAuthorizing(t *te
 			Scopes:             []string{ContextTokenScopeToolsUse},
 			TransactionContext: map[string]any{"allowedTools": []string{"file_read"}},
 		}})
-		_, setupErr = prepareCompatCoordinatorTools(c, context.Background(), req, compatCoordinatorSetup{
-			Client:              handler.client,
+		_, setupErr = prepareCompatCoordinatorTools(c, req, compatCoordinatorSetup{
 			Namespace:           "default",
 			ToolUseAction:       "anthropicTools",
 			AuthorizationConfig: authz,
@@ -179,7 +170,6 @@ func TestPrepareCompatCoordinatorToolsFiltersAllowedToolsBeforeAuthorizing(t *te
 }
 
 func TestPrepareCompatCoordinatorToolsToolUseAuthErrorDoesNotApplyPromptOrStripMessages(t *testing.T) {
-	handler, _ := setupTestAnthropicHandler()
 	authz, err := NewContextTokenAuthorizationConfig(ContextTokenAuthorizationConfigOptions{Mode: ContextTokenAuthorizationModeEnforce})
 	if err != nil {
 		t.Fatalf("NewContextTokenAuthorizationConfig: %v", err)
@@ -195,8 +185,7 @@ func TestPrepareCompatCoordinatorToolsToolUseAuthErrorDoesNotApplyPromptOrStripM
 	app := fiber.New()
 	app.Post("/", func(c fiber.Ctx) error {
 		c.Locals(UserInfoContextKey, &UserInfo{AuthType: AuthTypeContextToken, ContextToken: &ContextToken{Scopes: []string{}}})
-		_, setupErr = prepareCompatCoordinatorTools(c, context.Background(), req, compatCoordinatorSetup{
-			Client:              handler.client,
+		_, setupErr = prepareCompatCoordinatorTools(c, req, compatCoordinatorSetup{
 			Namespace:           "default",
 			ToolUseAction:       "openAITools",
 			AuthorizationConfig: authz,

--- a/internal/api/compat_custom_tools_test.go
+++ b/internal/api/compat_custom_tools_test.go
@@ -1,0 +1,237 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+	"github.com/orka-agents/orka/internal/tools"
+)
+
+func TestCompatCoordinatorToolsExcludeKubernetesTools(t *testing.T) {
+	for _, api := range []string{"openai", "anthropic"} {
+		t.Run(api, func(t *testing.T) {
+			file, err := os.CreateTemp("/tmp", "orka-compat-tool-*")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = os.Remove(file.Name()) })
+			const fileContent = "built-in file_read result"
+			_, err = file.WriteString(fileContent)
+			require.NoError(t, err)
+			require.NoError(t, file.Close())
+
+			var endpointCalls atomic.Int32
+			endpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				endpointCalls.Add(1)
+				_, _ = io.WriteString(w, `{"content":"custom tool result"}`)
+			}))
+			t.Cleanup(endpoint.Close)
+
+			captured := make(chan AnthropicRequest, 2)
+			var modelCalls atomic.Int32
+			model := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var request AnthropicRequest
+				if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				select {
+				case captured <- request:
+				default:
+				}
+				w.Header().Set("Content-Type", "application/json")
+				switch modelCalls.Add(1) {
+				case 1:
+					// Also attempt an unadvertised custom tool to verify rejection.
+					_, _ = fmt.Fprintf(w, `{"id":"msg-tools","type":"message","role":"assistant","model":"test-model","content":[{"type":"tool_use","id":"custom-call","name":"example-lookup","input":{"query":"test"}},{"type":"tool_use","id":"builtin-call","name":"file_read","input":{"path":%q}}],"stop_reason":"tool_use","usage":{"input_tokens":1,"output_tokens":1}}`, file.Name())
+				case 2:
+					_, _ = fmt.Fprintf(w, `{"id":"msg-result","type":"message","role":"assistant","model":"test-model","content":[{"type":"text","text":%q}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`, goalStateSentinel+"\n"+fileContent)
+				default:
+					http.Error(w, "unexpected model call", http.StatusBadRequest)
+				}
+			}))
+			t.Cleanup(model.Close)
+
+			app, path := setupCompatCustomToolsApp(t, api, model.URL, endpoint.URL)
+			request := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"model":"anthropic/test-model","messages":[{"role":"user","content":"read the file"}],"max_tokens":1024}`))
+			request.Header.Set("Content-Type", "application/json")
+			response, err := app.Test(request, fiber.TestConfig{Timeout: 10 * time.Second})
+			require.NoError(t, err)
+			defer func() { _ = response.Body.Close() }()
+			body, err := io.ReadAll(response.Body)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, response.StatusCode, string(body))
+			require.Contains(t, string(body), fileContent)
+			require.EqualValues(t, 0, endpointCalls.Load(), "custom HTTP tools must not execute")
+			require.EqualValues(t, 2, modelCalls.Load())
+			require.Len(t, captured, 2)
+
+			allowed := append(slices.Clone(builtinProxyTools), coordinatorProxyTools...)
+			requests := []AnthropicRequest{<-captured, <-captured}
+			for _, upstream := range requests {
+				names := make(map[string]bool)
+				for _, definition := range upstream.Tools {
+					require.Contains(t, allowed, definition.Name, "only supported tools may be advertised")
+					require.NotContains(t, names, definition.Name, "tool definitions must be unique")
+					names[definition.Name] = true
+					registered, ok := tools.DefaultRegistry.Get(definition.Name)
+					require.True(t, ok, "advertised tool %q must be registered", definition.Name)
+					require.Equal(t, registered.Description(), definition.Description)
+					require.JSONEq(t, string(registered.Parameters()), string(definition.InputSchema))
+				}
+				require.Contains(t, names, "file_read")
+				require.NotContains(t, names, "example-lookup")
+			}
+			results := compatCustomToolResults(t, requests[1].Messages)
+			require.JSONEq(t, `{"success":false,"error":"tool \"example-lookup\" is not available in this request"}`, results["custom-call"])
+			var result tools.FileReadResult
+			require.NoError(t, json.Unmarshal([]byte(results["builtin-call"]), &result))
+			require.Equal(t, fileContent, result.Content)
+			require.Equal(t, file.Name(), result.Path)
+		})
+	}
+}
+
+func TestCompatToolsDisabledPreservesClientDefinitions(t *testing.T) {
+	for _, api := range []string{"openai", "anthropic"} {
+		t.Run(api, func(t *testing.T) {
+			clientTools := []AnthropicTool{
+				{Name: "example-lookup", Description: "Client lookup", InputSchema: json.RawMessage(`{"type":"object","properties":{"query":{"type":"string","enum":["first","second"]}},"required":["query"]}`)},
+				{Name: "file_read", Description: "Client file reader", InputSchema: json.RawMessage(`{"type":"object","properties":{"filename":{"type":"string"},"options":{"type":"object","properties":{"lines":{"type":"integer","minimum":1,"maximum":5}}}},"required":["filename"]}`)},
+			}
+			captured := make(chan AnthropicRequest, 1)
+			var modelCalls atomic.Int32
+			model := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var request AnthropicRequest
+				if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				if modelCalls.Add(1) != 1 {
+					http.Error(w, "server-side tool loop must be disabled", http.StatusBadRequest)
+					return
+				}
+				captured <- request
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"id":"msg-client","type":"message","role":"assistant","model":"test-model","content":[{"type":"tool_use","id":"client-call","name":"file_read","input":{"filename":"client.txt"}}],"stop_reason":"tool_use","usage":{"input_tokens":1,"output_tokens":1}}`)
+			}))
+			t.Cleanup(model.Close)
+
+			app, path := setupCompatCustomToolsApp(t, api, model.URL, "http://unused.invalid/tool")
+			requestBody := map[string]any{
+				"model": "anthropic/test-model", "max_tokens": 1024,
+				"messages": []map[string]string{{"role": "user", "content": "read a client file"}},
+				"tools":    clientTools,
+			}
+			if api == "openai" {
+				functions := make([]map[string]any, 0, len(clientTools))
+				for _, tool := range clientTools {
+					functions = append(functions, map[string]any{"type": "function", "function": map[string]any{
+						"name": tool.Name, "description": tool.Description, "parameters": tool.InputSchema,
+					}})
+				}
+				requestBody["tools"] = functions
+			}
+			encoded, err := json.Marshal(requestBody)
+			require.NoError(t, err)
+			request := httptest.NewRequest(http.MethodPost, path, strings.NewReader(string(encoded)))
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("X-Orka-Tools", "disabled")
+			response, err := app.Test(request, fiber.TestConfig{Timeout: 10 * time.Second})
+			require.NoError(t, err)
+			defer func() { _ = response.Body.Close() }()
+			body, err := io.ReadAll(response.Body)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, response.StatusCode, string(body))
+			require.Contains(t, string(body), "client-call")
+			require.Contains(t, string(body), "file_read")
+			require.EqualValues(t, 1, modelCalls.Load())
+			require.Len(t, captured, 1)
+			upstream := <-captured
+			require.Len(t, upstream.Tools, len(clientTools))
+			for i, expected := range clientTools {
+				require.Equal(t, expected.Name, upstream.Tools[i].Name)
+				require.Equal(t, expected.Description, upstream.Tools[i].Description)
+				require.JSONEq(t, string(expected.InputSchema), string(upstream.Tools[i].InputSchema))
+			}
+		})
+	}
+}
+
+func setupCompatCustomToolsApp(t *testing.T, api, modelURL, toolURL string) (*fiber.App, string) {
+	t.Helper()
+	objects := make([]runtime.Object, 0, 4)
+	objects = append(objects,
+		&corev1alpha1.Provider{
+			ObjectMeta: metav1.ObjectMeta{Name: "anthropic", Namespace: "default"},
+			Spec: corev1alpha1.ProviderSpec{
+				Type: corev1alpha1.ProviderTypeAnthropic, DefaultModel: "test-model", BaseURL: modelURL,
+				SecretRef: corev1alpha1.ProviderSecretRef{Name: "anthropic-secret", Key: "api-key"},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "anthropic-secret", Namespace: "default"},
+			Data:       map[string][]byte{"api-key": []byte("test-key")},
+		},
+	)
+	for _, name := range []string{"example-lookup", "file_read"} {
+		objects = append(objects, &corev1alpha1.Tool{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: corev1alpha1.ToolSpec{
+				Description: "Kubernetes custom tool",
+				Parameters:  &apiextensionsv1.JSON{Raw: []byte(`{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}`)},
+				HTTP:        &corev1alpha1.HTTPExecution{URL: toolURL, Method: http.MethodPost},
+			},
+		})
+	}
+	if api == "openai" {
+		handler, app := setupTestOpenAIHandler(objects...)
+		path := "/openai/v1/chat/completions"
+		app.Post(path, handler.HandleChatCompletions)
+		return app, path
+	}
+	handler, app := setupTestAnthropicHandler(objects...)
+	path := "/anthropic/v1/messages"
+	app.Post(path, handler.HandleMessages)
+	return app, path
+}
+
+func compatCustomToolResults(t *testing.T, messages []AnthropicMessage) map[string]string {
+	t.Helper()
+	results := make(map[string]string)
+	for _, message := range messages {
+		blocks, err := parseAnthropicContent(message.Content)
+		require.NoError(t, err)
+		for _, block := range blocks {
+			if block.Type != "tool_result" {
+				continue
+			}
+			content, err := parseAnthropicContent(block.Content)
+			require.NoError(t, err)
+			require.Len(t, content, 1)
+			results[block.ToolUseID] = content[0].Text
+		}
+	}
+	return results
+}

--- a/internal/api/context_token_compat_tools_test.go
+++ b/internal/api/context_token_compat_tools_test.go
@@ -40,7 +40,7 @@ func TestContextTokenAllowedToolsFiltersInjectedProxyTools(t *testing.T) {
 	app.Use(NewAuthMiddleware(handler.client, AuthConfig{ContextTokens: ctxTokenConfig}))
 	app.Get("/filter", func(c fiber.Ctx) error {
 		compReq := &llm.CompletionRequest{}
-		injectOrkaTools(c.Context(), handler.client, compReq, "default")
+		injectOrkaTools(compReq)
 		gotNames = completionToolNames(filterCompletionToolsForContextToken(c, handler.contextTokenAuthorization, compReq.Tools))
 		return c.SendStatus(http.StatusNoContent)
 	})

--- a/internal/api/openai_compat.go
+++ b/internal/api/openai_compat.go
@@ -286,8 +286,7 @@ func (h *OpenAICompatHandler) HandleChatCompletions(c fiber.Ctx) error {
 
 	// Inject Orka tools and run the server-side agentic loop by default.
 	// Set X-Orka-Tools: disabled to use as a transparent proxy instead.
-	orkaToolsEnabled, err := prepareCompatCoordinatorTools(c, ctx, compReq, compatCoordinatorSetup{
-		Client:              newExternalToolClient(h.client, h.kubeClient, userInfo, namespace, h.watchNamespace, h.enforceNamespaceIsolation, h.gatewayEventStore),
+	orkaToolsEnabled, err := prepareCompatCoordinatorTools(c, compReq, compatCoordinatorSetup{
 		Namespace:           namespace,
 		ToolUseAction:       "openAITools",
 		AuthorizationConfig: h.contextTokenAuthorization,

--- a/website/docs/reference/anthropic-compat.md
+++ b/website/docs/reference/anthropic-compat.md
@@ -183,9 +183,11 @@ specific to the Anthropic shape.
 4. Step 3 repeats until the model returns text only.
 5. That final response goes back to you.
 
-The loop executes the [18 built-in coordinator tools](openai-compat.md#coordinator-mode).
-Custom `Tool` CRDs with `parameters` can appear in the model's tool list, but the loop
-cannot execute their HTTP requests. Calling one returns `tool "..." not found`.
+The loop advertises and executes the registered
+[built-in and coordinator tools](openai-compat.md#coordinator-mode). Custom Kubernetes
+`Tool` resources are not advertised or executed, including those with a built-in name.
+With `X-Orka-Tools: disabled`, your client's tool definitions pass through unchanged and
+your client handles tool execution.
 
 ### Streaming behavior
 

--- a/website/docs/reference/openai-compat.md
+++ b/website/docs/reference/openai-compat.md
@@ -206,9 +206,9 @@ The 18 injected tools:
 | Track work | `check_task_progress`, `fetch_task_output`, `wait_for_task`, `cancel_task`, `list_agents`, `list_tasks` |
 | Pull requests | `create_pull_request`, `check_pull_request_ci` |
 
-Custom `Tool` CRDs in the namespace that define `parameters` are also advertised to the
-model, but the compatibility loop cannot execute their HTTP requests. Calling one returns
-`tool "..." not found`. Use the built-ins listed above for coordinator requests.
+Orka advertises only the tools listed above that are registered for server-side execution.
+Custom Kubernetes `Tool` resources are not advertised or executed by either compatibility
+endpoint. A custom `Tool` with a built-in name cannot replace or duplicate its definition.
 
 ### Turning it off
 
@@ -216,8 +216,9 @@ model, but the compatibility loop cannot execute their HTTP requests. Calling on
 X-Orka-Tools: disabled
 ```
 
-This header disables the coordinator rewrite and Orka's tool loop. Your client manages
-its own tools and tool loop. Requests still pass through Orka's OpenAI request conversion;
+This header disables the coordinator rewrite and Orka's tool loop. Your client's tool
+definitions pass through unchanged, and your client manages its own tool execution.
+Requests still pass through Orka's OpenAI request conversion;
 for example, `top_p`, `frequency_penalty`, and `presence_penalty` are not forwarded to the
 provider. Provider resolution and credential handling are unchanged.
 


### PR DESCRIPTION
The OpenAI and Anthropic compatibility APIs now advertise only supported tools from the execution registry. Kubernetes `Tool` resources are no longer added to coordinator requests, so unsupported tools cannot appear in the model's choices or duplicate a built-in definition.

Adds public-handler regressions for both APIs covering custom-tool exclusion and rejection without HTTP calls, built-in `file_read` execution and results, name collisions, and unchanged client tool definitions with `X-Orka-Tools: disabled`. Updates both compatibility guides.

Fixes #502.

Validation:

- Reproduced the custom-tool advertisement failure in both APIs before the fix.
- Focused compatibility and context-token tests passed.
- `make lint-fix` passed.
- `make test` passed.
