### PR TITLE
test(acp): require publication evidence for release qualification

### DIFF
--- a/.github/workflows/live-acp-release-gate.yml
+++ b/.github/workflows/live-acp-release-gate.yml
@@ -9,8 +9,8 @@ on:
         default: https://github.com/orka-agents/orka.git
         type: string
       publication_repository:
-        description: HTTPS URL of a distinct GitHub fork used for publication
-        required: true
+        description: Optional fork URL; must match the protected environment canary setting
+        required: false
         type: string
       source_ref:
         description: Full SHA of the dispatched workflow commit; must equal the selected base branch head
@@ -36,17 +36,47 @@ jobs:
     timeout-minutes: 240
     environment: live-acp-release-gate
     env:
+      RELEASE_GATE: "1"
+      ACP_E2E_REPO: ${{ inputs.source_repository }}
+      ACP_E2E_REF: ${{ inputs.source_ref }}
+      ACP_E2E_WRITE_SOURCE_REPO: ${{ inputs.source_repository }}
+      ACP_E2E_WRITE_SOURCE_REF: ${{ inputs.source_ref }}
+      ACP_E2E_WRITE_PUBLICATION_REPO: ${{ inputs.publication_repository || vars.ACP_E2E_WRITE_PUBLICATION_REPO }}
+      ACP_E2E_WRITE_PR_BASE: ${{ inputs.pr_base }}
+      ACP_E2E_WRITE_CREATE_PR: "1"
       ACP_E2E_OPENCODE_CONTEXT_WINDOW: "32768"
       ACP_E2E_OPENCODE_MAX_TOKENS: "4096"
       ACP_E2E_OPENCODE_MODEL: "openai/gpt-5.4"
       ACP_E2E_KIND_TAG: acp-release-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
+      # This seed survives invalid dispatches, checkout failures, and missing
+      # credentials. Do not copy arbitrary dispatch inputs into the artifact.
+      - name: Initialize acceptance evidence
+        env:
+          ACP_E2E_REPORT_FILE: ${{ runner.temp }}/live-acp-release-gate/acceptance.json
+        run: |
+          set -Eeuo pipefail
+          printf 'ACP_E2E_REPORT_FILE=%s\n' "${ACP_E2E_REPORT_FILE}" >>"${GITHUB_ENV}"
+          mkdir -p "$(dirname "${ACP_E2E_REPORT_FILE}")"
+          candidate=""
+          if [[ "${ACP_E2E_WRITE_SOURCE_REF}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            candidate="${ACP_E2E_WRITE_SOURCE_REF,,}"
+          fi
+          jq -n --arg candidate "${candidate}" --arg sha "${GITHUB_SHA}" \
+            --arg repository "${GITHUB_REPOSITORY}" --arg ref "${GITHUB_REF}" \
+            --arg run "${GITHUB_RUN_ID}" --arg attempt "${GITHUB_RUN_ATTEMPT}" \
+            '{schemaVersion:1, gate:"live-acp-release-gate", mode:"release",
+              candidateSHA:$candidate, checkoutSHA:$sha, result:"not_qualified",
+              stage:"trusted_dispatch", workflow:{repository:$repository, ref:$ref,
+                sha:$sha, runID:$run, runAttempt:$attempt, event:"workflow_dispatch"}}' \
+            >"${ACP_E2E_REPORT_FILE}"
+
       - name: Validate trusted dispatch inputs
         env:
           CHECKED_OUT_SHA: ${{ github.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           PR_BASE: ${{ inputs.pr_base }}
-          PUBLICATION_REPOSITORY: ${{ inputs.publication_repository }}
+          CONFIGURED_PUBLICATION_REPOSITORY: ${{ vars.ACP_E2E_WRITE_PUBLICATION_REPO }}
           SOURCE_REF: ${{ inputs.source_ref }}
           SOURCE_REPOSITORY: ${{ inputs.source_repository }}
         run: |
@@ -69,11 +99,16 @@ jobs:
             echo "source_repository must identify this repository: ${expected_source}.git" >&2
             exit 1
           fi
-          if [[ ! "${PUBLICATION_REPOSITORY}" =~ ^https://github\.com/[^/?#]+/[^/?#]+(\.git)?$ ]]; then
+          if [[ ! "${ACP_E2E_WRITE_PUBLICATION_REPO}" =~ ^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
             echo "publication_repository must be an HTTPS github.com repository URL." >&2
             exit 1
           fi
-          normalized_publication="${PUBLICATION_REPOSITORY%.git}"
+          normalized_publication="${ACP_E2E_WRITE_PUBLICATION_REPO%.git}"
+          configured_publication="${CONFIGURED_PUBLICATION_REPOSITORY%.git}"
+          if [[ -z "${configured_publication}" || "${normalized_publication,,}" != "${configured_publication,,}" ]]; then
+            echo "Configure ACP_E2E_WRITE_PUBLICATION_REPO in the environment; dispatch must use that canary fork." >&2
+            exit 1
+          fi
           if [[ "${normalized_source,,}" == "${normalized_publication,,}" ]]; then
             echo "publication_repository must be a distinct fork." >&2
             exit 1
@@ -116,36 +151,67 @@ jobs:
           kubectl version --client=true
 
       - name: Run destructive canonical ACP release gate in Kind
+        id: gate
+        # Leave time for failure evidence and cleanup before the job deadline.
+        timeout-minutes: 210
         env:
-          ACP_E2E_REF: ${{ inputs.source_ref }}
-          ACP_E2E_REPO: ${{ inputs.source_repository }}
-          ACP_E2E_WRITE_CREATE_PR: "1"
+          # Transfer cluster teardown to the post-upload step below.
+          ACP_E2E_KEEP_CLUSTER: "1"
           ACP_E2E_WRITE_CREDENTIAL_TOKEN: ${{ secrets.ACP_E2E_WRITE_CREDENTIAL_TOKEN }}
           ACP_E2E_WRITE_FORGE_CREDENTIAL_TOKEN: ${{ secrets.ACP_E2E_WRITE_FORGE_CREDENTIAL_TOKEN }}
-          ACP_E2E_WRITE_PR_BASE: ${{ inputs.pr_base }}
-          ACP_E2E_WRITE_PUBLICATION_REPO: ${{ inputs.publication_repository }}
           ACP_E2E_WRITE_READ_CREDENTIAL_TOKEN: ${{ secrets.ACP_E2E_WRITE_READ_CREDENTIAL_TOKEN }}
-          ACP_E2E_WRITE_SOURCE_REF: ${{ inputs.source_ref }}
-          ACP_E2E_WRITE_SOURCE_REPO: ${{ inputs.source_repository }}
           ACP_E2E_WRITE_TARGET_READ_CREDENTIAL_TOKEN: ${{ secrets.ACP_E2E_WRITE_TARGET_READ_CREDENTIAL_TOKEN }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.ACP_E2E_WRITE_FORGE_CREDENTIAL_TOKEN }}
-          RELEASE_GATE: "1"
+        run: bash scripts/live-acp-runtime-kind-e2e.sh
+
+      - name: Upload evidence before cluster teardown
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: live-acp-release-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/live-acp-release-gate/acceptance.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Remove the disposable cluster and registry
+        if: always() && steps.gate.outcome != 'skipped'
         run: |
           set -Eeuo pipefail
+          source scripts/lib/live-acp-runtime-kind-bootstrap.sh
+          if ! jq -e '.cluster.creationAttempted == true' "${ACP_E2E_REPORT_FILE}" >/dev/null; then
+            exit 0
+          fi
+          jq -e --arg tag "${ACP_E2E_KIND_TAG}" '.cluster.tag == $tag' "${ACP_E2E_REPORT_FILE}" >/dev/null
+          LIVE_ACP_REPO_ROOT="${GITHUB_WORKSPACE}"
+          LIVE_ACP_KINDCTL_BIN="${GITHUB_WORKSPACE}/.agents/skills/kindctl/bin/kindctl"
+          LIVE_ACP_KIND_TAG="${ACP_E2E_KIND_TAG}"
+          LIVE_ACP_KIND_CREATED=1
+          LIVE_ACP_KIND_CLUSTER="$(jq -r '.cluster.name // ""' "${ACP_E2E_REPORT_FILE}")"
+          LIVE_ACP_REGISTRY_STARTED="$(jq -r 'if .cluster.registryStarted then 1 else 0 end' "${ACP_E2E_REPORT_FILE}")"
+          live_acp_kind_delete_cluster
 
-          required_secrets=(
-            COPILOT_GITHUB_TOKEN
-            ACP_E2E_WRITE_READ_CREDENTIAL_TOKEN
-            ACP_E2E_WRITE_TARGET_READ_CREDENTIAL_TOKEN
-            ACP_E2E_WRITE_CREDENTIAL_TOKEN
-            ACP_E2E_WRITE_FORGE_CREDENTIAL_TOKEN
-          )
-          for name in "${required_secrets[@]}"; do
-            if [[ -z "${!name}" ]]; then
-              echo "${name} must be configured in the live-acp-release-gate environment." >&2
-              exit 1
-            fi
-          done
+      - name: Qualify the candidate from complete evidence
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          if [[ ! -f scripts/lib/live-acp-release-report.sh ]]; then
+            echo "Candidate is not qualified: trusted checkout never completed." >&2
+            exit 1
+          fi
+          source scripts/lib/live-acp-release-report.sh
+          base_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${ACP_E2E_WRITE_PR_BASE}" --jq '.sha')"
+          # shellcheck disable=SC2016 # This is a jq program.
+          acp_report_update '.observations.baseHeads.completion = $sha' --arg sha "${base_sha}"
+          acp_report_finish
 
-          bash scripts/live-acp-runtime-kind-e2e.sh
+      - name: Upload final acceptance report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: live-acp-release-acceptance-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/live-acp-release-gate/acceptance.json
+          if-no-files-found: error
+          retention-days: 90

--- a/scripts/lib/live-acp-release-report.sh
+++ b/scripts/lib/live-acp-release-report.sh
@@ -46,12 +46,12 @@ acp_report_init() {
         schemaVersion: 1, gate: "live-acp-release-gate", mode: "release",
         candidateSHA: ($candidate | sha), checkoutSHA: ($checkout | sha),
         sourceRepository: ($source | repo), publicationRepository: ($publication | repo),
-        baseBranch: $base, run: $run,
+        baseBranch: $base, expectedBranch: null, run: $run,
         workflow: {repository: $repository, ref: $ref, sha: ($workflowSHA | sha),
           runID: $runID, runAttempt: $attempt, event: $event},
         startedAt: (now | todateiso8601), finishedAt: null,
         result: "not_qualified", stage: "preflight", validation: "not_started",
-        validatorExitCode: null, bootstrapExitCode: null,
+        validatorStarted: false, validatorExitCode: null, bootstrapExitCode: null,
         checks: {publication: false, credentialsFrozen: false,
           publisherSecretReadDenied: false, baseUnchanged: false},
         builtImages: {}, images: {}, task: null, credentials: [],
@@ -118,7 +118,8 @@ acp_report_qualified() {
       and (.candidateSHA | sha) and .candidateSHA == .checkoutSHA
       and .sourceRepository == "https://github.com/orka-agents/orka"
       and (.publicationRepository | present) and .publicationRepository != .sourceRepository
-      and .validation == "passed" and .validatorExitCode == 0 and .bootstrapExitCode == 0
+      and .validation == "passed" and .validatorStarted == true
+      and .validatorExitCode == 0 and .bootstrapExitCode == 0
       and .checks.publication == true and .checks.credentialsFrozen == true
       and .checks.publisherSecretReadDenied == true and .checks.baseUnchanged == true
       and .canary.expectedCommitBytesMatched == true and .canary.remoteBytesMatched == true
@@ -136,6 +137,7 @@ acp_report_qualified() {
       and (.task.delivery.publicationID | present)
       and (.task.delivery.outcome == "VerifiedExact" or .task.delivery.outcome == "DeliveredSuperseded")
       and .task.delivery.startingSHA == .candidateSHA
+      and (.expectedBranch | present) and .task.delivery.branch == .expectedBranch
       and (.task.delivery.expectedCommitSHA | sha) and (.task.delivery.treeSHA | sha)
       and (.task.delivery.artifactDigest | digest)
       and (.observations.remoteHead | sha)

--- a/scripts/lib/live-acp-release-report.sh
+++ b/scripts/lib/live-acp-release-report.sh
@@ -139,9 +139,14 @@ acp_report_qualified() {
       and .task.delivery.startingSHA == .candidateSHA
       and (.expectedBranch | present) and .task.delivery.branch == .expectedBranch
       and (.task.delivery.expectedCommitSHA | sha) and (.task.delivery.treeSHA | sha)
+      and .task.delivery.expectedCommitSHA == .observations.expectedCommit.sha
+      and .task.delivery.treeSHA == .observations.expectedCommit.treeSHA
       and (.task.delivery.artifactDigest | digest)
       and (.observations.remoteHead | sha)
       and .observations.remoteHead == (.task.delivery.supersedingRemoteSHA | select(. != null and . != "") // $r.task.delivery.verifiedRemoteSHA)
+      and (if .task.delivery.outcome == "VerifiedExact"
+        then .observations.remoteHead == .task.delivery.expectedCommitSHA
+        else .observations.remoteHead != .task.delivery.expectedCommitSHA end)
       and .observations.pullRequest.number == .task.delivery.prReceipt.number
       and (.observations.pullRequest.number | type == "number" and . > 0)
       and .observations.pullRequest.state == "open"

--- a/scripts/lib/live-acp-release-report.sh
+++ b/scripts/lib/live-acp-release-report.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016 # acp_report_update arguments are jq programs.
+# Source-only, allowlisted evidence for the deployed ACP publication gate.
+# Never persist Task prompts/results, messages, annotations, or Secret data.
+
+acp_report_enabled() {
+  [[ "${RELEASE_GATE:-0}" == "1" && -n "${ACP_E2E_REPORT_FILE:-}" ]]
+}
+
+acp_report_update() {
+  acp_report_enabled || return 0
+  local filter="$1" candidate
+  shift
+  candidate="$(mktemp "${ACP_E2E_REPORT_FILE}.XXXXXX")" || return 1
+  if ! jq "$@" "${filter}" "${ACP_E2E_REPORT_FILE}" >"${candidate}"; then
+    rm -f "${candidate}"
+    return 1
+  fi
+  chmod 600 "${candidate}" && mv "${candidate}" "${ACP_E2E_REPORT_FILE}"
+}
+
+acp_report_init() {
+  acp_report_enabled || return 0
+  local checkout_sha
+  checkout_sha="$(git -C "$1" rev-parse HEAD)" || return 1
+  mkdir -p "$(dirname "${ACP_E2E_REPORT_FILE}")" || return 1
+  jq -n \
+    --arg candidate "${ACP_E2E_WRITE_SOURCE_REF:-}" \
+    --arg checkout "${checkout_sha}" \
+    --arg source "${ACP_E2E_WRITE_SOURCE_REPO:-}" \
+    --arg publication "${ACP_E2E_WRITE_PUBLICATION_REPO:-}" \
+    --arg base "${ACP_E2E_WRITE_PR_BASE:-main}" \
+    --arg repository "${GITHUB_REPOSITORY:-}" \
+    --arg ref "${GITHUB_REF:-}" \
+    --arg workflowSHA "${GITHUB_SHA:-}" \
+    --arg runID "${GITHUB_RUN_ID:-}" \
+    --arg attempt "${GITHUB_RUN_ATTEMPT:-}" \
+    --arg event "${GITHUB_EVENT_NAME:-}" \
+    --arg run "${ACP_E2E_RUN_ID:-}" '
+      def sha: if test("^[a-fA-F0-9]{40}$") then ascii_downcase else null end;
+      def repo:
+        sub("\\.git$"; "")
+        | if test("^https://github\\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+          then ascii_downcase else null end;
+      {
+        schemaVersion: 1, gate: "live-acp-release-gate", mode: "release",
+        candidateSHA: ($candidate | sha), checkoutSHA: ($checkout | sha),
+        sourceRepository: ($source | repo), publicationRepository: ($publication | repo),
+        baseBranch: $base, run: $run,
+        workflow: {repository: $repository, ref: $ref, sha: ($workflowSHA | sha),
+          runID: $runID, runAttempt: $attempt, event: $event},
+        startedAt: (now | todateiso8601), finishedAt: null,
+        result: "not_qualified", stage: "preflight", validation: "not_started",
+        validatorExitCode: null, bootstrapExitCode: null,
+        checks: {publication: false, credentialsFrozen: false,
+          publisherSecretReadDenied: false, baseUnchanged: false},
+        builtImages: {}, images: {}, task: null, credentials: [],
+        observations: {baseHeads: {}},
+        cleanup: {remote: "not_started", kubernetes: "not_started",
+          validatorCredentials: "not_started", bootstrapCredentials: "not_started",
+          cluster: "not_started", registry: "not_started"},
+        preserved: null
+      }
+    ' >"${ACP_E2E_REPORT_FILE}" || return 1
+  chmod 600 "${ACP_E2E_REPORT_FILE}"
+}
+
+acp_report_task() {
+  acp_report_enabled || return 0
+  local projection
+  projection="$(jq -c '{
+    namespace: .metadata.namespace, name: .metadata.name, uid: .metadata.uid,
+    phase: .status.phase,
+    execution: (.status.execution // {} | {
+      state, outcome, attempt, promptID, runtimePoolName, runtimePoolUID,
+      runtimeInstanceID, runtimeSessionUID, runtimeSessionGeneration,
+      requestDigest, controllerEpoch, readCredentialResourceVersion,
+      publicationReadCredentialResourceVersion, publicationCredentialResourceVersion,
+      forgeCredentialResourceVersion
+    }),
+    delivery: (.status.delivery // {} | {
+      state, outcome, publicationID,
+      sourceRepository: (.sourceRepository // {} | {provider, id}),
+      publicationRepository: (.publicationRepository // {} | {provider, id}),
+      branch, startingSHA, remoteBeforeSHA, treeSHA, expectedCommitSHA,
+      verifiedRemoteSHA, supersedingRemoteSHA, artifactDigest,
+      prReceipt: (.prReceipt // {} | {id, number, url, state, baseBranch, headBranch, headSHA})
+    })
+  }' <<<"$1")" || return 1
+  acp_report_update '.task = $task' --argjson task "${projection}"
+}
+
+# Called only after the validator has checked the exact Pod and resolved its
+# requested OCI index to the observed platform image digest.
+acp_report_image() {
+  acp_report_enabled || return 0
+  local role="$1" pod="$2" container="$3" projection
+  projection="$(jq -c --arg container "${container}" '
+    . as $pod
+    | (.spec.containers[] | select(.name == $container)) as $spec
+    | (.status.containerStatuses[] | select(.name == $container)) as $status
+    | {namespace: $pod.metadata.namespace, pod: $pod.metadata.name, podUID: $pod.metadata.uid,
+       container: $container, requestedImage: $spec.image, imageID: $status.imageID,
+       actualDigest: ($status.imageID | capture("(?<digest>sha256:[a-f0-9]{64})$").digest),
+       verified: true}
+  ' <<<"${pod}")" || return 1
+  [[ -n "${projection}" ]] || return 1
+  acp_report_update '.images[$role] = $image' --arg role "${role}" --argjson image "${projection}"
+}
+
+acp_report_qualified() {
+  jq -e '
+    def sha: type == "string" and test("^[a-f0-9]{40}$");
+    def digest: type == "string" and test("^sha256:[a-f0-9]{64}$");
+    def present: type == "string" and length > 0;
+    . as $r
+    | .schemaVersion == 1 and .gate == "live-acp-release-gate" and .mode == "release"
+      and (.candidateSHA | sha) and .candidateSHA == .checkoutSHA
+      and .sourceRepository == "https://github.com/orka-agents/orka"
+      and (.publicationRepository | present) and .publicationRepository != .sourceRepository
+      and .validation == "passed" and .validatorExitCode == 0 and .bootstrapExitCode == 0
+      and .checks.publication == true and .checks.credentialsFrozen == true
+      and .checks.publisherSecretReadDenied == true and .checks.baseUnchanged == true
+      and .canary.expectedCommitBytesMatched == true and .canary.remoteBytesMatched == true
+      and .canary.singleAddedFile == true and (.canary.path | present)
+      and (["preflight", "submission", "publication", "completion"] | all(.[];
+        $r.observations.baseHeads[.] == $r.candidateSHA))
+      and (["controller", "publisher", "codex", "opencode", "claude", "copilot"] | all(.[];
+        . as $role | $r.images[$role] | .verified == true
+        and (.actualDigest | digest) and (.podUID | present)
+        and (.requestedImage | test("@sha256:[a-f0-9]{64}$"))
+        and .requestedImage == $r.builtImages[$role]))
+      and (.task.uid | present) and .task.phase == "Succeeded"
+      and .task.execution.state == "Succeeded" and .task.execution.outcome == "Succeeded"
+      and .task.execution.attempt == 1 and (.task.execution.promptID | present)
+      and (.task.delivery.publicationID | present)
+      and (.task.delivery.outcome == "VerifiedExact" or .task.delivery.outcome == "DeliveredSuperseded")
+      and .task.delivery.startingSHA == .candidateSHA
+      and (.task.delivery.expectedCommitSHA | sha) and (.task.delivery.treeSHA | sha)
+      and (.task.delivery.artifactDigest | digest)
+      and (.observations.remoteHead | sha)
+      and .observations.remoteHead == (.task.delivery.supersedingRemoteSHA | select(. != null and . != "") // $r.task.delivery.verifiedRemoteSHA)
+      and .observations.pullRequest.number == .task.delivery.prReceipt.number
+      and (.observations.pullRequest.number | type == "number" and . > 0)
+      and .observations.pullRequest.state == "open"
+      and .observations.pullRequest.headSHA == .observations.remoteHead
+      and .observations.pullRequest.baseSHA == .candidateSHA
+      and .observations.pullRequest.baseBranch == .baseBranch
+      and .observations.pullRequest.headBranch == .task.delivery.branch
+      and .task.delivery.prReceipt.state == "Open"
+      and .task.delivery.prReceipt.headSHA == .observations.remoteHead
+      and .task.delivery.prReceipt.headBranch == .task.delivery.branch
+      and .task.delivery.prReceipt.baseBranch == .baseBranch
+      and .observations.pullRequest.sourceRepository == .sourceRepository
+      and .observations.pullRequest.publicationRepository == .publicationRepository
+      and (.credentials | length) == 4
+      and (.credentials | map(.role) | sort) == ["forge", "sourceRead", "targetRead", "targetWrite"]
+      and all(.credentials[]; (.namespace | present) and (.name | present) and (.resourceVersion | present))
+      and (.credentials | map(.namespace + "/" + .name) | unique | length) == 4
+      and all(.credentials[];
+        .resourceVersion == ($r.task.execution | if . == null then null else
+          {sourceRead:.readCredentialResourceVersion, targetRead:.publicationReadCredentialResourceVersion,
+           targetWrite:.publicationCredentialResourceVersion, forge:.forgeCredentialResourceVersion} end)[.role])
+      and .cleanup.remote == "passed" and .cleanup.kubernetes == "passed"
+      and .cleanup.validatorCredentials == "passed" and .cleanup.bootstrapCredentials == "passed"
+      and .cleanup.cluster == "passed" and .cleanup.registry == "passed"
+      and .preserved == null
+  ' "$1" >/dev/null
+}
+
+acp_report_finish() {
+  acp_report_enabled || return 0
+  acp_report_update '.finishedAt = (now | todateiso8601) | .result = "not_qualified"' || return 1
+  if acp_report_qualified "${ACP_E2E_REPORT_FILE}"; then
+    acp_report_update '.result = "qualified"'
+  else
+    printf '%s\n' 'ACP release candidate is not qualified; inspect acceptance.json.' >&2
+    return 1
+  fi
+}

--- a/scripts/lib/live-acp-runtime-kind-bootstrap.sh
+++ b/scripts/lib/live-acp-runtime-kind-bootstrap.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016 # acp_report_update arguments are jq programs.
 # Shared, source-only bootstrap for the live ACP runtime validator on Kind.
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
@@ -9,6 +10,8 @@ fi
 live_acp_kind_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/e2e-admission-tls.sh
 . "${live_acp_kind_lib_dir}/e2e-admission-tls.sh"
+# shellcheck source=scripts/lib/live-acp-release-report.sh
+. "${live_acp_kind_lib_dir}/live-acp-release-report.sh"
 unset live_acp_kind_lib_dir
 
 # Internal port-forward state is process-local. Reset inherited values so a
@@ -59,7 +62,20 @@ live_acp_kind_preflight() {
       ACP_E2E_WRITE_TARGET_READ_CREDENTIAL_TOKEN \
       ACP_E2E_WRITE_CREDENTIAL_TOKEN \
       ACP_E2E_WRITE_FORGE_CREDENTIAL_TOKEN; do
-      [[ -n "${!token_var:-}" ]] || live_acp_kind_die "${token_var} is required when RELEASE_GATE=1" || return 1
+      if [[ -z "${!token_var:-}" ]]; then
+        acp_report_update '.failure = {reason:"missing_credential", credential:$name}' --arg name "${token_var}" || return 1
+        live_acp_kind_die "${token_var} is required when RELEASE_GATE=1"
+        return 1
+      fi
+    done
+    local left right
+    local -a role_tokens=("${ACP_E2E_WRITE_READ_CREDENTIAL_TOKEN}" "${ACP_E2E_WRITE_TARGET_READ_CREDENTIAL_TOKEN}"
+      "${ACP_E2E_WRITE_CREDENTIAL_TOKEN}" "${ACP_E2E_WRITE_FORGE_CREDENTIAL_TOKEN}")
+    for ((left=0; left<4; left++)); do
+      for ((right=left+1; right<4; right++)); do
+        [[ "${role_tokens[$left]}" != "${role_tokens[$right]}" ]] || \
+          live_acp_kind_die "release-gate credentials must use four distinct values" || return 1
+      done
     done
   fi
   [[ -x "${LIVE_ACP_KINDCTL_BIN}" ]] || live_acp_kind_die "kindctl is not executable: ${LIVE_ACP_KINDCTL_BIN}" || return 1
@@ -95,6 +111,8 @@ live_acp_kind_create_cluster() {
   # Arm exact-tag deletion before create: Kind can leave a partial cluster even
   # when its create command returns non-zero.
   LIVE_ACP_KIND_CREATED=1
+  acp_report_update '.cluster = {tag:$tag, creationAttempted:true, registryStarted:false}' \
+    --arg tag "${LIVE_ACP_KIND_TAG}" || return 1
   live_acp_kind_run "${LIVE_ACP_KINDCTL_BIN}" "${args[@]}" || return $?
   LIVE_ACP_KUBECONFIG="$("${LIVE_ACP_KINDCTL_BIN}" path --tag "${LIVE_ACP_KIND_TAG}")"
   export KUBECONFIG="${LIVE_ACP_KUBECONFIG}"
@@ -102,14 +120,16 @@ live_acp_kind_create_cluster() {
   [[ "${LIVE_ACP_CONTEXT}" == kind-* ]] || live_acp_kind_die "scoped context is not a Kind context: ${LIVE_ACP_CONTEXT}" || return 1
   LIVE_ACP_KIND_CLUSTER="${LIVE_ACP_CONTEXT#kind-}"
   export LIVE_ACP_CONTEXT LIVE_ACP_KIND_CLUSTER LIVE_ACP_KUBECONFIG
+  acp_report_update '.cluster.name = $name' --arg name "${LIVE_ACP_KIND_CLUSTER}"
 }
 
 live_acp_kind_start_registry() {
   # shellcheck source=scripts/lib/kind-local-registry.sh
   . "${LIVE_ACP_REPO_ROOT}/scripts/lib/kind-local-registry.sh"
 
-  orka_kind_registry_start "${LIVE_ACP_KIND_CLUSTER}"
   LIVE_ACP_REGISTRY_STARTED=1
+  acp_report_update '.cluster.registryStarted = true'
+  orka_kind_registry_start "${LIVE_ACP_KIND_CLUSTER}"
 
   if [[ -n "${LIVE_ACP_VEKIL_LOCAL_IMAGE:-}" ]]; then
     # Publish the development Vekil before the Vekil deploy step so the
@@ -141,6 +161,11 @@ live_acp_kind_build_and_publish_images() {
   LIVE_ACP_GENERAL_WORKER_REF="$(orka_kind_registry_push "${LIVE_ACP_GENERAL_WORKER_IMAGE}" orka/general-worker)"
   export LIVE_ACP_CONTROLLER_REF LIVE_ACP_CODEX_REF LIVE_ACP_CLAUDE_REF LIVE_ACP_COPILOT_REF
   export LIVE_ACP_OPENCODE_REF LIVE_ACP_PUBLISHER_REF LIVE_ACP_GENERAL_WORKER_REF
+  acp_report_update '.builtImages = {controller:$controller, publisher:$publisher,
+    codex:$codex, claude:$claude, copilot:$copilot, opencode:$opencode}' \
+    --arg controller "${LIVE_ACP_CONTROLLER_REF}" --arg publisher "${LIVE_ACP_PUBLISHER_REF}" \
+    --arg codex "${LIVE_ACP_CODEX_REF}" --arg claude "${LIVE_ACP_CLAUDE_REF}" \
+    --arg copilot "${LIVE_ACP_COPILOT_REF}" --arg opencode "${LIVE_ACP_OPENCODE_REF}"
 }
 
 live_acp_kind_catalog_model_supports_endpoint() {
@@ -515,20 +540,54 @@ live_acp_kind_cleanup() {
   if [[ -n "${LIVE_ACP_SECRET_DIR:-}" ]]; then
     rm -rf -- "${LIVE_ACP_SECRET_DIR}" >/dev/null 2>&1 || cleanup_status=1
   fi
+  if (( cleanup_status == 0 )); then
+    acp_report_update '.cleanup.bootstrapCredentials = "passed"' || cleanup_status=1
+  else
+    acp_report_update '.cleanup.bootstrapCredentials = "failed"' || true
+  fi
+  if acp_report_enabled && jq -e '.preserved != null' "${ACP_E2E_REPORT_FILE}" >/dev/null; then
+    live_acp_kind_log "Preserving Kind resources because remote cleanup could not be proven safe"
+    acp_report_update '.cleanup.cluster = "preserved" | .cleanup.registry = "preserved"' || true
+    return 1
+  fi
   if [[ "${LIVE_ACP_KEEP_CLUSTER:-0}" == "1" ]]; then
     live_acp_kind_log "Keeping Kind cluster ${LIVE_ACP_KIND_CLUSTER:-<not-created>} (ACP_E2E_KEEP_CLUSTER=1)"
+    acp_report_update '.cleanup.cluster = "pending" | .cleanup.registry = "pending"' || cleanup_status=1
+    if (( status != 0 )); then return "${status}"; fi
+    return "${cleanup_status}"
+  fi
+  live_acp_kind_delete_cluster || cleanup_status=1
+  if (( status != 0 )); then
     return "${status}"
+  fi
+  return "${cleanup_status}"
+}
+
+# CI calls this after uploading the report, using only the recorded run tag and
+# cluster name. It does not repeat or overwrite credential cleanup results.
+live_acp_kind_delete_cluster() {
+  local cleanup_status=0
+  if acp_report_enabled && jq -e '.preserved != null' "${ACP_E2E_REPORT_FILE}" >/dev/null; then
+    acp_report_update '.cleanup.cluster = "preserved" | .cleanup.registry = "preserved"' || true
+    return 1
   fi
   if [[ "${LIVE_ACP_REGISTRY_STARTED:-0}" == "1" ]]; then
     # shellcheck source=scripts/lib/kind-local-registry.sh
     . "${LIVE_ACP_REPO_ROOT}/scripts/lib/kind-local-registry.sh"
-    orka_kind_registry_stop "${LIVE_ACP_KIND_CLUSTER:-}" || cleanup_status=1
+    if orka_kind_registry_stop "${LIVE_ACP_KIND_CLUSTER:-}"; then
+      acp_report_update '.cleanup.registry = "passed"' || cleanup_status=1
+    else
+      cleanup_status=1
+      acp_report_update '.cleanup.registry = "failed"' || true
+    fi
   fi
   if [[ "${LIVE_ACP_KIND_CREATED:-0}" == "1" ]]; then
-    "${LIVE_ACP_KINDCTL_BIN}" delete --tag "${LIVE_ACP_KIND_TAG}" || cleanup_status=1
-  fi
-  if (( status != 0 )); then
-    return "${status}"
+    if "${LIVE_ACP_KINDCTL_BIN}" delete --tag "${LIVE_ACP_KIND_TAG}"; then
+      acp_report_update '.cleanup.cluster = "passed"' || cleanup_status=1
+    else
+      cleanup_status=1
+      acp_report_update '.cleanup.cluster = "failed"' || true
+    fi
   fi
   return "${cleanup_status}"
 }

--- a/scripts/lib/live-acp-runtime-kind-bootstrap.sh
+++ b/scripts/lib/live-acp-runtime-kind-bootstrap.sh
@@ -567,9 +567,22 @@ live_acp_kind_cleanup() {
 # cluster name. It does not repeat or overwrite credential cleanup results.
 live_acp_kind_delete_cluster() {
   local cleanup_status=0
-  if acp_report_enabled && jq -e '.preserved != null' "${ACP_E2E_REPORT_FILE}" >/dev/null; then
-    acp_report_update '.cleanup.cluster = "preserved" | .cleanup.registry = "preserved"' || true
-    return 1
+  if acp_report_enabled; then
+    # A timeout can kill the validator before its EXIT trap records preservation.
+    # Once it was launched, require positive evidence of safe remote cleanup.
+    if ! jq -e '
+        .schemaVersion == 1 and .gate == "live-acp-release-gate" and .mode == "release"
+        and has("task") and has("preserved") and .preserved == null
+        and ((.validatorStarted == false and .task == null) or (.validatorStarted == true
+          and (.cleanup.remote == "passed" or (.cleanup.remote == "not_required" and .task == null))))
+      ' "${ACP_E2E_REPORT_FILE}" >/dev/null; then
+      live_acp_kind_log "Preserving Kind resources: remote cleanup is incomplete or unproven"
+      acp_report_update '.cleanup.cluster = "preserved" | .cleanup.registry = "preserved"
+        | .preserved //= {reason:"remote_cleanup_unproven", namespace:.task.namespace,
+            task:.task.name, publicationRepository:.publicationRepository,
+            branch:.expectedBranch, receiptHead:.task.delivery.verifiedRemoteSHA}' || true
+      return 1
+    fi
   fi
   if [[ "${LIVE_ACP_REGISTRY_STARTED:-0}" == "1" ]]; then
     # shellcheck source=scripts/lib/kind-local-registry.sh

--- a/scripts/live-acp-runtime-e2e.sh
+++ b/scripts/live-acp-runtime-e2e.sh
@@ -204,6 +204,7 @@ if [[ "${release_gate}" -eq 1 ]]; then
   if [[ "${LIVE_ACP_REPORT_INITIALIZED:-0}" != "1" ]]; then
     acp_report_init "${script_dir}/.."
   fi
+  acp_report_update '.validatorStarted = true'
 fi
 if [[ "${run_id}" != "${run_id_full}" ]]; then
   warn "ACP_E2E_RUN_ID was normalized to 24 characters to preserve unique resource-name suffixes: ${run_id}"
@@ -1042,6 +1043,8 @@ cleanup() {
   if ! cleanup_remote_effects; then
     cleanup_rc=1
     acp_report_update '.cleanup.remote = "preserved"' || true
+  elif [[ "${write_task_started}" -eq 0 ]]; then
+    acp_report_update '.cleanup.remote = "not_required"' || cleanup_rc=1
   fi
 
   if [[ "${keep_resources}" == "1" || "${remote_cleanup_preserve}" == "1" ]]; then
@@ -3254,8 +3257,9 @@ run_write_release_gate() {
   log "Running mandatory Codex clean-room publication and PR reconciliation gate"
   write_task_name="${task}"
   write_task_started=1
-  acp_report_update '.stage = "publication" | .task = {namespace:$ns,name:$task}' \
-    --arg ns "${namespace}" --arg task "${task}"
+  acp_report_update '.stage = "publication" | .expectedBranch = $branch
+    | .task = {namespace:$ns,name:$task}' \
+    --arg ns "${namespace}" --arg task "${task}" --arg branch "${write_branch}"
   apply_write_task "${task}" "${agent}"
   acp_report_task "$(task_json "${task}")"
   wait_until "Task/${task} RuntimePool assignment" "${state_wait_seconds}" wait_task_pool_name_value "${task}"

--- a/scripts/live-acp-runtime-e2e.sh
+++ b/scripts/live-acp-runtime-e2e.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016 # acp_report_update arguments are jq programs.
 set -Eeuo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -6,6 +7,8 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${script_dir}/lib/e2e-common.sh"
 # shellcheck source=scripts/lib/redact.sh
 . "${script_dir}/lib/redact.sh"
+# shellcheck source=scripts/lib/live-acp-release-report.sh
+. "${script_dir}/lib/live-acp-release-report.sh"
 
 usage() {
   cat <<'USAGE'
@@ -71,6 +74,7 @@ Release-gate write settings:
   ACP_E2E_WRITE_BRANCH               Unique branch; default includes the run ID
   ACP_E2E_WRITE_PR_BASE              Base branch (default: main)
   ACP_E2E_WRITE_PROMPT               Override the exact-one-file publication prompt
+  ACP_E2E_REPORT_FILE                Redacted acceptance JSON, retained after cleanup
   ACP_E2E_API_LOCAL_PORT             Local controller port-forward port (default: run-scoped)
 
 Workload discovery overrides:
@@ -190,10 +194,17 @@ done
 release_gate=0
 if bool_env "${RELEASE_GATE:-0}"; then
   release_gate=1
+  export RELEASE_GATE=1
 fi
 
 run_id_full="$(sanitize_name "${ACP_E2E_RUN_ID:-$(date -u +%Y%m%d%H%M%S)-$$}")"
 run_id="$(printf '%s' "${run_id_full}" | cut -c1-24)"
+if [[ "${release_gate}" -eq 1 ]]; then
+  export ACP_E2E_REPORT_FILE="${ACP_E2E_REPORT_FILE:-${script_dir}/../bin/acp-release-${run_id}/acceptance.json}"
+  if [[ "${LIVE_ACP_REPORT_INITIALIZED:-0}" != "1" ]]; then
+    acp_report_init "${script_dir}/.."
+  fi
+fi
 if [[ "${run_id}" != "${run_id_full}" ]]; then
   warn "ACP_E2E_RUN_ID was normalized to 24 characters to preserve unique resource-name suffixes: ${run_id}"
 fi
@@ -634,6 +645,7 @@ release_write_task_observer() {
 
 cleanup_remote_effects() {
   [[ "${release_gate}" -eq 1 && "${remote_cleanup_required}" -eq 1 ]] || return 0
+  acp_report_update '.stage = "remote_cleanup" | .cleanup.remote = "running"' || return 1
   log "Cleaning release-gate remote effects with exact-head guards"
 
   if ! settle_write_task_for_remote_cleanup; then
@@ -646,6 +658,7 @@ cleanup_remote_effects() {
     remote_cleanup_preserve=1
     return 1
   fi
+  acp_report_update '.observations.cleanupHead = $head' --arg head "${github_ref_lookup_sha}" || return 1
 
   if [[ "${github_ref_lookup_state}" == "absent" && -z "${remote_cleanup_head}" ]]; then
     sleep 3
@@ -660,7 +673,8 @@ cleanup_remote_effects() {
       remote_cleanup_preserve=1
       return 1
     fi
-    release_write_task_observer
+    release_write_task_observer || return 1
+    acp_report_update '.cleanup.remote = "passed"'
     return $?
   fi
 
@@ -710,6 +724,7 @@ cleanup_remote_effects() {
     return 1
   fi
   log "Remote PR/branch cleanup completed"
+  acp_report_update '.cleanup.remote = "passed"'
 }
 
 task_cleanup_settled() {
@@ -1014,21 +1029,38 @@ cleanup() {
   trap '' INT TERM
   set +e
 
+  if [[ "${write_task_started}" -eq 1 ]]; then
+    local last_task
+    if last_task="$(task_json "${write_task_name}" 2>/dev/null)"; then
+      acp_report_task "${last_task}" || cleanup_rc=1
+    fi
+  fi
   if ! recover_namespace_ownership; then
     cleanup_rc=1
     remote_cleanup_preserve=1
   fi
   if ! cleanup_remote_effects; then
     cleanup_rc=1
+    acp_report_update '.cleanup.remote = "preserved"' || true
   fi
 
   if [[ "${keep_resources}" == "1" || "${remote_cleanup_preserve}" == "1" ]]; then
+    [[ "${release_gate}" -ne 1 ]] || cleanup_rc=1
+    acp_report_update '.cleanup.kubernetes = "preserved" | .preserved = {
+      namespace:$namespace, task:$task, publicationRepository:.publicationRepository,
+      branch:$branch, verifiedHead:$head, pullRequestNumber:$pr
+    }' --arg namespace "${namespace}" --arg task "${write_task_name}" \
+      --arg branch "${remote_cleanup_branch}" --arg head "${remote_cleanup_head}" \
+      --arg pr "${remote_cleanup_pr_number}" || cleanup_rc=1
     if [[ "${namespace_created}" -eq 1 || "${namespace_shared}" -eq 1 ]]; then
       warn "preserving namespace ${namespace}"
     fi
   elif [[ "${namespace_created}" -eq 1 || "${namespace_shared}" -eq 1 ]]; then
     if ! delete_test_namespace_now; then
       cleanup_rc=1
+      acp_report_update '.cleanup.kubernetes = "failed"' || true
+    else
+      acp_report_update '.cleanup.kubernetes = "passed"' || cleanup_rc=1
     fi
   fi
 
@@ -1039,10 +1071,14 @@ cleanup() {
   if ! rm -rf "${temp_root}"; then
     warn "failed to remove temporary credential directory ${temp_root}"
     cleanup_rc=1
+    acp_report_update '.cleanup.validatorCredentials = "failed"' || true
+  else
+    acp_report_update '.cleanup.validatorCredentials = "passed"' || cleanup_rc=1
   fi
   if [[ "${rc}" -eq 0 && "${cleanup_rc}" -ne 0 ]]; then
     rc="${cleanup_rc}"
   fi
+  acp_report_update '.validatorExitCode = $rc' --argjson rc "${rc}" || rc=1
   exit "${rc}"
 }
 trap cleanup EXIT
@@ -1443,6 +1479,15 @@ assert_deployment_digest() {
   assert_pod_matches_deployment_images "${deployment_json}" "${pod_json}" || \
     die "Deployment/${deployment} Pod images do not match the current Deployment template"
   assert_all_pod_images "${orka_namespace}" "${pod}"
+  local report_role
+  case "${deployment}" in
+    "${controller_deployment}") report_role=controller ;;
+    "${publisher_deployment}") report_role=publisher ;;
+    "${provider_proxy_deployment}") report_role=providerProxy ;;
+    "${scm_proxy_deployment}") report_role=scmProxy ;;
+    *) return 0 ;;
+  esac
+  acp_report_image "${report_role}" "${pod_json}" "${container}"
 }
 
 publisher_service_account=""
@@ -2126,6 +2171,7 @@ capture_pool_snapshot() {
     podAddress:$pool[0].status.activeInstance.podAddress,
     podImageID:($pod[0].status.containerStatuses[] | select(.name == "runtime") | .imageID)
   }' >"${output_file}"
+  acp_report_image "${provider}" "$(cat "${pod_file}")" runtime
 }
 
 assert_task_fence() {
@@ -2919,6 +2965,7 @@ prepare_release_gate_environment() {
   base_json="$(gh api "repos/${write_source_slug}/branches/${write_pr_base}")" || \
     die "PR base branch ${write_pr_base} does not exist in ${write_source_slug}"
   base_sha="$(jq -r '.commit.sha // ""' <<<"${base_json}")"
+  acp_report_update '.observations.baseHeads.preflight = $sha' --arg sha "${base_sha}"
   [[ "$(lower "${write_source_commit}")" == "$(lower "${base_sha}")" ]] || \
     die "ACP_E2E_WRITE_SOURCE_REF must equal the current ${write_pr_base} base-branch head for an isolated one-file PR"
   github_content_lookup "${write_source_slug}" "${write_expected_file}" "${write_source_commit}" || \
@@ -3039,6 +3086,7 @@ verify_remote_publication() {
     ' <<<"${delivery}" >/dev/null || die "publication repository/branch identity tuple is incomplete or incorrect"
 
   github_ref_lookup "${write_publication_slug}" "${write_branch}" || die "independent observer could not read publication branch"
+  acp_report_update '.observations.remoteHead = $head' --arg head "${github_ref_lookup_sha}"
   [[ "${github_ref_lookup_state}" == "present" && "${github_ref_lookup_sha}" == "${remote}" ]] || \
     die "independent remote branch head does not match the Task delivery receipt"
 
@@ -3093,7 +3141,16 @@ verify_remote_publication() {
     die "PR receipt is missing a numeric pull request number"
   fi
   pr_json="$(gh api "repos/${write_source_slug}/pulls/${pr_number}")"
+  local pr_observation
+  pr_observation="$(jq -c '{number, state, headSHA:.head.sha, baseSHA:.base.sha,
+    baseBranch:.base.ref, headBranch:.head.ref,
+    sourceRepository:("https://github.com/" + (.base.repo.full_name | ascii_downcase)),
+    publicationRepository:("https://github.com/" + (.head.repo.full_name | ascii_downcase))
+  }' <<<"${pr_json}")"
+  acp_report_update '.observations.pullRequest = $pr' --argjson pr "${pr_observation}"
   base_now_json="$(gh api "repos/${write_source_slug}/branches/${write_pr_base}")"
+  acp_report_update '.observations.baseHeads.publication = $sha' \
+    --arg sha "$(jq -r '.commit.sha // ""' <<<"${base_now_json}")"
   [[ "$(jq -r '.commit.sha // ""' <<<"${base_now_json}")" == "${starting}" ]] || \
     die "PR base branch moved after release-gate source resolution"
   pr_files_json="$(gh api --paginate --slurp "repos/${write_source_slug}/pulls/${pr_number}/files?per_page=100")"
@@ -3138,6 +3195,10 @@ verify_remote_publication() {
 
   remote_cleanup_head="${remote}"
   remote_cleanup_pr_number="${pr_number}"
+  acp_report_update '.checks.publication = true | .canary = {
+    path:$path, content:($content + "\n"), expectedCommitBytesMatched:true,
+    remoteBytesMatched:true, singleAddedFile:true
+  }' --arg path "${write_expected_file}" --arg content "${write_expected_content}"
 }
 
 run_write_release_gate() {
@@ -3174,22 +3235,36 @@ run_write_release_gate() {
   expected_forge_rv="$(k -n "${namespace}" get secret "${write_forge_credential_target}" -o jsonpath='{.metadata.resourceVersion}')"
   [[ -n "${expected_read_rv}" && -n "${expected_target_read_rv}" && -n "${expected_forge_rv}" ]] || \
     die "one or more role-separated credential Secrets have no resourceVersion"
+  acp_report_update '.checks.publisherSecretReadDenied = true | .credentials = [
+    {role:"sourceRead",namespace:$ns,name:$read,resourceVersion:$readRV},
+    {role:"targetRead",namespace:$ns,name:$targetRead,resourceVersion:$targetReadRV},
+    {role:"targetWrite",namespace:$ns,name:$write,resourceVersion:$writeRV},
+    {role:"forge",namespace:$ns,name:$forge,resourceVersion:$forgeRV}
+  ]' --arg ns "${namespace}" --arg read "${write_read_credential_target}" --arg readRV "${expected_read_rv}" \
+    --arg targetRead "${write_target_read_credential_target}" --arg targetReadRV "${expected_target_read_rv}" \
+    --arg write "${write_credential_target}" --arg writeRV "${expected_credential_rv}" \
+    --arg forge "${write_forge_credential_target}" --arg forgeRV "${expected_forge_rv}"
 
   local base_now_sha
   base_now_sha="$(gh api "repos/${write_source_slug}/branches/${write_pr_base}" --jq '.commit.sha')"
+  acp_report_update '.observations.baseHeads.submission = $sha' --arg sha "${base_now_sha}"
   [[ "${base_now_sha}" == "${write_source_commit}" ]] || \
     die "PR base branch moved before write Task submission"
 
   log "Running mandatory Codex clean-room publication and PR reconciliation gate"
   write_task_name="${task}"
   write_task_started=1
+  acp_report_update '.stage = "publication" | .task = {namespace:$ns,name:$task}' \
+    --arg ns "${namespace}" --arg task "${task}"
   apply_write_task "${task}" "${agent}"
+  acp_report_task "$(task_json "${task}")"
   wait_until "Task/${task} RuntimePool assignment" "${state_wait_seconds}" wait_task_pool_name_value "${task}"
   pool="$(wait_task_pool_name_value "${task}")"
   snapshot="${temp_root}/${task}-write-pool.json"
   capture_pool_snapshot "${pool}" codex "${codex_model}" write "${snapshot}"
   wait_task_terminal "${task}"
   payload="$(task_json "${task}")"
+  acp_report_task "${payload}"
   if ! jq -e '
     .status.phase == "Succeeded"
     and .status.execution.state == "Succeeded"
@@ -3218,6 +3293,7 @@ run_write_release_gate() {
     die "write Task did not freeze the target-read credential resourceVersion"
   [[ "$(jq -r '.status.execution.forgeCredentialResourceVersion // ""' <<<"${payload}")" == "${expected_forge_rv}" ]] || \
     die "write Task did not freeze the forge credential resourceVersion"
+  acp_report_update '.checks.credentialsFrozen = true'
 
   verify_remote_publication "${payload}"
   mark_task_validated "${task}"
@@ -3297,6 +3373,7 @@ settle_write_task_for_remote_cleanup() {
   [[ "${task_probe_state}" == "present" ]] || return 1
 
   pool="$(jq -r '.status.execution.runtimePoolName // ""' "${task_probe_file}")" || return 1
+  acp_report_task "$(cat "${task_probe_file}")" || return 1
   if [[ -n "${pool}" ]]; then
     require_runtimepool_mutation_scope || return 1
     probe_runtimepool "${pool}" || return 1
@@ -3398,6 +3475,7 @@ preflight_release_workloads() {
 }
 
 prepare_release_gate_environment
+acp_report_update '.stage = "validation" | .validation = "running"'
 
 log "Preflight for context ${context}"
 k config get-contexts "${context}" -o name | grep -Fxq "${context}" || die "kubectl context ${context} was not found"
@@ -3558,10 +3636,16 @@ if [[ "${release_gate}" -eq 1 ]]; then
   if [[ "${keep_resources}" != "1" ]]; then
     stop_api_forward || die "failed to stop controller API port-forward before final cleanup"
     delete_test_namespace_now || die "release-gate Kubernetes cleanup did not complete safely"
+    acp_report_update '.cleanup.kubernetes = "passed"'
   else
-    warn "ACP_E2E_KEEP_RESOURCES=1; release-gate Kubernetes resources are intentionally preserved"
+    die "ACP_E2E_KEEP_RESOURCES=1 preserves evidence but cannot qualify a release"
   fi
-  log "ACP v2 RELEASE GATE PASSED on context ${context}"
+  completion_base_sha="$(gh api "repos/${write_source_slug}/branches/${write_pr_base}" --jq '.commit.sha')"
+  acp_report_update '.observations.baseHeads.completion = $sha' --arg sha "${completion_base_sha}"
+  [[ "${completion_base_sha}" == "${write_source_commit}" ]] || \
+    die "PR base branch moved before release-gate completion; candidate is not qualified"
+  acp_report_update '.checks.baseUnchanged = true | .validation = "passed" | .stage = "cleanup"'
+  log "ACP v2 release checks passed on context ${context}; final qualification requires the cleanup report"
 else
   if [[ "${shared_mutation_checks_skipped}" -eq 1 ]]; then
     log "ACP v2 shared-namespace smoke validation passed on context ${context}; controller restart and RuntimePool lifecycle/replacement checks were skipped. Use an isolated namespace for complete smoke acceptance."

--- a/scripts/live-acp-runtime-e2e.sh
+++ b/scripts/live-acp-runtime-e2e.sh
@@ -3094,8 +3094,10 @@ verify_remote_publication() {
     die "independent remote branch head does not match the Task delivery receipt"
 
   commit_json="$(gh api "repos/${write_publication_slug}/git/commits/${expected}")"
-  [[ "$(jq -r '.tree.sha // ""' <<<"${commit_json}")" == "${tree}" ]] || \
-    die "Task treeSHA does not match the independently observed expected commit tree"
+  acp_report_update '.observations.expectedCommit = $commit' \
+    --argjson commit "$(jq -c '{sha, treeSHA:.tree.sha}' <<<"${commit_json}")"
+  jq -e --arg sha "${expected}" --arg tree "${tree}" '.sha == $sha and .tree.sha == $tree' \
+    <<<"${commit_json}" >/dev/null || die "Task commit/tree receipt does not match the independently observed expected commit"
   jq -e --arg parent "${starting}" '.parents | length == 1 and .[0].sha == $parent' \
     <<<"${commit_json}" >/dev/null || die "expected publication commit is not based exactly on startingSHA"
   expected_compare_json="$(gh api "repos/${write_publication_slug}/compare/${starting}...${expected}")"

--- a/scripts/live-acp-runtime-kind-e2e.sh
+++ b/scripts/live-acp-runtime-kind-e2e.sh
@@ -187,4 +187,7 @@ validator_args+=(--namespace "${namespace}")
 # namespace cannot contain unrelated RuntimePool consumers.
 export ACP_E2E_ALLOW_SHARED_POOL_MUTATION="${ACP_E2E_ALLOW_SHARED_POOL_MUTATION:-1}"
 live_acp_kind_log "Running canonical live ACP runtime validator"
+# Persist this before launching the child. If it is killed, an absent Task
+# receipt alone cannot establish that publication never started.
+acp_report_update '.validatorStarted = true'
 "${LIVE_ACP_VALIDATOR_SCRIPT}" "${validator_args[@]}"

--- a/scripts/live-acp-runtime-kind-e2e.sh
+++ b/scripts/live-acp-runtime-kind-e2e.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016 # acp_report_update arguments are jq programs.
 set -Eeuo pipefail
 umask 077
 
@@ -26,6 +27,7 @@ Environment:
   ACP_E2E_OPENCODE_MAX_TOKENS reviewed OpenCode output limit (required)
   ACP_E2E_ROLLOUT_TIMEOUT rollout timeout (default: 10m)
   RELEASE_GATE=1          forwarded to the canonical validator
+  ACP_E2E_REPORT_FILE     redacted acceptance JSON (release mode only)
 USAGE
 }
 
@@ -94,6 +96,29 @@ export LIVE_ACP_CONTROLLER_IMAGE LIVE_ACP_CODEX_IMAGE LIVE_ACP_CLAUDE_IMAGE LIVE
 export LIVE_ACP_OPENCODE_IMAGE LIVE_ACP_PUBLISHER_IMAGE LIVE_ACP_GENERAL_WORKER_IMAGE
 export LIVE_ACP_SECRET_DIR
 
+finish_kind_run() {
+  local status=$? cleanup_status=0
+  trap - EXIT
+  set +e
+  live_acp_kind_cleanup "${status}" || cleanup_status=$?
+  if (( status == 0 && cleanup_status != 0 )); then status="${cleanup_status}"; fi
+  acp_report_update '.bootstrapExitCode = $status' --argjson status "${status}" || status=1
+  if (( preflight_only == 0 )) && [[ "${LIVE_ACP_KEEP_CLUSTER}" != "1" ]]; then
+    acp_report_finish || status=1
+  fi
+  exit "${status}"
+}
+
+if live_acp_kind_enabled "${RELEASE_GATE:-0}"; then
+  export RELEASE_GATE=1
+  export ACP_E2E_REPORT_FILE="${ACP_E2E_REPORT_FILE:-${repo_root}/bin/acp-release-${image_tag}/acceptance.json}"
+  acp_report_init "${repo_root}"
+  export LIVE_ACP_REPORT_INITIALIZED=1
+fi
+trap finish_kind_run EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 if live_acp_kind_enabled "${RELEASE_GATE:-0}"; then
   [[ -n "${ACP_E2E_WRITE_SOURCE_REPO:-}" ]] || \
     live_acp_kind_die "ACP_E2E_WRITE_SOURCE_REPO is required when RELEASE_GATE=1"
@@ -139,9 +164,16 @@ if (( preflight_only )); then
   exit 0
 fi
 
+if live_acp_kind_enabled "${RELEASE_GATE:-0}"; then
+  [[ "$(git -C "${repo_root}" rev-parse HEAD)" == "${write_ref_lower}" ]] || \
+    live_acp_kind_die "release candidate must equal the image build checkout HEAD"
+  [[ -z "$(git -C "${repo_root}" status --porcelain --untracked-files=normal)" ]] || \
+    live_acp_kind_die "release images must be built from a clean candidate checkout"
+fi
+
 LIVE_ACP_SECRET_DIR="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/live-acp-kind-secrets.XXXXXX")"
 export LIVE_ACP_SECRET_DIR
-trap 'status=$?; live_acp_kind_cleanup "${status}"; exit "${status}"' EXIT
+acp_report_update '.stage = "bootstrap"'
 live_acp_kind_bootstrap
 
 validator_args=(--context "${LIVE_ACP_CONTEXT}")

--- a/scripts/tests/live-acp-release-publication-test.sh
+++ b/scripts/tests/live-acp-release-publication-test.sh
@@ -55,6 +55,7 @@ gh_raw_file() {
 }
 gh() {
   local endpoint="${*: -1}" parent="${write_source_commit}" observed_tree="${tree}"
+  local observed_commit="${head}"
   local base="${write_source_commit}" branch="${write_branch}" number=42 merged=null
   if [[ "$*" == *'--method PATCH'* ]]; then
     printf 'close_pr\n' >>"${temp_root}/events"
@@ -63,9 +64,11 @@ gh() {
   fi
   case "${endpoint}" in
     "repos/${write_publication_slug}/git/commits/${head}")
+      [[ "${fault}" != wrong_commit ]] || observed_commit="${other}"
       [[ "${fault}" != wrong_parent ]] || parent="${other}"
       [[ "${fault}" != wrong_tree ]] || observed_tree="${other}"
-      jq -n --arg parent "${parent}" --arg tree "${observed_tree}" '{parents:[{sha:$parent}],tree:{sha:$tree}}'
+      jq -n --arg sha "${observed_commit}" --arg parent "${parent}" --arg tree "${observed_tree}" \
+        '{sha:$sha,parents:[{sha:$parent}],tree:{sha:$tree}}'
       ;;
     "repos/${write_publication_slug}/compare/${write_source_commit}...${head}")
       jq -n --arg path "${write_expected_file}" '{status:"ahead",files:[{filename:$path,status:"added"}]}'
@@ -106,8 +109,11 @@ payload="$(jq -n --arg base "${write_source_commit}" --arg head "${head}" --arg 
   }')"
 acp_report_init "${root}"
 verify_remote_publication "${payload}"
-jq -e '.checks.publication == true and .canary.remoteBytesMatched == true' "${ACP_E2E_REPORT_FILE}" >/dev/null
-for fault in wrong_content wrong_parent wrong_tree wrong_head wrong_branch wrong_pr moved_base read_failure; do
+jq -e --arg sha "${head}" --arg tree "${tree}" '
+  .checks.publication == true and .canary.remoteBytesMatched == true
+  and .observations.expectedCommit == {sha:$sha,treeSHA:$tree}
+' "${ACP_E2E_REPORT_FILE}" >/dev/null
+for fault in wrong_content wrong_commit wrong_parent wrong_tree wrong_head wrong_branch wrong_pr moved_base read_failure; do
   acp_report_init "${root}"
   if (verify_remote_publication "${payload}") >"${temp_root}/failure.log" 2>&1; then
     printf 'publication accepted invalid independent evidence: %s\n' "${fault}" >&2

--- a/scripts/tests/live-acp-release-publication-test.sh
+++ b/scripts/tests/live-acp-release-publication-test.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034 # Variables are consumed by the extracted validator functions.
+set -Eeuo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+script="${root}/scripts/live-acp-runtime-e2e.sh"
+# shellcheck source=scripts/lib/live-acp-release-report.sh
+. "${root}/scripts/lib/live-acp-release-report.sh"
+for function in is_sha is_uint lower verify_remote_publication cleanup_remote_effects \
+  validate_exact_pull_request ensure_pull_request_closed_unmerged; do
+  eval "$(awk -v name="${function}" '$0 == name "() {" {copy=1} copy {print} copy && /^}$/ {exit}' "${script}")"
+done
+
+temp_root="$(mktemp -d "${TMPDIR:-/tmp}/acp-publication-test.XXXXXX")"
+trap 'rm -rf "${temp_root}"' EXIT
+export RELEASE_GATE=1 ACP_E2E_REPORT_FILE="${temp_root}/acceptance.json"
+ACP_E2E_WRITE_SOURCE_REF="$(git -C "${root}" rev-parse HEAD)"
+export ACP_E2E_WRITE_SOURCE_REF
+export ACP_E2E_WRITE_SOURCE_REPO=https://github.com/orka-agents/orka.git
+export ACP_E2E_WRITE_PUBLICATION_REPO=https://github.com/sozercan/orka-acp-release-gate.git
+write_source_slug=orka-agents/orka
+write_publication_slug=sozercan/orka-acp-release-gate
+write_source_identity="github.com/${write_source_slug}"
+write_publication_identity="github.com/${write_publication_slug}"
+write_source_database_id=123
+write_source_commit="${ACP_E2E_WRITE_SOURCE_REF}"
+write_branch=orka/acp-release-gate-test
+write_pr_base=main
+write_expected_file=canary-test.txt
+write_expected_content='ACP v2 release gate test'
+head=1111111111111111111111111111111111111111
+tree=2222222222222222222222222222222222222222
+other=3333333333333333333333333333333333333333
+fault=""
+printf 'open\n' >"${temp_root}/pr-state"
+
+die() { printf '%s\n' "$*" >&2; exit 1; }
+warn() { printf '%s\n' "$*" >&2; }
+log() { :; }
+github_ref_lookup() {
+  [[ "${fault}" != read_failure ]] || return 1
+  github_ref_lookup_state=present
+  github_ref_lookup_sha="${head}"
+  if [[ -f "${temp_root}/ref-state" ]]; then
+    github_ref_lookup_state="$(cat "${temp_root}/ref-state")"
+  fi
+  [[ "${fault}" != wrong_head ]] || github_ref_lookup_sha="${other}"
+}
+gh_raw_file() {
+  if [[ "${fault}" == wrong_content ]]; then
+    printf 'incorrect canary bytes\n'
+  else
+    printf '%s\n' "${write_expected_content}"
+  fi
+}
+gh() {
+  local endpoint="${*: -1}" parent="${write_source_commit}" observed_tree="${tree}"
+  local base="${write_source_commit}" branch="${write_branch}" number=42 merged=null
+  if [[ "$*" == *'--method PATCH'* ]]; then
+    printf 'close_pr\n' >>"${temp_root}/events"
+    printf 'closed\n' >"${temp_root}/pr-state"
+    return 0
+  fi
+  case "${endpoint}" in
+    "repos/${write_publication_slug}/git/commits/${head}")
+      [[ "${fault}" != wrong_parent ]] || parent="${other}"
+      [[ "${fault}" != wrong_tree ]] || observed_tree="${other}"
+      jq -n --arg parent "${parent}" --arg tree "${observed_tree}" '{parents:[{sha:$parent}],tree:{sha:$tree}}'
+      ;;
+    "repos/${write_publication_slug}/compare/${write_source_commit}...${head}")
+      jq -n --arg path "${write_expected_file}" '{status:"ahead",files:[{filename:$path,status:"added"}]}'
+      ;;
+    "repos/${write_publication_slug}/compare/${head}...${head}")
+      jq -n --arg sha "${head}" '{status:"identical",merge_base_commit:{sha:$sha}}'
+      ;;
+    "repos/${write_source_slug}/branches/${write_pr_base}")
+      [[ "${fault}" != moved_base ]] || base="${other}"
+      jq -n --arg sha "${base}" '{commit:{sha:$sha}}'
+      ;;
+    "repos/${write_source_slug}/pulls/42/files?per_page=100")
+      jq -n --arg path "${write_expected_file}" '[[{filename:$path,status:"added"}]]'
+      ;;
+    "repos/${write_source_slug}/pulls/42")
+      [[ "${fault}" != wrong_pr ]] || number=43
+      [[ "${fault}" != wrong_branch ]] || branch=someone-elses-branch
+      [[ "${fault}" != merged_pr ]] || merged='"2026-01-01T00:00:00Z"'
+      jq -n --argjson number "${number}" --arg state "$(cat "${temp_root}/pr-state")" \
+        --arg base "${base}" --arg branch "${branch}" --arg head "${head}" --argjson merged "${merged}" \
+        --arg source "${write_source_slug}" --arg publication "${write_publication_slug}" '{
+          number:$number,state:$state,merged_at:$merged,
+          base:{sha:$base,ref:"main",repo:{full_name:$source}},
+          head:{sha:$head,ref:$branch,repo:{full_name:$publication}}}'
+      ;;
+    *) printf 'unexpected GitHub fixture endpoint\n' >&2; return 97 ;;
+  esac
+}
+payload="$(jq -n --arg base "${write_source_commit}" --arg head "${head}" --arg tree "${tree}" \
+  --arg branch "${write_branch}" --arg source "${write_source_identity}" --arg publication "${write_publication_identity}" '{
+    status:{delivery:{outcome:"VerifiedExact",publicationID:"pub-id",startingSHA:$base,treeSHA:$tree,
+      expectedCommitSHA:$head,verifiedRemoteSHA:$head,remoteBeforeSHA:"",
+      artifactDigest:"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      branch:$branch,sourceRepository:{provider:"github",id:$source},
+      publicationRepository:{provider:"github",id:$publication},
+      prReceipt:{number:42,id:"github:123:42",url:"https://github.com/orka-agents/orka/pull/42",
+        state:"Open",baseBranch:"main",headBranch:$branch,headSHA:$head}}}
+  }')"
+acp_report_init "${root}"
+verify_remote_publication "${payload}"
+jq -e '.checks.publication == true and .canary.remoteBytesMatched == true' "${ACP_E2E_REPORT_FILE}" >/dev/null
+for fault in wrong_content wrong_parent wrong_tree wrong_head wrong_branch wrong_pr moved_base read_failure; do
+  acp_report_init "${root}"
+  if (verify_remote_publication "${payload}") >"${temp_root}/failure.log" 2>&1; then
+    printf 'publication accepted invalid independent evidence: %s\n' "${fault}" >&2
+    exit 1
+  fi
+  jq -e '.checks.publication == false and .result == "not_qualified"' "${ACP_E2E_REPORT_FILE}" >/dev/null
+done
+printf '%s\n' 'ok - deployed publication verification rejects wrong bytes, parent, tree, head, branch, PR, moved base and failed reads'
+
+release_gate=1
+remote_cleanup_required=1
+remote_cleanup_branch="${write_branch}"
+remote_cleanup_publication_slug="${write_publication_slug}"
+remote_cleanup_publication_repo="${ACP_E2E_WRITE_PUBLICATION_REPO}"
+remote_cleanup_source_slug="${write_source_slug}"
+remote_cleanup_pr_base=main
+remote_cleanup_head="${head}"
+remote_cleanup_pr_number=42
+git_askpass_file="${temp_root}/unused-askpass"
+gh_token_file="${temp_root}/unused-token"
+git_observer_repo="${temp_root}/unused-observer"
+settle_write_task_for_remote_cleanup() {
+  printf 'settle\n' >>"${temp_root}/events"
+  [[ "${fault}" != active_writer ]]
+}
+configure_git_observer_auth() { :; }
+release_write_task_observer() { printf 'release_observer\n' >>"${temp_root}/events"; }
+git() {
+  if [[ "$*" == *'rev-parse HEAD'* ]]; then command git "$@"; return; fi
+  [[ "$*" == *"--force-with-lease=refs/heads/${write_branch}:${head}"* ]] || return 98
+  [[ "$*" == *":refs/heads/${write_branch}"* ]] || return 98
+  printf 'delete_branch\n' >>"${temp_root}/events"
+  [[ "${fault}" != failed_lease ]] || return 1
+  printf 'absent\n' >"${temp_root}/ref-state"
+}
+for fault in none active_writer wrong_head wrong_branch wrong_pr merged_pr read_failure failed_lease; do
+  acp_report_init "${root}"
+  remote_cleanup_preserve=0
+  : >"${temp_root}/events"
+  printf 'present\n' >"${temp_root}/ref-state"
+  printf 'open\n' >"${temp_root}/pr-state"
+  if cleanup_remote_effects >"${temp_root}/cleanup.log" 2>&1; then
+    [[ "${fault}" == none ]] || { echo "unsafe cleanup accepted ${fault}" >&2; exit 1; }
+    printf 'settle\nclose_pr\ndelete_branch\nrelease_observer\n' >"${temp_root}/expected-events"
+    cmp "${temp_root}/events" "${temp_root}/expected-events"
+    jq -e '.cleanup.remote == "passed"' "${ACP_E2E_REPORT_FILE}" >/dev/null
+  else
+    [[ "${fault}" != none && "${remote_cleanup_preserve}" == 1 ]] || exit 1
+    [[ "$(cat "${temp_root}/ref-state")" == present ]] || exit 1
+    if [[ "${fault}" != failed_lease ]]; then
+      [[ "$(cat "${temp_root}/events")" == settle ]] || {
+        echo "cleanup mutated a PR or branch without safe evidence: ${fault}" >&2
+        exit 1
+      }
+    fi
+  fi
+done
+printf '%s\n' 'ok - cleanup settles writers before PR closure, uses an exact-head lease and preserves ambiguous remote effects'

--- a/scripts/tests/live-acp-release-report-test.sh
+++ b/scripts/tests/live-acp-release-report-test.sh
@@ -70,10 +70,11 @@ acp_report_update '
   | .observations = {
     baseHeads:{preflight:.candidateSHA,submission:.candidateSHA,publication:.candidateSHA,completion:.candidateSHA},
     remoteHead:$head,
+    expectedCommit:{sha:$head,treeSHA:$tree},
     pullRequest:{number:42,state:"open",headSHA:$head,baseSHA:.candidateSHA,
       baseBranch:"main",headBranch:.task.delivery.branch,
       sourceRepository:.sourceRepository,publicationRepository:.publicationRepository}}
-' --arg head "${commit}"
+' --arg head "${commit}" --arg tree "${tree}"
 if grep -F "${sentinel}" "${ACP_E2E_REPORT_FILE}" >/dev/null; then
   echo 'acceptance report copied excluded Task or Pod content' >&2
   exit 1
@@ -82,6 +83,19 @@ acp_report_finish
 jq -e '.result == "qualified" and .finishedAt != null' "${ACP_E2E_REPORT_FILE}" >/dev/null
 cp "${ACP_E2E_REPORT_FILE}" "${fixture}/qualified.json"
 printf '%s\n' 'ok - complete publication evidence qualifies without Task content or credentials'
+
+jq --arg head 3333333333333333333333333333333333333333 '
+  .task.delivery.state = "DeliveredSuperseded" | .task.delivery.outcome = "DeliveredSuperseded"
+  | .task.delivery.supersedingRemoteSHA = $head | .task.delivery.prReceipt.headSHA = $head
+  | .observations.remoteHead = $head | .observations.pullRequest.headSHA = $head
+' "${fixture}/qualified.json" >"${ACP_E2E_REPORT_FILE}"
+acp_report_finish
+acp_report_update '.task.delivery.state = "VerifiedExact" | .task.delivery.outcome = "VerifiedExact"'
+if acp_report_finish 2>/dev/null; then
+  echo 'VerifiedExact qualified with a distinct superseding remote head' >&2
+  exit 1
+fi
+printf '%s\n' 'ok - a superseding head requires DeliveredSuperseded and preserves the observed commit receipt'
 
 while IFS= read -r mutation; do
   jq "${mutation}" "${fixture}/qualified.json" >"${ACP_E2E_REPORT_FILE}"
@@ -106,12 +120,19 @@ done <<'MUTATIONS'
 .observations.baseHeads.submission = "0000000000000000000000000000000000000000"
 .observations.baseHeads.completion = "0000000000000000000000000000000000000000"
 .observations.remoteHead = "0000000000000000000000000000000000000000"
+.observations.expectedCommit.sha = "3333333333333333333333333333333333333333"
+.observations.expectedCommit.treeSHA = "3333333333333333333333333333333333333333"
+del(.observations.expectedCommit)
 .observations.pullRequest.number = 43
 .observations.pullRequest.headBranch = "somebody-elses-branch"
 .expectedBranch = "somebody-elses-branch"
 .observations.pullRequest.sourceRepository = .publicationRepository
 .task.delivery.prReceipt = null
 .task.delivery.artifactDigest = null
+.task.delivery.expectedCommitSHA = "3333333333333333333333333333333333333333"
+.task.delivery.treeSHA = "3333333333333333333333333333333333333333"
+.task.delivery.expectedCommitSHA = "3333333333333333333333333333333333333333" | .observations.expectedCommit.sha = .task.delivery.expectedCommitSHA
+.task.delivery.outcome = "DeliveredSuperseded"
 .task.execution.attempt = 2
 .task.execution.forgeCredentialResourceVersion = "rotated"
 .credentials = []

--- a/scripts/tests/live-acp-release-report-test.sh
+++ b/scripts/tests/live-acp-release-report-test.sh
@@ -57,7 +57,8 @@ for role in controller publisher codex opencode claude copilot; do
   acp_report_update '.builtImages[$role] = $ref' --arg role "${role}" --arg ref "${ref}"
 done
 acp_report_update '
-  .validation = "passed" | .validatorExitCode = 0 | .bootstrapExitCode = 0
+  .validation = "passed" | .validatorStarted = true | .validatorExitCode = 0 | .bootstrapExitCode = 0
+  | .expectedBranch = .task.delivery.branch
   | .checks |= with_entries(.value = true)
   | .canary = {path:"canary.txt",expectedCommitBytesMatched:true,remoteBytesMatched:true,singleAddedFile:true}
   | .cleanup |= with_entries(.value = "passed")
@@ -94,6 +95,7 @@ done <<'MUTATIONS'
 .candidateSHA = "0000000000000000000000000000000000000000"
 .sourceRepository = .publicationRepository
 .validation = "not_started"
+.validatorStarted = false
 .validatorExitCode = 1
 .bootstrapExitCode = 1
 .checks.publication = false
@@ -106,6 +108,7 @@ done <<'MUTATIONS'
 .observations.remoteHead = "0000000000000000000000000000000000000000"
 .observations.pullRequest.number = 43
 .observations.pullRequest.headBranch = "somebody-elses-branch"
+.expectedBranch = "somebody-elses-branch"
 .observations.pullRequest.sourceRepository = .publicationRepository
 .task.delivery.prReceipt = null
 .task.delivery.artifactDigest = null
@@ -210,3 +213,29 @@ done <<'MUTATIONS'
 .conclusion = "failure"
 MUTATIONS
 printf '%s\n' 'ok - workflow reruns and status changes during artifact download invalidate qualification'
+
+awk '
+  $0 == "      - name: Validate trusted dispatch inputs" { step=1; next }
+  step && $0 == "        run: |" { body=1; next }
+  body && /^      - name:/ { exit }
+  body { sub(/^          /, ""); print }
+' "${root}/.github/workflows/live-acp-release-gate.yml" >"${fixture}/dispatch.sh"
+[[ -s "${fixture}/dispatch.sh" ]]
+validate_dispatch() {
+  CHECKED_OUT_SHA="${GITHUB_SHA}" DEFAULT_BRANCH=main PR_BASE=main \
+    CONFIGURED_PUBLICATION_REPOSITORY=https://github.com/sozercan/orka-acp-release-gate.git \
+    SOURCE_REF="${GITHUB_SHA}" SOURCE_REPOSITORY=https://github.com/orka-agents/orka.git \
+    bash "${fixture}/dispatch.sh"
+}
+for publication in https://github.com/sozercan/orka-acp-release-gate.git https://github.com/sozercan/orka-acp-release-gate; do
+  ACP_E2E_WRITE_PUBLICATION_REPO="${publication}" validate_dispatch
+done
+if GITHUB_REF=refs/pull/42/merge validate_dispatch >/dev/null 2>&1; then
+  echo 'trusted dispatch accepted a pull-request ref' >&2
+  exit 1
+fi
+if ACP_E2E_WRITE_PUBLICATION_REPO=https://github.com/other/fork.git validate_dispatch >/dev/null 2>&1; then
+  echo 'trusted dispatch accepted an unconfigured publication target' >&2
+  exit 1
+fi
+printf '%s\n' 'ok - actual dispatch guard accepts the documented .git URL and rejects untrusted refs and targets'

--- a/scripts/tests/live-acp-release-report-test.sh
+++ b/scripts/tests/live-acp-release-report-test.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016 # acp_report_update arguments are jq programs.
+set -Eeuo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=scripts/lib/live-acp-release-report.sh
+. "${root}/scripts/lib/live-acp-release-report.sh"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/acp-release-report-test.XXXXXX")"
+trap 'rm -rf "${fixture}"' EXIT
+export RELEASE_GATE=1 ACP_E2E_REPORT_FILE="${fixture}/acceptance.json"
+ACP_E2E_WRITE_SOURCE_REF="$(git -C "${root}" rev-parse HEAD)"
+export ACP_E2E_WRITE_SOURCE_REF
+export ACP_E2E_WRITE_SOURCE_REPO=https://github.com/orka-agents/orka.git
+export ACP_E2E_WRITE_PUBLICATION_REPO=https://github.com/sozercan/orka-acp-release-gate.git
+export ACP_E2E_WRITE_PR_BASE=main ACP_E2E_RUN_ID=report-test
+export GITHUB_REPOSITORY=orka-agents/orka GITHUB_REF=refs/heads/main
+export GITHUB_SHA="${ACP_E2E_WRITE_SOURCE_REF}" GITHUB_RUN_ID="9999$$"
+export GITHUB_RUN_ATTEMPT=1 GITHUB_EVENT_NAME=workflow_dispatch
+acp_report_init "${root}"
+if acp_report_finish 2>/dev/null; then
+  echo 'an unexecuted release gate qualified' >&2
+  exit 1
+fi
+
+sentinel='excluded-private-evidence'
+commit=1111111111111111111111111111111111111111
+tree=2222222222222222222222222222222222222222
+digest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+task_payload="$(jq -n --arg sha "${GITHUB_SHA}" --arg commit "${commit}" --arg tree "${tree}" \
+  --arg digest "${digest}" --arg sentinel "${sentinel}" '{
+    metadata:{namespace:"test",name:"write-test",uid:"task-uid",annotations:{private:$sentinel}},
+    spec:{prompt:$sentinel},
+    status:{phase:"Succeeded",message:$sentinel,result:$sentinel,
+      execution:{state:"Succeeded",outcome:"Succeeded",attempt:1,promptID:"prompt-id",
+        runtimePoolName:"write-pool",runtimePoolUID:"pool-uid",runtimeInstanceID:"instance-id",
+        runtimeSessionUID:"session-uid",runtimeSessionGeneration:1,requestDigest:$digest,
+        controllerEpoch:1,readCredentialResourceVersion:"1",publicationReadCredentialResourceVersion:"2",
+        publicationCredentialResourceVersion:"3",forgeCredentialResourceVersion:"4",message:$sentinel},
+      delivery:{state:"VerifiedExact",outcome:"VerifiedExact",publicationID:"publication-id",
+        sourceRepository:{provider:"github",id:"github.com/orka-agents/orka",private:$sentinel},
+        publicationRepository:{provider:"github",id:"github.com/sozercan/orka-acp-release-gate"},
+        branch:"orka/acp-release-gate-test",startingSHA:$sha,remoteBeforeSHA:"",treeSHA:$tree,
+        expectedCommitSHA:$commit,verifiedRemoteSHA:$commit,artifactDigest:$digest,message:$sentinel,
+        prReceipt:{id:"github:123:42",number:42,url:"https://github.com/orka-agents/orka/pull/42",
+          state:"Open",baseBranch:"main",headBranch:"orka/acp-release-gate-test",headSHA:$commit,
+          private:$sentinel}}}
+  }')"
+acp_report_task "${task_payload}"
+for role in controller publisher codex opencode claude copilot; do
+  ref="registry.example/orka/${role}@${digest}"
+  pod="$(jq -n --arg role "${role}" --arg ref "${ref}" --arg sentinel "${sentinel}" '{
+    metadata:{namespace:"test",name:$role,uid:($role + "-uid"),annotations:{private:$sentinel}},
+    spec:{containers:[{name:"runtime",image:$ref,env:[{name:"PRIVATE",value:$sentinel}]}]},
+    status:{containerStatuses:[{name:"runtime",imageID:($ref | sub("registry.example";"docker-pullable://registry.example"))}]}
+  }')"
+  acp_report_image "${role}" "${pod}" runtime
+  acp_report_update '.builtImages[$role] = $ref' --arg role "${role}" --arg ref "${ref}"
+done
+acp_report_update '
+  .validation = "passed" | .validatorExitCode = 0 | .bootstrapExitCode = 0
+  | .checks |= with_entries(.value = true)
+  | .canary = {path:"canary.txt",expectedCommitBytesMatched:true,remoteBytesMatched:true,singleAddedFile:true}
+  | .cleanup |= with_entries(.value = "passed")
+  | .credentials = [
+    {role:"sourceRead",namespace:"test",name:"source",resourceVersion:"1"},
+    {role:"targetRead",namespace:"test",name:"target",resourceVersion:"2"},
+    {role:"targetWrite",namespace:"test",name:"write",resourceVersion:"3"},
+    {role:"forge",namespace:"test",name:"forge",resourceVersion:"4"}]
+  | .observations = {
+    baseHeads:{preflight:.candidateSHA,submission:.candidateSHA,publication:.candidateSHA,completion:.candidateSHA},
+    remoteHead:$head,
+    pullRequest:{number:42,state:"open",headSHA:$head,baseSHA:.candidateSHA,
+      baseBranch:"main",headBranch:.task.delivery.branch,
+      sourceRepository:.sourceRepository,publicationRepository:.publicationRepository}}
+' --arg head "${commit}"
+if grep -F "${sentinel}" "${ACP_E2E_REPORT_FILE}" >/dev/null; then
+  echo 'acceptance report copied excluded Task or Pod content' >&2
+  exit 1
+fi
+acp_report_finish
+jq -e '.result == "qualified" and .finishedAt != null' "${ACP_E2E_REPORT_FILE}" >/dev/null
+cp "${ACP_E2E_REPORT_FILE}" "${fixture}/qualified.json"
+printf '%s\n' 'ok - complete publication evidence qualifies without Task content or credentials'
+
+while IFS= read -r mutation; do
+  jq "${mutation}" "${fixture}/qualified.json" >"${ACP_E2E_REPORT_FILE}"
+  if acp_report_finish 2>/dev/null; then
+    printf 'incomplete or inconsistent report qualified: %s\n' "${mutation}" >&2
+    exit 1
+  fi
+  jq -e '.result == "not_qualified"' "${ACP_E2E_REPORT_FILE}" >/dev/null
+done <<'MUTATIONS'
+.mode = "smoke"
+.candidateSHA = "0000000000000000000000000000000000000000"
+.sourceRepository = .publicationRepository
+.validation = "not_started"
+.validatorExitCode = 1
+.bootstrapExitCode = 1
+.checks.publication = false
+.canary.remoteBytesMatched = false
+.canary.expectedCommitBytesMatched = false
+.canary.singleAddedFile = false
+.checks.publisherSecretReadDenied = false
+.observations.baseHeads.submission = "0000000000000000000000000000000000000000"
+.observations.baseHeads.completion = "0000000000000000000000000000000000000000"
+.observations.remoteHead = "0000000000000000000000000000000000000000"
+.observations.pullRequest.number = 43
+.observations.pullRequest.headBranch = "somebody-elses-branch"
+.observations.pullRequest.sourceRepository = .publicationRepository
+.task.delivery.prReceipt = null
+.task.delivery.artifactDigest = null
+.task.execution.attempt = 2
+.task.execution.forgeCredentialResourceVersion = "rotated"
+.credentials = []
+.credentials[1].name = .credentials[0].name
+.images.publisher.imageID = null | .images.publisher.actualDigest = null
+.images.codex.verified = false
+del(.images.copilot)
+.builtImages.controller = "registry.example/unqualified@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+.cleanup.remote = "preserved"
+.cleanup.kubernetes = "failed"
+.cleanup.validatorCredentials = "failed"
+.cleanup.bootstrapCredentials = "failed"
+.cleanup.cluster = "pending"
+.cleanup.registry = "failed"
+.preserved = {branch:"inspect-me"}
+MUTATIONS
+printf '%s\n' 'ok - skipped publication, moved base, inconsistent receipts, missing images and incomplete cleanup fail qualification'
+
+ACP_E2E_WRITE_SOURCE_REPO="https://${sentinel}@github.com/orka-agents/orka" \
+  ACP_E2E_WRITE_SOURCE_REF="${sentinel}" acp_report_init "${root}"
+jq -e '.candidateSHA == null and .sourceRepository == null' "${ACP_E2E_REPORT_FILE}" >/dev/null
+if grep -F "${sentinel}" "${ACP_E2E_REPORT_FILE}" >/dev/null; then
+  echo 'invalid inputs leaked into the failure report' >&2
+  exit 1
+fi
+printf '%s\n' 'ok - invalid source URLs and candidate inputs are omitted from failure evidence'
+
+mkdir "${fixture}/bin"
+export QUALIFICATION_FIXTURE="${fixture}"
+jq -n --arg sha "${GITHUB_SHA}" '{status:"completed",conclusion:"success",event:"workflow_dispatch",
+  head_sha:$sha,head_branch:"main",repository:{full_name:"orka-agents/orka"},
+  head_repository:{full_name:"orka-agents/orka"},path:".github/workflows/live-acp-release-gate.yml",run_attempt:1}' \
+  >"${fixture}/run-original.json"
+jq -n --arg name "live-acp-release-acceptance-${GITHUB_RUN_ID}-1" \
+  '[{artifacts:[{name:$name,expired:false}]}]' >"${fixture}/artifacts.json"
+cat >"${fixture}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+if [[ "$1" == api ]]; then
+  case "$*" in
+    *'/artifacts?'*) cat "${QUALIFICATION_FIXTURE}/artifacts.json" ;;
+    *'/actions/runs/'*) cat "${QUALIFICATION_FIXTURE}/run.json" ;;
+    *) printf 'main\n' ;;
+  esac
+elif [[ "$1 $2" == 'run download' ]]; then
+  while [[ "$1" != --dir ]]; do shift; done
+  mkdir -p "$2"
+  cp "${QUALIFICATION_FIXTURE}/qualified.json" "$2/acceptance.json"
+else
+  exit 99
+fi
+STUB
+chmod +x "${fixture}/bin/gh"
+cp "${fixture}/run-original.json" "${fixture}/run.json"
+PATH="${fixture}/bin:${PATH}" bash "${root}/scripts/verify-acp-release-qualification.sh" \
+  "${GITHUB_SHA}" "${GITHUB_RUN_ID}" >/dev/null
+rm -rf "${root}/bin/acp-release-qualification-${GITHUB_RUN_ID}-1"
+while IFS= read -r mutation; do
+  jq "${mutation}" "${fixture}/run-original.json" >"${fixture}/run.json"
+  if PATH="${fixture}/bin:${PATH}" bash "${root}/scripts/verify-acp-release-qualification.sh" \
+      "${GITHUB_SHA}" "${GITHUB_RUN_ID}" >/dev/null 2>&1; then
+    printf 'untrusted workflow metadata qualified: %s\n' "${mutation}" >&2
+    exit 1
+  fi
+done <<'MUTATIONS'
+.event = "pull_request"
+.event = "schedule"
+.head_branch = "topic"
+.head_sha = "0000000000000000000000000000000000000000"
+.head_repository.full_name = "external/orka"
+.path = ".github/workflows/live-acp-runtime-e2e.yml"
+.conclusion = "failure"
+.status = "in_progress"
+.run_attempt = 2
+MUTATIONS
+printf '%s\n' 'ok - qualification requires the exact trusted workflow, commit, successful run and current attempt artifact'

--- a/scripts/tests/live-acp-release-report-test.sh
+++ b/scripts/tests/live-acp-release-report-test.sh
@@ -150,13 +150,20 @@ set -Eeuo pipefail
 if [[ "$1" == api ]]; then
   case "$*" in
     *'/artifacts?'*) cat "${QUALIFICATION_FIXTURE}/artifacts.json" ;;
-    *'/actions/runs/'*) cat "${QUALIFICATION_FIXTURE}/run.json" ;;
+    *'/actions/runs/'*)
+      if [[ -f "${QUALIFICATION_FIXTURE}/download-complete" && -f "${QUALIFICATION_FIXTURE}/run-after-download.json" ]]; then
+        cat "${QUALIFICATION_FIXTURE}/run-after-download.json"
+      else
+        cat "${QUALIFICATION_FIXTURE}/run.json"
+      fi
+      ;;
     *) printf 'main\n' ;;
   esac
 elif [[ "$1 $2" == 'run download' ]]; then
   while [[ "$1" != --dir ]]; do shift; done
   mkdir -p "$2"
   cp "${QUALIFICATION_FIXTURE}/qualified.json" "$2/acceptance.json"
+  touch "${QUALIFICATION_FIXTURE}/download-complete"
 else
   exit 99
 fi
@@ -185,3 +192,21 @@ done <<'MUTATIONS'
 .run_attempt = 2
 MUTATIONS
 printf '%s\n' 'ok - qualification requires the exact trusted workflow, commit, successful run and current attempt artifact'
+
+cp "${fixture}/run-original.json" "${fixture}/run.json"
+while IFS= read -r mutation; do
+  jq "${mutation}" "${fixture}/run-original.json" >"${fixture}/run-after-download.json"
+  rm -f "${fixture}/download-complete"
+  if PATH="${fixture}/bin:${PATH}" bash "${root}/scripts/verify-acp-release-qualification.sh" \
+      "${GITHUB_SHA}" "${GITHUB_RUN_ID}" >/dev/null 2>&1; then
+    rm -rf "${root}/bin/acp-release-qualification-${GITHUB_RUN_ID}-1"
+    printf 'workflow change during artifact download qualified: %s\n' "${mutation}" >&2
+    exit 1
+  fi
+done <<'MUTATIONS'
+.run_attempt = 2 | .status = "in_progress" | .conclusion = null
+.run_attempt = 2
+.status = "queued" | .conclusion = null
+.conclusion = "failure"
+MUTATIONS
+printf '%s\n' 'ok - workflow reruns and status changes during artifact download invalidate qualification'

--- a/scripts/tests/live-acp-runtime-e2e-test.sh
+++ b/scripts/tests/live-acp-runtime-e2e-test.sh
@@ -11,6 +11,8 @@ fi
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 script="${root}/scripts/live-acp-runtime-e2e.sh"
+# shellcheck source=scripts/lib/live-acp-release-report.sh
+. "${root}/scripts/lib/live-acp-release-report.sh"
 export ACP_E2E_OPENCODE_CONTEXT_WINDOW=32768
 export ACP_E2E_OPENCODE_MAX_TOKENS=4096
 body="$(awk '/^delete_test_namespace_now\(\) \{/,/^\}$/' "${script}")"

--- a/scripts/tests/live-acp-runtime-kind-e2e-test.sh
+++ b/scripts/tests/live-acp-runtime-kind-e2e-test.sh
@@ -258,7 +258,7 @@ printf '%s\n' 'ok - Vekil preflight requires endpoint metadata and live streamin
 
 fake_bin="$(mktemp -d "${TMPDIR:-/tmp}/live-acp-kind-test.XXXXXX")"
 trap 'rm -rf "${fake_bin}"' EXIT
-for command in curl gh git go jq kind kubectl make python3; do
+for command in curl gh go kind kubectl make python3; do
   cat >"${fake_bin}/${command}" <<'STUB'
 #!/usr/bin/env bash
 exit 0
@@ -349,7 +349,24 @@ if [[ "${cleanup_failure_status}" -ne 23 ]]; then
 fi
 printf '%s\n' 'ok - Kind cleanup failure fails successful validation without masking validator failures'
 
+finish_body="$(awk '/^finish_kind_run\(\) \{/,/^\}$/' "${wrapper}")"
+if (
+  eval "${finish_body}"
+  live_acp_kind_cleanup() { return 1; }
+  acp_report_update() { :; }
+  acp_report_finish() { :; }
+  preflight_only=0
+  LIVE_ACP_KEEP_CLUSTER=0
+  trap finish_kind_run EXIT
+  exit 0
+); then
+  echo 'wrapper EXIT trap discarded a cleanup failure after successful validation' >&2
+  exit 1
+fi
+printf '%s\n' 'ok - wrapper exit status includes cluster cleanup failures'
+
 provider_sentinel='must-not-appear-in-output'
+export ACP_E2E_REPORT_FILE="${fake_bin}/acceptance.json"
 output="$(PATH="${fake_bin}:${PATH}" COPILOT_GITHUB_TOKEN="${provider_sentinel}" "${wrapper}" --preflight-only 2>&1)"
 grep -F 'preflight passed' <<<"${output}" >/dev/null
 if grep -F "${provider_sentinel}" <<<"${output}" >/dev/null; then
@@ -374,6 +391,8 @@ if PATH="${fake_bin}:${PATH}" RELEASE_GATE=1 COPILOT_GITHUB_TOKEN="${provider_se
 fi
 grep -F 'ACP_E2E_WRITE_READ_CREDENTIAL_TOKEN is required when RELEASE_GATE=1' \
   "${fake_bin}/release-missing.out" >/dev/null
+jq -e '.result == "not_qualified" and .bootstrapExitCode == 1
+  and .failure.credential == "ACP_E2E_WRITE_READ_CREDENTIAL_TOKEN"' "${ACP_E2E_REPORT_FILE}" >/dev/null
 
 source_read_sentinel='source-read-value'
 target_read_sentinel='target-read-value'
@@ -400,6 +419,10 @@ for value in "${provider_sentinel}" "${source_read_sentinel}" "${target_read_sen
     "${target_write_sentinel}" "${forge_sentinel}"; do
   if grep -F "${value}" <<<"${release_output}" >/dev/null; then
     echo 'release preflight leaked a provider or publication credential' >&2
+    exit 1
+  fi
+  if grep -F "${value}" "${ACP_E2E_REPORT_FILE}" >/dev/null; then
+    echo 'release report leaked a provider or publication credential' >&2
     exit 1
   fi
 done

--- a/scripts/tests/live-acp-runtime-kind-e2e-test.sh
+++ b/scripts/tests/live-acp-runtime-kind-e2e-test.sh
@@ -441,3 +441,55 @@ grep -F 'ACP_E2E_REPO must equal ACP_E2E_WRITE_SOURCE_REPO' \
   "${fake_bin}/release-mismatch.out" >/dev/null
 
 printf '%s\n' 'ok - live ACP Kind bootstrap is noninteractive, secret-safe, and delegates to the canonical validator'
+
+cat >"${fake_bin}/record-kindctl" <<'STUB'
+#!/usr/bin/env bash
+[[ "$1" == delete ]] || exit 2
+printf '%s\n' "$*" >>"${CLEANUP_CALLS}"
+STUB
+chmod +x "${fake_bin}/record-kindctl"
+export RELEASE_GATE=1 CLEANUP_CALLS="${fake_bin}/cleanup-calls"
+LIVE_ACP_KINDCTL_BIN="${fake_bin}/record-kindctl"
+LIVE_ACP_KIND_TAG=interrupted-report-test
+LIVE_ACP_KIND_CREATED=1
+LIVE_ACP_REGISTRY_STARTED=0
+cat >"${fake_bin}/cleanup-base.json" <<'JSON'
+{
+  "schemaVersion": 1, "gate": "live-acp-release-gate", "mode": "release",
+  "validatorStarted": true, "task": {"namespace":"test", "name":"canary"},
+  "expectedBranch": "orka/acp-release-gate-test", "preserved": null,
+  "cleanup": {"remote":"running"}
+}
+JSON
+while IFS= read -r mutation; do
+  jq "${mutation}" "${fake_bin}/cleanup-base.json" >"${ACP_E2E_REPORT_FILE}"
+  : >"${CLEANUP_CALLS}"
+  if live_acp_kind_delete_cluster >"${fake_bin}/interrupted-cleanup.out" 2>&1; then
+    echo "cluster teardown accepted incomplete cleanup evidence: ${mutation}" >&2
+    exit 1
+  fi
+  [[ ! -s "${CLEANUP_CALLS}" ]]
+  jq -e '.cleanup.cluster == "preserved" and .cleanup.registry == "preserved"
+    and .preserved != null' "${ACP_E2E_REPORT_FILE}" >/dev/null
+done <<'MUTATIONS'
+.
+.cleanup.remote = "not_started"
+del(.cleanup.remote)
+del(.validatorStarted)
+.validatorStarted = false
+.cleanup.remote = "not_required"
+.cleanup.remote = "passed" | .preserved = {reason:"inspect"}
+MUTATIONS
+
+while IFS= read -r mutation; do
+  jq "${mutation}" "${fake_bin}/cleanup-base.json" >"${ACP_E2E_REPORT_FILE}"
+  : >"${CLEANUP_CALLS}"
+  live_acp_kind_delete_cluster
+  grep -Fx 'delete --tag interrupted-report-test' "${CLEANUP_CALLS}" >/dev/null
+  jq -e '.cleanup.cluster == "passed" and .preserved == null' "${ACP_E2E_REPORT_FILE}" >/dev/null
+done <<'MUTATIONS'
+.validatorStarted = false | .task = null
+.cleanup.remote = "passed"
+.cleanup.remote = "not_required" | .task = null
+MUTATIONS
+printf '%s\n' 'ok - interrupted validators preserve clusters until remote cleanup is explicitly proven safe'

--- a/scripts/verify-acp-release-qualification.sh
+++ b/scripts/verify-acp-release-qualification.sh
@@ -51,6 +51,18 @@ if ! acp_report_qualified "${report}" || ! jq -e \
   exit 1
 fi
 
+# Reruns reuse the run ID. Require the same completed attempt after downloading
+# and validating its report, before accepting or retaining that evidence.
+gh api "repos/${repository}/actions/runs/${run_id}" >"${report_dir}/run-after-download.json"
+if ! jq -e --slurpfile initial "${report_dir}/run.json" '
+    def identity: {run_attempt, status, conclusion, event, head_sha, head_branch, path,
+      repository:.repository.full_name, head_repository:.head_repository.full_name};
+    identity == ($initial[0] | identity)
+  ' "${report_dir}/run-after-download.json" >/dev/null; then
+  echo 'Not qualified: the workflow attempt or outcome changed while its report was being verified.' >&2
+  exit 1
+fi
+
 destination="${script_dir}/../bin/acp-release-qualification-${run_id}-${attempt}"
 mkdir -p "${destination}"
 cp "${report}" "${destination}/acceptance.json"

--- a/scripts/verify-acp-release-qualification.sh
+++ b/scripts/verify-acp-release-qualification.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+if [[ $# != 2 || ! "$1" =~ ^[a-fA-F0-9]{40}$ || ! "$2" =~ ^[1-9][0-9]*$ ]]; then
+  echo 'Usage: scripts/verify-acp-release-qualification.sh FULL_CANDIDATE_SHA WORKFLOW_RUN_ID' >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/live-acp-release-report.sh
+. "${script_dir}/lib/live-acp-release-report.sh"
+candidate="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+run_id="$2"
+repository=orka-agents/orka
+report_dir="$(mktemp -d "${TMPDIR:-/tmp}/acp-release-qualification.XXXXXX")"
+trap 'rm -rf "${report_dir}"' EXIT
+
+default_branch="$(gh api "repos/${repository}" --jq '.default_branch')"
+gh api "repos/${repository}/actions/runs/${run_id}" >"${report_dir}/run.json"
+if ! jq -e --arg sha "${candidate}" --arg branch "${default_branch}" --arg repo "${repository}" '
+    .status == "completed" and .conclusion == "success"
+    and .event == "workflow_dispatch" and .head_sha == $sha and .head_branch == $branch
+    and .repository.full_name == $repo and .head_repository.full_name == $repo
+    and .path == ".github/workflows/live-acp-release-gate.yml"
+    and (.run_attempt | type == "number" and . > 0)
+  ' "${report_dir}/run.json" >/dev/null; then
+  echo 'Not qualified: require a successful default-branch Live ACP Release Gate run for this exact candidate.' >&2
+  exit 1
+fi
+attempt="$(jq -r '.run_attempt' "${report_dir}/run.json")"
+artifact="live-acp-release-acceptance-${run_id}-${attempt}"
+gh api --paginate --slurp "repos/${repository}/actions/runs/${run_id}/artifacts?per_page=100" >"${report_dir}/artifacts.json"
+if ! jq -e --arg name "${artifact}" '
+    [.[] | .artifacts[] | select(.name == $name and .expired == false)] | length == 1
+  ' "${report_dir}/artifacts.json" >/dev/null; then
+  echo 'Not qualified: the current workflow attempt has no unique, unexpired acceptance report.' >&2
+  exit 1
+fi
+gh run download "${run_id}" --repo "${repository}" --name "${artifact}" --dir "${report_dir}/download"
+report="${report_dir}/download/acceptance.json"
+if ! acp_report_qualified "${report}" || ! jq -e \
+    --arg sha "${candidate}" --arg run "${run_id}" --arg attempt "${attempt}" \
+    --arg repo "${repository}" --arg ref "refs/heads/${default_branch}" '
+      .result == "qualified" and .candidateSHA == $sha and .checkoutSHA == $sha
+      and .workflow.sha == $sha and .workflow.repository == $repo and .workflow.ref == $ref
+      and .workflow.runID == $run and .workflow.runAttempt == $attempt
+      and .workflow.event == "workflow_dispatch"
+    ' "${report}" >/dev/null; then
+  echo 'Not qualified: the report is incomplete or does not match the trusted candidate and workflow attempt.' >&2
+  exit 1
+fi
+
+destination="${script_dir}/../bin/acp-release-qualification-${run_id}-${attempt}"
+mkdir -p "${destination}"
+cp "${report}" "${destination}/acceptance.json"
+printf 'Qualified %s using https://github.com/%s/actions/runs/%s/attempts/%s\n' \
+  "${candidate}" "${repository}" "${run_id}" "${attempt}"
+printf 'Acceptance report: %s/acceptance.json\n' "${destination}"

--- a/website/docs/development/acp-release-gate.md
+++ b/website/docs/development/acp-release-gate.md
@@ -135,6 +135,11 @@ resources, establish writer quiescence and their current identities, and remove
 only confirmed canary effects. Never replace the lease with unconditional branch
 deletion or force-remove Task finalizers to get a passing result.
 
+After the validator starts, cluster teardown requires an explicit completed
+remote-cleanup result, or confirmation that no write Task started. A timeout or
+interrupted cleanup with incomplete evidence preserves the cluster and registry
+and fails qualification, even if the validator could not finish its exit trap.
+
 Local preserved clusters remain available through the run's `kindctl` tag.
 GitHub-hosted runners are disposable, so download the failure artifact for
 inspection; runner disposal does not count as verified cleanup. After resolving

--- a/website/docs/development/acp-release-gate.md
+++ b/website/docs/development/acp-release-gate.md
@@ -1,0 +1,141 @@
+---
+description: Qualify an ACP release candidate with deployed publication, independent GitHub verification, and safe cleanup.
+---
+
+# ACP publication release qualification
+
+A release containing the RuntimePool ACP path requires a successful **Live ACP
+Release Gate** report for its exact candidate commit. Ordinary ACP smoke, Task
+success, component tests, and a report for another commit do not qualify it.
+Complete this check after reviewing release metadata and before tagging the
+candidate. The tag publication workflow does not run this credentialed gate for
+you.
+
+## Canary and environment
+
+The source is `orka-agents/orka`. The dedicated publication target is
+[`sozercan/orka-acp-release-gate`](https://github.com/sozercan/orka-acp-release-gate),
+an actual fork of that source. Do not use it for development branches. Each
+attempt creates a unique `orka/acp-release-gate-*` branch and a temporary PR
+against the source default branch. The validator checks the fork relationship
+through GitHub before submitting work.
+
+Configure the `live-acp-release-gate` environment in `orka-agents/orka`:
+
+- Select deployment branches by name and allow only the `main` branch. Do not
+  allow tags, PR refs, or arbitrary branches. Required reviewers can be added if
+  maintainer approval is desired.
+- Set the environment variable `ACP_E2E_WRITE_PUBLICATION_REPO` to
+  `https://github.com/sozercan/orka-acp-release-gate.git`. An optional dispatch
+  override must identify this same repository.
+- Configure the following secrets. The four GitHub credentials must have
+  distinct values. Each Kubernetes copy uses the `token` key.
+
+| Secret | Required access and use |
+| --- | --- |
+| `COPILOT_GITHUB_TOKEN` | Provider authentication for the configured Codex, OpenCode, Claude, and Copilot models through Vekil. The repository secret can supply this value. It is not Git publication authority. |
+| `ACP_E2E_WRITE_READ_CREDENTIAL_TOKEN` | Source repository Contents read and metadata read. Used by the source clone boundary. |
+| `ACP_E2E_WRITE_TARGET_READ_CREDENTIAL_TOKEN` | Canary fork Contents read and metadata read. Used for target preflight and publication verification. |
+| `ACP_E2E_WRITE_CREDENTIAL_TOKEN` | Canary fork Contents write and metadata read. Used by the separate publisher for the branch compare-and-swap push. No source write or PR authority is needed. |
+| `ACP_E2E_WRITE_FORGE_CREDENTIAL_TOKEN` | Source Pull requests write, source and fork Contents read, and fork Contents write for branch cleanup. Used for PR reconciliation and by the independent `gh`/Git observer to verify both repositories, close the exact unmerged PR, and delete its branch with an exact-head lease. |
+
+The forge/observer credential must work across the source organization and the
+fork owner. A fine-grained PAT grants write access under only one resource
+owner. For this public repository pair, a dedicated canary account with a
+classic PAT scoped to `public_repo` is one option; keep that account's write
+memberships limited to the canary resources. Follow organization token policy
+and expiry requirements. See GitHub's
+[personal access token permissions and limitations](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
+
+Set values through the environment settings or the interactive `gh secret set`
+prompt. Do not put values in dispatch inputs, shell command literals, reports,
+or PR descriptions. Git and forge credentials never enter the ACP child process
+tree. The publisher obtains operation-scoped authority through its existing
+broker and must continue to fail the gate if its ServiceAccount can read these
+Secrets directly. Reports record only Secret names, namespaces, and resource
+versions.
+
+## Run and qualify a candidate
+
+The workflow is manual, serialized, and restricted to the trusted default
+branch. Its code must already be on that branch. Build and publication use the
+same full source SHA. Release changes made on another branch must first land on
+the default branch; evidence for the parent commit cannot qualify a different
+release commit.
+
+From a trusted checkout, dispatch the current candidate:
+
+```bash
+candidate="$(gh api repos/orka-agents/orka/commits/main --jq .sha)"
+gh workflow run live-acp-release-gate.yml --repo orka-agents/orka --ref main \
+  -f source_ref="${candidate}" \
+  -f source_repository=https://github.com/orka-agents/orka.git \
+  -f pr_base=main
+
+gh run list --repo orka-agents/orka --workflow live-acp-release-gate.yml \
+  --commit "${candidate}" --event workflow_dispatch \
+  --json databaseId,headSha,status,conclusion,url
+```
+
+Select the dispatched run ID from that list, wait for completion, and verify it:
+
+```bash
+gh run watch RUN_ID --repo orka-agents/orka --exit-status
+bash scripts/verify-acp-release-qualification.sh "${candidate}" RUN_ID
+```
+
+The verifier requires a successful dispatch of `live-acp-release-gate.yml` from
+this repository's default branch at the exact candidate SHA. It downloads the
+final report for the current run attempt and checks its candidate, workflow
+identity, publication evidence, image observations, and cleanup results. It
+exits nonzero for missing, expired, incomplete, or mismatched evidence. Keep its
+local `bin/acp-release-qualification-RUN_ID-ATTEMPT/acceptance.json` with the
+release records and link the workflow run from the release checklist. Do not tag
+an ACP candidate until this command succeeds. A local disposable-cluster run is
+useful for diagnosis; release qualification requires the trusted workflow run.
+
+## Evidence and failures
+
+The job uploads `live-acp-release-evidence-RUN_ID-ATTEMPT` before tearing down
+Kind, then `live-acp-release-acceptance-RUN_ID-ATTEMPT` after teardown. Both
+contain only `acceptance.json` and remain available for 90 days. Archive the
+verified final artifact with longer-lived release records before it expires.
+The first artifact is diagnostic evidence and cannot qualify a release while
+cluster cleanup is pending.
+
+The report includes the dispatched and checked-out SHAs, built image references,
+actual controller, publisher, and runtime Pod image digests, Task UID and attempt
+fences, publication and PR receipts, independently observed remote head and PR
+identity, frozen credential versions, and separate cleanup outcomes. It omits
+Task prompts/results, free-form messages, Pod environment values, and Secret
+contents. A failure before deployment records the candidate and failed stage;
+unobserved fields remain absent or incomplete.
+
+One Codex Task must create exactly the requested new file. The gate compares its
+bytes at the expected commit and independently observed remote head, verifies
+the commit parent/tree and one-file diff, and reads the open PR from GitHub.
+`checks.publication: true` records successful publication verification;
+`result: qualified` additionally requires the remaining runtime checks and all
+cleanup to succeed. A preserved cluster, failed branch deletion, skipped
+publication, or missing credential cannot produce a qualified report.
+
+The source base must still equal the candidate at preflight, Task submission,
+PR verification, and completion. If `main` moves, the report shows the observed
+base SHA and the candidate remains unqualified. Let safe cleanup finish, then
+dispatch the new full head SHA. Do not edit the report or reuse an earlier
+report for the new candidate.
+
+Cleanup first proves that the Task and publisher can no longer write. It closes
+only the exact unmerged canary PR, then deletes the unique branch only if its
+head still equals the independently observed head, using `--force-with-lease`.
+It rereads both effects before removing owned Kubernetes resources and temporary
+credentials. A changed head, ambiguous receipt, merged PR, or failed read fails
+the gate and identifies preserved resources in the report. Inspect those exact
+resources, establish writer quiescence and their current identities, and remove
+only confirmed canary effects. Never replace the lease with unconditional branch
+deletion or force-remove Task finalizers to get a passing result.
+
+Local preserved clusters remain available through the run's `kindctl` tag.
+GitHub-hosted runners are disposable, so download the failure artifact for
+inspection; runner disposal does not count as verified cleanup. After resolving
+a preserved canary, start a new attempt with a new branch.

--- a/website/docs/development/acp-release-gate.md
+++ b/website/docs/development/acp-release-gate.md
@@ -111,6 +111,11 @@ Task prompts/results, free-form messages, Pod environment values, and Secret
 contents. A failure before deployment records the candidate and failed stage;
 unobserved fields remain absent or incomplete.
 
+The report also retains GitHub's independently observed publication commit and
+tree. The final Task receipt must match both; `VerifiedExact` additionally
+requires the remote head to equal that commit. Cleanup cannot replace this
+evidence with a different receipt and retain a qualified result.
+
 One Codex Task must create exactly the requested new file. The gate compares its
 bytes at the expected commit and independently observed remote head, verifies
 the commit parent/tree and one-file diff, and reads the open PR from GitHub.

--- a/website/docs/development/development.md
+++ b/website/docs/development/development.md
@@ -68,6 +68,12 @@ make promote-staging-manifest
 
 The first target updates release inputs and regenerates staging. The second copies the reviewed staging installer and chart into `deploy/` and `charts/orka/`. Normally `.github/workflows/release-pr.yml` runs both and opens the release-preparation PR. A matching `v*` tag packages and publishes those committed root snapshots; tag workflows do not regenerate or promote manifests.
 
+Before tagging a release containing the RuntimePool ACP path, require a successful
+[ACP publication release qualification](acp-release-gate.md) report for the exact
+candidate commit. Dispatch the protected gate from the default branch and run
+`scripts/verify-acp-release-qualification.sh FULL_CANDIDATE_SHA WORKFLOW_RUN_ID`.
+Ordinary nightly smoke and component tests do not satisfy this publication check.
+
 CRDs are generated into `config/crd/bases/`, while `config/crd/kustomization.yaml` selects the production APIs packaged in the installer and chart. The development-only fake workspace CRDs and RBAC are kept in the separate `config/development/fake-workspace-provider` package. Helm makes production CRDs available on fresh install but does not update them during upgrades. Apply the CRDs from the exact target chart before upgrading the controller — see [Upgrading](../operations/upgrading.md).
 
 ## Testing

--- a/website/docs/development/testing.md
+++ b/website/docs/development/testing.md
@@ -147,8 +147,8 @@ missing or mismatched artifacts staying not ready.
   environment to the default branch; do not require reviewers if scheduled runs
   must proceed unattended.
 - `.github/workflows/live-acp-release-gate.yml` is manual-only and serialized.
-  Protect the `live-acp-release-gate` environment with required reviewers and a
-  default-branch deployment rule. It accepts explicit source/fork URLs, a full
+  Restrict the `live-acp-release-gate` environment to the default branch. It
+  accepts the configured canary fork, a full
   source SHA that must equal the dispatched workflow commit and default-branch
   head, and the default branch as the PR base. It requires these environment
   secrets:
@@ -158,6 +158,10 @@ missing or mismatched artifacts staying not ready.
   `ACP_E2E_WRITE_FORGE_CREDENTIAL_TOKEN`. Configure the four publication
   credentials as distinct, least-privilege GitHub credentials for source read,
   target read, target write, and forge/verification cleanup respectively.
+  [ACP publication release qualification](acp-release-gate.md) documents the
+  dedicated fork, exact permissions, trusted dispatch, report verification,
+  and recovery from a moved base or preserved canary. Release qualification
+  requires that report for the exact candidate; smoke success is insufficient.
 - Neither live ACP workflow runs for `pull_request`, so PR-controlled code never
   receives provider or publication credentials. Both check out with persisted
   credentials disabled and expose secrets only to the final local script step.
@@ -221,7 +225,7 @@ set `ACP_E2E_WRITE_SOURCE_REPO`, `ACP_E2E_WRITE_PUBLICATION_REPO`,
 export RELEASE_GATE=1
 export ACP_E2E_WRITE_CREATE_PR=1
 export ACP_E2E_WRITE_SOURCE_REPO=https://github.com/orka-agents/orka.git
-export ACP_E2E_WRITE_PUBLICATION_REPO=https://github.com/OWNER/orka.git
+export ACP_E2E_WRITE_PUBLICATION_REPO=https://github.com/sozercan/orka-acp-release-gate.git
 export ACP_E2E_WRITE_SOURCE_REF="$(git rev-parse HEAD)"
 export ACP_E2E_WRITE_PR_BASE=main
 read -rsp 'Source-read token: ' ACP_E2E_WRITE_READ_CREDENTIAL_TOKEN && echo
@@ -237,7 +241,11 @@ bash scripts/live-acp-runtime-kind-e2e.sh
 In release mode the Kind wrapper binds `ACP_E2E_REPO` and `ACP_E2E_REF` to the
 write source repository and SHA, and rejects explicitly supplied read values
 that differ. The read/runtime phases and publication phase therefore validate
-the same immutable source.
+the same immutable source. The image build requires a clean checkout at that
+commit. Local reports are saved under `bin/acp-release-*/acceptance.json`, or
+`ACP_E2E_REPORT_FILE` when set. `--keep-cluster` leaves cleanup pending and cannot
+qualify a release; use the trusted workflow and report verifier above for release
+records.
 
 Do not enable shell xtrace for either invocation. The scripts create Kubernetes
 Secrets without printing their values and redact provider/GitHub token patterns

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -78,6 +78,7 @@ const sidebars = {
       items: [
         'development/development',
         'development/testing',
+        'development/acp-release-gate',
         'development/security-scanning-design',
         'development/agent-runtime-adapter-contract',
       ],


### PR DESCRIPTION
The deployed ACP release gate currently discards its acceptance evidence, and its Kind wrapper can hide teardown failures after successful validation. Save an allowlisted report throughout the run and require complete publication, image, credential-version, and cleanup evidence before qualifying the candidate.

- Upload diagnostic evidence before cluster teardown and the final acceptance report afterward, including on failure.
- Bind the report to the candidate checkout, built image references, actual Pod image digests, Task attempt, publication/PR receipts, and independent GitHub observations. Require final Task commit/tree receipts to match the independently observed GitHub commit and tree, including after cleanup refreshes the Task. Recheck the source base at completion.
- Restrict publication to the canary fork configured in the protected environment. Preserve the existing publisher/ACP credential boundaries and exact-head cleanup guards. After validator launch, require positive safe-cleanup evidence before deleting the cluster; interrupted cleanup preserves it and fails qualification.
- Add a command that verifies a successful trusted workflow run and its current-attempt artifact for the exact candidate. Recheck run metadata after download to reject concurrent reruns. Document the canary, credential permissions, release procedure, and recovery steps.

Validation passed: release-report and publication fault-injection suites, existing live ACP validator/Kind/port-forward regression suites, shell syntax, production ShellCheck, actionlint, and the documentation production build. The new tests reject wrong file bytes, commit/PR identity mismatches, moved heads, missing or stale evidence, and incomplete cleanup. The dispatch regression executes the actual workflow guard with both documented URL forms.

The `live-acp-release-gate` environment now allows only `main` and identifies the verified `sozercan/orka-acp-release-gate` fork. Its four publication credentials still need provisioning. A successful live acceptance run has not been recorded; after this workflow reaches `main`, dispatch the full current source SHA and verify its report. Keep the issue open until that run completes publication, independent verification, PR reconciliation, and safe cleanup.

Refs #492.
