### PR TITLE
feat(cli): complete values for output, type, and status flags

### DIFF
--- a/cmd/cli/completion_test.go
+++ b/cmd/cli/completion_test.go
@@ -92,7 +92,7 @@ func TestCLIFlagCompletion(t *testing.T) {
 			}
 
 			var gotLines []string
-			for _, line := range strings.Split(strings.TrimRight(out.String(), "\n"), "\n") {
+			for line := range strings.SplitSeq(strings.TrimRight(out.String(), "\n"), "\n") {
 				if strings.TrimSpace(line) != "" {
 					gotLines = append(gotLines, line)
 				}

--- a/cmd/cli/completion_test.go
+++ b/cmd/cli/completion_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright (c) 2026.
+
+MIT License - see LICENSE file for details.
+*/
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	corev1alpha1 "github.com/orka-agents/orka/api/v1alpha1"
+)
+
+func TestCLIFlagCompletion(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantLines []string
+		directive string
+	}{
+		{
+			name:      "output formats",
+			args:      []string{"task", "list", "--output", ""},
+			wantLines: []string{"table", "json", "yaml"},
+			directive: ":4",
+		},
+		{
+			name:      "output formats shorthand",
+			args:      []string{"task", "list", "-o", ""},
+			wantLines: []string{"table", "json", "yaml"},
+			directive: ":4",
+		},
+		{
+			name:      "output prefix filters",
+			args:      []string{"task", "list", "--output", "j"},
+			wantLines: []string{"json"},
+			directive: ":4",
+		},
+		{
+			name:      "task types",
+			args:      []string{"task", "create", "--type", ""},
+			wantLines: []string{"ai", "container", "agent"},
+			directive: ":4",
+		},
+		{
+			name: "task statuses",
+			args: []string{"task", "list", "--status", ""},
+			wantLines: []string{
+				string(corev1alpha1.TaskPhasePending),
+				string(corev1alpha1.TaskPhaseRunning),
+				string(corev1alpha1.TaskPhaseFinalizing),
+				string(corev1alpha1.TaskPhaseSucceeded),
+				string(corev1alpha1.TaskPhaseFailed),
+				string(corev1alpha1.TaskPhaseScheduled),
+				string(corev1alpha1.TaskPhaseCancelled),
+			},
+			directive: ":4",
+		},
+		{
+			name:      "task status prefix filters",
+			args:      []string{"task", "list", "--status", "S"},
+			wantLines: []string{"Succeeded", "Scheduled"},
+			directive: ":4",
+		},
+		{
+			name:      "unmatched prefix yields no suggestions",
+			args:      []string{"task", "list", "--status", "zz"},
+			wantLines: nil,
+			directive: ":4",
+		},
+		{
+			name:      "download output keeps filename completion",
+			args:      []string{"task", "download", "--output", ""},
+			wantLines: nil,
+			directive: ":0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := newRootCmd()
+			var out bytes.Buffer
+			root.SetOut(&out)
+
+			args := append([]string{"__complete"}, tt.args...)
+			root.SetArgs(args)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("Execute() error: %v", err)
+			}
+
+			var gotLines []string
+			for _, line := range strings.Split(strings.TrimRight(out.String(), "\n"), "\n") {
+				if strings.TrimSpace(line) != "" {
+					gotLines = append(gotLines, line)
+				}
+			}
+			if len(gotLines) == 0 {
+				t.Fatalf("no output from __complete")
+			}
+			if got := gotLines[len(gotLines)-1]; got != tt.directive {
+				t.Fatalf("directive = %q, want %q (output: %q)", got, tt.directive, out.String())
+			}
+			gotSuggestions := gotLines[:len(gotLines)-1]
+			if len(tt.wantLines) == 0 {
+				if len(gotSuggestions) != 0 {
+					t.Fatalf("suggestions = %v, want none", gotSuggestions)
+				}
+				return
+			}
+			if strings.Join(gotSuggestions, "\n") != strings.Join(tt.wantLines, "\n") {
+				t.Fatalf("suggestions = %v, want %v", gotSuggestions, tt.wantLines)
+			}
+		})
+	}
+}

--- a/cmd/cli/output.go
+++ b/cmd/cli/output.go
@@ -25,6 +25,29 @@ const (
 
 func addOutputFlag(cmd *cobra.Command, defaultValue string) {
 	cmd.Flags().StringP("output", "o", defaultValue, "Output format: table, json, yaml")
+	_ = cmd.RegisterFlagCompletionFunc("output", completeOutputFormat)
+}
+
+// completeOutputFormat suggests the shared output formats for flag
+// completion, filtered by the typed prefix. Commands that treat --output as
+// a destination path (such as task download) register their own flag and
+// never reach this function.
+func completeOutputFormat(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return completeWithPrefix(toComplete, outputTable, outputJSON, outputYAML), cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeWithPrefix keeps only the values that start with the typed prefix.
+func completeWithPrefix(prefix string, values ...string) []string {
+	if prefix == "" {
+		return values
+	}
+	filtered := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.HasPrefix(value, prefix) {
+			filtered = append(filtered, value)
+		}
+	}
+	return filtered
 }
 
 func outputFormat(cmd *cobra.Command) (string, error) {

--- a/cmd/cli/task.go
+++ b/cmd/cli/task.go
@@ -34,6 +34,31 @@ const (
 	cliTaskTypeCont  = "container"
 )
 
+// completeTaskType suggests the canonical task types for flag completion,
+// filtered by the typed prefix. The suggestions are static, so completion
+// never contacts an Orka server.
+func completeTaskType(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return completeWithPrefix(toComplete,
+		string(corev1alpha1.TaskTypeAI),
+		string(corev1alpha1.TaskTypeContainer),
+		string(corev1alpha1.TaskTypeAgent),
+	), cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeTaskStatus suggests the canonical task phases for flag completion,
+// filtered by the typed prefix.
+func completeTaskStatus(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return completeWithPrefix(toComplete,
+		string(corev1alpha1.TaskPhasePending),
+		string(corev1alpha1.TaskPhaseRunning),
+		string(corev1alpha1.TaskPhaseFinalizing),
+		string(corev1alpha1.TaskPhaseSucceeded),
+		string(corev1alpha1.TaskPhaseFailed),
+		string(corev1alpha1.TaskPhaseScheduled),
+		string(corev1alpha1.TaskPhaseCancelled),
+	), cobra.ShellCompDirectiveNoFileComp
+}
+
 func newTaskCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "task",
@@ -256,6 +281,7 @@ func newTaskCreateCmd() *cobra.Command {
 		cliTaskTypeAI,
 		"Task type: "+cliTaskTypeAI+", "+cliTaskTypeCont+", "+cliTaskTypeAgent,
 	)
+	_ = cmd.RegisterFlagCompletionFunc("type", completeTaskType)
 	cmd.Flags().StringVar(&image, "image", "", "Container image")
 	cmd.Flags().StringArrayVar(&commandVals, "command", nil, "Command entry to run (repeat for multiple entries)")
 	cmd.Flags().StringArrayVar(&argVals, "arg", nil, "Command argument (repeat for multiple arguments)")
@@ -346,6 +372,7 @@ func newTaskListCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&status, "status", "", "Filter by status (client-side scan; may page through many tasks)")
+	_ = cmd.RegisterFlagCompletionFunc("status", completeTaskStatus)
 	cmd.Flags().StringVar(&transactionID, "transaction", "", "Filter by transaction ID (client-side scan)")
 	cmd.Flags().IntVar(&limit, "limit", 20, "Maximum number of results")
 	cmd.Flags().StringVar(&continueToken, "continue", "", "Continue token for the next page")

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -357,6 +357,16 @@ orka completion fish > ~/.config/fish/completions/orka.fish
 
 Regenerate completions after upgrading `orka` if commands or flags change.
 
+Several flags offer value completion, so Tab suggests the valid choices without consulting the server:
+
+```bash
+orka task list --output <TAB>   # table, json, yaml
+orka task create --type <TAB>   # ai, container, agent
+orka task list --status <TAB>   # Pending, Running, Finalizing, ...
+```
+
+`task download --output` is left out on purpose: there the flag names a destination file, so completion keeps suggesting files.
+
 ## Other utility commands
 
 | Command | Purpose |


### PR DESCRIPTION
## Summary

Registers Cobra flag completion so Tab after a known flag suggests the valid values instead of nothing:

- Output formats registered through `addOutputFlag`: `table`, `json`, `yaml`.
- `task create --type`: `ai`, `container`, `agent` (canonical `TaskType` values).
- `task list --status`: `Pending`, `Running`, `Finalizing`, `Succeeded`, `Failed`, `Scheduled`, `Cancelled` (canonical `TaskPhase` values).

Suggestions are static and filtered by the typed prefix, so completion works without an Orka server and never executes the target command. The `NoFileComp` directive suppresses filename suggestions for these enum flags. `task download --output` is untouched: it registers its own destination-path flag, so it keeps filename completion.

Try it:

```bash
orka __complete task list --output ""     # table, json, yaml
orka __complete task list --output j      # json
orka __complete task create --type ""     # ai, container, agent
orka __complete task list --status "F"    # Finalizing, Failed
orka __complete task download --output "" # no enum suggestions, :0 directive
```

## Tests

Table-driven `TestCLIFlagCompletion` in `cmd/cli/completion_test.go` covers empty input, partial prefixes, unmatched prefixes, both `--output` and `-o`, all three flag groups, and the returned completion directive. It also verifies that `task download --output` does not suggest enum values.

## Verification

```bash
go test ./cmd/cli -run '^TestCLIFlagCompletion' -count=1   # 8/8 pass
go vet ./cmd/cli                                           # pass
git diff --check                                           # pass
```

Note: the full `go test ./cmd/cli` suite has pre-existing Windows-only failures in `helpers_test.go` (config-path tests rely on `$HOME` redirects, which `os.UserHomeDir` ignores on Windows). They are unrelated to this change and fail on the base revision as well.

## Documentation

Added a "value completion" example block to the shell completion section of `website/docs/reference/cli.md`.

Fixes #521.