### PR TITLE
docs(website): add contribution workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,4 +61,6 @@ bun install
 bun run dev
 ```
 
+For the documentation website workflow, see [website/README.md](website/README.md).
+
 Additional development guidance is available in [website/docs/development/development.md](website/docs/development/development.md).

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,53 @@
+# Contributing to the website
+
+The `website/` directory contains Orka's public documentation site. It is a Docusaurus
+site with its own Node.js and Yarn toolchain. The `ui/` directory is the Orka dashboard
+and uses Bun; use the workflow below for documentation changes.
+
+## Prerequisites
+
+- Node.js 24, matching the version used by the website CI workflow
+- Corepack, available with the Node.js installation
+- Git
+
+The repository pins Yarn 1.22.22 through `website/package.json`. From the repository
+root, enable Corepack and install the website dependencies:
+
+```bash
+corepack enable
+cd website
+yarn --version              # 1.22.22
+yarn install --frozen-lockfile
+```
+
+## Edit the documentation
+
+Existing pages live under `website/docs/`. Edit the Markdown file for an existing page,
+or add a new Markdown file there and register it in `website/sidebars.js` so readers can
+find it in the navigation. The Docusaurus configuration uses `/orka/` as the site base
+path, so local URLs include that prefix.
+
+## Development preview
+
+Start the development server from `website/`:
+
+```bash
+yarn start --host 127.0.0.1
+```
+
+Open the printed address, normally `http://127.0.0.1:3000/orka/`. Visit the page you
+changed, follow its links, and check that the surrounding navigation works. Stop the
+server with `Ctrl+C` when finished.
+
+## Production preview
+
+Build the site and serve the generated files locally:
+
+```bash
+yarn build
+yarn serve --host 127.0.0.1
+```
+
+Open the `/orka/` base path again and check the changed page and its links. Stop the
+preview with `Ctrl+C`; the generated `website/build/` directory is ignored and should
+not be committed.


### PR DESCRIPTION
## Summary

- Add `website/README.md` with the website prerequisites, Yarn setup, documentation editing workflow, and development and production preview commands.
- Link the website guide from `CONTRIBUTING.md` so website and dashboard workflows are clearly separated.

## Verification

- `corepack yarn install --frozen-lockfile` in `website/` (Yarn 1.22.22)
- `corepack yarn build` in `website/`
- Served the production build on port 3017; `/orka/` and `/orka/docs/getting-started` returned HTTP 200
- Started the development server on port 3018; `/orka/` and `/orka/docs/getting-started` returned HTTP 200
- `git diff --check`

The repository workflow uses Node.js 24; the local build and preview checks ran with Node.js 22.23.2, which satisfies the website's declared Node.js engine requirement.

Closes #525
