### PR TITLE
chore(devcontainer): install pinned Bun for dashboard contributors

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,11 @@
       "moby": false,
       "dockerDefaultAddressPool": "base=172.30.0.0/16,size=24"
     },
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "24",
+      "pnpmVersion": "none"
+    }
   },
 
   "runArgs": ["--privileged", "--init"],

--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -5,6 +5,26 @@ echo "Installing Kubebuilder development tools..."
 
 ARCH=$(go env GOARCH)
 
+# Install Bun (pinned to the version used by the UI test job)
+PINNED_BUN_VERSION="1.3.13"
+if ! command -v bun &> /dev/null || [ "$(bun --version)" != "${PINNED_BUN_VERSION}" ]; then
+  BUN_ARCH=x64
+  if [ "${ARCH}" = "arm64" ]; then
+    BUN_ARCH=aarch64
+  fi
+  if ! command -v unzip &> /dev/null; then
+    apt-get update >/dev/null
+    apt-get install -y --no-install-recommends unzip >/dev/null
+  fi
+  echo "Installing Bun ${PINNED_BUN_VERSION} (linux-${BUN_ARCH})..."
+  curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${PINNED_BUN_VERSION}/bun-linux-${BUN_ARCH}.zip" -o /tmp/bun.zip \
+    || { echo "ERROR: failed to download Bun ${PINNED_BUN_VERSION} for linux-${BUN_ARCH}" >&2; exit 1; }
+  unzip -o /tmp/bun.zip -d /usr/local
+  chmod +x "/usr/local/bun-linux-${BUN_ARCH}/bun"
+  ln -sf "/usr/local/bun-linux-${BUN_ARCH}/bun" /usr/local/bin/bun
+  rm -f /tmp/bun.zip
+fi
+
 # Install kind
 if ! command -v kind &> /dev/null; then
   curl -Lo ./kind "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
@@ -43,6 +63,7 @@ docker network inspect kind >/dev/null 2>&1 || docker network create kind || tru
 
 # Verify installations
 echo "Installed versions:"
+bun --version
 kind version
 kubebuilder version
 kubectl version --client

--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -7,16 +7,21 @@ ARCH=$(go env GOARCH)
 
 # Install Bun (pinned to the version used by the UI test job)
 PINNED_BUN_VERSION="1.3.13"
-BUN_PATH=$(type -P bun || true)
-if [ -z "${BUN_PATH}" ] || [ "$(bun --version)" != "${PINNED_BUN_VERSION}" ]; then
+if [ ! -x /usr/local/bin/bun ] || [ "$(/usr/local/bin/bun --version)" != "${PINNED_BUN_VERSION}" ]; then
+  # Digests from the pinned release's SHASUMS256.txt.
   case "${ARCH}" in
     amd64)
       BUN_ARCH=x64
+      BUN_SHA256=79c0771fa8b92c33aae41e15a0e0d307ea99d0e2f00317c71c6c53237a78e25a
       if ! grep -qw avx2 /proc/cpuinfo; then
         BUN_ARCH=x64-baseline
+        BUN_SHA256=9d8a24292a7068090205daac0a5a223f5f69736f5287e37bf88d3b4031edc750
       fi
       ;;
-    arm64) BUN_ARCH=aarch64 ;;
+    arm64)
+      BUN_ARCH=aarch64
+      BUN_SHA256=70bae41b3908b0a120e1e58c5c8af30e74afae3b8d11b0d3fdd8e787ddfb4b22
+      ;;
     *) echo "ERROR: Bun is not supported on linux-${ARCH}" >&2; exit 1 ;;
   esac
   if ! command -v unzip &> /dev/null; then
@@ -26,17 +31,20 @@ if [ -z "${BUN_PATH}" ] || [ "$(bun --version)" != "${PINNED_BUN_VERSION}" ]; th
   echo "Installing Bun ${PINNED_BUN_VERSION} (linux-${BUN_ARCH})..."
   curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${PINNED_BUN_VERSION}/bun-linux-${BUN_ARCH}.zip" -o /tmp/bun.zip \
     || { echo "ERROR: failed to download Bun ${PINNED_BUN_VERSION} for linux-${BUN_ARCH}" >&2; exit 1; }
+  printf '%s  /tmp/bun.zip\n' "${BUN_SHA256}" | sha256sum --check --status \
+    || { echo "ERROR: Bun archive checksum verification failed" >&2; exit 1; }
   unzip -o /tmp/bun.zip -d /usr/local
   chmod +x "/usr/local/bun-linux-${BUN_ARCH}/bun"
   ln -sf "/usr/local/bun-linux-${BUN_ARCH}/bun" /usr/local/bin/bun
-  # Keep an existing Bun earlier on PATH pinned in subsequent shells too.
-  if [ -n "${BUN_PATH}" ] && ! [ "${BUN_PATH}" -ef /usr/local/bin/bun ]; then
-    ln -sf /usr/local/bin/bun "${BUN_PATH}"
-  fi
   rm -f /tmp/bun.zip
 fi
-if [ "$(bun --version)" != "${PINNED_BUN_VERSION}" ]; then
-  echo "ERROR: Bun ${PINNED_BUN_VERSION} is not the active version on PATH" >&2
+if [ "$(/usr/local/bin/bun --version)" != "${PINNED_BUN_VERSION}" ]; then
+  echo "ERROR: Bun ${PINNED_BUN_VERSION} installation verification failed" >&2
+  exit 1
+fi
+if ! command -v bun &> /dev/null || [ "$(bun --version)" != "${PINNED_BUN_VERSION}" ]; then
+  echo "ERROR: Bun ${PINNED_BUN_VERSION} is installed at /usr/local/bin/bun but is not active on PATH" >&2
+  echo "Move /usr/local/bin before other Bun installations on PATH and rerun setup." >&2
   exit 1
 fi
 

--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -7,11 +7,18 @@ ARCH=$(go env GOARCH)
 
 # Install Bun (pinned to the version used by the UI test job)
 PINNED_BUN_VERSION="1.3.13"
-if ! command -v bun &> /dev/null || [ "$(bun --version)" != "${PINNED_BUN_VERSION}" ]; then
-  BUN_ARCH=x64
-  if [ "${ARCH}" = "arm64" ]; then
-    BUN_ARCH=aarch64
-  fi
+BUN_PATH=$(type -P bun || true)
+if [ -z "${BUN_PATH}" ] || [ "$(bun --version)" != "${PINNED_BUN_VERSION}" ]; then
+  case "${ARCH}" in
+    amd64)
+      BUN_ARCH=x64
+      if ! grep -qw avx2 /proc/cpuinfo; then
+        BUN_ARCH=x64-baseline
+      fi
+      ;;
+    arm64) BUN_ARCH=aarch64 ;;
+    *) echo "ERROR: Bun is not supported on linux-${ARCH}" >&2; exit 1 ;;
+  esac
   if ! command -v unzip &> /dev/null; then
     apt-get update >/dev/null
     apt-get install -y --no-install-recommends unzip >/dev/null
@@ -22,7 +29,15 @@ if ! command -v bun &> /dev/null || [ "$(bun --version)" != "${PINNED_BUN_VERSIO
   unzip -o /tmp/bun.zip -d /usr/local
   chmod +x "/usr/local/bun-linux-${BUN_ARCH}/bun"
   ln -sf "/usr/local/bun-linux-${BUN_ARCH}/bun" /usr/local/bin/bun
+  # Keep an existing Bun earlier on PATH pinned in subsequent shells too.
+  if [ -n "${BUN_PATH}" ] && ! [ "${BUN_PATH}" -ef /usr/local/bin/bun ]; then
+    ln -sf /usr/local/bin/bun "${BUN_PATH}"
+  fi
   rm -f /tmp/bun.zip
+fi
+if [ "$(bun --version)" != "${PINNED_BUN_VERSION}" ]; then
+  echo "ERROR: Bun ${PINNED_BUN_VERSION} is not the active version on PATH" >&2
+  exit 1
 fi
 
 # Install kind

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,4 +61,14 @@ bun install
 bun run dev
 ```
 
+Using the devcontainer: the container setup installs Bun, so a rebuilt container can run the UI workflow directly. After changing `.devcontainer/post-install.sh`, rebuild with **Dev Containers: Rebuild Container**; the dashboard checks are the same commands used by CI:
+
+```bash
+cd ui
+bun install --frozen-lockfile
+bun run lint
+bun run test
+bun run build
+```
+
 Additional development guidance is available in [website/docs/development/development.md](website/docs/development/development.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ bun install
 bun run dev
 ```
 
-Using the devcontainer: the container setup installs Bun, so a rebuilt container can run the UI workflow directly. After changing `.devcontainer/post-install.sh`, rebuild with **Dev Containers: Rebuild Container**; the dashboard checks are the same commands used by CI:
+Using the devcontainer: the container setup installs Bun and Node.js, which the UI test runner requires. After changing files in `.devcontainer/`, rebuild with **Dev Containers: Rebuild Container**; the dashboard checks are the same commands used by CI:
 
 ```bash
 cd ui


### PR DESCRIPTION
Installs Bun 1.3.13 and Node.js 24 in the devcontainer so dashboard contributors can run the documented UI workflow after rebuilding. The Bun pin matches the UI CI jobs. Node is required by the UI test tooling: without it, Vitest falls back to Bun and fails while importing unchanged schemas.

Bun setup selects the amd64 or arm64 release asset, uses x64-baseline without AVX2, and verifies a pinned official SHA-256 digest before extraction. It reuses a valid installation, verifies the active version, and preserves external executables and version-manager shims. If a different version shadows the pin, setup fails with PATH-ordering guidance. A working 1.3.13 shim remains supported. `CONTRIBUTING.md` documents rebuilding the container and running the UI commands.

Validation:

- Shell syntax checks, devcontainer JSON parsing, and `git diff --check` passed.
- The published Node devcontainer feature provisioned Node 24 in the declared `golang:1.27.0` Linux arm64 image. Fresh shells resolved both Node and Bun 1.3.13.
- Frozen UI install, build, lint, and tests passed with that feature and Bun: 126 test files and 1,106 tests.
- Native Bun installation, reruns, upgrades, and managed-shim preservation passed. Matching-version shims were accepted unchanged; mismatched versions failed with guidance and worked after correcting PATH.
- All three release archives matched their published digests. amd64 asset selection and extraction passed with simulated CPU flags and execution. Corrupted archives failed before extraction; unsupported architectures and residual version mismatches failed as expected.

Fixes #526.
