### PR TITLE
docs(website): add website contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,3 +62,7 @@ bun run dev
 ```
 
 Additional development guidance is available in [website/docs/development/development.md](website/docs/development/development.md).
+
+## Website (documentation site)
+
+The documentation site in `website/` uses its own Node/Yarn toolchain (the dashboard in `ui/` uses Bun). See [website/README.md](website/README.md) for prerequisites, the local preview, and the production build.

--- a/website/README.md
+++ b/website/README.md
@@ -32,7 +32,9 @@ The development server prints a local address, normally `http://127.0.0.1:3000/o
 
 ## Edit pages
 
-Documentation sources live in `website/docs/`; Docusaurus routes them by filename under the base path. The page navigation is defined in `website/sidebars.js`.
+Documentation sources live in `website/docs/`. Their URLs start with `/orka/docs/`, combining `baseUrl` and `routeBasePath` from `website/docusaurus.config.js`. A page's front-matter `slug` sets its path within that prefix; without a `slug`, Docusaurus derives the path from the source file path. For example, `website/docs/reference/cli.md` declares `slug: /cli-reference`, so its preview URL is `http://127.0.0.1:3000/orka/docs/cli-reference`.
+
+The page navigation is defined in `website/sidebars.js`.
 
 - To change an existing page, edit its Markdown file under `website/docs/` and inspect it in the running preview.
 - To add a new page, create the Markdown file under `website/docs/` and add it to the relevant sidebar entry in `website/sidebars.js`.

--- a/website/README.md
+++ b/website/README.md
@@ -5,7 +5,9 @@ This directory contains the public Orka documentation site (Docusaurus). Do not 
 ## Prerequisites
 
 - Node.js (the website CI uses Node.js 24)
-- Corepack, which ships with recent Node.js distributions
+- Corepack
+
+If `corepack --version` is unavailable, install it with `npm install --global corepack` first. [Node.js 25 and later no longer bundle Corepack](https://github.com/nodejs/corepack#how-to-install).
 
 Enable Yarn through Corepack so the repository-pinned version is used:
 

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,49 @@
+# Orka documentation website
+
+This directory contains the public Orka documentation site (Docusaurus). Do not mix its toolchain with the `ui/` dashboard: the website uses Node.js with Yarn, while the dashboard uses Bun.
+
+## Prerequisites
+
+- Node.js (the website CI uses Node.js 24)
+- Corepack, which ships with recent Node.js distributions
+
+Enable Yarn through Corepack so the repository-pinned version is used:
+
+```bash
+corepack enable
+```
+
+The project pins Yarn 1.22.22 in `website/package.json` (`packageManager` field).
+
+## Install and preview
+
+Run from the repository root:
+
+```bash
+cd website
+yarn --version   # should print 1.22.22
+yarn install --frozen-lockfile
+yarn start --host 127.0.0.1
+```
+
+The development server prints a local address, normally `http://127.0.0.1:3000/orka/` (the site is built under the `/orka/` base path). Open it, browse to a documentation page, and follow its links. Stop the server with Ctrl+C.
+
+## Edit pages
+
+Documentation sources live in `website/docs/`; Docusaurus routes them by filename under the base path. The page navigation is defined in `website/sidebars.js`.
+
+- To change an existing page, edit its Markdown file under `website/docs/` and inspect it in the running preview.
+- To add a new page, create the Markdown file under `website/docs/` and add it to the relevant sidebar entry in `website/sidebars.js`.
+
+## Production build and preview
+
+From `website/`, after stopping the development server:
+
+```bash
+yarn build
+yarn serve --host 127.0.0.1
+```
+
+`yarn build` validates the site (links, references, and build itself) and writes the static output; `yarn serve` previews that output locally, again under the `/orka/` base path. Stop the server with Ctrl+C.
+
+These commands only preview locally; they do not publish anything. Publishing happens through the repository's website workflow on the `main` branch.


### PR DESCRIPTION
## Summary

Adds `website/README.md`, a short copyable guide for contributors who want to fix or add documentation pages, and links it from `CONTRIBUTING.md`.

The guide covers:

- Prerequisites: Node.js (CI uses Node.js 24), Corepack, pinned Yarn 1.22.22 via the `packageManager` field.
- Installation and the development preview from the repository root (`yarn install --frozen-lockfile`, `yarn start --host 127.0.0.1`), including the `/orka/` base path and Ctrl+C to stop.
- Where documentation sources live (`website/docs/`), how Docusaurus routes them, and how to add a page to `website/sidebars.js`.
- The production build and local production preview (`yarn build`, `yarn serve --host 127.0.0.1`).
- An explicit note that the website uses Node/Yarn while the dashboard in `ui/` uses Bun, so readers do not mix package managers.

## Verification (Node v22.21.1, Corepack, Yarn 1.22.22)

```text
corepack enable                                      pass
yarn --version                                       1.22.22
yarn install --frozen-lockfile                       pass, no lockfile changes
yarn start --host 127.0.0.1                          http://127.0.0.1:3000/orka/ returned HTTP 200
yarn build                                           clean production build in ~35s
```

The diff contains only the two Markdown files; no lockfile, dependency, or generated changes.

Fixes #525.