### PR TITLE
fix(dashboard): keep log line numbers stable while filtering

### DIFF
--- a/ui/src/components/tasks/structured-log-viewer.test.tsx
+++ b/ui/src/components/tasks/structured-log-viewer.test.tsx
@@ -83,6 +83,61 @@ describe('StructuredLogViewer', () => {
     expect(screen.getByText(/Something failed/)).toBeInTheDocument()
   })
 
+  it('keeps original row numbers and shows loaded counts while filtering', async () => {
+    mockedUseTaskLogs.mockReturnValue({
+      logs: ['[INFO] Starting', '[INFO] Ready', '[ERROR] Request failed', '[ERROR] Request failed'],
+      isStreaming: false,
+      isLive: false,
+      error: null,
+      refetch: vi.fn(),
+      clear: vi.fn(),
+    })
+
+    render(<StructuredLogViewer taskId="task-1" />)
+    expect(screen.getByText('(4 lines)')).toBeInTheDocument()
+
+    const searchInput = screen.getByPlaceholderText('Filter logs...')
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+    await user.type(searchInput, 'error')
+
+    const logLines = screen.getAllByTestId('log-line')
+    expect(logLines).toHaveLength(2)
+    expect(screen.getByText('(2 of 4 loaded lines)')).toBeInTheDocument()
+    // Duplicate messages stay separate rows with their buffer positions.
+    expect(logLines[0]).toHaveTextContent('3')
+    expect(logLines[1]).toHaveTextContent('4')
+    expect(logLines[0]).toHaveTextContent('Request failed')
+    expect(logLines[1]).toHaveTextContent('Request failed')
+  })
+
+  it('shows a no-matches message and clearing the filter restores all rows', async () => {
+    mockedUseTaskLogs.mockReturnValue({
+      logs: ['[INFO] Starting', '[INFO] Ready', '[ERROR] Request failed', '[ERROR] Request failed'],
+      isStreaming: false,
+      isLive: false,
+      error: null,
+      refetch: vi.fn(),
+      clear: vi.fn(),
+    })
+
+    render(<StructuredLogViewer taskId="task-1" />)
+
+    const searchInput = screen.getByPlaceholderText('Filter logs...')
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+    await user.type(searchInput, 'zzz')
+
+    expect(screen.getByTestId('log-no-matches')).toHaveTextContent('No matching lines for "zzz".')
+    expect(screen.queryByTestId('log-line')).toBeNull()
+
+    await user.click(screen.getByRole('button', { name: /clear filter/i }))
+
+    expect(screen.queryByTestId('log-no-matches')).toBeNull()
+    expect(screen.getAllByTestId('log-line')).toHaveLength(4)
+    expect(screen.getByText('(4 lines)')).toBeInTheDocument()
+  })
+
   it('shows error state with retry button', () => {
     const refetchFn = vi.fn()
     mockedUseTaskLogs.mockReturnValue({

--- a/ui/src/components/tasks/structured-log-viewer.tsx
+++ b/ui/src/components/tasks/structured-log-viewer.tsx
@@ -49,9 +49,11 @@ export function StructuredLogViewer({ taskId, taskPhase }: { taskId: string; tas
   const bottomRef = useRef<HTMLDivElement>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
+  const indexedLogs = logs.map((line, index) => ({ index: index + 1, line }))
+
   const filteredLogs = search
-    ? logs.filter(line => line.toLowerCase().includes(search.toLowerCase()))
-    : logs
+    ? indexedLogs.filter(({ line }) => line.toLowerCase().includes(search.toLowerCase()))
+    : indexedLogs
 
   const scrollToBottom = useCallback(() => {
     if (bottomRef.current?.scrollIntoView) {
@@ -112,7 +114,9 @@ export function StructuredLogViewer({ taskId, taskPhase }: { taskId: string; tas
           <CardTitle className="flex items-center gap-2">
             Logs
             <span className="text-xs font-normal text-muted-foreground">
-              ({filteredLogs.length} line{filteredLogs.length !== 1 ? 's' : ''})
+              {search
+                ? `(${filteredLogs.length} of ${logs.length} loaded line${logs.length !== 1 ? 's' : ''})`
+                : `(${filteredLogs.length} line${filteredLogs.length !== 1 ? 's' : ''})`}
             </span>
             {isLive && (
               <span className="flex items-center gap-1 text-xs font-normal text-live">
@@ -171,12 +175,17 @@ export function StructuredLogViewer({ taskId, taskPhase }: { taskId: string; tas
             onScroll={handleScroll}
             className="p-4 font-mono text-xs"
           >
-            {filteredLogs.map((line, i) => {
-              const level = parseLogLevel(line)
+            {search && filteredLogs.length === 0 && (
+              <div className="py-4 text-sm text-muted-foreground" data-testid="log-no-matches">
+                {`No matching lines for "${search}".`}
+              </div>
+            )}
+            {filteredLogs.map(row => {
+              const level = parseLogLevel(row.line)
               return (
-                <div key={i} className={`py-0.5 ${levelColors[level]}`} data-testid="log-line">
-                  <span className="mr-3 select-none text-muted-foreground">{i + 1}</span>
-                  <HighlightedText text={line} search={search} />
+                <div key={`log-${row.index}`} className={`py-0.5 ${levelColors[level]}`} data-testid="log-line">
+                  <span className="mr-3 select-none text-muted-foreground">{row.index}</span>
+                  <HighlightedText text={row.line} search={search} />
                 </div>
               )
             })}


### PR DESCRIPTION
## Summary

Filtering task logs no longer renumbers the matching rows. Each loaded row keeps its position in the current buffer, so a row shown as number 3 stays number 3 when it is the only search match, and duplicate messages remain separate rows with their own numbers.

Changes in `ui/src/components/tasks/structured-log-viewer.tsx`:

- Rows are associated with their buffer position before the search filter is applied; rendering uses the saved number plus a stable key.
- While a filter is active, the header shows both counts, e.g. `(2 of 4 loaded lines)`; without a filter it keeps the previous `(N lines)` form.
- A search with no matches renders `No matching lines for "<query>".` instead of a blank area.
- Clearing the search restores all rows and numbers; the separate "Clear logs" action keeps its current purpose.
- Search, case-insensitivity, and highlighting behavior are unchanged.

## Tests

Extended `structured-log-viewer.test.tsx` (8 tests pass):

- `keeps original row numbers and shows loaded counts while filtering`: four-line fixture with duplicate `[ERROR] Request failed` messages; searching `error` shows rows numbered 3 and 4 and the `(2 of 4 loaded lines)` count.
- `shows a no-matches message and clearing the filter restores all rows`: `zzz` shows the message and zero `log-line` rows; clicking "Clear filter" restores all four rows and the `(4 lines)` count.

## Verification

```bash
bun install --frozen-lockfile                                    # pass
bun run test src/components/tasks/structured-log-viewer.test.tsx  # 8/8 pass
bun run lint                                                     # pass
bun run test                                                     # pass (full UI suite)
bun run build                                                    # pass
```

Note: `bun run build` regenerated `ui/src/routeTree.gen.ts` with identical content (line-ending difference only); it is not part of the diff.

Fixes #522.