### PR TITLE
fix(dashboard): surface loading, failure, and retry states in task result panel

### DIFF
--- a/ui/src/components/tasks/task-result-viewer.test.tsx
+++ b/ui/src/components/tasks/task-result-viewer.test.tsx
@@ -67,6 +67,80 @@ describe('TaskResultViewer', () => {
     })
   })
 
+  it('holds the loading state while the first request is unresolved', async () => {
+    let release: (value: unknown) => void = () => {}
+    const gate = new Promise((resolve) => { release = resolve })
+    server.use(
+      http.get('/api/v1/tasks/:id/result', async () => {
+        await gate
+        return HttpResponse.json({ result: 'held result' })
+      }),
+    )
+    const user = userEvent.setup()
+    render(<TaskResultViewer taskId="task-held" />)
+    await user.click(screen.getByText('Load Result'))
+    await waitFor(() => {
+      expect(screen.getByTestId('result-loading')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('held result')).not.toBeInTheDocument()
+    release('')
+    await waitFor(() => {
+      expect(screen.getByText('held result')).toBeInTheDocument()
+    })
+  })
+
+  it('shows a server error with Retry and recovers on retry', async () => {
+    server.use(
+      http.get('/api/v1/tasks/:id/result', () =>
+        HttpResponse.json({ error: { code: 500, message: 'result store failed' } }, { status: 500 }),
+      ),
+    )
+    const user = userEvent.setup()
+    render(<TaskResultViewer taskId="task-err" />)
+    await user.click(screen.getByText('Load Result'))
+    await waitFor(() => {
+      expect(screen.getByTestId('result-error')).toHaveTextContent('result store failed')
+    })
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    expect(screen.queryByText('No result available', { exact: false })).not.toBeInTheDocument()
+
+    server.use(
+      http.get('/api/v1/tasks/:id/result', () => HttpResponse.json({ result: 'recovered' })),
+    )
+    await user.click(screen.getByRole('button', { name: /retry/i }))
+    await waitFor(() => {
+      expect(screen.getByText('recovered')).toBeInTheDocument()
+    })
+  })
+
+  it('shows a distinct unavailable state on 404', async () => {
+    server.use(
+      http.get('/api/v1/tasks/:id/result', () =>
+        HttpResponse.json({ message: 'not found' }, { status: 404 }),
+      ),
+    )
+    const user = userEvent.setup()
+    render(<TaskResultViewer taskId="task-missing" />)
+    await user.click(screen.getByText('Load Result'))
+    await waitFor(() => {
+      expect(screen.getByTestId('result-error')).toHaveTextContent('No result available for this task yet.')
+    })
+    expect(screen.getByRole('button', { name: /load result/i })).toBeInTheDocument()
+  })
+
+  it('shows a network failure with Retry', async () => {
+    server.use(
+      http.get('/api/v1/tasks/:id/result', () => HttpResponse.error()),
+    )
+    const user = userEvent.setup()
+    render(<TaskResultViewer taskId="task-net" />)
+    await user.click(screen.getByText('Load Result'))
+    await waitFor(() => {
+      expect(screen.getByTestId('result-error')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+  })
+
   it('renders structured result with verdict badge', async () => {
     const structured = JSON.stringify({
       summary: 'All tests pass',

--- a/ui/src/components/tasks/task-result-viewer.tsx
+++ b/ui/src/components/tasks/task-result-viewer.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { GitBranch } from 'lucide-react'
 import { DiffViewer } from './diff-viewer'
 import { TaskFilesChanged } from './task-files-changed'
+import { isNotFoundError } from '@/lib/api-client'
 
 interface StructuredResult {
   summary?: string
@@ -80,13 +81,45 @@ function StructuredResultView({ result }: { result: StructuredResult }) {
 }
 
 export function TaskResultViewer({ taskId }: { taskId: string }) {
-  const { data, isLoading, refetch, isFetched } = useTaskResult(taskId)
+  const { data, isLoading, isFetched, error, refetch } = useTaskResult(taskId)
 
   const resultText = data?.result
   const structured = useMemo(() => {
     if (!resultText) return null
     return tryParseStructuredResult(resultText)
   }, [resultText])
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader><CardTitle>Result</CardTitle></CardHeader>
+        <CardContent>
+          <div data-testid="result-loading" className="h-32 w-full">
+            <Skeleton className="h-32 w-full" />
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error) {
+    const unavailable = isNotFoundError(error)
+    return (
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Result</CardTitle>
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            {unavailable ? 'Load Result' : 'Retry'}
+          </Button>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground" data-testid="result-error">
+            {unavailable ? 'No result available for this task yet.' : error.message}
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
 
   if (!isFetched) {
     return (
@@ -95,15 +128,6 @@ export function TaskResultViewer({ taskId }: { taskId: string }) {
           <CardTitle>Result</CardTitle>
           <Button variant="outline" size="sm" onClick={() => refetch()}>Load Result</Button>
         </CardHeader>
-      </Card>
-    )
-  }
-
-  if (isLoading) {
-    return (
-      <Card>
-        <CardHeader><CardTitle>Result</CardTitle></CardHeader>
-        <CardContent><Skeleton className="h-32 w-full" /></CardContent>
       </Card>
     )
   }


### PR DESCRIPTION
## Summary

The task Result tab now distinguishes the untouched state from an in-flight request and from failures, instead of showing "No result available" after an error with no way back.

Changes in `ui/src/components/tasks/task-result-viewer.tsx`:

- The loading skeleton is shown during the first active fetch, before the untouched state is considered. The request button is not rendered while a request is in flight, so Retry cannot fire while already loading.
- A settled failure is rendered explicitly via the query's `error`:
  - 404: distinct "No result available for this task yet." message with a "Load Result" button.
  - Server and network failures: the readable API error message with a Retry button backed by `refetch`.
- Opening the panel still does not start a result request (the query remains disabled until the user clicks).

Plain-text and structured-result rendering, the namespace-aware query key, and query retry conventions are unchanged.

## Tests

Extended `task-result-viewer.test.tsx` (13 tests pass):

- `holds the loading state while the first request is unresolved`: a gated MSW response asserts the loading skeleton is visible before the response resolves.
- `shows a server error with Retry and recovers on retry`: HTTP 500 renders the `result store failed` message and Retry; switching the handler to success and clicking Retry shows the recovered result.
- `shows a distinct unavailable state on 404`: renders the unavailable message with a "Load Result" action.
- `shows a network failure with Retry`: `HttpResponse.error()` produces the error state with Retry.

## Verification

```bash
bun run test src/components/tasks/task-result-viewer.test.tsx   # 13/13 pass
bun run lint                                                   # pass
bun run test                                                   # full suite: 1110 passed; 4 pre-existing flaky failures in
                                                               # repository-monitor-create-form.test.tsx and
                                                               # task-create-form.test.tsx, which pass in isolation and are
                                                               # unrelated to this change
```

Fixes #523.