### PR TITLE
fix(api): stop serving the dashboard for unrouted compatibility API paths

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -131,7 +131,7 @@ func effectiveStatusCode(c fiber.Ctx, err error) int {
 		}
 	}
 	if status == fiber.StatusNotFound {
-		if _, unsupported := unsupportedCompatRoutes[c.Path()]; unsupported {
+		if _, unsupported := unsupportedCompatRoutes[routeLookupPath(c.Path())]; unsupported {
 			status = fiber.StatusNotImplemented
 		}
 	}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -114,7 +114,8 @@ func NewTracingMiddleware() fiber.Handler {
 // Handler errors are mapped by the app error handler only after middleware
 // unwinds, so the response still carries the default 200 here. A 404 on a
 // non-API path is served as the SPA index page with 200 by that same error
-// handler, so it is reported as a success rather than a failure.
+// handler, so it is reported as a success rather than a failure, and a 404 for
+// a deliberately unsupported compatibility route is rewritten there to 501.
 func effectiveStatusCode(c fiber.Ctx, err error) int {
 	status := c.Response().StatusCode()
 	if err != nil && status < fiber.StatusBadRequest {
@@ -127,6 +128,11 @@ func effectiveStatusCode(c fiber.Ctx, err error) int {
 	if status == fiber.StatusNotFound && spaFallbackEligible(c.Path()) {
 		if _, ok := spaIndexHTML(); ok {
 			status = fiber.StatusOK
+		}
+	}
+	if status == fiber.StatusNotFound {
+		if _, unsupported := unsupportedCompatRoutes[c.Path()]; unsupported {
+			status = fiber.StatusNotImplemented
 		}
 	}
 	return status

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -368,6 +368,9 @@ func TestEffectiveStatusCodeReportsSPAFallbackAsSuccess(t *testing.T) {
 		{"api path", "/api/v1/missing", fiber.StatusNotFound},
 		{"healthz", "/healthz", fiber.StatusNotFound},
 		{"readyz", "/readyz", fiber.StatusNotFound},
+		{"openai compat path", "/openai/v1/nonexistent", fiber.StatusNotFound},
+		{"openai unimplemented endpoint", "/openai/v1/responses", fiber.StatusNotImplemented},
+		{"anthropic compat path", "/anthropic/v1/messages/count_tokens", fiber.StatusNotFound},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -372,6 +372,8 @@ func TestEffectiveStatusCodeReportsSPAFallbackAsSuccess(t *testing.T) {
 		{"openai unimplemented endpoint", "/openai/v1/responses", fiber.StatusNotImplemented},
 		{"anthropic compat path", "/anthropic/v1/messages/count_tokens", fiber.StatusNotFound},
 		{"webhook path", "/webhooks/gitlab", fiber.StatusNotFound},
+		{"upper-case compat path", "/OPENAI/v1/nonexistent", fiber.StatusNotFound},
+		{"upper-case unimplemented endpoint", "/OpenAI/v1/Responses", fiber.StatusNotImplemented},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -371,6 +371,7 @@ func TestEffectiveStatusCodeReportsSPAFallbackAsSuccess(t *testing.T) {
 		{"openai compat path", "/openai/v1/nonexistent", fiber.StatusNotFound},
 		{"openai unimplemented endpoint", "/openai/v1/responses", fiber.StatusNotImplemented},
 		{"anthropic compat path", "/anthropic/v1/messages/count_tokens", fiber.StatusNotFound},
+		{"webhook path", "/webhooks/gitlab", fiber.StatusNotFound},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -374,6 +374,11 @@ func TestEffectiveStatusCodeReportsSPAFallbackAsSuccess(t *testing.T) {
 		{"webhook path", "/webhooks/gitlab", fiber.StatusNotFound},
 		{"upper-case compat path", "/OPENAI/v1/nonexistent", fiber.StatusNotFound},
 		{"upper-case unimplemented endpoint", "/OpenAI/v1/Responses", fiber.StatusNotImplemented},
+		{"trailing-slash unimplemented endpoint", "/openai/v1/responses/", fiber.StatusNotImplemented},
+		{"openai root", "/openai", fiber.StatusNotFound},
+		{"anthropic root", "/anthropic", fiber.StatusNotFound},
+		{"internal root", "/internal", fiber.StatusNotFound},
+		{"webhooks root", "/webhooks", fiber.StatusNotFound},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/api/openai_compat.go
+++ b/internal/api/openai_compat.go
@@ -197,6 +197,10 @@ type OAIModelList struct {
 	Data   []OAIModel `json:"data"`
 }
 
+// OAIErrorTypeInvalidRequest is the OpenAI error type for a request the API
+// will not act on.
+const OAIErrorTypeInvalidRequest = "invalid_request_error"
+
 // OAIError is the OpenAI error response format.
 type OAIError struct {
 	Error OAIErrorDetail `json:"error"`

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -545,19 +545,29 @@ func (s *Server) Start(ctx context.Context) error {
 
 // apiPathPrefixes are the request prefixes served by an API rather than by the
 // dashboard. A 404 under one of them is a routing answer the caller needs to
-// see, not a client-side route for the SPA to resolve.
+// see, not a client-side route for the SPA to resolve. Lower case, matched
+// against a folded path: see routeLookupPath.
 var apiPathPrefixes = []string{"/api", "/openai/", "/anthropic/", "/internal/", "/webhooks/"}
+
+// routeLookupPath folds path the way the router matches it. Fiber is
+// case-insensitive by default, so /OPENAI/v1/chat/completions reaches the
+// registered handler and an unrouted /OPENAI/v1/responses has to be classified
+// the same way a lower-case one is.
+func routeLookupPath(path string) string {
+	return strings.ToLower(path)
+}
 
 // spaFallbackEligible reports whether a 404 for path is served as the SPA
 // index page instead of a JSON error. Telemetry middleware uses the same
 // predicate so the recorded status matches what the client receives.
 func spaFallbackEligible(path string) bool {
+	folded := routeLookupPath(path)
 	for _, prefix := range apiPathPrefixes {
-		if strings.HasPrefix(path, prefix) {
+		if strings.HasPrefix(folded, prefix) {
 			return false
 		}
 	}
-	return path != "/healthz" && path != "/readyz"
+	return folded != "/healthz" && folded != "/readyz"
 }
 
 // spaIndexHTML returns the embedded SPA index page, or false when the UI
@@ -628,6 +638,7 @@ func customErrorHandler(c fiber.Ctx, err error) error {
 
 // unsupportedCompatRoutes names endpoints of the emulated provider APIs that
 // Orka deliberately does not serve, and the supported route to use instead.
+// Keys are lower case and looked up with a folded path.
 // Saying so costs a client one line in its log rather than a parse failure
 // several frames from the cause.
 var unsupportedCompatRoutes = map[string]string{
@@ -637,7 +648,7 @@ var unsupportedCompatRoutes = map[string]string{
 // compatRouteNotFound answers an unrouted compatibility-API path in the error
 // format that API's clients expect. It reports whether it handled the path.
 func compatRouteNotFound(c fiber.Ctx) (bool, error) {
-	path := c.Path()
+	path := routeLookupPath(c.Path())
 	status := fiber.StatusNotFound
 
 	message, unsupported := unsupportedCompatRoutes[path]

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -546,7 +546,7 @@ func (s *Server) Start(ctx context.Context) error {
 // apiPathPrefixes are the request prefixes served by an API rather than by the
 // dashboard. A 404 under one of them is a routing answer the caller needs to
 // see, not a client-side route for the SPA to resolve.
-var apiPathPrefixes = []string{"/api", "/openai/", "/anthropic/", "/internal/"}
+var apiPathPrefixes = []string{"/api", "/openai/", "/anthropic/", "/internal/", "/webhooks/"}
 
 // spaFallbackEligible reports whether a 404 for path is served as the SPA
 // index page instead of a JSON error. Telemetry middleware uses the same

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -661,6 +661,8 @@ func compatRouteNotFound(c fiber.Ctx) (bool, error) {
 		// The endpoint is a real part of the emulated API and this server does
 		// not implement it, which is 501 rather than "no such route".
 		status = fiber.StatusNotImplemented
+		// Provider SDKs should not retry this permanent failure.
+		c.Set("X-Should-Retry", "false")
 	} else {
 		message = fmt.Sprintf("unknown path %s", path)
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -543,12 +543,21 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 }
 
+// apiPathPrefixes are the request prefixes served by an API rather than by the
+// dashboard. A 404 under one of them is a routing answer the caller needs to
+// see, not a client-side route for the SPA to resolve.
+var apiPathPrefixes = []string{"/api", "/openai/", "/anthropic/", "/internal/"}
+
 // spaFallbackEligible reports whether a 404 for path is served as the SPA
 // index page instead of a JSON error. Telemetry middleware uses the same
 // predicate so the recorded status matches what the client receives.
 func spaFallbackEligible(path string) bool {
-	isAPI := len(path) >= 4 && path[:4] == "/api"
-	return !isAPI && path != "/healthz" && path != "/readyz"
+	for _, prefix := range apiPathPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return false
+		}
+	}
+	return path != "/healthz" && path != "/readyz"
 }
 
 // spaIndexHTML returns the embedded SPA index page, or false when the UI
@@ -601,10 +610,53 @@ func customErrorHandler(c fiber.Ctx, err error) error {
 		}
 	}
 
+	// Callers of the compatibility APIs are provider SDKs that parse only that
+	// provider's error envelope, so an unrouted path answers in its format.
+	if code == fiber.StatusNotFound {
+		if handled, resp := compatRouteNotFound(c); handled {
+			return resp
+		}
+	}
+
 	return c.Status(code).JSON(fiber.Map{
 		"error": fiber.Map{
 			"code":    code,
 			"message": message,
 		},
 	})
+}
+
+// unsupportedCompatRoutes names endpoints of the emulated provider APIs that
+// Orka deliberately does not serve, and the supported route to use instead.
+// Saying so costs a client one line in its log rather than a parse failure
+// several frames from the cause.
+var unsupportedCompatRoutes = map[string]string{
+	"/openai/v1/responses": "the OpenAI Responses API is not supported by this endpoint; use /openai/v1/chat/completions",
+}
+
+// compatRouteNotFound answers an unrouted compatibility-API path in the error
+// format that API's clients expect. It reports whether it handled the path.
+func compatRouteNotFound(c fiber.Ctx) (bool, error) {
+	path := c.Path()
+	status := fiber.StatusNotFound
+
+	message, unsupported := unsupportedCompatRoutes[path]
+	if unsupported {
+		// The endpoint is a real part of the emulated API and this server does
+		// not implement it, which is 501 rather than "no such route".
+		status = fiber.StatusNotImplemented
+	} else {
+		message = fmt.Sprintf("unknown path %s", path)
+	}
+
+	switch {
+	case strings.HasPrefix(path, "/openai/"):
+		return true, c.Status(status).JSON(OAIError{Error: OAIErrorDetail{
+			Message: message,
+			Type:    OAIErrorTypeInvalidRequest,
+		}})
+	case strings.HasPrefix(path, "/anthropic/"):
+		return true, anthropicError(c, status, "not_found_error", message)
+	}
+	return false, nil
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -543,18 +543,23 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 }
 
-// apiPathPrefixes are the request prefixes served by an API rather than by the
+// apiPathRoots are the request path roots served by an API rather than by the
 // dashboard. A 404 under one of them is a routing answer the caller needs to
-// see, not a client-side route for the SPA to resolve. Lower case, matched
-// against a folded path: see routeLookupPath.
-var apiPathPrefixes = []string{"/api", "/openai/", "/anthropic/", "/internal/", "/webhooks/"}
+// see, not a client-side route for the SPA to resolve. Lower case and without
+// a trailing slash, matched against a normalized path: see routeLookupPath.
+var apiPathRoots = []string{"/api", "/openai", "/anthropic", "/internal", "/webhooks"}
 
-// routeLookupPath folds path the way the router matches it. Fiber is
-// case-insensitive by default, so /OPENAI/v1/chat/completions reaches the
-// registered handler and an unrouted /OPENAI/v1/responses has to be classified
-// the same way a lower-case one is.
+// routeLookupPath normalizes path the way the router matches it. Fiber is
+// case-insensitive and non-strict about a trailing slash by default, so
+// /OPENAI/v1/chat/completions and /openai/v1/chat/completions/ both reach the
+// registered handler. Unrouted paths have to be classified the same way, or a
+// caller gets a different answer for a spelling the router treats as identical.
 func routeLookupPath(path string) string {
-	return strings.ToLower(path)
+	folded := strings.ToLower(path)
+	for len(folded) > 1 && strings.HasSuffix(folded, "/") {
+		folded = folded[:len(folded)-1]
+	}
+	return folded
 }
 
 // spaFallbackEligible reports whether a 404 for path is served as the SPA
@@ -562,8 +567,8 @@ func routeLookupPath(path string) string {
 // predicate so the recorded status matches what the client receives.
 func spaFallbackEligible(path string) bool {
 	folded := routeLookupPath(path)
-	for _, prefix := range apiPathPrefixes {
-		if strings.HasPrefix(folded, prefix) {
+	for _, root := range apiPathRoots {
+		if folded == root || strings.HasPrefix(folded, root+"/") {
 			return false
 		}
 	}
@@ -661,12 +666,12 @@ func compatRouteNotFound(c fiber.Ctx) (bool, error) {
 	}
 
 	switch {
-	case strings.HasPrefix(path, "/openai/"):
+	case path == "/openai" || strings.HasPrefix(path, "/openai/"):
 		return true, c.Status(status).JSON(OAIError{Error: OAIErrorDetail{
 			Message: message,
 			Type:    OAIErrorTypeInvalidRequest,
 		}})
-	case strings.HasPrefix(path, "/anthropic/"):
+	case path == "/anthropic" || strings.HasPrefix(path, "/anthropic/"):
 		return true, anthropicError(c, status, "not_found_error", message)
 	}
 	return false, nil

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -385,6 +385,20 @@ func TestCustomErrorHandler_CompatAPI404_ReturnsProviderError(t *testing.T) {
 			},
 		},
 		{
+			name: "openai upper case",
+			path: "/OPENAI/v1/nonexistent",
+			assertErr: func(t *testing.T, body []byte) {
+				t.Helper()
+				var payload OAIError
+				if err := json.Unmarshal(body, &payload); err != nil {
+					t.Fatalf("body is not an OpenAI error envelope: %v (%s)", err, body)
+				}
+				if payload.Error.Type != "invalid_request_error" {
+					t.Errorf("error.type = %q, want invalid_request_error", payload.Error.Type)
+				}
+			},
+		},
+		{
 			name: "anthropic",
 			path: "/anthropic/v1/nonexistent",
 			assertErr: func(t *testing.T, body []byte) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -8,9 +8,12 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
@@ -351,6 +354,102 @@ func TestCustomErrorHandler_Health404_ReturnsJSON(t *testing.T) {
 
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestCustomErrorHandler_CompatAPI404_ReturnsProviderError(t *testing.T) {
+	// An unrouted path under a compatibility API must not be answered with the
+	// dashboard's index page: the caller is a provider SDK, and HTML parsed as
+	// JSON surfaces several frames from the cause. It also has to carry that
+	// provider's error envelope, which is the only shape its client reads.
+	tests := []struct {
+		name      string
+		path      string
+		assertErr func(t *testing.T, body []byte)
+	}{
+		{
+			name: "openai",
+			path: "/openai/v1/nonexistent",
+			assertErr: func(t *testing.T, body []byte) {
+				t.Helper()
+				var payload OAIError
+				if err := json.Unmarshal(body, &payload); err != nil {
+					t.Fatalf("body is not an OpenAI error envelope: %v (%s)", err, body)
+				}
+				if payload.Error.Type != "invalid_request_error" {
+					t.Errorf("error.type = %q, want invalid_request_error", payload.Error.Type)
+				}
+				if !strings.Contains(payload.Error.Message, "/openai/v1/nonexistent") {
+					t.Errorf("error.message = %q, want it to name the path", payload.Error.Message)
+				}
+			},
+		},
+		{
+			name: "anthropic",
+			path: "/anthropic/v1/nonexistent",
+			assertErr: func(t *testing.T, body []byte) {
+				t.Helper()
+				var payload AnthropicError
+				if err := json.Unmarshal(body, &payload); err != nil {
+					t.Fatalf("body is not an Anthropic error envelope: %v (%s)", err, body)
+				}
+				if payload.Type != "error" {
+					t.Errorf("type = %q, want error", payload.Type)
+				}
+				if payload.Error.Type != "not_found_error" {
+					t.Errorf("error.type = %q, want not_found_error", payload.Error.Type)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := fiber.New(fiber.Config{ErrorHandler: customErrorHandler})
+
+			resp, err := app.Test(httptest.NewRequest(http.MethodPost, tt.path, nil))
+			if err != nil {
+				t.Fatalf("Test request failed: %v", err)
+			}
+			if resp.StatusCode != http.StatusNotFound {
+				t.Fatalf("StatusCode = %d, want %d", resp.StatusCode, http.StatusNotFound)
+			}
+			if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+				t.Fatalf("Content-Type = %q, want application/json", ct)
+			}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("Failed to read body: %v", err)
+			}
+			tt.assertErr(t, body)
+		})
+	}
+}
+
+func TestCustomErrorHandler_OpenAIResponses_ReturnsNotImplemented(t *testing.T) {
+	// The Responses API is the default wire format of several agent
+	// frameworks. It is a real endpoint this server does not serve, so it
+	// answers 501 and names the route that does work, rather than 404.
+	app := fiber.New(fiber.Config{ErrorHandler: customErrorHandler})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil))
+	if err != nil {
+		t.Fatalf("Test request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotImplemented {
+		t.Fatalf("StatusCode = %d, want %d", resp.StatusCode, http.StatusNotImplemented)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read body: %v", err)
+	}
+	var payload OAIError
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("body is not an OpenAI error envelope: %v (%s)", err, body)
+	}
+	if !strings.Contains(payload.Error.Message, "/openai/v1/chat/completions") {
+		t.Errorf("error.message = %q, want it to name the supported route", payload.Error.Message)
 	}
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -453,6 +453,9 @@ func TestCustomErrorHandler_OpenAIResponses_ReturnsNotImplemented(t *testing.T) 
 	if resp.StatusCode != http.StatusNotImplemented {
 		t.Fatalf("StatusCode = %d, want %d", resp.StatusCode, http.StatusNotImplemented)
 	}
+	if got := resp.Header.Get("X-Should-Retry"); got != "false" {
+		t.Fatalf("X-Should-Retry = %q, want false", got)
+	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
Pointed a Microsoft Agent Framework app at Orka's OpenAI endpoint and everything 500s on the app side:

```
AttributeError: 'str' object has no attribute 'metadata'
  .../agent_framework_openai/_chat_client.py:2539 in _parse_response_from_openai
```

Turns out `OpenAIChatClient` in agent-framework 1.x is the Responses client, so it POSTs to `/openai/v1/responses`. Orka doesn't route that, but instead of 404ing it hits the SPA catch-all and gets back 200 with an HTML body, which the SDK then tries to parse as JSON.

Shows up as a success in the logs too:

```
INFO api-server request completed  {"method":"POST","path":"/openai/v1/responses",
                                    "status":200,"duration":"14.041µs"}
```

and in the metrics, since `effectiveStatusCode` uses the same `spaFallbackEligible` check:

```
orka_api_requests_total{endpoint="/openai/v1",method="POST",status="2xx"} 3
```

## Repro

No cluster needed, the fallback is in the error handler. Drop this in `internal/api/` on main:

```go
func TestReproCompatPathReturnsHTML(t *testing.T) {
	app := fiber.New(fiber.Config{ErrorHandler: customErrorHandler})
	resp, _ := app.Test(httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil))
	body, _ := io.ReadAll(resp.Body)
	t.Logf("status = %d, content-type = %s, body = %.60s",
		resp.StatusCode, resp.Header.Get("Content-Type"), body)
}
```

```console
$ make ensure-ui-embed
$ go test ./internal/api/ -run TestReproCompatPathReturnsHTML -v
    status = 200, content-type = text/html; charset=utf-8, body = <!doctype html><html>...
```

Against a running Orka:

```console
$ curl -sS -X POST http://<orka>/openai/v1/responses \
    -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
    -d '{"model":"local/qwen2.5:3b","input":"ping"}' -i | head -3
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
```

## Fix

`spaFallbackEligible` only exempted `/api`, `/healthz` and `/readyz`, so `/anthropic/`, `/internal/` and `/webhooks/` have this too. An Anthropic SDK calling `/anthropic/v1/messages/count_tokens` gets 200+HTML today, and so does a sender posting to a mistyped webhook URL, which then reads it as delivered. Now excludes every non-dashboard prefix. Left `/api` without a trailing slash so nothing changes there.

Unrouted compat paths now come back in the provider's error shape. The comment on `customErrorHandler` already says they do, but that only held for routed handlers, fallthroughs got the generic envelope which those SDKs don't read.

`POST /openai/v1/responses` returns 501 pointing at chat/completions:

```json
{"error":{"message":"the OpenAI Responses API is not supported by this endpoint; use /openai/v1/chat/completions","type":"invalid_request_error","param":null,"code":null}}
```

`effectiveStatusCode` does the same rewrite, otherwise the client gets 501 and the metric still says 404.

Both lookups go through one `routeLookupPath` that folds case and trims a trailing slash, since Fiber is case-insensitive and non-strict about trailing slashes by default. `/OPENAI/v1/chat/completions` and `/openai/v1/chat/completions/` both reach the handler, so without normalizing, `/OPENAI/v1/responses` still returned 200 HTML and `/openai/v1/responses/` returned 404 where `/openai/v1/responses` returned 501.

Matching is by path root instead of raw prefix, so the bare `/openai`, `/anthropic`, `/internal` and `/webhooks` are covered too. Side effect worth flagging: `/apifoo` was treated as an API path by the old `path[:4]` check and now falls to the SPA. Say if that was deliberate and I'll restore it.

This is just the refusal. Whether to actually serve Responses is #540.

## Notes

`goconst` flagged my new `"invalid_request_error"` literal, so I added `OAIErrorTypeInvalidRequest` next to `OAIError` and used it in the new code only. Left the five existing literals alone, can sweep them here if you'd rather.

Unrelated, but `make lint-fix` reformatted five files I hadn't touched in `internal/controller` and `internal/tools`. Reverted them here. `--new` means they never get reported, so they'd quietly ride along on anyone's PR.

## Verification

- `make lint` clean
- `go test ./internal/api/` passes
- `make test` passes except `TestCodeExecTool_Execute_Node`, which fails identically on a clean main here so I don't think it's mine
- New tests: two cases in `TestEffectiveStatusCodeReportsSPAFallbackAsSuccess`, plus `TestCustomErrorHandler_CompatAPI404_ReturnsProviderError` and `TestCustomErrorHandler_OpenAIResponses_ReturnsNotImplemented`. All fail on main.
