### PR TITLE
chore(substrate): pin upstream v0.1.0

### DIFF
--- a/hack/agent-substrate/README.md
+++ b/hack/agent-substrate/README.md
@@ -1,7 +1,8 @@
 # Official Substrate pin
 
-`upstream.env` pins the unmodified provider commit and the SHA-256 of its
-`ateapi.proto`. Orka does not apply provider patches or consume fork-only APIs.
+`upstream.env` pins [Agent Substrate v0.1.0](https://github.com/agent-substrate/substrate/tree/v0.1.0)
+to its unmodified release commit and the SHA-256 of its `ateapi.proto`.
+Orka does not apply provider patches or consume fork-only APIs.
 
 `scripts/lib/substrate-upstream.sh` verifies the official repository, commit,
 and clean tracked source before installation. It uses a dedicated gVisor kind

--- a/hack/agent-substrate/upstream.env
+++ b/hack/agent-substrate/upstream.env
@@ -1,5 +1,5 @@
-# The provider, protocol, and conformance suite use this unmodified upstream commit.
+# Agent Substrate v0.1.0, pinned by commit for provider, protocol, and conformance.
 SUBSTRATE_UPSTREAM_REPOSITORY=https://github.com/agent-substrate/substrate.git
-SUBSTRATE_UPSTREAM_COMMIT=7a9abab35044670ce357d9eea89175a153718cbc
-SUBSTRATE_UPSTREAM_PROTO_SHA256=ac3a89f07bacce977e1d80b5bb9463485095f8cb52a2e1a0262c9b07d7c95500
+SUBSTRATE_UPSTREAM_COMMIT=fa6d949685a6318940a9a0195c867c864009b820
+SUBSTRATE_UPSTREAM_PROTO_SHA256=768f5af413c36fef6e46096b5b18beb7d0ad2293ef5e38478511121035240a76
 SUBSTRATE_PROTOC_VERSION=36.0

--- a/internal/substratepb/ateapi.pb.go
+++ b/internal/substratepb/ateapi.pb.go
@@ -3309,7 +3309,6 @@ type SystemInfoVolumeSource struct {
 	// +k8s:optional
 	// +k8s:maxItems=8
 	// +k8s:listType=atomic
-	// +k8s:customValidation # paths unique across entries
 	DataSources   []*SystemInfoDataSource `protobuf:"bytes,1,rep,name=data_sources,json=dataSources,proto3" json:"data_sources,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -3473,13 +3472,9 @@ type ActorMetadataItem struct {
 	// +k8s:minimum=1
 	// +k8s:maximum=3 # keep this in sync with the ActorMetadataField enum
 	Field ActorMetadataField `protobuf:"varint,1,opt,name=field,proto3,enum=ateapi.ActorMetadataField" json:"field,omitempty"`
-	// path must be a clean relative Unix path: at most 16 '/'-separated
-	// segments, none of them empty, '.' or '..', and no NUL byte.
-	//
 	// +k8s:required
 	// +k8s:minLength=1
 	// +k8s:maxLength=255
-	// +k8s:customValidation # projected-path rule shared with atelet, see internal/volumepath
 	Path          string `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -3537,13 +3532,9 @@ type TrustBundleDataSource struct {
 	// +k8s:minLength=1
 	// +k8s:maxLength=253
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	// path must be a clean relative Unix path: at most 16 '/'-separated
-	// segments, none of them empty, '.' or '..', and no NUL byte.
-	//
 	// +k8s:required
 	// +k8s:minLength=1
 	// +k8s:maxLength=255
-	// +k8s:customValidation # projected-path rule shared with atelet, see internal/volumepath
 	Path          string `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -6635,7 +6626,7 @@ type MintCertRequest struct {
 	// subject public key.
 	//
 	// +k8s:required
-	// +k8s:maxBytes=16384
+	// +k8s:customValidation # size bound; maxLength is string-only
 	CertificateSigningRequest []byte `protobuf:"bytes,2,opt,name=certificate_signing_request,json=certificateSigningRequest,proto3" json:"certificate_signing_request,omitempty"`
 	// Actor incarnation expected by the activation. This is only a stale-request
 	// guard: ateapi derives the actor and its identity from the worker assignment.

--- a/internal/substratepb/ateapi.proto
+++ b/internal/substratepb/ateapi.proto
@@ -1117,7 +1117,6 @@ message SystemInfoVolumeSource {
   // +k8s:optional
   // +k8s:maxItems=8
   // +k8s:listType=atomic
-  // +k8s:customValidation # paths unique across entries
   repeated SystemInfoDataSource data_sources = 1;
 }
 
@@ -1156,13 +1155,9 @@ message ActorMetadataItem {
   // +k8s:maximum=3 # keep this in sync with the ActorMetadataField enum
   ActorMetadataField field = 1;
 
-  // path must be a clean relative Unix path: at most 16 '/'-separated
-  // segments, none of them empty, '.' or '..', and no NUL byte.
-  //
   // +k8s:required
   // +k8s:minLength=1
   // +k8s:maxLength=255
-  // +k8s:customValidation # projected-path rule shared with atelet, see internal/volumepath
   string path = 2;
 }
 
@@ -1183,13 +1178,9 @@ message TrustBundleDataSource {
   // +k8s:maxLength=253
   string name = 1;
 
-  // path must be a clean relative Unix path: at most 16 '/'-separated
-  // segments, none of them empty, '.' or '..', and no NUL byte.
-  //
   // +k8s:required
   // +k8s:minLength=1
   // +k8s:maxLength=255
-  // +k8s:customValidation # projected-path rule shared with atelet, see internal/volumepath
   string path = 2;
 }
 
@@ -1980,7 +1971,7 @@ message MintCertRequest {
   // subject public key.
   //
   // +k8s:required
-  // +k8s:maxBytes=16384
+  // +k8s:customValidation # size bound; maxLength is string-only
   bytes certificate_signing_request = 2;
 
   // Actor incarnation expected by the activation. This is only a stale-request

--- a/website/docs/concepts/substrate.md
+++ b/website/docs/concepts/substrate.md
@@ -6,7 +6,7 @@ description: "Agent Substrate execution, data-only suspension, checkpoints, and 
 # Agent Substrate workspaces
 
 Orka runs direct workspaces, MCP servers, and built-in ACP runtimes on the
-unmodified [Agent Substrate](https://github.com/agent-substrate/substrate)
+unmodified [Agent Substrate v0.1.0](https://github.com/agent-substrate/substrate/tree/v0.1.0)
 provider. The supported source and protocol are pinned together in
 `hack/agent-substrate/upstream.env`. Provider forks, local patches, and
 fork-specific `ActorSnapshot` APIs are not part of this integration.


### PR DESCRIPTION
Pin the Substrate provider and protocol to the official [v0.1.0 release](https://github.com/agent-substrate/substrate/tree/v0.1.0), regenerate the Go bindings, and update the documentation to name the supported release. RPCs and message fields are unchanged.

Validation passed:

- `make lint-fix` and `make test`
- Focused Substrate/native workspace tests and protobuf pin verification with protoc 36.0
- Substrate E2E hardening checks
- Full live conformance against unmodified v0.1.0: direct and MCP execution, ACP continuity across controller restart, DataOnly suspension and checkpoint restore, runtime-loss recovery, cancellation, timeout, and cleanup
