### PR TITLE
fix(controller): surface WaitingForApproval condition on parked tasks

### DIFF
--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -88,6 +88,15 @@ const (
 	// ConditionTypeWaitingForApproval indicates a running task is parked on a human approval.
 	ConditionTypeWaitingForApproval = "WaitingForApproval"
 
+	// approvalConditionReasonPending marks WaitingForApproval true while at least one
+	// derived approval for the task is still undecided.
+	approvalConditionReasonPending = "ApprovalPending"
+
+	// approvalConditionReasonResolved marks WaitingForApproval false once a previously
+	// parked task has no undecided approvals left and execution can resume. Terminal
+	// paths set the same condition false with their own outcome-specific reasons.
+	approvalConditionReasonResolved = "ApprovalResolved"
+
 	// jobCreationVisibilityGracePeriod avoids failing a task when the controller cache
 	// has not observed the Job immediately after create.
 	jobCreationVisibilityGracePeriod = 30 * time.Second
@@ -4386,6 +4395,9 @@ func (r *TaskReconciler) parkOnPendingApproval(ctx context.Context, task *corev1
 		return ctrl.Result{}, false, err
 	}
 	if len(pending) == 0 {
+		if err := r.clearWaitingForApprovalCondition(ctx, task); err != nil {
+			return ctrl.Result{}, false, err
+		}
 		return ctrl.Result{}, false, nil
 	}
 	approval := pending[0]
@@ -4408,13 +4420,48 @@ func (r *TaskReconciler) parkOnPendingApproval(ctx context.Context, task *corev1
 		target,
 		task.Status.Iteration,
 	)
-	if task.Status.Message != waitingMessage {
+	// The condition mirrors the status message so external consumers can watch a typed
+	// signal instead of parsing free-form text. The message format is load-bearing for
+	// resumingAfterApprovalDecision and must keep its existing prefix and layout.
+	conditionChanged := meta.SetStatusCondition(&task.Status.Conditions, metav1.Condition{
+		Type:               ConditionTypeWaitingForApproval,
+		Status:             metav1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Reason:             approvalConditionReasonPending,
+		Message:            waitingMessage,
+	})
+	messageChanged := task.Status.Message != waitingMessage
+	if messageChanged {
 		task.Status.Message = waitingMessage
+	}
+	// Parking requeues every 30s. Writing status only on an observed change keeps the
+	// park loop from generating a watch event per requeue.
+	if messageChanged || conditionChanged {
 		if err := r.Status().Update(ctx, task); err != nil {
 			return ctrl.Result{}, false, err
 		}
 	}
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, true, nil
+}
+
+// clearWaitingForApprovalCondition marks a previously parked task as no longer waiting
+// once its approvals are decided. Terminal paths already set this condition false with
+// outcome-specific reasons; this covers the resume path, which is not terminal and would
+// otherwise leave a stale WaitingForApproval=True on a task that is running again.
+func (r *TaskReconciler) clearWaitingForApprovalCondition(ctx context.Context, task *corev1alpha1.Task) error {
+	if task == nil || !meta.IsStatusConditionTrue(task.Status.Conditions, ConditionTypeWaitingForApproval) {
+		return nil
+	}
+	if !meta.SetStatusCondition(&task.Status.Conditions, metav1.Condition{
+		Type:               ConditionTypeWaitingForApproval,
+		Status:             metav1.ConditionFalse,
+		LastTransitionTime: metav1.Now(),
+		Reason:             approvalConditionReasonResolved,
+		Message:            "no pending approvals",
+	}) {
+		return nil
+	}
+	return r.Status().Update(ctx, task)
 }
 
 func (r *TaskReconciler) handleAutonomousApprovalState(ctx context.Context, task *corev1alpha1.Task) (ctrl.Result, bool, error) {

--- a/internal/controller/task_controller_unit_test.go
+++ b/internal/controller/task_controller_unit_test.go
@@ -8814,3 +8814,200 @@ func TestHandleDeletionWaitsForHarnessV1AttemptReclamation(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+const (
+	approvalParkTaskName      = "approval-task"
+	approvalParkTaskNamespace = "default"
+	approvalParkTargetTool    = "dispatch_work_order"
+)
+
+// approvalParkEvent builds a minimal approval execution event for the parking tests.
+func approvalParkEvent(t *testing.T, eventType, approvalID, taskUID string) store.ExecutionEvent {
+	t.Helper()
+	content, err := json.Marshal(map[string]string{
+		"approvalID": approvalID,
+		"targetTool": approvalParkTargetTool,
+		"taskUID":    taskUID,
+	})
+	if err != nil {
+		t.Fatalf("marshal approval content: %v", err)
+	}
+	return store.ExecutionEvent{
+		Namespace:  approvalParkTaskNamespace,
+		StreamType: store.ExecutionEventStreamTypeTask,
+		StreamID:   approvalParkTaskName,
+		TaskName:   approvalParkTaskName,
+		Type:       eventType,
+		Severity:   events.ExecutionEventSeverityInfo,
+		ToolCallID: approvalID,
+		Content:    content,
+	}
+}
+
+// newApprovalParkFixture builds a reconciler whose task stream already contains evts.
+func newApprovalParkFixture(
+	t *testing.T,
+	taskUID string,
+	seed []metav1.Condition,
+	evts ...store.ExecutionEvent,
+) (*TaskReconciler, *corev1alpha1.Task) {
+	t.Helper()
+	task := &corev1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      approvalParkTaskName,
+			Namespace: approvalParkTaskNamespace,
+			UID:       types.UID(taskUID),
+		},
+		Spec: corev1alpha1.TaskSpec{Type: corev1alpha1.TaskTypeAI},
+		Status: corev1alpha1.TaskStatus{
+			Phase:      corev1alpha1.TaskPhaseRunning,
+			Conditions: seed,
+		},
+	}
+	r := newUnitReconciler(newTestScheme(), task)
+	for i := range evts {
+		if _, err := r.ExecutionEventStore.AppendExecutionEvent(context.Background(), &evts[i]); err != nil {
+			t.Fatalf("AppendExecutionEvent() error = %v", err)
+		}
+	}
+	return r, task
+}
+
+func TestParkOnPendingApproval_SetsWaitingForApprovalCondition(t *testing.T) {
+	const taskUID, approvalID = "task-uid-1", "approval-1"
+	ctx := context.Background()
+	r, task := newApprovalParkFixture(t, taskUID, nil,
+		approvalParkEvent(t, events.ExecutionEventTypeApprovalRequested, approvalID, taskUID))
+
+	result, parked, err := r.parkOnPendingApproval(ctx, task)
+	if err != nil {
+		t.Fatalf("parkOnPendingApproval() error = %v", err)
+	}
+	if !parked {
+		t.Fatal("parkOnPendingApproval() parked = false, want true")
+	}
+	if result.RequeueAfter != 30*time.Second {
+		t.Fatalf("parkOnPendingApproval() RequeueAfter = %v, want 30s", result.RequeueAfter)
+	}
+
+	stored := &corev1alpha1.Task{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(task), stored); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	condition := meta.FindStatusCondition(stored.Status.Conditions, ConditionTypeWaitingForApproval)
+	if condition == nil {
+		t.Fatal("WaitingForApproval condition missing, want it set on a parked task")
+	}
+	if condition.Status != metav1.ConditionTrue {
+		t.Fatalf("WaitingForApproval status = %v, want True", condition.Status)
+	}
+	if condition.Reason != approvalConditionReasonPending {
+		t.Fatalf("WaitingForApproval reason = %q, want %q", condition.Reason, approvalConditionReasonPending)
+	}
+	if !strings.Contains(condition.Message, approvalID) {
+		t.Fatalf("WaitingForApproval message = %q, want it to carry approval ID %q", condition.Message, approvalID)
+	}
+
+	// resumingAfterApprovalDecision and test/e2e/approval_gate_test.go both parse this
+	// message. The condition is additive and must not change the existing format.
+	wantMessage := fmt.Sprintf("waiting for approval %s for %s at iteration 0", approvalID, approvalParkTargetTool)
+	if stored.Status.Message != wantMessage {
+		t.Fatalf("status.message = %q, want %q", stored.Status.Message, wantMessage)
+	}
+}
+
+func TestParkOnPendingApproval_ClearsConditionAfterDecision(t *testing.T) {
+	const taskUID, approvalID = "task-uid-2", "approval-2"
+	ctx := context.Background()
+	r, task := newApprovalParkFixture(t, taskUID,
+		[]metav1.Condition{{
+			Type:               ConditionTypeWaitingForApproval,
+			Status:             metav1.ConditionTrue,
+			LastTransitionTime: metav1.Now(),
+			Reason:             approvalConditionReasonPending,
+			Message:            "waiting for approval " + approvalID,
+		}},
+		approvalParkEvent(t, events.ExecutionEventTypeApprovalRequested, approvalID, taskUID),
+		approvalParkEvent(t, events.ExecutionEventTypeApprovalApproved, approvalID, taskUID))
+
+	_, parked, err := r.parkOnPendingApproval(ctx, task)
+	if err != nil {
+		t.Fatalf("parkOnPendingApproval() error = %v", err)
+	}
+	if parked {
+		t.Fatal("parkOnPendingApproval() parked = true, want false once the approval is decided")
+	}
+
+	stored := &corev1alpha1.Task{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(task), stored); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	condition := meta.FindStatusCondition(stored.Status.Conditions, ConditionTypeWaitingForApproval)
+	if condition == nil {
+		t.Fatal("WaitingForApproval condition missing after resume")
+	}
+	if condition.Status != metav1.ConditionFalse {
+		t.Fatalf("WaitingForApproval status = %v, want False after the approval is decided", condition.Status)
+	}
+	if condition.Reason != approvalConditionReasonResolved {
+		t.Fatalf("WaitingForApproval reason = %q, want %q", condition.Reason, approvalConditionReasonResolved)
+	}
+}
+
+func TestParkOnPendingApproval_SkipsStatusWriteWhenUnchanged(t *testing.T) {
+	const taskUID, approvalID = "task-uid-3", "approval-3"
+	ctx := context.Background()
+	r, task := newApprovalParkFixture(t, taskUID, nil,
+		approvalParkEvent(t, events.ExecutionEventTypeApprovalRequested, approvalID, taskUID))
+
+	if _, _, err := r.parkOnPendingApproval(ctx, task); err != nil {
+		t.Fatalf("first parkOnPendingApproval() error = %v", err)
+	}
+	first := &corev1alpha1.Task{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(task), first); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	// Parking requeues every 30s; a steady-state park must not write status again.
+	if _, _, err := r.parkOnPendingApproval(ctx, task); err != nil {
+		t.Fatalf("second parkOnPendingApproval() error = %v", err)
+	}
+	second := &corev1alpha1.Task{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(task), second); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if first.ResourceVersion != second.ResourceVersion {
+		t.Fatalf("resourceVersion changed on a steady-state park: %s -> %s",
+			first.ResourceVersion, second.ResourceVersion)
+	}
+}
+
+func TestParkOnPendingApproval_NoConditionWhenNeverParked(t *testing.T) {
+	ctx := context.Background()
+	r, task := newApprovalParkFixture(t, "task-uid-4", nil)
+
+	before := &corev1alpha1.Task{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(task), before); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	_, parked, err := r.parkOnPendingApproval(ctx, task)
+	if err != nil {
+		t.Fatalf("parkOnPendingApproval() error = %v", err)
+	}
+	if parked {
+		t.Fatal("parkOnPendingApproval() parked = true, want false without approvals")
+	}
+
+	stored := &corev1alpha1.Task{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(task), stored); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if condition := meta.FindStatusCondition(stored.Status.Conditions, ConditionTypeWaitingForApproval); condition != nil {
+		t.Fatalf("WaitingForApproval condition = %#v, want none on a task that never parked", condition)
+	}
+	if before.ResourceVersion != stored.ResourceVersion {
+		t.Fatalf("resourceVersion changed without approvals: %s -> %s",
+			before.ResourceVersion, stored.ResourceVersion)
+	}
+}


### PR DESCRIPTION
## Problem

`ConditionTypeWaitingForApproval` is declared at `internal/controller/task_controller.go:88-89` and written in exactly four places — all of them `ConditionFalse`:

| Location | Reason |
|---|---|
| `task_controller.go:2524` (`beginTaskFinalization`) | `TaskFinalizing` |
| `task_controller.go:2616` (`completeTaskWithOutcome`) | `TaskSucceeded` / `TaskFailed` / `TaskCancelled` |
| `acp_task_queue.go:890` | `TaskCancelled` |
| `acp_task_queue.go:1048` | `TaskFailed` |

**Nothing ever set it true.** `parkOnPendingApproval` wrote only `Status.Message` and never touched `Status.Conditions`.

Meanwhile `website/docs/operations/agent-runtime-security.md:32` instructs operators to "Treat `WaitingForApproval=True` as an intentional parked state". That behaviour did not exist, so the only way to observe a parked task was to string-match free-form status text:

```go
// task_controller.go:4450 — the controller's own resume logic
waitingStatus := strings.HasPrefix(task.Status.Message, "waiting for approval ")
```

`test/e2e/approval_gate_test.go:352-367` does the same with a regex. An unstructured, unversioned `status.message` prefix was load-bearing for both Orka's internal resume path and every external consumer.

## What this changes

1. **Set the condition true when parking.** `parkOnPendingApproval` now sets `WaitingForApproval=True` with reason `ApprovalPending` and a message carrying the approval ID.

2. **Clear it on resume.** The four existing writers cover terminal paths only. Resume after an approval decision is *not* terminal — the task goes back to `Phase: Pending` and continues — so without this it would keep `WaitingForApproval=True` while actively running. `clearWaitingForApprovalCondition` sets it false with reason `ApprovalResolved` when no undecided approvals remain.

3. **Suppress redundant writes.** Parking requeues every 30s (`RequeueAfter: 30 * time.Second`). Status is written only when the message *or* the condition actually changed, so a steady-state park does not emit a watch event per pass. The clear path is guarded by `meta.IsStatusConditionTrue`, so it is a no-op for the overwhelmingly common case of a task that never parked.

## Deliberately not changed

**The `status.message` format is untouched.** This is the single highest-risk part of the change and the change is strictly additive. `resumingAfterApprovalDecision` (`task_controller.go:4450`) and the approval-gate e2e test both parse that string; altering its prefix or layout would break resume. A test asserts the exact expected message so a future edit fails loudly.

The condition message intentionally mirrors the status message rather than carrying a separate rendering, so the two cannot drift.

## Scope

This is intentionally narrow: it makes an existing, already-declared condition behave as documented. It does not add approval expiry, a namespace-wide approvals index, metrics, or any notification egress — all of which remain absent and are separate concerns.

It is, however, a prerequisite for anything that needs to *observe* a parked task without polling per-task REST or parsing status text — e.g. surfacing approvals to an external chat surface through the gateway plane. That work is not in this PR.

## Verification

- `go test ./internal/controller/ -run TestParkOnPendingApproval -v` — 4 new tests pass.
- **Red/green confirmed.** With the condition write and the clear call neutered (constants retained so the package still compiles), `TestParkOnPendingApproval_SetsWaitingForApprovalCondition` and `TestParkOnPendingApproval_ClearsConditionAfterDecision` both fail. The other two are regression guards that correctly hold either way.
- `make manifests generate` — **no CRD or generated drift.** `Conditions` already exists on `TaskStatus`; this adds no API surface.
- `make test` — **84 packages, 0 failures.**
- `gofmt -l` and `go vet ./internal/controller/` — clean.

### New tests

| Test | Asserts |
|---|---|
| `..._SetsWaitingForApprovalCondition` | Parked task gets `True` / `ApprovalPending`, message carries the approval ID, **and `status.message` still matches the exact legacy format** |
| `..._ClearsConditionAfterDecision` | A task seeded as parked flips to `False` / `ApprovalResolved` once the approval is decided |
| `..._SkipsStatusWriteWhenUnchanged` | Two consecutive parks leave `resourceVersion` unchanged — no watch-event churn on the 30s requeue |
| `..._NoConditionWhenNeverParked` | No approvals ⇒ no condition added and no status write at all |

## Reviewer notes / known caveats

- `clearWaitingForApprovalCondition` uses a plain `Status().Update` rather than `updateStatusWithRetry`, matching the adjacent park write. A conflict surfaces as a reconcile error and is retried by the controller. Happy to switch to `updateStatusWithRetry` if preferred — I kept it symmetric with the existing park path rather than changing write semantics in the same PR.
- The `!meta.SetStatusCondition(...)` early return inside `clearWaitingForApprovalCondition` is defensive; it is unreachable after the `IsStatusConditionTrue` guard.
- Approvals only apply to `type: ai` tasks on autonomous agents (`handleAutonomousApprovalState` returns early otherwise), so ACP/agent-runtime tasks are unaffected.

### Local environment caveats (not introduced by this change)

- `make lint-fix` fails locally with `the Go language version (go1.26) used to build golangci-lint is lower than the targeted Go version (1.27.0)`. **Verified pre-existing** — it fails identically on clean `main` with this change stashed. Ran `gofmt` and `go vet` instead; relying on CI for lint.
- The first `make test` run had one failure in `TestWorkspaceAgentSecuredCompletionTerminatesNamespaceProcesses` (`cmd/orka-workspace-agent`). That package has **zero dependency on `internal/controller`** (`go list -deps` confirms), it passes uncached in isolation, and a second full `make test` run was completely green. Treating it as a load-sensitive flake, unrelated to this change.
- `$autoreview` could **not** be run: none of its engines (`codex`, `claude`, `amp`, `pi`, `kimi`) are installed on this machine. TruffleHog was installed to satisfy the scan gate, but the review itself did not execute. **This should be run before the PR leaves draft.**

Opened as a draft pending that review and a maintainer's view on the two reviewer notes above.
